### PR TITLE
[MISC] Revert unpinning wandb 0.25.

### DIFF
--- a/.github/workflows/alarm.yml
+++ b/.github/workflows/alarm.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Install deps
         run: |
-          python -m pip install --quiet --upgrade wandb frozendict
+          # Pin wandb<0.25: 0.25.x changed api.runs() to no longer populate
+          # run.config in batch queries, breaking alarm.py's config["revision"] lookup.
+          python -m pip install --quiet --upgrade 'wandb<0.25' frozendict
 
       - name: Download speed artifacts from triggering run
         id: dl_speed

--- a/.github/workflows/scripts/alarm.py
+++ b/.github/workflows/scripts/alarm.py
@@ -285,9 +285,7 @@ class Alarm:
         wandb_parser: WandbParser,
     ) -> dict[str, dict[frozendict[str, str], dict[str, float | int]]]:
         api = wandb.Api()
-        runs_iter: Iterable[Run] = api.runs(
-            f"{self.wandb_entity}/{wandb_parser.project}", order="-created_at", lazy=False
-        )
+        runs_iter: Iterable[Run] = api.runs(f"{self.wandb_entity}/{wandb_parser.project}", order="-created_at")
 
         commit_hashes = set()
         records_by_commit_hash: dict[str, dict[frozendict[str, str], dict[str, float | int]]] = defaultdict(


### PR DESCRIPTION
## Description

- we are seeing weird benchmark reports like https://github.com/Genesis-Embodied-AI/Genesis/runs/69717194498
- we fear it might be because of unpinning wandb
- whether it is the reason or not, repinning at least eliminates the unpinning as a possible cause