### PR TITLE
Update Dockerfile for Ubuntu 24.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,10 +35,11 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 && \
 # Install Rust for build requirements
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-RUN pip install "pybind11[global]"
+
+RUN python3 -m pip install --break-system-packages "pybind11[global]"
 
 # Install CMake
-RUN pip install --no-cache-dir cmake==3.31.6
+RUN python3 -m pip install --break-system-packages --no-cache-dir cmake==3.31.6
 
 # Build LuisaRender
 WORKDIR /workspace
@@ -64,9 +65,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     wget \
+    gosu \
     bash-completion \
     libgl1 \
-    libgl1-mesa-glx \
+    libgl1-mesa-dri \
     libglu1-mesa \
     libegl-dev \
     libegl1 \
@@ -88,11 +90,11 @@ WORKDIR /workspace
 RUN useradd --shell /bin/bash -u 1001 -c "" -m user
 
 # --------------------------- Genesis ----------------------------
-RUN pip install --no-cache-dir open3d
+RUN python3 -m pip install --break-system-packages --no-cache-dir open3d 
 RUN git clone https://github.com/Genesis-Embodied-AI/Genesis.git && \
     cd Genesis && \
-    pip install . && \
-    pip install --no-cache-dir PyOpenGL==3.1.5
+    python3 -m pip install --break-system-packages . && \
+    python3 -m pip install --break-system-packages --no-cache-dir PyOpenGL==3.1.5
 
 # -------------------- Surface Reconstruction --------------------
 # Set the LD_LIBRARY_PATH directly in the environment
@@ -114,13 +116,37 @@ COPY nvidia_icd.json /usr/share/vulkan/icd.d/nvidia_icd.json
 COPY nvidia_layers.json /etc/vulkan/implicit_layer.d/nvidia_layers.json
 
 # ---------------------- Custom Entrypoint -----------------------
-RUN echo '#!/bin/bash\n\
-if [ -n "${LOCAL_USER_ID}" ]; then\n\
-  echo "Starting with UID: $LOCAL_USER_ID"\n\
-  usermod -u $LOCAL_USER_ID user\n\
-  chown -R user:user /opt/conda/lib/python${PYTHON_VERSION}/site-packages/genesis/ext/LuisaRender/\n\
-fi\n\
-exec /bin/bash' > /entrypoint.sh && \
-chmod +x /entrypoint.sh
+RUN cat <<'EOF' > /entrypoint.sh
+#!/bin/bash
+set -e
+
+detectUIDConflict() {
+    USER_NAME=user
+    TARGET_UID=${LOCAL_USER_ID:-1000}
+
+    EXISTING_USER=$(getent passwd "$TARGET_UID" | cut -d: -f1 || true)
+
+    if [ -n "$EXISTING_USER" ] && [ "$EXISTING_USER" != "$USER_NAME" ]; then
+        echo "UID $TARGET_UID already belongs to $EXISTING_USER — removing it"
+        userdel "$EXISTING_USER" || true
+    fi
+}
+
+if [ -n "${LOCAL_USER_ID}" ]; then
+  echo "Starting with UID: $LOCAL_USER_ID"
+
+  detectUIDConflict
+
+  usermod -u "$LOCAL_USER_ID" user
+
+  chown -R user:user /opt/conda/lib/python${PYTHON_VERSION}/site-packages/genesis/ext/LuisaRender/ || true
+  # run as user
+  exec gosu user "$@"
+else
+  exec "$@"
+fi
+EOF
+
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 && \
 # Install Rust for build requirements
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-
 RUN python3 -m pip install --break-system-packages "pybind11[global]"
 
 # Install CMake
@@ -86,11 +85,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-# ------------------------ No root user --------------------------
-RUN useradd --shell /bin/bash -u 1001 -c "" -m user
-
 # --------------------------- Genesis ----------------------------
-RUN python3 -m pip install --break-system-packages --no-cache-dir open3d 
+RUN python3 -m pip install --break-system-packages --no-cache-dir open3d
 RUN git clone https://github.com/Genesis-Embodied-AI/Genesis.git && \
     cd Genesis && \
     python3 -m pip install --break-system-packages . && \
@@ -116,37 +112,25 @@ COPY nvidia_icd.json /usr/share/vulkan/icd.d/nvidia_icd.json
 COPY nvidia_layers.json /etc/vulkan/implicit_layer.d/nvidia_layers.json
 
 # ---------------------- Custom Entrypoint -----------------------
+# Resolve a user matching the caller's host UID at startup. If no user owns that UID yet, create one; if one does
+# (including root), reuse it as-is. This avoids mutating the base image's accounts and works for any LOCAL_USER_ID.
 RUN cat <<'EOF' > /entrypoint.sh
 #!/bin/bash
-set -e
-
-detectUIDConflict() {
-    USER_NAME=user
-    TARGET_UID=${LOCAL_USER_ID:-1000}
-
-    EXISTING_USER=$(getent passwd "$TARGET_UID" | cut -d: -f1 || true)
-
-    if [ -n "$EXISTING_USER" ] && [ "$EXISTING_USER" != "$USER_NAME" ]; then
-        echo "UID $TARGET_UID already belongs to $EXISTING_USER — removing it"
-        userdel "$EXISTING_USER" || true
-    fi
-}
 
 if [ -n "${LOCAL_USER_ID}" ]; then
-  echo "Starting with UID: $LOCAL_USER_ID"
-
-  detectUIDConflict
-
-  usermod -u "$LOCAL_USER_ID" user
-
-  chown -R user:user /opt/conda/lib/python${PYTHON_VERSION}/site-packages/genesis/ext/LuisaRender/ || true
-  # run as user
-  exec gosu user "$@"
+    USER_NAME=$(getent passwd "${LOCAL_USER_ID}" | cut -d: -f1)
+    if [ -z "${USER_NAME}" ]; then
+        USER_NAME=user
+        useradd --shell /bin/bash --uid "${LOCAL_USER_ID}" -m "${USER_NAME}"
+    fi
+    chown -R "${USER_NAME}" "/opt/conda/lib/python${PYTHON_VERSION}/site-packages/genesis/ext/LuisaRender/" || true
+    exec gosu "${USER_NAME}" "$@"
 else
-  exec "$@"
+    exec "$@"
 fi
 EOF
 
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
Since Ubuntu 24.04 `pip install` is no longer supported. One has to create a python virtual environment and activate it or uses the flag `--break-system-packages` less safer.

Ubuntu 24.04 has default `user`. To fix that one has to delete the default `user` and re-create it or using another username.

## Motivation and Context
For using newer Ubuntu and Python

## How Has This Been / Can This Be Tested?
- In Genesis root folder, build the docker image with `docker build -t genesis:testing -f docker/Dockerfile docker/` or pull it from my docker hub `docker pull i3salng/genesis:latest`

- create a source file `genesis_ws` with this content:
```
# 1. define env
# 1.1 If your local folders have different names, change `WORKDIR` below.

WORKDIR=`pwd`
SHMSIZE="2gb"
CCACHE_DIR=${HOME}/.ccache
XAUTH=/tmp/.docker.xauth
DOCKER_REPO="i3salng/genesis:latest"
CONTAINER_NAME="genesis"
COMMAND="bash"

# 2. run
# 2.1. specify the source of the connections that we want:
xhost +local:docker

# 2.2. run docker container:
docker run -it --rm --privileged --gpus all \
--shm-size=$SHMSIZE \
--group-add 20 --group-add=audio \
--env=LOCAL_USER_ID="$(id -u)" \
--env=ALSA_CARD=PCH \
--env=CCACHE_DIR="${CCACHE_DIR}" \
-v ${CCACHE_DIR}:${CCACHE_DIR}:rw \
-v /dev/dri:/dev/dri \
-v /tmp/.X11-unix:/tmp/.X11-unix/:rw \
-v $XAUTH:$XAUTH \
-v $WORKDIR:/workspace \
-e DISPLAY=$DISPLAY \
-e NVIDIA_VISIBLE_DEVICES=all \
-e NVIDIA_DRIVER_CAPABILITIES=all \
-e QT_X11_NO_MITSHM=1 \
--net=host \
--name=${CONTAINER_NAME} ${DOCKER_REPO} ${COMMAND}
```
- start the container with `source <path/to/genesis_ws>`
- test the `hello_genesis.py` : `python examples/tutorials/hello_genesis.py`
