### PR TITLE
[FEATURE] Make visual raycasting opt-in for Kinematic materials

### DIFF
--- a/examples/sensors/depth_camera_custom_vverts.py
+++ b/examples/sensors/depth_camera_custom_vverts.py
@@ -72,7 +72,7 @@ def main():
             fixed=True,
             enable_custom_vverts=True,
         ),
-        material=gs.materials.Kinematic(),
+        material=gs.materials.Kinematic(use_visual_raycasting=True),
         surface=gs.surfaces.Default(color=(0.2, 0.8, 0.4)),
     )
 
@@ -86,7 +86,7 @@ def main():
             pos=(0, 0, 0),
             fixed=True,
         ),
-        material=gs.materials.Kinematic(),
+        material=gs.materials.Kinematic(use_visual_raycasting=True),
         surface=gs.surfaces.Default(color=(1.0, 0.3, 0.3)),
     )
 

--- a/genesis/engine/materials/kinematic.py
+++ b/genesis/engine/materials/kinematic.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from .base import EntityT, Material
 
 
@@ -8,8 +6,6 @@ class Kinematic(Material[EntityT]):
     Visualization-only material for ghost/reference entities.
 
     Kinematic entities are rendered but do not participate in physics simulation, collision detection, or constraint
-    solving. Their visual mesh is always raycastable (use_visual_raycasting=True); the Rigid subclass relaxes the
-    field type to StrictBool with default False.
+    solving. They are ignored by raycaster sensors by default; set use_visual_raycasting=True to include their visual
+    mesh in the raycaster BVH.
     """
-
-    use_visual_raycasting: Literal[True] = True

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -826,10 +826,12 @@ def test_raycaster_hits(show_viewer, n_envs):
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
-def test_raycaster_against_visual(tmp_path, show_viewer, n_envs):
-    # Two depth cameras, one per opt-in entity:
-    #   - cam_kin -> KinematicEntity sphere (use_visual_raycasting=True by default). set_vverts overrides survive
-    #     step() so the depth camera reads the user-driven positions, and set_vverts(None) hands control back to FK.
+@pytest.mark.parametrize("kin_raycastable", [True, False])
+def test_raycaster_against_visual(tmp_path, show_viewer, n_envs, kin_raycastable):
+    # Two depth cameras, one per entity:
+    #   - cam_kin -> KinematicEntity sphere. When use_visual_raycasting=True the depth camera reads the entity's
+    #     visual mesh (including set_vverts overrides, which survive step() until set_vverts(None) hands control
+    #     back to FK). When False the kinematic entity is completely ignored by the raycaster.
     #   - cam_rigid -> RigidEntity whose visual mesh (sphere radius 0.2) is intentionally different from its collision
     #     mesh (capsule radius 0.05). With use_visual_raycasting=True the depth must match the visual sphere.
     urdf_path = tmp_path / "vis_diff.urdf"
@@ -871,7 +873,7 @@ def test_raycaster_against_visual(tmp_path, show_viewer, n_envs):
             fixed=True,
             enable_custom_vverts=True,
         ),
-        material=gs.materials.Kinematic(),
+        material=gs.materials.Kinematic(use_visual_raycasting=kin_raycastable),
     )
     scene.add_entity(
         morph=gs.morphs.URDF(
@@ -916,8 +918,12 @@ def test_raycaster_against_visual(tmp_path, show_viewer, n_envs):
     scene.step()
 
     # Each camera at x=-1 along its own z-row looks along +x. The center pixel hits the closest point of its target
-    # sphere at x=-0.2 -> depth 0.8. For cam_rigid this comes from the visual BVH (not the collision capsule).
-    assert_allclose(cam_kin.read_image()[..., 15, 20], 0.8, tol=1e-2)
+    # sphere at x=-0.2 -> depth 0.8. For cam_rigid this comes from the visual BVH (not the collision capsule). When
+    # the kinematic entity opts out of raycasting, cam_kin sees nothing and returns the no_hit_value (max_range=5.0).
+    NO_HIT = 5.0  # max_range
+    kin_at_origin = 0.8 if kin_raycastable else NO_HIT
+    kin_scaled = 0.6 if kin_raycastable else NO_HIT
+    assert_allclose(cam_kin.read_image()[..., 15, 20], kin_at_origin, tol=1e-2)
     assert_allclose(cam_rigid.read_image()[..., 15, 20], 0.8, tol=1e-2)
 
     # Scale the kinematic sphere by 2x around its center via per-vertex set_vverts. The new radius is 0.4, so the
@@ -927,20 +933,20 @@ def test_raycaster_against_visual(tmp_path, show_viewer, n_envs):
     center = np.array([0.0, 0.0, 0.5], dtype=np.float32)
     kin_sphere.set_vverts((fk_vverts - center) * 2.0 + center)
     scene.step()
-    assert_allclose(cam_kin.read_image()[..., 15, 20], 0.6, tol=1e-2)
+    assert_allclose(cam_kin.read_image()[..., 15, 20], kin_scaled, tol=1e-2)
     assert_allclose(cam_rigid.read_image()[..., 15, 20], 0.8, tol=1e-2)
 
     # Push the kinematic sphere far away. cam_kin should report no_hit_value at the center pixel; cam_rigid still sees
     # the rigid visual sphere.
     kin_sphere.set_vverts((100.0, 100.0, 100.0))
     scene.step()
-    assert_allclose(cam_kin.read_image()[..., 15, 20], 5.0, tol=gs.EPS)
+    assert_allclose(cam_kin.read_image()[..., 15, 20], NO_HIT, tol=gs.EPS)
     assert_allclose(cam_rigid.read_image()[..., 15, 20], 0.8, tol=1e-2)
 
     # Restoring FK control returns the original hit distance on cam_kin; cam_rigid stays put.
     kin_sphere.set_vverts(None)
     scene.step()
-    assert_allclose(cam_kin.read_image()[..., 15, 20], 0.8, tol=1e-2)
+    assert_allclose(cam_kin.read_image()[..., 15, 20], kin_at_origin, tol=1e-2)
     assert_allclose(cam_rigid.read_image()[..., 15, 20], 0.8, tol=1e-2)
 
 


### PR DESCRIPTION
## Summary
- Dropped the `Literal[True]` override on `Kinematic.use_visual_raycasting`; the field now inherits `StrictBool = False` from `Material`, so kinematic entities are ignored by raycaster sensors unless they explicitly opt in.
- Updated `examples/sensors/depth_camera_custom_vverts.py` to opt in (the example is the canonical demo of kinematic raycasting).
- Extended `test_raycaster_against_visual` with a `kin_raycastable` parametrization to cover both cases.

## Motivation
Kinematic materials are primarily for ghost / reference / debug-overlay entities. Defaulting them to raycastable surprised users who added a debug overlay to a scene and saw it bleed into their depth camera output. Making it opt-in matches the existing `Rigid` default (`False`) and keeps Kinematic strictly visualization-only out of the box.

## Test plan
- [x] `pytest -n 0 tests/test_sensors.py -m required` (33/33 pass on macOS arm64, software renderer).
- [x] `pytest -n 0 tests/test_sensors.py::test_raycaster_against_visual` (4 parametrized cases pass: `kin_raycastable ∈ {True, False}` × `n_envs ∈ {0, 2}`).