### PR TITLE
[FEATURE] Add support of link filtering to contact sensors.

### DIFF
--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -9,7 +9,13 @@ import genesis as gs
 from genesis.options.sensors import Contact as ContactSensorOptions
 from genesis.options.sensors import ContactForce as ContactForceSensorOptions
 from genesis.utils.geom import inv_transform_by_quat, qd_inv_transform_by_quat, transform_by_quat
-from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_torch, tensor_to_array
+from genesis.utils.misc import (
+    append_filter_links_idx,
+    concat_with_tensor,
+    make_tensor_field,
+    qd_to_torch,
+    tensor_to_array,
+)
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, Sensor, SimpleSensor, SimpleSensorMetadata
@@ -23,6 +29,27 @@ if TYPE_CHECKING:
     from .sensor_manager import SensorManager
 
 
+@qd.func
+def _func_link_is_filtered(filter_links_idx: qd.types.ndarray(), i_s: int, link: int):
+    """Whether ``link`` is in sensor ``i_s``'s filter list. ``-1`` padding entries never match a real link index."""
+    is_filtered = False
+    for i_f in range(filter_links_idx.shape[-1]):
+        if filter_links_idx[i_s, i_f] == link:
+            is_filtered = True
+    return is_filtered
+
+
+def _drop_filtered_counterpart_contacts(
+    is_a: torch.Tensor, is_b: torch.Tensor, link_a, link_b, shared_metadata
+) -> None:
+    filt = shared_metadata.filtered_sensor_idx
+    if filt.numel() == 0:
+        return
+    sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
+    is_a[:, filt, :] &= ~(link_b[:, None, :, None] == sub_filter).any(dim=-1)
+    is_b[:, filt, :] &= ~(link_a[:, None, :, None] == sub_filter).any(dim=-1)
+
+
 @qd.kernel
 def _kernel_get_contacts_forces(
     sensors_link_idx: qd.types.ndarray(),
@@ -30,6 +57,7 @@ def _kernel_get_contacts_forces(
     link_a: qd.types.ndarray(),
     link_b: qd.types.ndarray(),
     links_quat: qd.types.ndarray(),
+    filter_links_idx: qd.types.ndarray(),  # (n_sensors, max_filter_links); unused slots are -1
     output: qd.types.ndarray(),
 ):
     for i_c, i_s, i_b in qd.ndrange(link_a.shape[-1], sensors_link_idx.shape[-1], output.shape[-1]):
@@ -51,10 +79,15 @@ def _kernel_get_contacts_forces(
             force_a = qd_inv_transform_by_quat(-force_vec, quat_a)
             force_b = qd_inv_transform_by_quat(force_vec, quat_b)
 
-            if contact_data_link_a == sensors_link_idx[i_s]:
+            # Accumulate the force on whichever side is the sensor link, unless the counterpart link is filtered.
+            if contact_data_link_a == sensors_link_idx[i_s] and not _func_link_is_filtered(
+                filter_links_idx, i_s, contact_data_link_b
+            ):
                 for j in qd.static(range(3)):
                     output[j_s + j, i_b] += force_a[j]
-            if contact_data_link_b == sensors_link_idx[i_s]:
+            if contact_data_link_b == sensors_link_idx[i_s] and not _func_link_is_filtered(
+                filter_links_idx, i_s, contact_data_link_a
+            ):
                 for j in qd.static(range(3)):
                     output[j_s + j, i_b] += force_b[j]
 
@@ -103,15 +136,10 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, None, ContactSensorMetada
             self._shared_metadata.expanded_links_idx, link_idx, expand=(1,), dim=0
         )
 
-        num_sensors, cur_num_filter_links = self._shared_metadata.filter_links_idx.shape
-        max_num_filter_links = max(cur_num_filter_links, len(self._options.filter_link_idx))
-        filter_links_idx = torch.full((num_sensors + 1, max_num_filter_links), -1, dtype=gs.tc_int, device=gs.device)
-        filter_links_idx[:num_sensors, :cur_num_filter_links] = self._shared_metadata.filter_links_idx
-        filter_links_idx[num_sensors, : len(self._options.filter_link_idx)] = torch.tensor(
-            self._options.filter_link_idx, dtype=gs.tc_int, device=gs.device
+        num_sensors = self._shared_metadata.filter_links_idx.shape[0]
+        self._shared_metadata.filter_links_idx = append_filter_links_idx(
+            self._shared_metadata.filter_links_idx, self._options.filter_link_idx
         )
-        self._shared_metadata.filter_links_idx = filter_links_idx
-
         if len(self._options.filter_link_idx) > 0:
             self._shared_metadata.filtered_sensor_idx = concat_with_tensor(
                 self._shared_metadata.filtered_sensor_idx, num_sensors, expand=(1,), dim=0
@@ -146,18 +174,9 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, None, ContactSensorMetada
 
         is_contact_a = link_a[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         is_contact_b = link_b[..., None, :] == shared_metadata.expanded_links_idx[..., None]
+        _drop_filtered_counterpart_contacts(is_contact_a, is_contact_b, link_a, link_b, shared_metadata)
         # Float-valued contact count per sensor (intermediate cache is float; bool projection in `_post_process`).
         result = (is_contact_a | is_contact_b).sum(dim=-1).to(dtype=gs.tc_float)
-        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors keep the
-        # cheap aggregate result above.
-        if shared_metadata.filtered_sensor_idx.numel() > 0:
-            filt = shared_metadata.filtered_sensor_idx
-            sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
-            filtered_a = (link_b[:, None, :, None] == sub_filter).any(dim=-1)
-            filtered_b = (link_a[:, None, :, None] == sub_filter).any(dim=-1)
-            sub_is_a = is_contact_a[:, filt, :]
-            sub_is_b = is_contact_b[:, filt, :]
-            result[:, filt] = ((sub_is_a & ~filtered_a) | (sub_is_b & ~filtered_b)).sum(dim=-1).to(dtype=gs.tc_float)
         raw_data_T[:] = result.T
 
     @classmethod
@@ -198,6 +217,11 @@ class ContactForceSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata)
 
     min_force: torch.Tensor = make_tensor_field((0, 3))
     max_force: torch.Tensor = make_tensor_field((0, 3))
+    # (num_force_sensors, max_num_filter_links); unused slots are -1.
+    filter_links_idx: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
+    # Indices into links_idx of sensors that have at least one filter link. Lets the GT update skip the
+    # 4D contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
+    filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
 
 
 class ContactForceSensor(
@@ -227,6 +251,15 @@ class ContactForceSensor(
         self._shared_metadata.max_force = concat_with_tensor(
             self._shared_metadata.max_force, self._options.max_force, expand=(1, 3)
         )
+
+        num_sensors = self._shared_metadata.filter_links_idx.shape[0]
+        self._shared_metadata.filter_links_idx = append_filter_links_idx(
+            self._shared_metadata.filter_links_idx, self._options.filter_link_idx
+        )
+        if len(self._options.filter_link_idx) > 0:
+            self._shared_metadata.filtered_sensor_idx = concat_with_tensor(
+                self._shared_metadata.filtered_sensor_idx, num_sensors, expand=(1,), dim=0
+            )
 
     def _get_return_format(self) -> tuple[int, ...]:
         return (3,)
@@ -266,6 +299,7 @@ class ContactForceSensor(
             # Forces are aggregated BEFORE moving them in local frame for efficiency.
             force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
             force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
+            _drop_filtered_counterpart_contacts(force_mask_a, force_mask_b, link_a, link_b, shared_metadata)
             force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
             sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
             sensors_quat = links_quat[:, shared_metadata.links_idx]
@@ -280,6 +314,7 @@ class ContactForceSensor(
                 link_a.contiguous(),
                 link_b.contiguous(),
                 links_quat.contiguous(),
+                shared_metadata.filter_links_idx,
                 raw_data_T,
             )
 

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -9,13 +9,7 @@ import genesis as gs
 from genesis.options.sensors import Contact as ContactSensorOptions
 from genesis.options.sensors import ContactForce as ContactForceSensorOptions
 from genesis.utils.geom import inv_transform_by_quat, qd_inv_transform_by_quat, transform_by_quat
-from genesis.utils.misc import (
-    append_filter_links_idx,
-    concat_with_tensor,
-    make_tensor_field,
-    qd_to_torch,
-    tensor_to_array,
-)
+from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_torch, tensor_to_array
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, Sensor, SimpleSensor, SimpleSensorMetadata
@@ -30,34 +24,48 @@ if TYPE_CHECKING:
 
 
 @qd.func
-def _func_link_is_filtered(filter_links_idx: qd.types.ndarray(), i_s: int, link: int):
-    """Whether ``link`` is in sensor ``i_s``'s filter list. ``-1`` padding entries never match a real link index."""
+def _func_link_is_filtered(i_s: int, link: int, filter_links_idx: qd.types.ndarray()):
+    """Whether ``link`` is in sensor ``i_s``'s filter row.
+
+    The -1 padding never matches a real (non-negative) link, so every column can be scanned unconditionally.
+    """
     is_filtered = False
     for i_f in range(filter_links_idx.shape[-1]):
         if filter_links_idx[i_s, i_f] == link:
             is_filtered = True
+            break
     return is_filtered
 
 
 def _drop_filtered_counterpart_contacts(
-    is_a: torch.Tensor, is_b: torch.Tensor, link_a, link_b, shared_metadata
+    is_a: torch.Tensor,
+    is_b: torch.Tensor,
+    link_a: torch.Tensor,
+    link_b: torch.Tensor,
+    shared_metadata: "ContactFilterMetadataMixin",
 ) -> None:
-    filt = shared_metadata.filtered_sensor_idx
-    if filt.numel() == 0:
+    """Clear (in place) each per-side contact mask wherever the counterpart link is in the sensor's filter row.
+
+    Only the sensors listed in ``filtered_sensor_idx`` are touched, so the unfiltered majority keeps the untouched
+    masks. ``is_a`` / ``is_b`` are ``(B, n_sensors, n_contacts)`` bool masks; ``link_a`` / ``link_b`` are the
+    ``(B, n_contacts)`` contact-participant links.
+    """
+    filtered_sensors = shared_metadata.filtered_sensor_idx
+    if filtered_sensors.numel() == 0:
         return
-    sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
-    is_a[:, filt, :] &= ~(link_b[:, None, :, None] == sub_filter).any(dim=-1)
-    is_b[:, filt, :] &= ~(link_a[:, None, :, None] == sub_filter).any(dim=-1)
+    filter_rows = shared_metadata.filter_links_idx[filtered_sensors][None, :, None, :]
+    is_a[:, filtered_sensors, :] &= ~(link_b[:, None, :, None] == filter_rows).any(dim=-1)
+    is_b[:, filtered_sensors, :] &= ~(link_a[:, None, :, None] == filter_rows).any(dim=-1)
 
 
 @qd.kernel
 def _kernel_get_contacts_forces(
     sensors_link_idx: qd.types.ndarray(),
+    filter_links_idx: qd.types.ndarray(),
     contact_forces: qd.types.ndarray(),
     link_a: qd.types.ndarray(),
     link_b: qd.types.ndarray(),
     links_quat: qd.types.ndarray(),
-    filter_links_idx: qd.types.ndarray(),  # (n_sensors, max_filter_links); unused slots are -1
     output: qd.types.ndarray(),
 ):
     for i_c, i_s, i_b in qd.ndrange(link_a.shape[-1], sensors_link_idx.shape[-1], output.shape[-1]):
@@ -79,32 +87,59 @@ def _kernel_get_contacts_forces(
             force_a = qd_inv_transform_by_quat(-force_vec, quat_a)
             force_b = qd_inv_transform_by_quat(force_vec, quat_b)
 
-            # Accumulate the force on whichever side is the sensor link, unless the counterpart link is filtered.
+            # Accumulate the force on whichever side is the sensor link, dropping it when the counterpart is filtered.
             if contact_data_link_a == sensors_link_idx[i_s] and not _func_link_is_filtered(
-                filter_links_idx, i_s, contact_data_link_b
+                i_s, contact_data_link_b, filter_links_idx
             ):
                 for j in qd.static(range(3)):
                     output[j_s + j, i_b] += force_a[j]
             if contact_data_link_b == sensors_link_idx[i_s] and not _func_link_is_filtered(
-                filter_links_idx, i_s, contact_data_link_a
+                i_s, contact_data_link_a, filter_links_idx
             ):
                 for j in qd.static(range(3)):
                     output[j_s + j, i_b] += force_b[j]
 
 
 @dataclass
-class ContactSensorMetadata(SimpleSensorMetadata):
+class ContactFilterMetadataMixin:
+    """
+    Shared state for sensors that scope contacts by counterpart link (see ``ContactFilterOptionsMixin``).
+
+    ``filter_links_idx`` is a ``(n_sensors, max_num_filter_links)`` table; each sensor's row lists its filter links,
+    unused slots (and rows for sensors with no filter) are ``-1`` so a kernel can scan every column unconditionally.
+    ``filtered_sensor_idx`` lists the rows that declared a filter, letting the aggregation-path sensors (Contact,
+    ContactForce) skip the per-contact comparison for the unfiltered majority; the contact-prefilter tactile sensors
+    instead apply the filter directly in their build kernels.
+    """
+
+    filter_links_idx: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
+    filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+    def append_filter(self, filter_link_idx) -> None:
+        """Append one sensor's filter links as a new table row.
+
+        Grows the column count to fit and back-fills unused slots (and empty filters) with ``-1``. The table keeps at
+        least one column so an all-empty table stays a valid (non-zero-dim) kernel argument. Rows with a non-empty
+        filter also register in ``filtered_sensor_idx``.
+        """
+        n_sensors, current_max = self.filter_links_idx.shape
+        new_max = max(current_max, len(filter_link_idx), 1)
+        table = torch.full((n_sensors + 1, new_max), -1, dtype=gs.tc_int, device=gs.device)
+        table[:n_sensors, :current_max] = self.filter_links_idx
+        if len(filter_link_idx) > 0:
+            table[n_sensors, : len(filter_link_idx)] = torch.tensor(filter_link_idx, dtype=gs.tc_int, device=gs.device)
+            self.filtered_sensor_idx = concat_with_tensor(self.filtered_sensor_idx, n_sensors, expand=(1,), dim=0)
+        self.filter_links_idx = table
+
+
+@dataclass
+class ContactSensorMetadata(ContactFilterMetadataMixin, SimpleSensorMetadata):
     """
     Metadata for all rigid contact sensors.
     """
 
     solver: "RigidSolver | None" = None
     expanded_links_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    # (num_contact_sensors, max_num_filter_links); unused slots are -1.
-    filter_links_idx: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
-    # Indices into expanded_links_idx of sensors that have at least one filter link. Lets the GT update skip the 4D
-    # contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
-    filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     # Per-sensor bool threshold (broadcast over B); _post_process returns `tensor > thresholds`.
     thresholds: torch.Tensor = make_tensor_field((0,))
 
@@ -136,14 +171,7 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, None, ContactSensorMetada
             self._shared_metadata.expanded_links_idx, link_idx, expand=(1,), dim=0
         )
 
-        num_sensors = self._shared_metadata.filter_links_idx.shape[0]
-        self._shared_metadata.filter_links_idx = append_filter_links_idx(
-            self._shared_metadata.filter_links_idx, self._options.filter_link_idx
-        )
-        if len(self._options.filter_link_idx) > 0:
-            self._shared_metadata.filtered_sensor_idx = concat_with_tensor(
-                self._shared_metadata.filtered_sensor_idx, num_sensors, expand=(1,), dim=0
-            )
+        self._shared_metadata.append_filter(self._options.filter_link_idx)
 
         self._shared_metadata.thresholds = concat_with_tensor(
             self._shared_metadata.thresholds, float(self._options.threshold), expand=(1,)
@@ -210,18 +238,13 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, None, ContactSensorMetada
 
 
 @dataclass
-class ContactForceSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
+class ContactForceSensorMetadata(ContactFilterMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata):
     """
     Shared metadata for all contact force sensors.
     """
 
     min_force: torch.Tensor = make_tensor_field((0, 3))
     max_force: torch.Tensor = make_tensor_field((0, 3))
-    # (num_force_sensors, max_num_filter_links); unused slots are -1.
-    filter_links_idx: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
-    # Indices into links_idx of sensors that have at least one filter link. Lets the GT update skip the
-    # 4D contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
-    filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
 
 
 class ContactForceSensor(
@@ -252,14 +275,7 @@ class ContactForceSensor(
             self._shared_metadata.max_force, self._options.max_force, expand=(1, 3)
         )
 
-        num_sensors = self._shared_metadata.filter_links_idx.shape[0]
-        self._shared_metadata.filter_links_idx = append_filter_links_idx(
-            self._shared_metadata.filter_links_idx, self._options.filter_link_idx
-        )
-        if len(self._options.filter_link_idx) > 0:
-            self._shared_metadata.filtered_sensor_idx = concat_with_tensor(
-                self._shared_metadata.filtered_sensor_idx, num_sensors, expand=(1,), dim=0
-            )
+        self._shared_metadata.append_filter(self._options.filter_link_idx)
 
     def _get_return_format(self) -> tuple[int, ...]:
         return (3,)
@@ -310,11 +326,11 @@ class ContactForceSensor(
             raw_data_T.zero_()
             _kernel_get_contacts_forces(
                 shared_metadata.links_idx,
+                shared_metadata.filter_links_idx,
                 force.contiguous(),
                 link_a.contiguous(),
                 link_b.contiguous(),
                 links_quat.contiguous(),
-                shared_metadata.filter_links_idx,
                 raw_data_T,
             )
 

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -19,6 +19,7 @@ from genesis.utils.raycast_qd import closest_point_on_triangle, get_triangle_ver
 from .raycaster import RaycastContext
 
 from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, SimpleSensor, SimpleSensorMetadata
+from .contact_force import ContactFilterMetadataMixin, _func_link_is_filtered
 from .probe import (
     ProbeSensorMetadataMixin,
     ProbeSensorMixin,
@@ -96,6 +97,7 @@ _MAX_GEOMS_PER_SENSOR = 64
 @qd.kernel
 def _kernel_build_sensor_contact_idx(
     sensor_link_idx: qd.types.ndarray(),
+    filter_links_idx: qd.types.ndarray(),
     sensor_contacts_idx: qd.types.ndarray(),
     sensor_n_contacts: qd.types.ndarray(),
     collider_state: array_class.ColliderState,
@@ -104,8 +106,11 @@ def _kernel_build_sensor_contact_idx(
     Per-(env, sensor) compact contact index for the KinematicTaxel pre-pass.
 
     Parallelizes over ``(n_batches, n_sensors)`` so the main kernel's per-probe contact-list scan drops from
-    O(n_probes * n_contacts) to O(n_probes * sensor_n_contacts). Cap-overflows (count >= last dim of
-    ``sensor_contacts_idx``) silently truncate; see the module-level ``_MAX_CONTACTS_PER_SENSOR`` comment.
+    O(n_probes * n_contacts) to O(n_probes * sensor_n_contacts). The counterpart filter is applied here, before the
+    per-sensor cap: a contact whose only tie to the sensor link is through a filtered counterpart is dropped and
+    never consumes a cap slot, so a large filtered manifold (e.g. the ground) cannot starve an allowed contact.
+    Cap-overflows (count >= last dim of ``sensor_contacts_idx``) silently truncate; see the module-level
+    ``_MAX_CONTACTS_PER_SENSOR`` comment.
     """
     n_sensors = sensor_link_idx.shape[0]
     n_batches = sensor_n_contacts.shape[0]
@@ -119,7 +124,9 @@ def _kernel_build_sensor_contact_idx(
                 break
             link_a = collider_state.contact_data.link_a[i_c, i_b]
             link_b = collider_state.contact_data.link_b[i_c, i_b]
-            if link_a == link or link_b == link:
+            is_on_a = link_a == link and not _func_link_is_filtered(i_s, link_b, filter_links_idx)
+            is_on_b = link_b == link and not _func_link_is_filtered(i_s, link_a, filter_links_idx)
+            if is_on_a or is_on_b:
                 sensor_contacts_idx[i_b, i_s, count] = i_c
                 count = count + 1
         sensor_n_contacts[i_b, i_s] = count
@@ -128,6 +135,7 @@ def _kernel_build_sensor_contact_idx(
 @qd.kernel
 def _kernel_build_sensor_geom_idx(
     sensor_link_idx: qd.types.ndarray(),
+    filter_links_idx: qd.types.ndarray(),
     sensor_geoms_idx: qd.types.ndarray(),
     sensor_n_geoms: qd.types.ndarray(),
     collider_state: array_class.ColliderState,
@@ -138,6 +146,9 @@ def _kernel_build_sensor_geom_idx(
     Parallelizes over ``(n_batches, n_sensors)``, recording each contact's opposing geom (the side not on the
     sensor link). Deduping collapses the multicontact fan-out (tens of contacts on one pressing object -> one
     geom) so the SDF path's per-probe loop runs once per distinct contacting geom, not once per contact point.
+    A contact whose counterpart link is in sensor ``i_s``'s ``filter_links_idx`` row is skipped here, so the SDF
+    query loop never sees the filtered geom (the raycast path filters symmetrically in
+    ``_kernel_build_sensor_candidate_geom_mask``), keeping the filter out of the per-probe hot loops.
     Cap-overflows (count >= last dim of ``sensor_geoms_idx``) silently truncate; see the module-level
     ``_MAX_GEOMS_PER_SENSOR`` comment.
     """
@@ -154,7 +165,8 @@ def _kernel_build_sensor_geom_idx(
             # A self-contact (sensor link on both sides) is deduped naturally below.
             for side in qd.static(range(2)):
                 c_link = link_a if side == 0 else link_b
-                if c_link == link:
+                counterpart_link = link_b if side == 0 else link_a
+                if c_link == link and not _func_link_is_filtered(i_s, counterpart_link, filter_links_idx):
                     i_g = (
                         collider_state.contact_data.geom_b[i_c, i_b]
                         if side == 0
@@ -503,7 +515,8 @@ def _kernel_build_sensor_candidate_geom_mask(
     to skip triangles whose owning geom isn't in the sensor's current contact list. Only the geom on the side opposite
     the sensor link is marked (mirroring the SDF path's ``i_g = <other geom>`` selection); marking the sensor's own
     geom would let the BVH closest-point test latch onto the sensor's own surface, pinning the reported depth to
-    ``probe_radius`` regardless of the pressing object.
+    ``probe_radius`` regardless of the pressing object. The counterpart filter is already applied while building
+    ``sensor_contacts_idx``, so every listed contact is an allowed one.
     """
     n_batches = sensor_n_contacts.shape[0]
     n_sensors = sensor_n_contacts.shape[1]
@@ -941,11 +954,16 @@ class KinematicTactileSensorMixin(ContactDepthQuerySensorMixin, ProbeSensorMixin
     subclasses add their own metadata.
     """
 
+    def build(self):
+        super().build()
+        self._shared_metadata.append_filter(self._options.filter_link_idx)
+
 
 @dataclass
 class ContactDepthProbeMetadata(
     ViscoelasticHysteresisMetadataMixin,
     ProbeSensorMetadataMixin,
+    ContactFilterMetadataMixin,
     ContactPrefilterMetadataMixin,
     ContactDepthQueryMetadataMixin,
     RigidSensorMetadataMixin,
@@ -1001,6 +1019,7 @@ class ContactDepthProbeSensor(
         if (shared_metadata.contact_depth_query or "sdf") == "sdf":
             _kernel_build_sensor_geom_idx(
                 shared_metadata.links_idx,
+                shared_metadata.filter_links_idx,
                 shared_metadata.sensor_geoms_idx,
                 shared_metadata.sensor_n_geoms,
                 solver.collider._collider_state,
@@ -1025,6 +1044,7 @@ class ContactDepthProbeSensor(
         else:
             _kernel_build_sensor_contact_idx(
                 shared_metadata.links_idx,
+                shared_metadata.filter_links_idx,
                 shared_metadata.sensor_contacts_idx,
                 shared_metadata.sensor_n_contacts,
                 solver.collider._collider_state,
@@ -1175,6 +1195,7 @@ class KinematicTaxelMetadata(
     ViscoelasticHysteresisMetadataMixin,
     SpatialCrosstalkMetadataMixin,
     ProbeSensorMetadataMixin,
+    ContactFilterMetadataMixin,
     ContactPrefilterMetadataMixin,
     ContactDepthQueryMetadataMixin,
     RigidSensorMetadataMixin,
@@ -1271,6 +1292,7 @@ class KinematicTaxelSensor(
         if (shared_metadata.contact_depth_query or "sdf") == "sdf":
             _kernel_build_sensor_geom_idx(
                 shared_metadata.links_idx,
+                shared_metadata.filter_links_idx,
                 shared_metadata.sensor_geoms_idx,
                 shared_metadata.sensor_n_geoms,
                 solver.collider._collider_state,
@@ -1305,6 +1327,7 @@ class KinematicTaxelSensor(
         else:
             _kernel_build_sensor_contact_idx(
                 shared_metadata.links_idx,
+                shared_metadata.filter_links_idx,
                 shared_metadata.sensor_contacts_idx,
                 shared_metadata.sensor_n_contacts,
                 solver.collider._collider_state,

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -66,16 +66,6 @@ def _check_len_match(value, expected_len: int, name: str, ref_name: str):
         )
 
 
-def _validate_filter_link_idx(scene: "Scene", filter_link_idx, sensor_name: str):
-    """Check that a contact sensor's ``filter_link_idx`` are valid global (solver-space) rigid link indices."""
-    if filter_link_idx:
-        n_links = scene.sim.rigid_solver.n_links
-        if np.any(np.array(filter_link_idx) < 0) or np.any(np.array(filter_link_idx) >= n_links):
-            gs.raise_exception(
-                f"{sensor_name} filter_link_idx should be in range [0, {n_links}). Got {filter_link_idx}"
-            )
-
-
 class SensorOptions(Options, Generic[SensorT]):
     """
     Base class for all sensor options.
@@ -196,6 +186,33 @@ class RigidEntitySensorOptionsMixin(RigidSensorOptionsMixin[SensorT]):
         super().validate_scene(scene)
         if self.entity_idx < 0:
             gs.raise_exception(f"{type(self).__name__} requires entity_idx >= 0, got {self.entity_idx}.")
+
+
+class ContactFilterOptionsMixin(RigidSensorOptionsMixin[SensorT]):
+    """
+    Shared options for the contact sensors whose reading can be scoped to ignore contacts with chosen counterpart
+    links -- Contact, ContactForce, and the contact-driven tactile probes (ContactProbe, ContactDepthProbe,
+    KinematicTaxel).
+
+    Parameters
+    ----------
+    filter_link_idx : array-like[int], optional
+        Global rigid link indices (solver link space). Contacts with the sensor link whose other participant is one
+        of these links are ignored: the sensor behaves as if those counterparts were not touching. Use it to scope a
+        reading to a chosen set of contacts (e.g. force on a foot from the ground, excluding self-contact). Default
+        is empty, so every contact with the sensor link counts.
+    """
+
+    filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
+
+    def validate_scene(self, scene: "Scene"):
+        super().validate_scene(scene)
+        if self.filter_link_idx:
+            n_links = scene.sim.rigid_solver.n_links
+            if np.any(np.array(self.filter_link_idx) < 0) or np.any(np.array(self.filter_link_idx) >= n_links):
+                gs.raise_exception(
+                    f"{type(self).__name__}: filter_link_idx must be in [0, {n_links}). Got {self.filter_link_idx}."
+                )
 
 
 class SimpleSensorOptions(SensorOptions[SensorT]):
@@ -330,15 +347,12 @@ class JointTorque(RigidEntitySensorOptionsMixin["JointTorqueSensor"], SimpleSens
             )
 
 
-class Contact(RigidSensorOptionsMixin["ContactSensor"], SimpleSensorOptions["ContactSensor"]):
+class Contact(ContactFilterOptionsMixin["ContactSensor"], SimpleSensorOptions["ContactSensor"]):
     """
     Sensor that returns bool based on whether associated RigidLink is in contact.
 
     Parameters
     ----------
-    filter_link_idx : array-like[int], optional
-        Global rigid link indices (solver link space). Contacts with the sensor link where the other
-        participant is one of these links are ignored. Default is empty (no filtering).
     threshold : float, optional
         The bool-conversion threshold applied at read time to the underlying float contact magnitude
         (kernel produces float). A bin reads ``True`` iff its magnitude exceeds this value. Default
@@ -349,26 +363,17 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"], SimpleSensorOptions["Con
         The rgba color of the debug sphere. Defaults to (1.0, 0.0, 1.0, 0.5).
     """
 
-    filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
     threshold: NonNegativeFloat = 0.0
     debug_sphere_radius: PositiveFloat = 0.05
     debug_color: UnitIntervalVec4Type = (1.0, 0.0, 1.0, 0.5)
 
-    def validate_scene(self, scene: "Scene"):
-        super().validate_scene(scene)
-        _validate_filter_link_idx(scene, self.filter_link_idx, "Contact sensor")
 
-
-class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOptions["ContactForceSensor"]):
+class ContactForce(ContactFilterOptionsMixin["ContactForceSensor"], SimpleSensorOptions["ContactForceSensor"]):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
 
     Parameters
     ----------
-    filter_link_idx : array-like[int], optional
-        Global rigid link indices (solver link space). Contacts with the sensor link where the other
-        participant is one of these links are ignored (their force is not included). Default is empty
-        (no filtering).
     min_force : float | array-like[float, float, float], optional
         The minimum detectable absolute force per each axis. Values below this will be treated as 0. Default is 0.
     max_force : float | array-like[float, float, float], optional
@@ -378,8 +383,6 @@ class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOp
     debug_scale : float, optional
         The scale factor for the debug force arrow. Defaults to 0.01.
     """
-
-    filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
 
     resolution: LaxVec3FType = 0.0
 
@@ -393,10 +396,6 @@ class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOp
         super().model_post_init(context)
         if np.any(np.array(self.max_force) <= np.array(self.min_force)):
             gs.raise_exception(f"min_force should be less than max_force, got: {self.min_force} and {self.max_force}")
-
-    def validate_scene(self, scene: "Scene"):
-        super().validate_scene(scene)
-        _validate_filter_link_idx(scene, self.filter_link_idx, "ContactForce sensor")
 
 
 class TemperatureProperties(NamedTuple):

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -66,6 +66,16 @@ def _check_len_match(value, expected_len: int, name: str, ref_name: str):
         )
 
 
+def _validate_filter_link_idx(scene: "Scene", filter_link_idx, sensor_name: str):
+    """Check that a contact sensor's ``filter_link_idx`` are valid global (solver-space) rigid link indices."""
+    if filter_link_idx:
+        n_links = scene.sim.rigid_solver.n_links
+        if np.any(np.array(filter_link_idx) < 0) or np.any(np.array(filter_link_idx) >= n_links):
+            gs.raise_exception(
+                f"{sensor_name} filter_link_idx should be in range [0, {n_links}). Got {filter_link_idx}"
+            )
+
+
 class SensorOptions(Options, Generic[SensorT]):
     """
     Base class for all sensor options.
@@ -346,12 +356,7 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"], SimpleSensorOptions["Con
 
     def validate_scene(self, scene: "Scene"):
         super().validate_scene(scene)
-        if self.filter_link_idx:
-            n_links = scene.sim.rigid_solver.n_links
-            if np.any(np.array(self.filter_link_idx) < 0) or np.any(np.array(self.filter_link_idx) >= n_links):
-                gs.raise_exception(
-                    f"Contact sensor filter_link_idx should be in range [0, {n_links}). Got {self.filter_link_idx}"
-                )
+        _validate_filter_link_idx(scene, self.filter_link_idx, "Contact sensor")
 
 
 class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOptions["ContactForceSensor"]):
@@ -360,6 +365,10 @@ class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOp
 
     Parameters
     ----------
+    filter_link_idx : array-like[int], optional
+        Global rigid link indices (solver link space). Contacts with the sensor link where the other
+        participant is one of these links are ignored (their force is not included). Default is empty
+        (no filtering).
     min_force : float | array-like[float, float, float], optional
         The minimum detectable absolute force per each axis. Values below this will be treated as 0. Default is 0.
     max_force : float | array-like[float, float, float], optional
@@ -369,6 +378,8 @@ class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOp
     debug_scale : float, optional
         The scale factor for the debug force arrow. Defaults to 0.01.
     """
+
+    filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
 
     resolution: LaxVec3FType = 0.0
 
@@ -382,6 +393,10 @@ class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOp
         super().model_post_init(context)
         if np.any(np.array(self.max_force) <= np.array(self.min_force)):
             gs.raise_exception(f"min_force should be less than max_force, got: {self.min_force} and {self.max_force}")
+
+    def validate_scene(self, scene: "Scene"):
+        super().validate_scene(scene)
+        _validate_filter_link_idx(scene, self.filter_link_idx, "ContactForce sensor")
 
 
 class TemperatureProperties(NamedTuple):

--- a/genesis/options/sensors/tactile.py
+++ b/genesis/options/sensors/tactile.py
@@ -10,7 +10,6 @@ from genesis.typing import (
     IArrayType,
     NonNegativeFloat,
     NonNegativeInt,
-    OptionalIArrayType,
     PositiveFArrayType,
     PositiveFloat,
     PositiveInt,
@@ -21,6 +20,7 @@ from genesis.typing import (
 )
 
 from .options import (
+    ContactFilterOptionsMixin,
     ProbeSensorOptionsMixin,
     ProbesWithNormalSensorOptionsMixin,
     RigidSensorOptionsMixin,
@@ -28,11 +28,9 @@ from .options import (
     SensorT,
     SimpleSensorOptions,
     _check_len_match,
-    _validate_filter_link_idx,
 )
 
 if TYPE_CHECKING:
-    from genesis.engine.scene import Scene
     from genesis.engine.sensors.kinematic_tactile import (
         ContactDepthProbeSensor,
         ContactProbeSensor,
@@ -213,25 +211,6 @@ class TactileProbeSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
             gs.raise_exception(f"dead_taxel_value_range must satisfy low <= high. Got ({low}, {high}).")
 
 
-class FilterableTactileProbeSensorOptionsMixin(TactileProbeSensorOptionsMixin[SensorT]):
-    """
-    Options for tactile probe sensors that resolve depth against the physics solver's active contact pairs (as
-    opposed to a sampled point cloud), and can therefore scope which contacts count by the counterpart link.
-
-    Parameters
-    ----------
-    filter_link_idx : array-like[int], optional
-        Global rigid link indices (solver link space). Contacts with the sensor link where the other participant is
-        one of these links are ignored (they contribute no penetration/force). Default is empty (no filtering).
-    """
-
-    filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
-
-    def validate_scene(self, scene: "Scene"):
-        super().validate_scene(scene)
-        _validate_filter_link_idx(scene, self.filter_link_idx, f"{type(self).__name__} sensor")
-
-
 class PointCloudTactileSensorMixin(TactileProbeSensorOptionsMixin[SensorT]):
     """
     Options mixin for tactile sensors that sample a point cloud from tracked link meshes.
@@ -292,9 +271,9 @@ class ContactHysteresisOptionsMixin(SensorOptions[SensorT]):
 
 
 class ContactProbe(
-    RigidSensorOptionsMixin["ContactProbeSensor"],
+    ContactFilterOptionsMixin["ContactProbeSensor"],
     SimpleSensorOptions["ContactProbeSensor"],
-    FilterableTactileProbeSensorOptionsMixin["ContactProbeSensor"],
+    TactileProbeSensorOptionsMixin["ContactProbeSensor"],
     ViscoelasticHysteresisOptionsMixin["ContactProbeSensor"],
     ContactHysteresisOptionsMixin["ContactProbeSensor"],
 ):
@@ -326,9 +305,9 @@ class ContactProbe(
 
 
 class ContactDepthProbe(
-    RigidSensorOptionsMixin["ContactDepthProbeSensor"],
+    ContactFilterOptionsMixin["ContactDepthProbeSensor"],
     SimpleSensorOptions["ContactDepthProbeSensor"],
-    FilterableTactileProbeSensorOptionsMixin["ContactDepthProbeSensor"],
+    TactileProbeSensorOptionsMixin["ContactDepthProbeSensor"],
     ViscoelasticHysteresisOptionsMixin["ContactDepthProbeSensor"],
 ):
     """
@@ -344,9 +323,9 @@ class ContactDepthProbe(
 
 
 class KinematicTaxel(
-    RigidSensorOptionsMixin["KinematicTaxelSensor"],
+    ContactFilterOptionsMixin["KinematicTaxelSensor"],
     SimpleSensorOptions["KinematicTaxelSensor"],
-    FilterableTactileProbeSensorOptionsMixin["KinematicTaxelSensor"],
+    TactileProbeSensorOptionsMixin["KinematicTaxelSensor"],
     ViscoelasticHysteresisOptionsMixin["KinematicTaxelSensor"],
     SpatialCrosstalkOptionsMixin["KinematicTaxelSensor"],
 ):

--- a/genesis/options/sensors/tactile.py
+++ b/genesis/options/sensors/tactile.py
@@ -10,6 +10,7 @@ from genesis.typing import (
     IArrayType,
     NonNegativeFloat,
     NonNegativeInt,
+    OptionalIArrayType,
     PositiveFArrayType,
     PositiveFloat,
     PositiveInt,
@@ -27,9 +28,11 @@ from .options import (
     SensorT,
     SimpleSensorOptions,
     _check_len_match,
+    _validate_filter_link_idx,
 )
 
 if TYPE_CHECKING:
+    from genesis.engine.scene import Scene
     from genesis.engine.sensors.kinematic_tactile import (
         ContactDepthProbeSensor,
         ContactProbeSensor,
@@ -210,6 +213,25 @@ class TactileProbeSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
             gs.raise_exception(f"dead_taxel_value_range must satisfy low <= high. Got ({low}, {high}).")
 
 
+class FilterableTactileProbeSensorOptionsMixin(TactileProbeSensorOptionsMixin[SensorT]):
+    """
+    Options for tactile probe sensors that resolve depth against the physics solver's active contact pairs (as
+    opposed to a sampled point cloud), and can therefore scope which contacts count by the counterpart link.
+
+    Parameters
+    ----------
+    filter_link_idx : array-like[int], optional
+        Global rigid link indices (solver link space). Contacts with the sensor link where the other participant is
+        one of these links are ignored (they contribute no penetration/force). Default is empty (no filtering).
+    """
+
+    filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
+
+    def validate_scene(self, scene: "Scene"):
+        super().validate_scene(scene)
+        _validate_filter_link_idx(scene, self.filter_link_idx, f"{type(self).__name__} sensor")
+
+
 class PointCloudTactileSensorMixin(TactileProbeSensorOptionsMixin[SensorT]):
     """
     Options mixin for tactile sensors that sample a point cloud from tracked link meshes.
@@ -272,7 +294,7 @@ class ContactHysteresisOptionsMixin(SensorOptions[SensorT]):
 class ContactProbe(
     RigidSensorOptionsMixin["ContactProbeSensor"],
     SimpleSensorOptions["ContactProbeSensor"],
-    TactileProbeSensorOptionsMixin["ContactProbeSensor"],
+    FilterableTactileProbeSensorOptionsMixin["ContactProbeSensor"],
     ViscoelasticHysteresisOptionsMixin["ContactProbeSensor"],
     ContactHysteresisOptionsMixin["ContactProbeSensor"],
 ):
@@ -306,7 +328,7 @@ class ContactProbe(
 class ContactDepthProbe(
     RigidSensorOptionsMixin["ContactDepthProbeSensor"],
     SimpleSensorOptions["ContactDepthProbeSensor"],
-    TactileProbeSensorOptionsMixin["ContactDepthProbeSensor"],
+    FilterableTactileProbeSensorOptionsMixin["ContactDepthProbeSensor"],
     ViscoelasticHysteresisOptionsMixin["ContactDepthProbeSensor"],
 ):
     """
@@ -324,7 +346,7 @@ class ContactDepthProbe(
 class KinematicTaxel(
     RigidSensorOptionsMixin["KinematicTaxelSensor"],
     SimpleSensorOptions["KinematicTaxelSensor"],
-    TactileProbeSensorOptionsMixin["KinematicTaxelSensor"],
+    FilterableTactileProbeSensorOptionsMixin["KinematicTaxelSensor"],
     ViscoelasticHysteresisOptionsMixin["KinematicTaxelSensor"],
     SpatialCrosstalkOptionsMixin["KinematicTaxelSensor"],
 ):

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -489,22 +489,6 @@ def make_tensor_field(shape: tuple[int, ...] = (), dtype_factory: Callable[[], t
     return field(default_factory=_default_factory)
 
 
-def append_filter_links_idx(filter_links_idx: torch.Tensor, filter_link_idx: Sequence[int]) -> torch.Tensor:
-    """Append one contact sensor's filter-link indices as a new row of the shared ``(n_sensors, max_filter_links)``
-    table, growing the column count to fit and back-filling unused slots (and empty filters) with ``-1``.
-
-    ``-1`` is a sentinel that never matches a real link index, so kernels can scan every column unconditionally. The
-    table keeps at least one column so that even an all-empty table stays a valid (non-zero-dim) kernel argument.
-    """
-    n_sensors, cur_max = filter_links_idx.shape
-    new_max = max(cur_max, len(filter_link_idx), 1)
-    out = torch.full((n_sensors + 1, new_max), -1, dtype=gs.tc_int, device=gs.device)
-    out[:n_sensors, :cur_max] = filter_links_idx
-    if len(filter_link_idx) > 0:
-        out[n_sensors, : len(filter_link_idx)] = torch.tensor(filter_link_idx, dtype=gs.tc_int, device=gs.device)
-    return out
-
-
 def try_get_display_size() -> tuple[int | None, int | None, float | None]:
     """
     Try to connect to display if it exists and get the screen size.

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -489,6 +489,22 @@ def make_tensor_field(shape: tuple[int, ...] = (), dtype_factory: Callable[[], t
     return field(default_factory=_default_factory)
 
 
+def append_filter_links_idx(filter_links_idx: torch.Tensor, filter_link_idx: Sequence[int]) -> torch.Tensor:
+    """Append one contact sensor's filter-link indices as a new row of the shared ``(n_sensors, max_filter_links)``
+    table, growing the column count to fit and back-filling unused slots (and empty filters) with ``-1``.
+
+    ``-1`` is a sentinel that never matches a real link index, so kernels can scan every column unconditionally. The
+    table keeps at least one column so that even an all-empty table stays a valid (non-zero-dim) kernel argument.
+    """
+    n_sensors, cur_max = filter_links_idx.shape
+    new_max = max(cur_max, len(filter_link_idx), 1)
+    out = torch.full((n_sensors + 1, new_max), -1, dtype=gs.tc_int, device=gs.device)
+    out[:n_sensors, :cur_max] = filter_links_idx
+    if len(filter_link_idx) > 0:
+        out[n_sensors, : len(filter_link_idx)] = torch.tensor(filter_link_idx, dtype=gs.tc_int, device=gs.device)
+    return out
+
+
 def try_get_display_size() -> tuple[int | None, int | None, float | None]:
     """
     Try to connect to display if it exists and get the screen size.

--- a/tests/sensors/test_contact.py
+++ b/tests/sensors/test_contact.py
@@ -171,7 +171,7 @@ def test_gravity_force(n_envs, show_viewer, tol):
 
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
-def test_filter_link_idx(show_viewer):
+def test_filter_link_idx(show_viewer, tol):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             gravity=(0.0, 0.0, -10.0),
@@ -203,6 +203,17 @@ def test_filter_link_idx(show_viewer):
             filter_link_idx=(floor.link_start,),
         )
     )
+    force_sensor = scene.add_sensor(
+        gs.sensors.ContactForce(
+            entity_idx=box_on_floor.idx,
+        )
+    )
+    force_sensor_filtered = scene.add_sensor(
+        gs.sensors.ContactForce(
+            entity_idx=box_on_floor.idx,
+            filter_link_idx=(floor.link_start,),
+        )
+    )
     scene.build(n_envs=2)
     box.set_pos(
         (
@@ -218,3 +229,16 @@ def test_filter_link_idx(show_viewer):
     assert not filtered_data[0], "Contact sensor with filter_link_idx should filter out contact with the floor"
     assert data[1], "Contact sensor should detect contact with the box"
     assert filtered_data[1], "Contact sensor with filter_link_idx should still detect contact with the box"
+
+    force = force_sensor.read()
+    force_filtered = force_sensor_filtered.read()
+    # env 0: box_on_floor only touches the floor, which supports it (+z).
+    assert force[0, 2] > 1.0, "ContactForce should report the upward floor support force"
+    # filtering the floor (the only contact) leaves zero force
+    assert_allclose(force_filtered[0], 0.0, tol=tol)
+    # env 1: box_on_floor touches the floor (below, +z support) and the top box (above, -z push).
+    assert force[1, 2] > 1.0, "net contact force on box_on_floor is upward (floor support exceeds top-box weight)"
+    assert force_filtered[1, 2] < -1.0, "filtering the floor leaves only the top box's downward push"
+    # filtering the floor must change the result
+    with np.testing.assert_raises(AssertionError):
+        assert_allclose(force[1], force_filtered[1], tol=tol)

--- a/tests/sensors/test_tactile.py
+++ b/tests/sensors/test_tactile.py
@@ -180,7 +180,7 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
         ),
         show_viewer=show_viewer,
     )
-    scene.add_entity(gs.morphs.Plane())
+    floor = scene.add_entity(gs.morphs.Plane())
     box = scene.add_entity(
         gs.morphs.Box(
             size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
@@ -276,6 +276,27 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
             draw_debug=show_viewer,
         )
     )
+    # filter_link_idx drops the ground link: only the bottom probe (idx 3) sees the ground, so filtering it must
+    # zero that probe while leaving the sphere-facing top probes (idx 0/2) identical to the unfiltered sensors.
+    contact_probe_ground_filtered = scene.add_sensor(
+        gs.sensors.ContactProbe(
+            contact_threshold=CONTACT_THRESHOLD,
+            filter_link_idx=(floor.link_start,),
+            **common_kwargs,
+        )
+    )
+    depth_probe_ground_filtered = scene.add_sensor(
+        gs.sensors.ContactDepthProbe(
+            filter_link_idx=(floor.link_start,),
+            **common_kwargs,
+        )
+    )
+    taxel_ground_filtered = scene.add_sensor(
+        gs.sensors.KinematicTaxel(
+            filter_link_idx=(floor.link_start,),
+            **taxel_kwargs,
+        )
+    )
 
     scene.build(n_envs=n_envs)
     scene.step()
@@ -309,6 +330,11 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
     assert_allclose(gained_force[..., 3, :], force[..., 3, :] * GAIN, tol=tol)
     assert_allclose(gained_taxel.read_ground_truth().force, force, tol=gs.EPS)
 
+    # Ground is the only contact so far, so filtering it zeros the bottom probe on every branch.
+    assert_allclose(depth_probe_ground_filtered.read_ground_truth(), 0.0, tol=gs.EPS)
+    assert not contact_probe_ground_filtered.read_ground_truth().any()
+    assert_allclose(taxel_ground_filtered.read_ground_truth().force, 0.0, tol=gs.EPS)
+
     # Now position the sphere to penetrate the top of the box.
     box_top_z = BOX_SIZE - PENETRATION
     sphere.set_pos((0.0, 0.0, box_top_z + SPHERE_RADIUS - PENETRATION))
@@ -325,6 +351,18 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
     assert_allclose(depth[..., 1], 0.0, tol=gs.EPS)
     assert (depth[..., 2] > tol).all(), "Large offset probe should detect the nearby sphere."
     assert (sphere_force[..., 0, 2] > tol).all(), "Sphere taxel should see the box underneath."
+
+    # With the sphere pressing the top and the ground under the bottom, filtering the ground zeros only the bottom
+    # probe (idx 3); the sphere-driven top probe (idx 0) is untouched and matches the unfiltered sensor.
+    depth_ground_filtered = depth_probe_ground_filtered.read_ground_truth()
+    force_ground_filtered = taxel_ground_filtered.read_ground_truth().force
+    contact_ground_filtered = contact_probe_ground_filtered.read_ground_truth()
+    assert_allclose(depth_ground_filtered[..., 3], 0.0, tol=gs.EPS)
+    assert_allclose(force_ground_filtered[..., 3, :], 0.0, tol=gs.EPS)
+    assert_allclose(depth_ground_filtered[..., 0], depth[..., 0], tol=tol)
+    assert_allclose(force_ground_filtered[..., 0, :], force[..., 0, :], tol=tol)
+    assert contact_ground_filtered[..., 0].all(), "top probe still contacts the sphere"
+    assert not contact_ground_filtered[..., 3].any(), "bottom probe no longer contacts the filtered ground"
 
     # Move sphere away and check no contact.
     sphere.set_pos((0.0, 0.0, box_top_z + SPHERE_RADIUS + PROBE_RADIUS + 0.2))
@@ -748,6 +786,15 @@ def test_contact_depth_query_sdf_vs_raycast_parity(show_viewer):
 
         common = dict(entity_idx=pad.idx, probe_local_pos=(CENTER_PROBE,), probe_radius=PROBE_R)
         depth = scene.add_sensor(gs.sensors.ContactDepthProbe(contact_depth_query=mode, **common))
+        # Filtering the ball (the only counterpart) must zero the depth on both backends: the SDF path drops it from
+        # the per-sensor geom list, the raycast path drops it from the candidate-geom mask.
+        depth_filtered = scene.add_sensor(
+            gs.sensors.ContactDepthProbe(
+                contact_depth_query=mode,
+                filter_link_idx=(ball.base_link_idx,),
+                **common,
+            )
+        )
         kin = scene.add_sensor(
             gs.sensors.KinematicTaxel(
                 normal_stiffness=100.0,
@@ -778,10 +825,15 @@ def test_contact_depth_query_sdf_vs_raycast_parity(show_viewer):
             tensor_to_array(depth.read_ground_truth()),
             tensor_to_array(kin.read_ground_truth().force).reshape(-1, 3),
             tensor_to_array(elast.read_ground_truth()),
+            tensor_to_array(depth_filtered.read_ground_truth()),
         )
 
-    sdf_d, sdf_f, sdf_e = build_and_read("sdf")
-    ray_d, ray_f, ray_e = build_and_read("raycast")
+    sdf_d, sdf_f, sdf_e, sdf_d_filtered = build_and_read("sdf")
+    ray_d, ray_f, ray_e, ray_d_filtered = build_and_read("raycast")
+
+    # Filtering the only counterpart zeros the depth on both backends (SDF geom list / raycast candidate mask).
+    assert_allclose(sdf_d_filtered, 0.0, tol=gs.EPS)
+    assert_allclose(ray_d_filtered, 0.0, tol=gs.EPS)
 
     # ContactDepthProbe -- both backends report a positive depth of the same order. They do not match tightly: SDF
     # uses the ball's analytic sphere SDF while raycast hits its faceted mesh, so the depths differ by a
@@ -798,6 +850,62 @@ def test_contact_depth_query_sdf_vs_raycast_parity(show_viewer):
 
     # ElastomerTaxel dilate displacement: face-on contact, identical on both modes when geom is a sphere primitive.
     assert_allclose(sdf_e, ray_e, tol=0.1 * PROBE_R)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_filtered_contact_survives_prefilter_cap(show_viewer, monkeypatch, n_envs):
+    # The raycast contact-depth path prefilters the sensor link's contacts into a capped per-sensor list before
+    # querying depth. The counterpart filter must run before that cap: otherwise a filtered manifold can fill the
+    # list and starve an allowed contact. Shrink the cap to 1 so a single filtered contact would exhaust it, then
+    # filter the sphere (whose contact is enumerated before the ground manifold). The allowed ground contact must
+    # still reach the bottom probe -- with the filter applied too late, both probes read zero.
+    monkeypatch.setattr("genesis.engine.sensors.kinematic_tactile._MAX_CONTACTS_PER_SENSOR", 1)
+    BOX_SIZE = 0.2
+    SPHERE_RADIUS = 0.1
+    PENETRATION = 0.02
+    PROBE_RADIUS = 0.05
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, 0.0),
+        ),
+        profiling_options=gs.options.ProfilingOptions(
+            show_FPS=False,
+        ),
+        show_viewer=show_viewer,
+    )
+    plane = scene.add_entity(gs.morphs.Plane())
+    box = scene.add_entity(
+        gs.morphs.Box(
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+            pos=(0.0, 0.0, BOX_SIZE / 2 - PENETRATION),
+        )
+    )
+    sphere = scene.add_entity(
+        gs.morphs.Sphere(
+            radius=SPHERE_RADIUS,
+            pos=(0.0, 0.0, BOX_SIZE + SPHERE_RADIUS - 2 * PENETRATION),
+            fixed=True,
+        )
+    )
+    probe = scene.add_sensor(
+        gs.sensors.ContactDepthProbe(
+            entity_idx=box.idx,
+            probe_local_pos=((0.0, 0.0, BOX_SIZE / 2), (0.0, 0.0, -BOX_SIZE / 2)),
+            probe_radius=PROBE_RADIUS,
+            contact_depth_query="raycast",
+            filter_link_idx=(sphere.base_link_idx,),
+        )
+    )
+    scene.build(n_envs=n_envs)
+    scene.step()
+
+    depth = probe.read_ground_truth()
+    # Bottom probe faces the unfiltered ground: it must survive the cap despite the filtered sphere contact.
+    assert (depth[..., 1] > gs.EPS).all(), "allowed ground contact must survive the counterpart-filter prefilter cap"
+    # Top probe faces the filtered sphere, which contributes nothing.
+    assert_allclose(depth[..., 0], 0.0, tol=gs.EPS)
 
 
 @pytest.mark.required


### PR DESCRIPTION
ContactForceSensor now accepts filter_link_idx, mirroring ContactSensor: contacts with the sensor link whose other participant is one of the listed links are excluded from the reported force. The filter is applied on both ground-truth-update paths; the vectorized zerocopy path and the _kernel_get_contacts_forces kernel. 
Adds test_contact_force_sensor_filter_link_idx.

<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

 ## Description

  `ContactForceSensor` now accepts `filter_link_idx` (default `()`), mirroring
  `ContactSensor` from #2655: contacts with the sensor link whose **other**
  participant is one of the listed links are excluded from the reported force.

    - `_kernel_get_contacts_forces` (the kernel fallback): takes
      `filter_links_idx` and skips a contact for a sensor when the counterpart
      is in that sensor's filter list;
    - `filtered_sensor_idx` gates the comparison so sensors without a filter
      keep the cheap path (same optimisation as `ContactSensor`).

  ## Related Issue

  Resolves Genesis-Embodied-AI/Genesis#2771

  ## Motivation and Context

  `ContactSensor` already filters its boolean by counterpart link, but `ContactForceSensor` only reported the total contact force on the link, with no way to scope it (e.g. "force on a foot from the ground, excluding self-contact"). 

  ## How Has This Been / Can This Be Tested?

      pytest tests/test_sensors.py::test_contact_force_sensor_filter_link_idx tests/test_sensors.py::test_contact_sensor_filter_link_idx

  `test_contact_force_sensor_filter_link_idx` puts a box on the floor (env 0) /  a box on the floor with another box stacked on top (env 1), with two `ContactForce` sensors on the bottom box — one plain, one with `filter_link_idx (floor.link_start,)`. It asserts the filtered sensor reads ~0 in env 0 and reads only the top box's downward push in env 1,  while the unfiltered sensor reads the net contact force in both. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
