### PR TITLE
Fix #2683: Fallback to nvidia-smi -L when /proc/driver/nvidia/gpus unavailable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,11 +240,27 @@ def _get_gpu_indices():
         try:
             return tuple(range(len(os.listdir(nvidia_gpu_interface_path))))
         except FileNotFoundError:
-            warnings.warn(
-                f"'{nvidia_gpu_interface_path}' is not available. Multi-GPU support will be disabled. This is expected "
-                "on WSL2 where the NVIDIA proc interface is not mounted.",
-                stacklevel=2,
+            pass  # Fall through to nvidia-smi fallback below
+
+        # Fallback: use nvidia-smi to enumerate GPUs (for cloud providers where /proc/driver/nvidia/gpus is unavailable)
+        try:
+            result = subprocess.run(
+                ["nvidia-smi", "-L"],
+                capture_output=True,
+                text=True,
+                check=True,
             )
+            gpu_count = sum(1 for line in result.stdout.splitlines() if line.startswith("GPU "))
+            if gpu_count > 0:
+                return tuple(range(gpu_count))
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            pass
+
+        warnings.warn(
+            f"'{nvidia_gpu_interface_path}' is not available and nvidia-smi fallback failed. Multi-GPU support will be disabled. This is expected "
+            "on WSL2 where the NVIDIA proc interface is not mounted.",
+            stacklevel=2,
+        )
 
     return (0,)
 
@@ -266,11 +282,31 @@ def _torch_get_gpu_idx(device):
             else:
                 return -1
         except FileNotFoundError:
-            warnings.warn(
-                f"'{nvidia_gpu_interface_path}' is not available. Multi-GPU support will be disabled. This is expected "
-                "on WSL2 where the NVIDIA proc interface is not mounted.",
-                stacklevel=2,
+            pass  # Fall through to nvidia-smi fallback below
+
+        # Fallback: use nvidia-smi to find GPU index by UUID
+        try:
+            result = subprocess.run(
+                ["nvidia-smi", "-L"],
+                capture_output=True,
+                text=True,
+                check=True,
             )
+            for line in result.stdout.splitlines():
+                if f"UUID: {device_uuid}" in line or device_uuid in line:
+                    # Extract GPU index from "GPU 0: ..." format
+                    match = re.match(r"GPU\s+(\d+):", line)
+                    if match:
+                        return int(match.group(1))
+            return -1
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            pass
+
+        warnings.warn(
+            f"'{nvidia_gpu_interface_path}' is not available and nvidia-smi fallback failed. Multi-GPU support will be disabled. This is expected "
+            "on WSL2 where the NVIDIA proc interface is not mounted.",
+            stacklevel=2,
+        )
 
     return 0
 


### PR DESCRIPTION
## Summary

Fixes #2683 — GPU enumeration fallback for cloud providers where `/proc/driver/nvidia/gpus` is unavailable.

### Problem
On certain cloud providers (e.g., packet.ai RTX 6000 PRO instances), the `/proc/driver/nvidia/gpus` interface is not available, causing benchmark tests and multi-GPU detection to fail.

### Solution
Added `nvidia-smi -L` as a fallback in two functions in `tests/conftest.py`:

1. **`_get_gpu_indices()`**: When `/proc/driver/nvidia/gpus` raises `FileNotFoundError`, enumerate GPUs by parsing `nvidia-smi -L` output (counting lines starting with "GPU ").

2. **`_torch_get_gpu_idx(device)`**: When `/proc/driver/nvidia/gpus` raises `FileNotFoundError`, find the GPU index by matching device UUID against `nvidia-smi -L` output, extracting the GPU number from the "GPU N:" prefix.

The warning message is updated to note when both the proc interface and nvidia-smi fallback fail.

### Testing
This change only affects Linux systems and only activates when the `/proc/driver/nvidia/gpus` path is unavailable — existing behavior is fully preserved on systems where it exists.