### PR TITLE
[MISC] Fix safe GJK fallback.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/gjk.py
+++ b/genesis/engine/solvers/rigid/collider/gjk.py
@@ -1770,6 +1770,14 @@ def func_safe_gjk_support(
     function perturbs the support direction to find the best support points that guarantee non-degenerate simplex
     in the GJK algorithm.
 
+    The support count (number of candidate support vertices tied for the maximum dot product) is only evaluated once
+    for the original direction (i=0). For perturbed directions (i=1..8), we skip the count and go straight to
+    computing support points and checking simplex validity. This is critical for performance because the count check
+    is ineffective for perturbed directions: the support field is discretized on a spherical grid, and an EPS-scale
+    perturbation maps to the same grid cells, yielding the same count every time. The previous approach recomputed
+    count for all 9 directions, wasting 8 evaluations that always returned > 1 for meshes with flat faces, without
+    ever using the perturbed support points.
+
     Parameters:
     ----------
     dir: gs.qd_vec3
@@ -1795,12 +1803,6 @@ def func_safe_gjk_support(
 
         # First order normalization based on Taylor series is accurate enough
         n_dir *= 2.0 - n_dir.dot(dir)
-
-        num_supports = func_count_support(geoms_info, support_field_info, i_ga, i_gb, quat_a, quat_b, n_dir)
-        if i > 0 and num_supports > 1:
-            # If this is a perturbed direction and we have more than one support point, we skip this iteration. If
-            # it was the original direction, we continue to find the support points to keep it as the baseline.
-            continue
 
         # Use the current direction to find the support points.
         for j in range(2):
@@ -1838,14 +1840,17 @@ def func_safe_gjk_support(
         mink = obj1 - obj2
 
         if i == 0:
+            # Only check support count for the original direction. If unique, we are done.
+            num_supports = func_count_support(geoms_info, support_field_info, i_ga, i_gb, quat_a, quat_b, n_dir)
             if num_supports > 1:
-                # If there were multiple valid support points, we move on to the next iteration to perturb the
-                # direction and find better support points.
+                # Ambiguous support (e.g. flat face) - keep as baseline, try perturbed directions.
                 continue
             else:
                 break
 
-        # If it was a perturbed direction, check if the support points have been found before.
+        # For perturbed directions, check if the support points have been found before or would form a
+        # degenerate simplex. The count is skipped because an EPS perturbation doesn't change which
+        # support-field grid cells are looked up, so it would return the same value as i=0.
         if i == 8:
             # If this was the last iteration, we don't check if it has been found before.
             break

--- a/genesis/engine/solvers/rigid/collider/support_field.py
+++ b/genesis/engine/solvers/rigid/collider/support_field.py
@@ -331,7 +331,13 @@ def _func_count_supports_mesh(
     i_g,
 ):
     """
-    Count the number of valid support points for a mesh in the given direction.
+    Count the number of distinct support vertices tied for the maximum dot product in the given direction.
+
+    The support field is a spherical grid indexed by (theta, phi). We look up 4 neighboring cells using
+    floor/ceil of the continuous grid coordinates (ii, jj). When ii or jj is an integer (common for
+    axis-aligned directions), floor == ceil and multiple iterations map to the same cell. Without
+    deduplication the same vertex is counted multiple times, inflating the count and triggering
+    unnecessary perturbation in safe_gjk_support.
     """
     theta = qd.atan2(d_mesh[1], d_mesh[0])  # [-pi, pi]
     phi = qd.acos(d_mesh[2])  # [0, pi]
@@ -342,7 +348,11 @@ def _func_count_supports_mesh(
     ii = (theta + math.pi) / math.pi / 2 * support_res
     jj = phi / math.pi * support_res
 
-    count = gs.qd_int(0)
+    # Collect unique cells, deduplicating floor == ceil collisions
+    cell_idx = qd.Vector([-1, -1, -1, -1], dt=gs.qd_int)
+    cell_dot = qd.Vector([0.0, 0.0, 0.0, 0.0], dt=gs.qd_float)
+    n_unique = gs.qd_int(0)
+
     for i4 in range(4):
         i, j = gs.qd_int(0), gs.qd_int(0)
         if i4 % 2:
@@ -360,14 +370,27 @@ def _func_count_supports_mesh(
                 j = 1
 
         support_idx = gs.qd_int(support_field_info.support_cell_start[i_g] + i * support_res + j)
-        _vid = support_field_info.support_vid[support_idx]
-        pos = support_field_info.support_v[support_idx]
-        dot = pos.dot(d_mesh)
 
-        if dot > dot_max:
+        # Skip duplicate cells (from floor == ceil on integer indices).
+        is_dup = False
+        for k in range(n_unique):
+            if cell_idx[k] == support_idx:
+                is_dup = True
+        if is_dup:
+            continue
+
+        pos = support_field_info.support_v[support_idx]
+        cell_dot[n_unique] = pos.dot(d_mesh)
+        cell_idx[n_unique] = support_idx
+        n_unique += 1
+
+    dot_max = gs.qd_float(-1e20)
+    count = gs.qd_int(0)
+    for k in range(n_unique):
+        if cell_dot[k] > dot_max:
             count = 1
-            dot_max = dot
-        elif dot == dot_max:
+            dot_max = cell_dot[k]
+        elif cell_dot[k] == dot_max:
             count += 1
 
     return count

--- a/genesis/engine/solvers/rigid/collider/support_field.py
+++ b/genesis/engine/solvers/rigid/collider/support_field.py
@@ -366,8 +366,7 @@ def _func_count_supports_mesh(
 
         if dot > dot_max:
             count = 1
-            # FIXME: This fix destroys performance (-25% total runtime FPS on benchmarks). Disabling for now...
-            # dot_max = dot
+            dot_max = dot
         elif dot == dot_max:
             count += 1
 


### PR DESCRIPTION
## Problem

PR https://github.com/Genesis-Embodied-AI/Genesis/pull/2714 fixed a correctness bug in `_func_count_supports_mesh` where `dot_max` was never updated, causing the support count to always return 1. The fix was reverted in https://github.com/Genesis-Embodied-AI/Genesis/pull/2716 because it caused an ~20% FPS regression on benchmarks.

## Root cause of the regression

In `func_safe_gjk_support`, the perturbation loop (i=0..8) was calling `func_count_support` for **all 9 directions** -- the original plus 8 EPS-perturbed variants. With the corrected count function, meshes with flat faces (very common: cube-like links on Franka) return count > 1 for the original direction. The loop then tries 8 perturbed directions, but since the EPS perturbation is far smaller than the support-field grid resolution, it maps to the **same grid cells** and yields the **same count** every time. The result: 8 wasted count evaluations that always return > 1, the loop falls through to i=8, and the function returns the exact same i=0 baseline result.

## Fix

Compute `func_count_support` only once at i=0. For perturbed directions (i=1..8), skip the count entirely and go straight to computing support points + checking simplex validity via `func_is_new_simplex_vertex_valid`. This way:

- **count == 1** (unique support): break immediately, same cost as before.
- **count > 1** (ambiguous, e.g. flat face): perturbed directions now actually compute support points and check if the resulting simplex vertex is non-degenerate, instead of fruitlessly re-checking the same count.