### PR TITLE
[BUG FIX] Fix device handling in _tc_slerp function

### DIFF
--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -1546,7 +1546,7 @@ def slerp(q0, q1, t):
     if isinstance(q0, np.ndarray):
         return _np_slerp(q0, q1, t)
     if isinstance(q0, torch.Tensor):
-        return _tc_slerp(q0, q1, torch.as_tensor(t, dtype=gs.tc_float, device=gs.device), gs.EPS)
+        return _tc_slerp(q0, q1, torch.as_tensor(t, dtype=gs.tc_float, device=q0.device), gs.EPS)
     gs.raise_exception(f"the input must be either torch.Tensor or np.ndarray. got: {type(q0)=}")
 
 


### PR DESCRIPTION
## Description

`slerp(q0, q1, t)` currently forces `t` onto `gs.device` regardless of where `q0` / `q1` live:

```python
return _tc_slerp(q0, q1, torch.as_tensor(t, dtype=gs.tc_float, device=gs.device), gs.EPS)
```

When `q0` / `q1` are on a different device (e.g. CPU tensors freshly loaded from disk on a GPU run), `_tc_slerp` mixes devices and raises:

```
RuntimeError: Expected all tensors to be on the same device,
but found at least two devices, cuda:0 and cpu!
  File ".../genesis/utils/geom.py", line 1523, in _tc_slerp
    s0 = torch.where(is_theta_eps, 1.0 - t, torch.sin((1.0 - t) * theta) * sin_theta_inv)
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
```

This one-line change makes `t` follow `q0.device` instead of the global `gs.device`, matching the device-agnostic behavior of the `_np_slerp` branch.

## Related Issue

No tracking issue. Surfaced downstream while running an Eden dataset reader on a GPU backend ([Eden#355](https://github.com/Kashu7100/Eden/pull/355)) where motion data is parsed on CPU in worker threads (to overlap I/O before a single bulk H2D copy) and then `slerp` is called for framerate interpolation.

## Motivation and Context

- **Correctness:** Today, any caller passing CPU tensors on a GPU run crashes here, even though the operation is purely a function of `q0` / `q1` / `t` and has no inherent need to live on `gs.device`.
- **Avoid coupling to a process-global.** `gs.device` is set by `gs.init()`. Tying `slerp` to it means out-of-band or pre-init use breaks; tying it to the input tensor is local and predictable.
- **Consistency with the numpy branch.** `_np_slerp` has no device coupling — making the torch branch follow the input device matches that contract.
- **Backwards compatible.** Every existing caller that already passes `q0` on `gs.device` keeps the exact same behavior; only the cross-device case changes (from `RuntimeError` to working).

A residual sharp edge — `q1.device != q0.device` would still error inside `_tc_slerp` — is left as-is since that is a caller bug rather than something `slerp` should silently paper over.

## How Has This Been / Can This Be Tested?

Repro (before this PR):

```python
import genesis as gs
import torch
from genesis.utils.geom import slerp

gs.init(backend=gs.gpu)
q0 = torch.tensor([[1.0, 0.0, 0.0, 0.0]])  # CPU
q1 = torch.tensor([[0.0, 1.0, 0.0, 0.0]])  # CPU
slerp(q0, q1, torch.tensor([0.5]))         # RuntimeError: cuda:0 vs cpu
```

After this PR: returns the interpolated quaternion on `q0.device` (CPU here).

GPU-only smoke test (existing behavior preserved):

```python
q0 = torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=gs.device)
q1 = torch.tensor([[0.0, 1.0, 0.0, 0.0]], device=gs.device)
slerp(q0, q1, torch.tensor([0.5]))  # unchanged: result on gs.device
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
