### PR TITLE
[MISC] Add full support of AMD GPU to unit test and benchmark infra.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ dev = [
     # Note that 'pytest-rerunfailures' is incompatible with 'pytest-forked'
     # - 16.0 is causing pytest-xdist to crash in case of failure or skipped tests
     # "pytest-rerunfailures!=16.0",
+    # GPU queries for the test infrastructure (tests/gpu_info.py); non-macOS so the CUDA device check runs on
+    # Linux and Windows. AMD's 'amdsmi' ships with ROCm, not PyPI, so the AMD backend is import-gated instead.
+    "nvidia-ml-py; platform_system != 'Darwin'",
     "setproctitle", # allows renaming the test processes on the cluster
     "syrupy",
     "huggingface_hub[hf_xet]",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,8 @@ from _pytest.mark import Expression, MarkMatcher
 from PIL import Image
 from syrupy.extensions.image import PNGImageSnapshotExtension
 
+from tests.gpu_info import detect_gpu_backend
+
 # Mock tkinter module for backward compatibility because it is a hard dependency for old Genesis versions
 has_tkinter = False
 try:
@@ -102,12 +104,14 @@ SKIP_NO_OMNIVERSE_KIT = _skip_reason("omniverse-kit support not available")
 
 
 def is_mem_monitoring_supported():
-    try:
-        assert sys.platform.startswith("linux")
-        subprocess.check_output(["nvidia-smi"], stderr=subprocess.STDOUT, timeout=10)
+    if not sys.platform.startswith("linux"):
+        return False, "mem-monitoring only supported on linux"
+
+    backend = detect_gpu_backend()
+    if backend is not None:
         return True, None
-    except Exception as exc:  # platform or nvidia-smi unavailable
-        return False, exc
+
+    return False, "no supported GPU backend detected"
 
 
 def pytest_make_parametrize_id(config, val, argname):
@@ -246,15 +250,17 @@ def _get_gpu_indices():
         return tuple(map(int, cuda_visible_devices.split(",")))
 
     if sys.platform == "linux":
-        nvidia_gpu_interface_path = "/proc/driver/nvidia/gpus/"
-        try:
-            return tuple(range(len(os.listdir(nvidia_gpu_interface_path))))
-        except FileNotFoundError:
-            warnings.warn(
-                f"'{nvidia_gpu_interface_path}' is not available. Multi-GPU support will be disabled. This is expected "
-                "on WSL2 where the NVIDIA proc interface is not mounted.",
-                stacklevel=2,
-            )
+        backend = detect_gpu_backend()
+        if backend is not None:
+            device_count = backend.get_device_count()
+            if device_count > 0:
+                return tuple(range(device_count))
+
+        warnings.warn(
+            "No GPU backend detected. Multi-GPU support will be disabled. This is expected "
+            "on WSL2 where the GPU interface is not mounted.",
+            stacklevel=2,
+        )
 
     return (0,)
 
@@ -266,23 +272,17 @@ def _torch_get_gpu_idx(device):
         device_property = torch.cuda.get_device_properties(device)
         device_uuid = str(device_property.uuid)
 
-        nvidia_gpu_interface_path = "/proc/driver/nvidia/gpus/"
-        try:
-            for device_idx, device_path in enumerate(os.listdir(nvidia_gpu_interface_path)):
-                with open(os.path.join(nvidia_gpu_interface_path, device_path, "information"), "r") as f:
-                    device_info = f.read()
-                if re.search(rf"GPU UUID:\s+GPU-{device_uuid}", device_info):
-                    return device_idx
-            else:
-                return -1
-        except FileNotFoundError:
-            warnings.warn(
-                f"'{nvidia_gpu_interface_path}' is not available. Multi-GPU support will be disabled. This is expected "
-                "on WSL2 where the NVIDIA proc interface is not mounted.",
-                stacklevel=2,
-            )
+        backend = detect_gpu_backend()
+        if backend is not None:
+            return backend.get_device_index_from_uuid(device_uuid)
 
-    return 0
+        warnings.warn(
+            "No GPU backend detected. Multi-GPU support will be disabled. This is expected "
+            "on WSL2 where the GPU interface is not mounted.",
+            stacklevel=2,
+        )
+
+    return -1
 
 
 def _get_egl_index(gpu_index):
@@ -339,34 +339,12 @@ def pytest_xdist_auto_num_workers(config):
     else:
         # Cannot rely on 'torch' because this would force loading devices before configuring CUDA device visibility
         devices_vram_memory = None
-        try:
-            result = subprocess.run(
-                ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-                text=True,
-            )
-            devices_vram_memory = tuple(int(e.strip()) for e in result.stdout.splitlines())
-        except ValueError:
-            # Unknown VRAM. Assuming unbounded.
-            vram_memory = float("inf")
-        except (FileNotFoundError, subprocess.CalledProcessError):
-            try:
-                result = subprocess.run(
-                    ["rocm-smi", "--showmeminfo", "vram", "-d", "0-255"],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    check=True,
-                    text=True,
-                )
-                devices_vram_memory = tuple(
-                    int(m.group(1)) for m in re.finditer(r"VRAM Total:\s+(\d+)\s*MiB", result.stdout)
-                )
-            except (FileNotFoundError, subprocess.CalledProcessError):
-                pass
-        if devices_vram_memory is not None:
-            assert len(set(devices_vram_memory)) == 1, "Heterogeneous Nvidia GPU devices not supported."
+        backend = detect_gpu_backend()
+        if backend is not None:
+            devices_vram_memory = backend.get_device_vram_mib()
+
+        if devices_vram_memory:
+            assert len(set(devices_vram_memory)) == 1, "Heterogeneous GPU devices not supported."
             num_gpus = len(devices_vram_memory)
             vram_memory = sum(devices_vram_memory) / 1024
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import ctypes
 import gc
 import logging
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -257,8 +256,7 @@ def _get_gpu_indices():
                 return tuple(range(device_count))
 
         warnings.warn(
-            "No GPU backend detected. Multi-GPU support will be disabled. This is expected "
-            "on WSL2 where the GPU interface is not mounted.",
+            "No GPU backend detected (neither NVML nor AMD SMI); multi-GPU support will be disabled.",
             stacklevel=2,
         )
 
@@ -266,23 +264,19 @@ def _get_gpu_indices():
 
 
 def _torch_get_gpu_idx(device):
-    if sys.platform == "linux":
-        import torch
+    # The caller only invokes this for a CUDA device, so torch is using this GPU and its identity must be
+    # confirmable. Returns the resolved physical device index, or -1 when it cannot be confirmed (no GPU
+    # management library, or a UUID unknown to it), which the caller turns into a hard error rather than
+    # letting an unverified device through.
+    import torch
 
-        device_property = torch.cuda.get_device_properties(device)
-        device_uuid = str(device_property.uuid)
+    device_uuid = str(torch.cuda.get_device_properties(device).uuid)
 
-        backend = detect_gpu_backend()
-        if backend is not None:
-            return backend.get_device_index_from_uuid(device_uuid)
+    backend = detect_gpu_backend()
+    if backend is None:
+        return -1
 
-        warnings.warn(
-            "No GPU backend detected. Multi-GPU support will be disabled. This is expected "
-            "on WSL2 where the GPU interface is not mounted.",
-            stacklevel=2,
-        )
-
-    return -1
+    return backend.get_device_index_from_uuid(device_uuid)
 
 
 def _get_egl_index(gpu_index):
@@ -814,6 +808,9 @@ def initialize_genesis(request, monkeypatch, tmp_path, backend, precision, perfo
             monkeypatch.setattr(RigidSimStaticConfig, "__init__", _RigidSimStaticConfig_init)
 
         if gs.backend != gs.cpu and gs.device.index is not None:
+            # The device torch selected must be one this worker is allowed to use. Anything else - including a
+            # -1 meaning the device could not be confirmed - fails hard rather than letting an unverified device
+            # through, on every platform.
             device_idx = _torch_get_gpu_idx(gs.device.index)
             if device_idx not in _get_gpu_indices():
                 raise RuntimeError(f"Invalid CUDA GPU device, got {device_idx}, not in {_get_gpu_indices()}.")

--- a/tests/gpu_info.py
+++ b/tests/gpu_info.py
@@ -1,0 +1,375 @@
+"""
+Cross-vendor GPU information module.
+Provides abstract interface for querying GPU device information.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+import subprocess
+import warnings
+import re
+import shutil
+
+
+class GpuBackend(ABC):
+    """Abstract base class for GPU backend implementations."""
+
+    @abstractmethod
+    def get_device_count(self) -> int:
+        """Get the number of available GPU devices."""
+        pass
+
+    @abstractmethod
+    def get_device_vram_mib(self) -> tuple[int, ...]:
+        """Get VRAM in MiB for each GPU device."""
+        pass
+
+    @abstractmethod
+    def get_device_index_from_uuid(self, device_uuid: str) -> int:
+        """Get device index from UUID."""
+        pass
+
+    @abstractmethod
+    def get_per_process_vram_mib(self) -> dict[int, int]:
+        """Get per-process VRAM usage in MiB."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def is_available(cls) -> bool:
+        """Report if the backend is available"""
+        pass
+
+
+class NvidiaBackend(GpuBackend):
+    """NVIDIA GPU backend implementation."""
+
+    NVIDIA_GPU_INTERFACE_PATH = Path("/proc/driver/nvidia/gpus/")
+    NVIDIA_SMI = "nvidia-smi"
+
+    UUID_RE_STR = "-".join((r"(?:[A-Fa-f0-9\-]{" f"{nr}" "})" for nr in (8, 4, 4, 4, 12)))
+
+    def __init__(self):
+        # allow to later warn the user something is off and per-process memory monitoring won't
+        # supported.
+        self.is_nvidia_gpu_interface_populated = self._check_nvidia_gpu_interface_populated()
+
+    @classmethod
+    def _check_nvidia_gpu_interface_populated(cls):
+        return cls.NVIDIA_GPU_INTERFACE_PATH.is_dir() and bool(list(cls.NVIDIA_GPU_INTERFACE_PATH.iterdir()))
+
+    @classmethod
+    def is_available(cls) -> bool:
+        nvidia_smi_avail = shutil.which(cls.NVIDIA_SMI) is not None
+
+        if nvidia_smi_avail and not cls._check_nvidia_gpu_interface_populated():
+            warnings.warn(
+                f"{cls.NVIDIA_GPU_INTERFACE_PATH!s} is not populated. Fallback to using nvidia-smi to discover GPUs. "
+                "If you're running your app in a container, beware that per-process monitoring fails as the nvidia driver "
+                "lacks support for process namespace."
+            )
+
+        return nvidia_smi_avail
+
+    def get_device_count(self) -> int:
+        """Get NVIDIA GPU count from proc interface."""
+        return (
+            (self.NVIDIA_GPU_INTERFACE_PATH.is_dir() and len(list(self.NVIDIA_GPU_INTERFACE_PATH.iterdir())))
+            or
+            # fallback to nvidia-smi
+            len(self._get_nvidia_smi_list_gpus())
+        )
+
+    @staticmethod
+    def _parse_nvidia_smi_query_memory(output: str) -> tuple[int, ...]:
+        vram_values = []
+        for line in output.splitlines():
+            line = line.strip()
+            if line:
+                # Convert from MB to MiB (they're the same for this purpose)
+                vram_values.append(int(line))
+
+        return tuple(vram_values)
+
+    @classmethod
+    def _call_nvidia_smi(cls, args: list[str] = []) -> str:
+        return subprocess.check_output(
+            [cls.NVIDIA_SMI] + args,
+            encoding="utf-8",
+        )
+
+    def get_device_vram_mib(self) -> tuple[int, ...]:
+        """Get VRAM in MiB for each NVIDIA GPU using nvidia-smi."""
+
+        output = self._call_nvidia_smi(
+            [
+                "--query-gpu=memory.total",
+                "--format=csv,noheader,nounits",
+            ]
+        )
+
+        per_process_vram_mib = self._parse_nvidia_smi_query_memory(output)
+
+        if not per_process_vram_mib and not self.is_nvidia_gpu_interface_populated:
+            warnings.warn(
+                "No memory usage per process returned by nvidia-smi. "
+                "Your configuration seems to be broken as Nvidia GPU /proc interface is not populated, "
+                "indicating an abnormal driver setup. "
+                "Querying per-process metrics , especially within a container or a Kuberneted pod, "
+                "is likely to return nothing (nvidia driver does not support process namespaces)."
+            )
+
+        return per_process_vram_mib
+
+    @classmethod
+    def _parse_nvidia_smi_list_gpus(cls, output: str) -> dict[int, str]:
+        device_idx_to_uuid = {}
+        for l in output.splitlines():
+            m = re.match(
+                rf"GPU (\d*): .*\(UUID: GPU-({cls.UUID_RE_STR})\)",
+                l,
+            )
+
+            assert m is not None, "nvidia-smi has changed its format"
+
+            device_idx = int(m.group(1))
+            device_uuid = m.group(2)
+
+            device_idx_to_uuid[device_idx] = device_uuid
+
+        return device_idx_to_uuid
+
+    def _get_nvidia_smi_list_gpus(self) -> dict[int, str]:
+        # fallback to nvidia-smi
+        output = self._call_nvidia_smi(["--list-gpus"])
+
+        return self._parse_nvidia_smi_list_gpus(output)
+
+    @classmethod
+    def _extract_uuid_from_nvidia_proc_information(cls, device_info: str) -> str | None:
+        m = re.match(rf"GPU UUID:\s+GPU-({cls.UUID_RE_STR})", device_info)
+
+        return m.group(1) if m is not None else None
+
+    def _get_proc_nvidia_list_gpus(self) -> dict[int, str]:
+        device_idx_to_uuid = {}
+        for device_idx, device_path in enumerate(self.NVIDIA_GPU_INTERFACE_PATH.iterdir()):
+            device_info_path = device_path / "information"
+            if not device_info_path.exists():
+                continue
+
+            with device_info_path.open() as f:
+                device_info = f.read()
+
+            device_uuid = self._extract_uuid_from_nvidia_proc_information(device_info)
+            assert device_uuid is not None, "/proc/driver/nvidia/gpus/<idx>/information has changed its format"
+            device_idx_to_uuid[device_idx] = device_uuid
+
+        return device_idx_to_uuid
+
+    def get_device_index_from_uuid(self, device_uuid: str) -> int:
+        """Get NVIDIA device index from UUID."""
+
+        for idx_to_uuid_fn in (
+            self._get_proc_nvidia_list_gpus,
+            self._get_nvidia_smi_list_gpus,  # fallback to nvidia-smi
+        ):
+            map_idx_to_uuid = idx_to_uuid_fn()
+
+            device_idx = next(
+                (map_idx for map_idx, map_uuid in map_idx_to_uuid.items() if device_uuid == map_uuid), None
+            )
+
+            if device_idx is not None:
+                return device_idx
+
+        return -1
+
+    def get_per_process_vram_mib(self) -> dict[int, int]:
+        """Get per-process VRAM usage for NVIDIA GPUs."""
+        output = self._call_nvidia_smi()
+
+        return self._parse_nvidia_smi_output(output)
+
+    def _parse_nvidia_smi_output(self, output: str) -> dict[int, int]:
+        """Parse nvidia-smi output for per-process memory usage."""
+        section = 0
+        subsec = 0
+        res = {}
+        for line in output.split("\n"):
+            if line.startswith("|==========="):
+                section += 1
+                subsec = 0
+                continue
+            if line.startswith("+-------"):
+                subsec += 1
+                continue
+            if section == 2 and subsec == 0:
+                if "No running processes" in line:
+                    continue
+                split_line = line.split()
+                if len(split_line) >= 5:
+                    pid = int(split_line[4])
+                    mem = int(split_line[-2].split("MiB")[0])
+                    res[pid] = mem
+        return res
+
+
+class AmdBackend(GpuBackend):
+    """AMD GPU backend implementation."""
+
+    KFD_SYSFS_PATH = Path("/sys/devices/virtual/kfd/kfd/topology")
+    ROCM_SMI = "rocm-smi"
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return cls.KFD_SYSFS_PATH.is_dir() and (shutil.which(cls.ROCM_SMI) is not None)
+
+    @classmethod
+    def _call_rocm_smi(cls, args: list[str] = []) -> str:
+        return subprocess.check_output(
+            [cls.ROCM_SMI] + args,
+            encoding="utf-8",
+        )
+
+    def _get_kfd_gpu_nodes_properties(self) -> dict[int, dict[str, int]]:
+        """Get KFD GPU node properties."""
+        kfd_sysfs_path_nodes = self.KFD_SYSFS_PATH / "nodes"
+        gpu_nodes_properties = {}
+
+        if not kfd_sysfs_path_nodes.is_dir():
+            return {}
+
+        for node_path in kfd_sysfs_path_nodes.iterdir():
+            with (node_path / "properties").open() as node_properties_f:
+                properties_str = node_properties_f.read()
+                node_props = self._parse_kfd_node_properties(properties_str)
+
+                if node_props["cpu_cores_count"] == 0:
+                    gpu_nodes_properties[int(node_path.name)] = node_props
+
+        return gpu_nodes_properties
+
+    @staticmethod
+    def _parse_kfd_node_properties(kfd_properties_str: str) -> dict[str, int]:
+        """Parse KFD node properties string."""
+        props = {}
+        for line in kfd_properties_str.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            name, value_str = line.split()
+            props[name] = int(value_str)
+
+        return props
+
+    def get_device_count(self) -> int:
+        """Get AMD GPU count from KFD sysfs."""
+        gpu_nodes = self._get_kfd_gpu_nodes_properties()
+        return len(gpu_nodes)
+
+    @staticmethod
+    def _parse_rocm_smi_showmeminfo(output: str) -> tuple[int, ...]:
+        return tuple(int(m.group(1)) for m in re.finditer(r"VRAM Total:\s+(\d+)\s*MiB", output))
+
+    def get_device_vram_mib(self) -> tuple[int, ...]:
+        """Get VRAM in MiB for each AMD GPU using rocm-smi."""
+        output = self._call_rocm_smi(["--showmeminfo", "vram", "-d", "0-255"])
+
+        # Parse rocm-smi output for VRAM info
+        return self._parse_rocm_smi_showmeminfo(output)
+
+    def get_device_index_from_uuid(self, device_uuid: str) -> int:
+        """Get AMD device index from UUID."""
+        device_uuid = device_uuid.replace("-", "")
+        hip_uuid = "".join([chr(int(device_uuid[i : i + 2], 16)) for i in range(0, len(device_uuid), 2)])
+        unique_id = int(hip_uuid, 16)
+
+        gpu_nodes_properties = self._get_kfd_gpu_nodes_properties()
+
+        for node_rank, gpu_props in enumerate(gpu_nodes_properties.values()):
+            if gpu_props.get("unique_id") == unique_id:
+                return node_rank
+
+        return -1
+
+    def get_per_process_vram_mib(self) -> dict[int, int]:
+        """Get per-process VRAM usage for AMD GPUs."""
+        output = self._call_rocm_smi(["--showpids"])
+
+        return self._parse_rocm_smi_showpids(output)
+
+    @staticmethod
+    def _parse_rocm_smi_showpids(output: str) -> dict[int, int]:
+        """Parse rocm-smi output for per-process memory usage."""
+        NO_PIDS = "No KFD PIDs currently running"
+
+        if NO_PIDS in output:
+            return {}
+
+        PID = "PID"
+        VRAM_USED = "VRAM USED"
+        TABLE_BORDER_STR = "===="
+
+        pid_idx = output.find(PID)
+        if pid_idx == -1:
+            return {}
+
+        output = output[pid_idx:]
+        lines = output.split("\n")
+        if not lines:
+            return {}
+
+        header = lines[0]
+
+        # Extract column spans from header
+        header_to_span = {}
+        for header_m in re.finditer(r"(\S+( |$))+ *", header):
+            header_name = header_m.group(0).strip()
+            header_to_span[header_name] = header_m.span()
+
+        if PID not in header_to_span or VRAM_USED not in header_to_span:
+            return {}
+
+        pid_to_mem_use = {}
+        for line in lines[1:]:
+            line = line.strip()
+            if not line or line.startswith(TABLE_BORDER_STR):
+                continue
+
+            header_to_info_str = {h: line[start:end].strip() for h, (start, end) in header_to_span.items()}
+
+            pid = int(header_to_info_str[PID])
+            mem_bytes = int(header_to_info_str[VRAM_USED])
+            # Convert bytes to MiB
+            pid_to_mem_use[pid] = mem_bytes >> 20
+
+        return pid_to_mem_use
+
+
+def detect_gpu_backend() -> GpuBackend | None:
+    """
+    Detect available GPU backend.
+
+    Returns:
+        NvidiaBackend if NVIDIA GPUs are detected,
+        AmdBackend if AMD GPUs are detected,
+        None otherwise.
+    """
+
+    Backend_candidates = [
+        NvidiaBackend,
+        AmdBackend,
+    ]
+
+    available_Backends = [Backend for Backend in Backend_candidates if Backend.is_available()]
+
+    if not available_Backends:
+        return None
+
+    if len(available_Backends) > 2:
+        warnings.warn("Multiple backends were detected on the current system.")
+
+    Backend = available_Backends[0]
+
+    return Backend()

--- a/tests/gpu_info.py
+++ b/tests/gpu_info.py
@@ -1,375 +1,175 @@
-"""
-Cross-vendor GPU information module.
-Provides abstract interface for querying GPU device information.
+"""Cross-vendor GPU information for the test infrastructure.
+
+Each backend queries the GPUs through the vendor management library - NVIDIA Management Library (NVML) via
+nvidia-ml-py for NVIDIA, AMD SMI (amdsmi) for AMD - rather than parsing command-line tools or reading the
+driver proc/sysfs interface. The management libraries reach the devices through the same driver path as the
+compute runtime, so they report the GPUs actually allocated to the current process even inside a container
+whose proc/sysfs interface does not reflect that allocation (e.g. an attached or namespaced container). The
+management libraries are optional dependencies, so they are imported lazily and each backend is gated on
+is_available().
 """
 
-from abc import ABC, abstractmethod
-from pathlib import Path
-import subprocess
 import warnings
-import re
-import shutil
+from abc import ABC, abstractmethod
 
 
 class GpuBackend(ABC):
-    """Abstract base class for GPU backend implementations."""
-
-    @abstractmethod
-    def get_device_count(self) -> int:
-        """Get the number of available GPU devices."""
-        pass
-
-    @abstractmethod
-    def get_device_vram_mib(self) -> tuple[int, ...]:
-        """Get VRAM in MiB for each GPU device."""
-        pass
-
-    @abstractmethod
-    def get_device_index_from_uuid(self, device_uuid: str) -> int:
-        """Get device index from UUID."""
-        pass
-
-    @abstractmethod
-    def get_per_process_vram_mib(self) -> dict[int, int]:
-        """Get per-process VRAM usage in MiB."""
-        pass
+    """Vendor-specific accessor for the GPUs visible to the current process."""
 
     @classmethod
     @abstractmethod
     def is_available(cls) -> bool:
-        """Report if the backend is available"""
-        pass
+        """Whether this backend's management library loads and its GPUs are usable in the current process."""
+
+    @abstractmethod
+    def get_device_count(self) -> int:
+        """Number of GPUs visible to the current process."""
+
+    @abstractmethod
+    def get_device_vram_mib(self) -> tuple[int, ...]:
+        """Total VRAM in MiB of each visible GPU, ordered by device index."""
+
+    @abstractmethod
+    def get_device_index_from_uuid(self, device_uuid: str) -> int:
+        """Device index of the GPU whose UUID matches, or -1 if no visible GPU does."""
+
+    @abstractmethod
+    def get_per_process_vram_mib(self) -> dict[int, int]:
+        """VRAM in MiB used across the visible GPUs by each process, keyed by process id."""
 
 
 class NvidiaBackend(GpuBackend):
-    """NVIDIA GPU backend implementation."""
-
-    NVIDIA_GPU_INTERFACE_PATH = Path("/proc/driver/nvidia/gpus/")
-    NVIDIA_SMI = "nvidia-smi"
-
-    UUID_RE_STR = "-".join((r"(?:[A-Fa-f0-9\-]{" f"{nr}" "})" for nr in (8, 4, 4, 4, 12)))
-
-    def __init__(self):
-        # allow to later warn the user something is off and per-process memory monitoring won't
-        # supported.
-        self.is_nvidia_gpu_interface_populated = self._check_nvidia_gpu_interface_populated()
-
-    @classmethod
-    def _check_nvidia_gpu_interface_populated(cls):
-        return cls.NVIDIA_GPU_INTERFACE_PATH.is_dir() and bool(list(cls.NVIDIA_GPU_INTERFACE_PATH.iterdir()))
+    """NVIDIA backend backed by the NVIDIA Management Library (NVML) through nvidia-ml-py."""
 
     @classmethod
     def is_available(cls) -> bool:
-        nvidia_smi_avail = shutil.which(cls.NVIDIA_SMI) is not None
+        try:
+            import pynvml
+        except ImportError:
+            return False
+        # Validate the same calls __init__ relies on, so a driver that loads but cannot enumerate reports the
+        # backend as unavailable here instead of raising when it is later constructed.
+        try:
+            pynvml.nvmlInit()
+            pynvml.nvmlDeviceGetCount()
+        except pynvml.NVMLError:
+            return False
+        return True
 
-        if nvidia_smi_avail and not cls._check_nvidia_gpu_interface_populated():
-            warnings.warn(
-                f"{cls.NVIDIA_GPU_INTERFACE_PATH!s} is not populated. Fallback to using nvidia-smi to discover GPUs. "
-                "If you're running your app in a container, beware that per-process monitoring fails as the nvidia driver "
-                "lacks support for process namespace."
-            )
+    def __init__(self):
+        import pynvml
 
-        return nvidia_smi_avail
+        # NVML reference-counts initialization and the test worker is short-lived, so the matching shutdown is
+        # left to process exit; the handles stay valid for the lifetime of this backend.
+        pynvml.nvmlInit()
+        self._pynvml = pynvml
+        self._handles = tuple(pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(pynvml.nvmlDeviceGetCount()))
 
     def get_device_count(self) -> int:
-        """Get NVIDIA GPU count from proc interface."""
-        return (
-            (self.NVIDIA_GPU_INTERFACE_PATH.is_dir() and len(list(self.NVIDIA_GPU_INTERFACE_PATH.iterdir())))
-            or
-            # fallback to nvidia-smi
-            len(self._get_nvidia_smi_list_gpus())
-        )
-
-    @staticmethod
-    def _parse_nvidia_smi_query_memory(output: str) -> tuple[int, ...]:
-        vram_values = []
-        for line in output.splitlines():
-            line = line.strip()
-            if line:
-                # Convert from MB to MiB (they're the same for this purpose)
-                vram_values.append(int(line))
-
-        return tuple(vram_values)
-
-    @classmethod
-    def _call_nvidia_smi(cls, args: list[str] = []) -> str:
-        return subprocess.check_output(
-            [cls.NVIDIA_SMI] + args,
-            encoding="utf-8",
-        )
+        return len(self._handles)
 
     def get_device_vram_mib(self) -> tuple[int, ...]:
-        """Get VRAM in MiB for each NVIDIA GPU using nvidia-smi."""
-
-        output = self._call_nvidia_smi(
-            [
-                "--query-gpu=memory.total",
-                "--format=csv,noheader,nounits",
-            ]
-        )
-
-        per_process_vram_mib = self._parse_nvidia_smi_query_memory(output)
-
-        if not per_process_vram_mib and not self.is_nvidia_gpu_interface_populated:
-            warnings.warn(
-                "No memory usage per process returned by nvidia-smi. "
-                "Your configuration seems to be broken as Nvidia GPU /proc interface is not populated, "
-                "indicating an abnormal driver setup. "
-                "Querying per-process metrics , especially within a container or a Kuberneted pod, "
-                "is likely to return nothing (nvidia driver does not support process namespaces)."
-            )
-
-        return per_process_vram_mib
-
-    @classmethod
-    def _parse_nvidia_smi_list_gpus(cls, output: str) -> dict[int, str]:
-        device_idx_to_uuid = {}
-        for l in output.splitlines():
-            m = re.match(
-                rf"GPU (\d*): .*\(UUID: GPU-({cls.UUID_RE_STR})\)",
-                l,
-            )
-
-            assert m is not None, "nvidia-smi has changed its format"
-
-            device_idx = int(m.group(1))
-            device_uuid = m.group(2)
-
-            device_idx_to_uuid[device_idx] = device_uuid
-
-        return device_idx_to_uuid
-
-    def _get_nvidia_smi_list_gpus(self) -> dict[int, str]:
-        # fallback to nvidia-smi
-        output = self._call_nvidia_smi(["--list-gpus"])
-
-        return self._parse_nvidia_smi_list_gpus(output)
-
-    @classmethod
-    def _extract_uuid_from_nvidia_proc_information(cls, device_info: str) -> str | None:
-        m = re.match(rf"GPU UUID:\s+GPU-({cls.UUID_RE_STR})", device_info)
-
-        return m.group(1) if m is not None else None
-
-    def _get_proc_nvidia_list_gpus(self) -> dict[int, str]:
-        device_idx_to_uuid = {}
-        for device_idx, device_path in enumerate(self.NVIDIA_GPU_INTERFACE_PATH.iterdir()):
-            device_info_path = device_path / "information"
-            if not device_info_path.exists():
-                continue
-
-            with device_info_path.open() as f:
-                device_info = f.read()
-
-            device_uuid = self._extract_uuid_from_nvidia_proc_information(device_info)
-            assert device_uuid is not None, "/proc/driver/nvidia/gpus/<idx>/information has changed its format"
-            device_idx_to_uuid[device_idx] = device_uuid
-
-        return device_idx_to_uuid
+        return tuple(self._pynvml.nvmlDeviceGetMemoryInfo(handle).total >> 20 for handle in self._handles)
 
     def get_device_index_from_uuid(self, device_uuid: str) -> int:
-        """Get NVIDIA device index from UUID."""
-
-        for idx_to_uuid_fn in (
-            self._get_proc_nvidia_list_gpus,
-            self._get_nvidia_smi_list_gpus,  # fallback to nvidia-smi
-        ):
-            map_idx_to_uuid = idx_to_uuid_fn()
-
-            device_idx = next(
-                (map_idx for map_idx, map_uuid in map_idx_to_uuid.items() if device_uuid == map_uuid), None
-            )
-
-            if device_idx is not None:
-                return device_idx
-
+        target = device_uuid.replace("-", "").lower()
+        for index, handle in enumerate(self._handles):
+            uuid = self._pynvml.nvmlDeviceGetUUID(handle)
+            if isinstance(uuid, bytes):
+                uuid = uuid.decode()
+            # NVML reports the UUID as 'GPU-<uuid>' while torch reports the bare UUID.
+            if uuid.removeprefix("GPU-").replace("-", "").lower() == target:
+                return index
         return -1
 
     def get_per_process_vram_mib(self) -> dict[int, int]:
-        """Get per-process VRAM usage for NVIDIA GPUs."""
-        output = self._call_nvidia_smi()
-
-        return self._parse_nvidia_smi_output(output)
-
-    def _parse_nvidia_smi_output(self, output: str) -> dict[int, int]:
-        """Parse nvidia-smi output for per-process memory usage."""
-        section = 0
-        subsec = 0
-        res = {}
-        for line in output.split("\n"):
-            if line.startswith("|==========="):
-                section += 1
-                subsec = 0
-                continue
-            if line.startswith("+-------"):
-                subsec += 1
-                continue
-            if section == 2 and subsec == 0:
-                if "No running processes" in line:
-                    continue
-                split_line = line.split()
-                if len(split_line) >= 5:
-                    pid = int(split_line[4])
-                    mem = int(split_line[-2].split("MiB")[0])
-                    res[pid] = mem
-        return res
+        usage: dict[int, int] = {}
+        for handle in self._handles:
+            # Genesis test workers use the GPU both for compute (Quadrants) and for rendering (EGL/OpenGL), which
+            # the driver reports as separate process lists.
+            for get_processes in (
+                self._pynvml.nvmlDeviceGetComputeRunningProcesses,
+                self._pynvml.nvmlDeviceGetGraphicsRunningProcesses,
+            ):
+                for proc in get_processes(handle):
+                    # usedGpuMemory is None when the driver cannot attribute memory to the process.
+                    if proc.usedGpuMemory is not None:
+                        usage[proc.pid] = usage.get(proc.pid, 0) + (proc.usedGpuMemory >> 20)
+        return usage
 
 
 class AmdBackend(GpuBackend):
-    """AMD GPU backend implementation."""
-
-    KFD_SYSFS_PATH = Path("/sys/devices/virtual/kfd/kfd/topology")
-    ROCM_SMI = "rocm-smi"
+    """AMD backend backed by AMD SMI (amdsmi), the management library shipped with ROCm."""
 
     @classmethod
     def is_available(cls) -> bool:
-        return cls.KFD_SYSFS_PATH.is_dir() and (shutil.which(cls.ROCM_SMI) is not None)
+        try:
+            import amdsmi
+        except ImportError:
+            return False
+        # Validate the same calls __init__ relies on, so a ROCm setup that loads but cannot enumerate (e.g. a
+        # container without /dev/kfd access) reports the backend as unavailable here instead of raising when it
+        # is later constructed.
+        try:
+            amdsmi.amdsmi_init()
+            amdsmi.amdsmi_get_processor_handles()
+        except amdsmi.AmdSmiException:
+            return False
+        return True
 
-    @classmethod
-    def _call_rocm_smi(cls, args: list[str] = []) -> str:
-        return subprocess.check_output(
-            [cls.ROCM_SMI] + args,
-            encoding="utf-8",
-        )
+    def __init__(self):
+        import amdsmi
 
-    def _get_kfd_gpu_nodes_properties(self) -> dict[int, dict[str, int]]:
-        """Get KFD GPU node properties."""
-        kfd_sysfs_path_nodes = self.KFD_SYSFS_PATH / "nodes"
-        gpu_nodes_properties = {}
-
-        if not kfd_sysfs_path_nodes.is_dir():
-            return {}
-
-        for node_path in kfd_sysfs_path_nodes.iterdir():
-            with (node_path / "properties").open() as node_properties_f:
-                properties_str = node_properties_f.read()
-                node_props = self._parse_kfd_node_properties(properties_str)
-
-                if node_props["cpu_cores_count"] == 0:
-                    gpu_nodes_properties[int(node_path.name)] = node_props
-
-        return gpu_nodes_properties
-
-    @staticmethod
-    def _parse_kfd_node_properties(kfd_properties_str: str) -> dict[str, int]:
-        """Parse KFD node properties string."""
-        props = {}
-        for line in kfd_properties_str.split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            name, value_str = line.split()
-            props[name] = int(value_str)
-
-        return props
+        # Shutdown is left to process exit, mirroring the NVIDIA backend.
+        amdsmi.amdsmi_init()
+        self._amdsmi = amdsmi
+        self._handles = tuple(amdsmi.amdsmi_get_processor_handles())
 
     def get_device_count(self) -> int:
-        """Get AMD GPU count from KFD sysfs."""
-        gpu_nodes = self._get_kfd_gpu_nodes_properties()
-        return len(gpu_nodes)
-
-    @staticmethod
-    def _parse_rocm_smi_showmeminfo(output: str) -> tuple[int, ...]:
-        return tuple(int(m.group(1)) for m in re.finditer(r"VRAM Total:\s+(\d+)\s*MiB", output))
+        return len(self._handles)
 
     def get_device_vram_mib(self) -> tuple[int, ...]:
-        """Get VRAM in MiB for each AMD GPU using rocm-smi."""
-        output = self._call_rocm_smi(["--showmeminfo", "vram", "-d", "0-255"])
-
-        # Parse rocm-smi output for VRAM info
-        return self._parse_rocm_smi_showmeminfo(output)
+        return tuple(
+            self._amdsmi.amdsmi_get_gpu_memory_total(handle, self._amdsmi.AmdSmiMemoryType.VRAM) >> 20
+            for handle in self._handles
+        )
 
     def get_device_index_from_uuid(self, device_uuid: str) -> int:
-        """Get AMD device index from UUID."""
-        device_uuid = device_uuid.replace("-", "")
-        hip_uuid = "".join([chr(int(device_uuid[i : i + 2], 16)) for i in range(0, len(device_uuid), 2)])
-        unique_id = int(hip_uuid, 16)
-
-        gpu_nodes_properties = self._get_kfd_gpu_nodes_properties()
-
-        for node_rank, gpu_props in enumerate(gpu_nodes_properties.values()):
-            if gpu_props.get("unique_id") == unique_id:
-                return node_rank
-
+        target = device_uuid.replace("-", "").lower()
+        for index, handle in enumerate(self._handles):
+            uuid = self._amdsmi.amdsmi_get_gpu_device_uuid(handle)
+            if uuid.replace("-", "").lower() == target:
+                return index
         return -1
 
     def get_per_process_vram_mib(self) -> dict[int, int]:
-        """Get per-process VRAM usage for AMD GPUs."""
-        output = self._call_rocm_smi(["--showpids"])
-
-        return self._parse_rocm_smi_showpids(output)
-
-    @staticmethod
-    def _parse_rocm_smi_showpids(output: str) -> dict[int, int]:
-        """Parse rocm-smi output for per-process memory usage."""
-        NO_PIDS = "No KFD PIDs currently running"
-
-        if NO_PIDS in output:
-            return {}
-
-        PID = "PID"
-        VRAM_USED = "VRAM USED"
-        TABLE_BORDER_STR = "===="
-
-        pid_idx = output.find(PID)
-        if pid_idx == -1:
-            return {}
-
-        output = output[pid_idx:]
-        lines = output.split("\n")
-        if not lines:
-            return {}
-
-        header = lines[0]
-
-        # Extract column spans from header
-        header_to_span = {}
-        for header_m in re.finditer(r"(\S+( |$))+ *", header):
-            header_name = header_m.group(0).strip()
-            header_to_span[header_name] = header_m.span()
-
-        if PID not in header_to_span or VRAM_USED not in header_to_span:
-            return {}
-
-        pid_to_mem_use = {}
-        for line in lines[1:]:
-            line = line.strip()
-            if not line or line.startswith(TABLE_BORDER_STR):
-                continue
-
-            header_to_info_str = {h: line[start:end].strip() for h, (start, end) in header_to_span.items()}
-
-            pid = int(header_to_info_str[PID])
-            mem_bytes = int(header_to_info_str[VRAM_USED])
-            # Convert bytes to MiB
-            pid_to_mem_use[pid] = mem_bytes >> 20
-
-        return pid_to_mem_use
+        usage: dict[int, int] = {}
+        for handle in self._handles:
+            for proc in self._amdsmi.amdsmi_get_gpu_process_list(handle):
+                # amdsmi_get_gpu_process_list returns process info dicts on recent ROCm and opaque handles on
+                # older ones, which must be resolved to a dict through amdsmi_get_gpu_process_info.
+                info = proc if isinstance(proc, dict) else self._amdsmi.amdsmi_get_gpu_process_info(handle, proc)
+                mem = info.get("memory_usage", {}).get("vram_mem") or info.get("mem")
+                if mem is not None:
+                    pid = int(info["pid"])
+                    usage[pid] = usage.get(pid, 0) + (int(mem) >> 20)
+        return usage
 
 
 def detect_gpu_backend() -> GpuBackend | None:
+    """Return a fresh instance of the first available GPU backend, or None when no GPU backend is usable.
+
+    A new instance is built on every call so the management library is initialized in the calling process,
+    which keeps the backend valid in forked children (pytest-forked runs every test in one) where the parent's
+    session and device handles would be stale.
     """
-    Detect available GPU backend.
+    backend_classes = (NvidiaBackend, AmdBackend)
+    available_backends = [backend_cls for backend_cls in backend_classes if backend_cls.is_available()]
 
-    Returns:
-        NvidiaBackend if NVIDIA GPUs are detected,
-        AmdBackend if AMD GPUs are detected,
-        None otherwise.
-    """
-
-    Backend_candidates = [
-        NvidiaBackend,
-        AmdBackend,
-    ]
-
-    available_Backends = [Backend for Backend in Backend_candidates if Backend.is_available()]
-
-    if not available_Backends:
+    if not available_backends:
         return None
 
-    if len(available_Backends) > 2:
-        warnings.warn("Multiple backends were detected on the current system.")
+    if len(available_backends) > 1:
+        warnings.warn("Multiple GPU backends were detected on the current system; using the first one.", stacklevel=2)
 
-    Backend = available_Backends[0]
-
-    return Backend()
+    return available_backends[0]()

--- a/tests/monitor_test_mem.py
+++ b/tests/monitor_test_mem.py
@@ -1,12 +1,14 @@
-from collections import defaultdict
-import subprocess
-import time
-import os
 import argparse
-import psutil
+import os
 import re
+import time
+from collections import defaultdict
 
-from tests.gpu_info import detect_gpu_backend
+import psutil
+
+# This module is launched as a standalone script ('python tests/monitor_test_mem.py'), so its own directory is
+# on sys.path and 'gpu_info' is imported as a top-level module rather than through the 'tests' package.
+from gpu_info import detect_gpu_backend
 
 
 CHECK_INTERVAL = 2.0
@@ -50,7 +52,7 @@ def parse_test_name(test_name: str) -> dict[str, str]:
 
 
 def get_cuda_usage() -> dict[int, int]:
-    """Get per-process GPU memory usage using the detected GPU backend."""
+    """VRAM in MiB used on the GPUs by each process, keyed by process id."""
     backend = detect_gpu_backend()
     if backend is not None:
         return backend.get_per_process_vram_mib()

--- a/tests/monitor_test_mem.py
+++ b/tests/monitor_test_mem.py
@@ -6,6 +6,8 @@ import argparse
 import psutil
 import re
 
+from tests.gpu_info import detect_gpu_backend
+
 
 CHECK_INTERVAL = 2.0
 
@@ -48,26 +50,12 @@ def parse_test_name(test_name: str) -> dict[str, str]:
 
 
 def get_cuda_usage() -> dict[int, int]:
-    output = subprocess.check_output(["nvidia-smi"]).decode("utf-8")
-    section = 0
-    subsec = 0
-    res = {}
-    for line in output.split("\n"):
-        if line.startswith("|============"):
-            section += 1
-            subsec = 0
-            continue
-        if line.startswith("+-------"):
-            subsec += 1
-            continue
-        if section == 2 and subsec == 0:
-            if "No running processes" in line:
-                continue
-            split_line = line.split()
-            pid = int(split_line[4])
-            mem = int(split_line[-2].split("MiB")[0])
-            res[pid] = mem
-    return res
+    """Get per-process GPU memory usage using the detected GPU backend."""
+    backend = detect_gpu_backend()
+    if backend is not None:
+        return backend.get_per_process_vram_mib()
+
+    raise RuntimeError("No supported GPU backend available.")
 
 
 def get_test_name_by_pid() -> dict[int, str]:


### PR DESCRIPTION
## Description

The test infrastructure queries GPUs through the vendor management libraries - NVIDIA Management Library (NVML) via `nvidia-ml-py`, AMD SMI via `amdsmi` (ships with ROCm) - behind a `GpuBackend` interface in `tests/gpu_info.py` (device count, VRAM, UUID-to-index resolution, per-process VRAM). This replaces the `/proc/driver/nvidia` scraping and `nvidia-smi`/`rocm-smi` text parsing, which broke on ROCm 7.2 output changes and inside containers whose proc/sysfs does not reflect the GPU actually allocated to the process.

The CUDA device cross-check in `conftest.py` is strict: a CUDA device whose identity cannot be confirmed through the management library fails hard on every platform rather than being silently accepted. A fresh backend is built on every query so forked test processes (`--forked`) re-initialize the library in their own process.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#2679

## Motivation and Context

Benchmark and memory monitoring were broken on ROCm (three independent `rocm-smi` parsing failures reproduced on RDNA4 and CDNA3), and GPU device validation returned wrong results in containerized environments. The AMD implementation follows the `amdsmi` calls validated on R9700 (RDNA4) and MI300 (CDNA3) hardware.

## How Has This Been / Can This Be Tested?

- NVIDIA: validated on an RTX PRO 6000 Blackwell cluster node, including the container case where the proc interface reports a different GPU than CUDA; full CI-matching run (`--forked -n 4 --backend gpu`) passes.
- macOS: backends report unavailable gracefully; Metal runs are unaffected.
- AMD: API calls match the `amdsmi` prototype validated on RDNA4/CDNA3 in the PR discussion; an end-to-end run on AMD hardware is still pending.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
