### PR TITLE
[BUG FIX] Fix batched sensor read when combining multiple sensor types.

### DIFF
--- a/examples/sensors/proximity_shadowhand.py
+++ b/examples/sensors/proximity_shadowhand.py
@@ -162,8 +162,7 @@ def main():
             else:
                 distances = []
                 for sensor in sensors:
-                    data = sensor.read()
-                    distances.append(data.distance)
+                    distances.append(sensor.read())
                 print(f"Proximity distances: {distances}")
 
             scene.step()

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -950,6 +950,7 @@ class KinematicContactProbe(
 
         shared_ground_truth_cache.zero_()
 
+        output = shared_ground_truth_cache.contiguous()
         _kernel_kinematic_contact_probe(
             shared_metadata.probe_positions,
             shared_metadata.probe_normals,
@@ -973,6 +974,8 @@ class KinematicContactProbe(
             gs.EPS,
             shared_ground_truth_cache,
         )
+        if not shared_ground_truth_cache.is_contiguous():
+            shared_ground_truth_cache.copy_(output)
 
     def _draw_debug(self, context: "RasterizerContext", buffer_updates: dict[str, np.ndarray]):
         self._draw_debug_probes(context, lambda data: data.penetration)
@@ -1099,6 +1102,7 @@ class ElastomerDisplacementSensor(
     ):
         solver = shared_metadata.solver
 
+        output = shared_ground_truth_cache.contiguous()
         _kernel_elastomer_displacement(
             shared_metadata.is_grid,
             shared_metadata.probe_positions,
@@ -1124,7 +1128,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.contact_buf,
             shared_metadata.contact_link_buf,
             gs.EPS,
-            shared_ground_truth_cache,
+            output,
         )
 
         _elastomer_displacement_grid_fft_dilate(
@@ -1138,7 +1142,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.dilate_coefficient,
             shared_metadata.dilate_max_delta,
             shared_metadata.grid_dilate_out_buffer,
-            shared_ground_truth_cache,
+            output,
         )
         _kernel_elastomer_displacement_grid_shear_twist(
             shared_metadata.probe_positions,
@@ -1156,8 +1160,10 @@ class ElastomerDisplacementSensor(
             solver.links_state,
             solver._sim.dt,
             gs.EPS,
-            shared_ground_truth_cache,
+            output,
         )
+        if not shared_ground_truth_cache.is_contiguous():
+            shared_ground_truth_cache.copy_(output)
 
     def _draw_debug(self, context: "RasterizerContext", buffer_updates: dict[str, np.ndarray]):
         self._draw_debug_probes(context, lambda data: torch.linalg.norm(data, dim=-1))

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -972,7 +972,7 @@ class KinematicContactProbe(
             solver.verts_info,
             solver.faces_info,
             gs.EPS,
-            shared_ground_truth_cache,
+            output,
         )
         if not shared_ground_truth_cache.is_contiguous():
             shared_ground_truth_cache.copy_(output)

--- a/genesis/engine/sensors/proximity.py
+++ b/genesis/engine/sensors/proximity.py
@@ -51,6 +51,7 @@ def _kernel_proximity(
     verts_info: array_class.VertsInfo,
     fixed_verts_state: array_class.VertsState,
     free_verts_state: array_class.VertsState,
+    positions_output: qd.types.ndarray(),
     output: qd.types.ndarray(),
 ):
     total_n_probes = probe_positions_local.shape[0]
@@ -105,11 +106,11 @@ def _kernel_proximity(
         probe_idx_in_sensor = i_p - sensor_probe_start[i_s]
         cache_start = sensor_cache_start[i_s]
         n_probes = n_probes_per_sensor[i_s]
+        probe_global_idx = sensor_probe_start[i_s] + probe_idx_in_sensor
 
         output[i_b, cache_start + probe_idx_in_sensor] = best_dist
-        output[i_b, cache_start + n_probes + probe_idx_in_sensor * 3 + 0] = best_point[0]
-        output[i_b, cache_start + n_probes + probe_idx_in_sensor * 3 + 1] = best_point[1]
-        output[i_b, cache_start + n_probes + probe_idx_in_sensor * 3 + 2] = best_point[2]
+        for j in qd.static(range(3)):
+            positions_output[i_b, probe_global_idx, j] = best_point[j]
 
 
 @dataclass
@@ -125,6 +126,7 @@ class ProximitySensorMetadataMixin:
     track_link_start: torch.Tensor = make_tensor_field((0,), dtype=gs.tc_int)
     track_link_end: torch.Tensor = make_tensor_field((0,), dtype=gs.tc_int)
     track_link_flat: torch.Tensor = make_tensor_field((0,), dtype=gs.tc_int)
+    nearest_positions: torch.Tensor = make_tensor_field((0, 0, 3))
     max_range: torch.Tensor = make_tensor_field((0,))
 
 
@@ -135,26 +137,10 @@ class ProximityMetadata(
     """Shared metadata for the Proximity sensor class."""
 
 
-class ProximityData(NamedTuple):
-    """
-    Data returned by the proximity sensor.
-
-    Parameters
-    ----------
-    distance : torch.Tensor, shape ([n_envs,] n_probes)
-        Distance in meters to the nearest point on any tracked mesh (or max_range if none in range).
-    points: torch.Tensor, shape ([n_envs,] n_probes, 3)
-        Nearest points in world frame for each probe to tracked meshes.
-    """
-
-    distance: torch.Tensor
-    points: torch.Tensor
-
-
 class ProximitySensor(
     RigidSensorMixin[ProximityMetadata],
     NoisySensorMixin[ProximityMetadata],
-    Sensor[ProximityOptions, ProximityMetadata, ProximityData],
+    Sensor[ProximityOptions, ProximityMetadata, tuple],
 ):
     """Proximity sensor: distance and nearest point from probe positions to tracked mesh surfaces."""
 
@@ -163,9 +149,10 @@ class ProximitySensor(
         self._n_probes = int(np.prod(self._probe_local_pos.shape[:-1]))
         super().__init__(sensor_options, sensor_idx, sensor_manager)
         self._debug_objects: list = []
+        self._nearest_points_slice: slice = slice(None)
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._n_probes,), (self._n_probes, 3)
+        return (self._n_probes,)
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
@@ -218,6 +205,16 @@ class ProximitySensor(
         )
 
         self._shared_metadata.total_n_probes += self._n_probes
+        self._shared_metadata.nearest_positions = torch.zeros(
+            (self._manager._sim._B, self._shared_metadata.total_n_probes, 3), dtype=gs.tc_float, device=gs.device
+        )
+        slice_start = self._shared_metadata.sensor_probe_start[self._idx]
+        self._nearest_points_slice = slice(slice_start, slice_start + self._n_probes)
+
+    @classmethod
+    def reset(cls, shared_metadata: ProximityMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
+        super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
+        shared_metadata.nearest_positions[envs_idx] = shared_metadata.probe_positions
 
     @classmethod
     def _update_shared_ground_truth_cache(
@@ -246,6 +243,7 @@ class ProximitySensor(
             solver.verts_info,
             solver.fixed_verts_state,
             solver.free_verts_state,
+            shared_metadata.nearest_positions,
             output,
         )
         if not shared_ground_truth_cache.is_contiguous():
@@ -280,8 +278,7 @@ class ProximitySensor(
         link_pos = self._link.get_pos(env_idx).squeeze()
         link_quat = self._link.get_quat(env_idx).squeeze()
         probe_world = tensor_to_array(gu.transform_by_trans_quat(self._probe_local_pos, link_pos, link_quat))
-        data = self.read_ground_truth(env_idx)
-        points = tensor_to_array(data.points)
+        points = self.nearest_points[env_idx]
 
         self._debug_objects.append(
             context.draw_debug_spheres(
@@ -298,3 +295,7 @@ class ProximitySensor(
                 color=self._options.debug_color,
             )
             self._debug_objects.append(line_obj)
+
+    @property
+    def nearest_points(self) -> torch.Tensor:
+        return self._shared_metadata.nearest_positions[:, self._nearest_points_slice, :]

--- a/genesis/engine/sensors/proximity.py
+++ b/genesis/engine/sensors/proximity.py
@@ -225,6 +225,7 @@ class ProximitySensor(
     ):
         solver = shared_metadata.solver
         shared_ground_truth_cache.zero_()
+        output = shared_ground_truth_cache.contiguous()
         _kernel_proximity(
             shared_metadata.probe_positions,
             shared_metadata.probe_sensor_idx,
@@ -245,8 +246,10 @@ class ProximitySensor(
             solver.verts_info,
             solver.fixed_verts_state,
             solver.free_verts_state,
-            shared_ground_truth_cache,
+            output,
         )
+        if not shared_ground_truth_cache.is_contiguous():
+            shared_ground_truth_cache.copy_(output)
 
     @classmethod
     def _update_shared_cache(

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -375,7 +375,8 @@ class IMU(RigidSensorOptionsMixin["IMUSensor"], NoisySensorOptionsMixin["IMUSens
 
 class Proximity(RigidSensorOptionsMixin["ProximitySensor"], NoisySensorOptionsMixin["ProximitySensor"]):
     """
-    Proximity sensor that reports distance and nearest point from probe positions to tracked mesh surfaces.
+    Proximity sensor that reports the nearest distances from probe positions to tracked mesh surfaces.
+    The read() output will provide the distances, and the nearest points can be accessed with `sensor.nearest_points`.
 
     Attached to a rigid entity link. Takes a list of local probe positions and a list of global link indices
     to track; for each probe, outputs the distance and nearest point (world frame) to the closest mesh

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -126,7 +126,6 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("n_envs", [0, 2])
 def test_add_and_read_all_registered_sensors(show_viewer, n_envs):
     """Add all sensors into scene and read them, verifying SensorManager cache and tensor contiguity"""
     from genesis.engine.sensors.sensor_manager import SensorManager
@@ -177,7 +176,7 @@ def test_add_and_read_all_registered_sensors(show_viewer, n_envs):
         sensor = scene.add_sensor(option_cls(**sensor_kwargs))
         sensors.append(sensor)
 
-    scene.build(n_envs=n_envs)
+    scene.build(n_envs=2)
     scene.step()
     for sensor in sensors:
         sensor.read()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1431,12 +1431,12 @@ def test_proximity_sensor_box_sphere(n_envs, show_viewer, tol):
     sphere_prox_data = sphere_prox_sensor.read_ground_truth()
 
     for i in range(len(BOX_PROBE_POS)):
-        assert_allclose(box_prox_data.distance[..., i], DISTANCE - SPHERE_RADIUS - BOX_PROBE_POS[i][2], tol=tol)
-    assert_allclose(box_prox_data.points, (0.0, 0.0, DISTANCE - SPHERE_RADIUS), tol=tol)
-    assert_allclose(sphere_prox_data.distance, DISTANCE, tol=tol)
+        assert_allclose(box_prox_data[..., i], DISTANCE - SPHERE_RADIUS - BOX_PROBE_POS[i][2], tol=tol)
+    assert_allclose(box_prox_sensor.nearest_points, (0.0, 0.0, DISTANCE - SPHERE_RADIUS), tol=tol)
+    assert_allclose(sphere_prox_data, DISTANCE, tol=tol)
 
     with np.testing.assert_raises(AssertionError):
-        assert_allclose(sphere_prox_noisy_data.distance, sphere_prox_data.distance, tol=tol)
+        assert_allclose(sphere_prox_noisy_data, sphere_prox_data, tol=tol)
 
     sphere1_pos = np.array((0.0, 0.0, DISTANCE * 3.0))
     sphere1.set_pos(sphere1_pos)
@@ -1446,9 +1446,9 @@ def test_proximity_sensor_box_sphere(n_envs, show_viewer, tol):
     box_prox_data = box_prox_sensor.read()
     sphere_prox_data = sphere_prox_sensor.read_ground_truth()
 
-    assert_allclose(box_prox_data.distance[..., 0], DISTANCE * 2.0 - SPHERE_RADIUS, tol=tol)
-    assert_allclose(box_prox_data.distance[..., 1], DISTANCE * 2.0 - SPHERE_RADIUS - 0.05, tol=tol)
-    assert_allclose(sphere_prox_data.distance, DISTANCE * 3.0, tol=tol)
+    assert_allclose(box_prox_data[..., 0], DISTANCE * 2.0 - SPHERE_RADIUS, tol=tol)
+    assert_allclose(box_prox_data[..., 1], DISTANCE * 2.0 - SPHERE_RADIUS - 0.05, tol=tol)
+    assert_allclose(sphere_prox_data, DISTANCE * 3.0, tol=tol)
 
     box_pos = np.array((0.0, 0.0, -MAX_RANGE))
     box.set_pos(box_pos)
@@ -1457,17 +1457,17 @@ def test_proximity_sensor_box_sphere(n_envs, show_viewer, tol):
     box_prox_data = box_prox_sensor.read()
     sphere_prox_data = sphere_prox_sensor.read_ground_truth()
 
-    assert_allclose(box_prox_data.distance, MAX_RANGE, tol=tol)
-    assert_allclose(sphere_prox_data.distance, MAX_RANGE, tol=tol)
+    assert_allclose(box_prox_data, MAX_RANGE, tol=tol)
+    assert_allclose(sphere_prox_data, MAX_RANGE, tol=tol)
     for i in range(len(BOX_PROBE_POS)):
         assert_allclose(
-            box_prox_data.points[..., i, :],
+            box_prox_sensor.nearest_points[..., i, :],
             np.array(BOX_PROBE_POS[i]) + box_pos,
             tol=tol,
             err_msg="When out of range, points should be the probe position in world frame",
         )
     assert_allclose(
-        sphere_prox_data.points,
+        sphere_prox_sensor.nearest_points,
         np.array(SPHERE_PROBE_POS) + sphere1_pos,
         tol=tol,
         err_msg="When out of range, points should be the probe position in world frame",

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -176,7 +176,7 @@ def test_add_and_read_all_registered_sensors():
         sensors.append(sensor)
 
     scene.build(n_envs=2)
-    
+
     scene.step()
     for sensor in sensors:
         sensor.read()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -126,13 +126,12 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
 
 
 @pytest.mark.required
-def test_add_and_read_all_registered_sensors(show_viewer, n_envs):
+def test_add_and_read_all_registered_sensors():
     """Add all sensors into scene and read them, verifying SensorManager cache and tensor contiguity"""
     from genesis.engine.sensors.sensor_manager import SensorManager
 
     scene = gs.Scene(
-        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
-        show_viewer=show_viewer,
+        show_viewer=False,
     )
     scene.add_entity(gs.morphs.Plane())
     box = scene.add_entity(
@@ -177,6 +176,7 @@ def test_add_and_read_all_registered_sensors(show_viewer, n_envs):
         sensors.append(sensor)
 
     scene.build(n_envs=2)
+    
     scene.step()
     for sensor in sensors:
         sensor.read()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -125,6 +125,64 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
         SensorManager.SENSOR_TYPES_MAP.pop(FakeSensorOptions, None)
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_add_and_read_all_registered_sensors(show_viewer, n_envs):
+    """Add all sensors into scene and read them, verifying SensorManager cache and tensor contiguity"""
+    from genesis.engine.sensors.sensor_manager import SensorManager
+
+    scene = gs.Scene(
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.2, 0.2, 0.2),
+            pos=(0.0, 0.0, 0.1),
+        )
+    )
+    sphere = scene.add_entity(
+        gs.morphs.Sphere(
+            radius=0.1,
+            pos=(0.2, 0.0, 0.1),
+        )
+    )
+
+    sensors = []
+
+    for option_cls in SensorManager.SENSOR_TYPES_MAP.keys():
+        sensor_kwargs = {}
+        if issubclass(option_cls, gs.sensors.BaseCameraOptions):
+            continue  # skip camera options
+        if issubclass(option_cls, gs.sensors.RigidSensorOptionsMixin):
+            sensor_kwargs.update(
+                entity_idx=box.idx,
+            )
+        if issubclass(option_cls, gs.sensors.Raycaster):
+            sensor_kwargs.update(
+                pattern=gs.sensors.raycaster.DepthCameraPattern(),
+            )
+        if issubclass(option_cls, gs.sensors.Proximity):
+            sensor_kwargs.update(
+                track_link_idx=(sphere.idx,),
+            )
+        if issubclass(option_cls, gs.sensors.TemperatureGrid):
+            sensor_kwargs.update(
+                properties_dict={
+                    -1: gs.sensors.TemperatureProperties(),
+                },
+            )
+
+        sensor = scene.add_sensor(option_cls(**sensor_kwargs))
+        sensors.append(sensor)
+
+    scene.build(n_envs=n_envs)
+    scene.step()
+    for sensor in sensors:
+        sensor.read()
+
+
 # ------------------------------------------------------------------------------------------
 # -------------------------------------- IMU Sensors ---------------------------------------
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
The contiguity of tensors is not preserved when we have two different sensor types with the same cache dtype because in SensorManager the sensor caches are structured as:
```python
self._ground_truth_cache[dtype][envs_idx, sensor_cls_cache_slices]
```
Ideally we need to switch the order to `[sensor_cls_cache_slices, envs_idx]` to preserve contiguity. But for now to fix the bug, let's add a contig check? We already do this for `Raycaster`.

## Related Issue
```
Traceback (most recent call last):
 ...
  File "/Users/trinity/Documents/GitHub/genesis/Genesis/genesis/engine/simulator.py", line 296, in step
    self._sensor_manager.step()
  File "/Users/trinity/Documents/GitHub/genesis/Genesis/genesis/engine/sensors/sensor_manager.py", line 167, in step
    sensor_cls._update_shared_ground_truth_cache(
  File "/Users/trinity/Documents/GitHub/genesis/Genesis/genesis/engine/sensors/proximity.py", line 228, in _update_shared_ground_truth_cache
    _kernel_proximity(
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/_quadrants_callable.py", line 96, in __call__
    return self.wrapper.__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/kernel_impl.py", line 141, in wrapped_func
    return primal(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/kernel.py", line 581, in __call__
    ret = self.launch_kernel(key, kernel_cpp, compiled_kernel_data, *py_args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/kernel.py", line 446, in launch_kernel
    num_args_, is_launch_ctx_cacheable_ = self._recursive_set_args(
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/_func_base.py", line 543, in _recursive_set_args
    raise ValueError(
ValueError: Non contiguous tensors are not supported, please call tensor.contiguous() before passing it into quadrants kernel.

[Genesis] [22:00:23] [ERROR] ValueError: Non contiguous tensors are not supported, please call tensor.contiguous() before passing it into quadrants kernel.
```

```
Traceback (most recent call last):
...
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/genesis/engine/simulator.py", line 296, in step
    self._sensor_manager.step()
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/genesis/engine/sensors/sensor_manager.py", line 167, in step
    sensor_cls._update_shared_ground_truth_cache(
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/genesis/engine/sensors/kinematic_tactile.py", line 1101, in _update_shared_ground_truth_cache
    _kernel_elastomer_displacement(
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/_quadrants_callable.py", line 96, in __call__
    return self.wrapper.__call__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/kernel_impl.py", line 141, in wrapped_func
    return primal(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/kernel.py", line 581, in __call__
    ret = self.launch_kernel(key, kernel_cpp, compiled_kernel_data, *py_args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/kernel.py", line 446, in launch_kernel
    num_args_, is_launch_ctx_cacheable_ = self._recursive_set_args(
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/trinity/Documents/GitHub/genesis/dexterous_hands/.venv/lib/python3.12/site-packages/quadrants/lang/_func_base.py", line 543, in _recursive_set_args
    raise ValueError(
ValueError: Non contiguous tensors are not supported, please call tensor.contiguous() before passing it into quadrants kernel.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
`pytest -n 0 --dev tests/test_sensors.py::test_add_and_read_all_registered_sensors `

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
