### PR TITLE
[MISC] Warmup sync after one step, whilst CUDA kernels cold-start.

### DIFF
--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -770,6 +770,24 @@ def run_benchmark(step_fn, *, n_envs, meta):
 
         qd.sync()
 
+    # Force CUDA-context init / lazy module load / first kernel SASS JIT to
+    # complete BEFORE entering the wall-clock warmup loop. Otherwise, the
+    # warmup's `meta.duration_warmup` budget can be partially consumed by
+    # CUDA setup (which happens on the first kernel launch into a fresh
+    # context) instead of by actual step()s. When that happens, the wall-
+    # clock warmup ends before the per-process cold-start phase (~5 s of
+    # slow step()s on hardware tested) is over, and the recording window
+    # then measures cold-start step time instead of steady-state — which
+    # manifested as intermittent 50%+ apparent `runtime_fps` regressions in
+    # `g1_fall` cluster benchmark runs even though steady-state step() time
+    # was unchanged. After this single sync-bracketed step the warmup loop's
+    # wall-clock budget contains only step() execution time, so 20 s of
+    # warmup actually means 20 s of step()s — enough to absorb the cold-
+    # start phase on every benchmark. Cost: 1 step() + 1 qd.sync().
+    step_fn()
+    if meta.needs_sync:
+        qd.sync()
+
     num_steps = 0
     is_recording = False
     time_start = time.time()


### PR DESCRIPTION
…warmup

Add one step_fn() + qd.sync() before entering the existing wall-clock warmup loop in run_benchmark(). Forces CUDA-context init, lazy CUDA module load, and first-launch SASS JIT to complete OUTSIDE the warmup wall-clock budget.

Without this, the very first step_fn() in a fresh CUDA context can block for many seconds on driver-side setup. That blocking time counts against meta.duration_warmup, leaving only a few seconds of actual step()s in the warmup window. When the warmup ends mid per-process cold-start, the recording window measures cold-start step time instead of steady-state, which manifested as intermittent 50%+ apparent runtime_fps regressions in g1_fall cluster benchmark runs even though steady-state step() time was unchanged. The first call's blocking depended on disk-cache state, lazy module load order, and prior process activity, so the artefact was node- and run-dependent, hence intermittent.

Verified on rtx-209-073 in fresh containers with the exact bench-script pytest invocation (count=3, full collection, default xdist):
  before fix: g1_fall runtime_fps = 322,644 / 322,353 / 322,396
  after  fix: g1_fall runtime_fps = 705,992 / 703,903 / 702,880
Main is unaffected. The remaining ~-4 % vs main is the real GPU-cost increase from the new fused-tile Cholesky kernels and is independent of this change.

dex_hand sanity check (heavy ~287 ms/step) unchanged: 14,210 / 14,231 fps vs 14,168 / 14,260 pre-fix. Cost of the added step is ~290 ms (one step), negligible against the test's 5 minute wall-clock.

<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
