### PR TITLE
[MISC] Reduce benchmark variance from perf_dispatch evaluation noise.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -3400,7 +3400,7 @@ def _get_static_config(*args, **kwargs):
 
 
 @qd.perf_dispatch(
-    get_geometry_hash=lambda *args, **kwargs: (*args, frozendict(kwargs)), warmup=1, active=1, repeat_after_seconds=5
+    get_geometry_hash=lambda *args, **kwargs: (*args, frozendict(kwargs)), first_warmup=1, warmup=0, active=2, repeat_after_seconds=5
 )
 def func_solve_body(
     entities_info: array_class.EntitiesInfo,

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -3400,7 +3400,11 @@ def _get_static_config(*args, **kwargs):
 
 
 @qd.perf_dispatch(
-    get_geometry_hash=lambda *args, **kwargs: (*args, frozendict(kwargs)), first_warmup=1, warmup=0, active=2, repeat_after_seconds=5
+    get_geometry_hash=lambda *args, **kwargs: (*args, frozendict(kwargs)),
+    first_warmup=1,
+    warmup=0,
+    active=2,
+    repeat_after_seconds=5,
 )
 def func_solve_body(
     entities_info: array_class.EntitiesInfo,


### PR DESCRIPTION
Change perf_dispatch parameters for func_solve_body:
- active: 1 -> 2 (two timing samples instead of one)
- warmup: 1 -> 0 (skip warmup on re-evaluation cycles)

The single-sample timing (active=1) caused noisy winner selection during the 5-second re-evaluation cycle, occasionally picking the slower implementation and causing ~10% FPS drops in benchmarks. Two samples significantly reduce this noise.

<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

# Benchmark Variance Root Cause & Fix

## Problem

`anymal_uniform_kinematic` (and `anymal_uniform`) benchmarks on `main` show sporadic ~10% FPS regressions. Approximately 1 in 12 runs drops significantly, creating a bimodal distribution: 11 runs cluster tightly (CV ~1.4%), while 1 outlier is dramatically worse.

## Root Cause

`func_solve_body` in `genesis/engine/solvers/rigid/constraint/solver.py` uses:

```python
@qd.perf_dispatch(
    ..., warmup=1, active=1, repeat_after_seconds=5
)
```

Every 5 seconds, `perf_dispatch` re-evaluates which solver implementation is fastest by:

1. Calling `runtime.sync()` to drain the GPU pipeline
2. Running each implementation (`func_solve_body_monolith` and `func_solve_decomposed`) with sync barriers — 1 warmup iteration + 1 timed iteration each
3. Picking the winner based on a **single timing sample**

**Single-sample timing is noisy** — occasionally `perf_dispatch` picks the slower implementation, which then runs for up to 5 seconds until the next re-evaluation. This produces a ~5-second burst of slower steps.

When this burst lands inside the 15-second benchmark recording window, FPS drops ~10%.

## Evidence

### Baseline variance (12 runs on `main`)

| Metric | Value |
|--------|-------|
| Mean FPS | 8,179,515 |
| CV | 3.19% |
| Range | 11.5% (7.43M – 8.37M) |
| Outliers (>5% below mean) | 1 of 12 runs (–9.2%) |

Per-step timing of the outlier run shows a transient ~5-second burst of slower steps:
- Steps 0–1300: 3.73–3.88 ms/step (normal)
- Steps 1400–2200: **5.58–5.75 ms/step** (slower, ~5 seconds — consistent with `repeat_after_seconds=5`)
- Steps 2300–3500: 3.71–3.96 ms/step (normal)

GPU clocks remained stable at 2310 MHz throughout — not a throttling issue.

### Ruled out: Python GC

GC collection counts were virtually identical between normal and outlier runs (gen0: 76 vs 75, gen1: 7 vs 6, gen2: 0 vs 0).

### Confirmation: forcing implementation eliminates variance

Running with `QD_PERFDISPATCH_FORCE=func_solve_body:func_solve_body_monolith` (bypasses all re-evaluation):

| Metric | Forced | Baseline |
|--------|--------|----------|
| CV | **0.28%** | 3.19% |
| Range | 0.94% | 11.5% |
| Outliers | **0** / 12 | 1 / 12 |

## Fix

Change `perf_dispatch` parameters from `warmup=1, active=1` to `warmup=0, active=2`:

```diff
 @qd.perf_dispatch(
-    ..., warmup=1, active=1, repeat_after_seconds=5
+    ..., warmup=0, active=2, repeat_after_seconds=5
 )
```

- **`active=2`**: Two timing samples per implementation instead of one, significantly reducing noise in winner selection.
- **`warmup=0`**: Removes the extra sync barrier from re-evaluation warmup iterations. (`first_warmup` remains at the default of 1, so the very first evaluation still warms up.)

This preserves `perf_dispatch`'s adaptive behavior while eliminating the noisy single-sample problem.

## Results with fix

### 12 runs (node rtx-209-087)

| Metric | active=2, warmup=0 | Forced (no re-eval) | Baseline (active=1, warmup=1) |
|--------|--------------------|--------------------|-------------------------------|
| Mean FPS | 8,048,155 | 7,954,723 | 8,179,515 |
| CV | **0.28%** | 0.27% | 3.19% |
| Range | 0.99% | 0.94% | 11.5% |
| Outliers | **0** | 0 | 1 |

Per-step analysis: zero slow windows across all 12 runs.

### 20 runs (node rtx-210-029)

| Metric | Value |
|--------|-------|
| Mean FPS | 7,930,795 |
| CV | **0.44%** |
| Range | 1.76% (7.85M – 7.99M) |
| Outliers (>5% below mean) | **0** / 20 |
| Outliers (>3% below mean) | **0** / 20 |

Mean FPS drops ~1.6% compared to the baseline (8.05M vs 8.18M in the 12-run test). However, the outlier-free variance (CV 0.28–0.44%) makes results more reliable for regression detection.


## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#<your-issue-number>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
