### PR TITLE
[BUG FIX] Add support of batching to 'RigidLink.set_mass'.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -6,17 +6,18 @@ import trimesh
 
 import genesis as gs
 from genesis.repr_base import RBC
+from genesis.typing import LaxPositiveFArrayType
 from genesis.utils import geom as gu
+from genesis.utils.misc import DeprecationError, qd_to_torch, tensor_to_array
 from genesis.utils.urdf import compose_inertial_properties, rotate_inertia
-
-from genesis.utils.misc import tensor_to_array, qd_to_torch, DeprecationError
 
 from .rigid_geom import RigidGeom, RigidVisGeom
 
 if TYPE_CHECKING:
+    from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
+
     from .rigid_entity import KinematicEntity, RigidEntity
     from .rigid_joint import RigidJoint
-    from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
 
 
 # If mass is too small, we do not care much about spatial inertia discrepancy
@@ -890,9 +891,14 @@ class RigidLink(KinematicLink):
         return torch.stack((verts.min(dim=-2).values, verts.max(dim=-2).values), dim=-2)
 
     @gs.assert_built
-    def set_mass(self, mass):
+    def set_mass(self, mass: LaxPositiveFArrayType):
         """
         Set the mass of the link.
+
+        Parameters
+        ----------
+        mass : float | array_like, shape (n_envs,)
+            The mass to set.
         """
         from genesis.engine.solvers.rigid.rigid_solver import kernel_adjust_link_inertia
 
@@ -900,14 +906,38 @@ class RigidLink(KinematicLink):
             gs.logger.warning("Updating the mass of a link that is fixed wrt world has no effect, skipping.")
             return
 
-        if mass < gs.EPS:
+        mass = tensor_to_array(mass)
+
+        if np.any(mass < gs.EPS):
             gs.raise_exception(f"Attempt to set mass of link '{self.name}' to {mass}. Mass must be strictly positive.")
 
-        ratio = float(mass / self._inertial_mass)
-        self._inertial_mass *= ratio
-        if self._invweight is not None:
-            self._invweight /= ratio
-        self._inertial_i *= ratio
+        if mass.ndim > 0 and (mass.ndim != 1 or mass.shape[0] != self._solver.n_envs):
+            gs.raise_exception(
+                f"Attempt to set mass of link '{self.name}' with shape {mass.shape}. "
+                f"Expected shape ({self._solver.n_envs},)."
+            )
+
+        ratio = mass / self._inertial_mass
+
+        n_envs = self._solver.n_envs
+        if ratio.ndim == 0:
+            ratio_scalar = float(ratio)
+            self._inertial_mass *= ratio_scalar
+            if self._invweight is not None:
+                self._invweight /= ratio_scalar
+            self._inertial_i *= ratio_scalar
+            ratio = np.full((max(n_envs, 1),), fill_value=ratio_scalar, dtype=gs.np_float)
+        else:
+            self._inertial_mass = np.asarray(self._inertial_mass, dtype=gs.np_float) * ratio
+            if self._invweight is not None:
+                invweight = np.asarray(self._invweight, dtype=gs.np_float)
+                if invweight.ndim == 1:
+                    invweight = np.broadcast_to(invweight[None, :], (n_envs, invweight.shape[0])).copy()
+                self._invweight = invweight / ratio[:, None]
+            inertial_i = np.asarray(self._inertial_i, dtype=gs.np_float)
+            if inertial_i.ndim == 2:
+                inertial_i = np.broadcast_to(inertial_i[None, :, :], (n_envs, 3, 3)).copy()
+            self._inertial_i = inertial_i * ratio[:, None, None]
 
         kernel_adjust_link_inertia(
             link_idx=self.idx,

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -917,31 +917,20 @@ class RigidLink(KinematicLink):
                 f"Expected shape ({self._solver.n_envs},)."
             )
 
-        ratio = mass / self._inertial_mass
+        ratio = np.asarray(mass / self._inertial_mass, dtype=gs.np_float)
+        if self._solver.n_envs > 0 and ratio.ndim == 0:
+            ratio = np.full((self._solver.n_envs,), fill_value=float(ratio), dtype=gs.np_float)
 
-        n_envs = self._solver.n_envs
-        if ratio.ndim == 0:
-            ratio_scalar = float(ratio)
-            self._inertial_mass *= ratio_scalar
-            if self._invweight is not None:
-                self._invweight /= ratio_scalar
-            self._inertial_i *= ratio_scalar
-            ratio = np.full((max(n_envs, 1),), fill_value=ratio_scalar, dtype=gs.np_float)
-        else:
-            self._inertial_mass = np.asarray(self._inertial_mass, dtype=gs.np_float) * ratio
-            if self._invweight is not None:
-                invweight = np.asarray(self._invweight, dtype=gs.np_float)
-                if invweight.ndim == 1:
-                    invweight = np.broadcast_to(invweight[None, :], (n_envs, invweight.shape[0])).copy()
-                self._invweight = invweight / ratio[:, None]
-            inertial_i = np.asarray(self._inertial_i, dtype=gs.np_float)
-            if inertial_i.ndim == 2:
-                inertial_i = np.broadcast_to(inertial_i[None, :, :], (n_envs, 3, 3)).copy()
-            self._inertial_i = inertial_i * ratio[:, None, None]
+        self._inertial_mass = self._inertial_mass * ratio
+
+        if self._invweight is not None:
+            self._invweight = self._invweight / ratio[:, None]
+
+        self._inertial_i = self._inertial_i * ratio[:, None, None]
 
         kernel_adjust_link_inertia(
             link_idx=self.idx,
-            ratio=ratio,
+            ratio=ratio if ratio.ndim > 0 else ratio[None],
             links_info=self._solver.links_info,
             static_rigid_sim_config=self._solver._static_rigid_sim_config,
         )

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -549,10 +549,10 @@ def kernel_adjust_link_inertia(
                 links_info.inertial_i[link_idx, i_b][j1, j2] *= ratio[i_b]
     else:
         for j in qd.static(range(2)):
-            links_info.invweight[link_idx][j] /= ratio[0]
-        links_info.inertial_mass[link_idx] *= ratio[0]
+            links_info.invweight[link_idx][j] /= ratio[None]
+        links_info.inertial_mass[link_idx] *= ratio[None]
         for j1, j2 in qd.static(qd.ndrange(3, 3)):
-            links_info.inertial_i[link_idx][j1, j2] *= ratio[0]
+            links_info.inertial_i[link_idx][j1, j2] *= ratio[None]
 
 
 @qd.kernel(fastcache=gs.use_fastcache)

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -536,23 +536,23 @@ def kernel_init_geom_fields(
 @qd.kernel(fastcache=gs.use_fastcache)
 def kernel_adjust_link_inertia(
     link_idx: qd.i32,
-    ratio: qd.f32,
+    ratio: qd.types.ndarray(),
     links_info: array_class.LinksInfo,
     static_rigid_sim_config: qd.template(),
 ):
     if qd.static(static_rigid_sim_config.batch_links_info):
-        for i_b in range(links_info.root_idx.shape[0]):
+        for i_b in range(links_info.root_idx.shape[1]):
             for j in qd.static(range(2)):
-                links_info.invweight[link_idx, i_b][j] /= ratio
-            links_info.inertial_mass[link_idx, i_b] *= ratio
+                links_info.invweight[link_idx, i_b][j] /= ratio[i_b]
+            links_info.inertial_mass[link_idx, i_b] *= ratio[i_b]
             for j1, j2 in qd.static(qd.ndrange(3, 3)):
-                links_info.inertial_i[link_idx, i_b][j1, j2] *= ratio
+                links_info.inertial_i[link_idx, i_b][j1, j2] *= ratio[i_b]
     else:
         for j in qd.static(range(2)):
-            links_info.invweight[link_idx][j] /= ratio
-        links_info.inertial_mass[link_idx] *= ratio
+            links_info.invweight[link_idx][j] /= ratio[0]
+        links_info.inertial_mass[link_idx] *= ratio[0]
         for j1, j2 in qd.static(qd.ndrange(3, 3)):
-            links_info.inertial_i[link_idx][j1, j2] *= ratio
+            links_info.inertial_i[link_idx][j1, j2] *= ratio[0]
 
 
 @qd.kernel(fastcache=gs.use_fastcache)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -16,7 +16,7 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.terrain as tu
 from genesis.ext import urdfpy
-from genesis.utils.misc import get_assets_dir, tensor_to_array, qd_to_numpy, qd_to_torch
+from genesis.utils.misc import get_assets_dir, qd_to_numpy, qd_to_torch, tensor_to_array
 
 from .utils import (
     assert_allclose,
@@ -4561,6 +4561,35 @@ def test_heterogeneous_fewer_envs_than_variants():
     assert mass.shape == (scene.n_envs,)
     # Different box sizes should have different masses
     assert mass[0] != mass[1]
+
+
+@pytest.mark.required
+def test_heterogeneous_mass_setters(tol):
+    """Test entity/link mass setters with heterogeneous morphs."""
+    scene = gs.Scene(show_viewer=False)
+    het_obj = scene.add_entity(
+        morph=[
+            gs.morphs.Box(size=(0.01, 0.01, 0.01)),
+            gs.morphs.Box(size=(0.02, 0.02, 0.02)),
+            gs.morphs.Sphere(radius=0.01),
+            gs.morphs.Sphere(radius=0.02),
+        ],
+    )
+    scene.build(n_envs=4)
+
+    # Entity-level setter should update all environments (scalar target).
+    het_obj.set_mass(1.0)
+    assert_allclose(het_obj.get_mass(), np.ones(scene.n_envs), tol=tol)
+
+    # Link-level setter should support per-environment mass targets.
+    link = next(link for link in het_obj.links if not link.is_fixed)
+    target_mass = (0.2, 0.4, 0.6, 0.8)
+    link.set_mass(target_mass)
+    assert_allclose(link.get_mass(), target_mass, tol=tol)
+
+    # Invalid shape should raise a clear exception.
+    with pytest.raises(gs.GenesisException):
+        link.set_mass((1.0, 2.0))
 
 
 @pytest.mark.required

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4577,9 +4577,10 @@ def test_heterogeneous_mass_setters(tol):
     )
     scene.build(n_envs=4)
 
-    # Entity-level setter should update all environments (scalar target).
     het_obj.set_mass(1.0)
-    assert_allclose(het_obj.get_mass(), np.ones(scene.n_envs), tol=tol)
+    assert_allclose(
+        het_obj.get_mass(), 1.0, tol=tol, err_msg="entity.set_mass(1.0) should set same mass for all variants"
+    )
 
     # Link-level setter should support per-environment mass targets.
     link = next(link for link in het_obj.links if not link.is_fixed)


### PR DESCRIPTION
## Description
Allow arraylike for set_mass

## Related Issue
Resolves https://github.com/Genesis-Embodied-AI/Genesis/issues/2542

## Motivation and Context
bug fix

## How Has This Been / Can This Be Tested?
`pytest tests/test_rigid_physics.py::test_heterogeneous_mass_setters`

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
