### PR TITLE
[FEATURE] Restructure sensor base hierarchy + eager _post_process + SensorDataSpec API.

### DIFF
--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, TypeVar, get_args, get_origin
+from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, Sequence, TypeVar, get_args, get_origin
 
 import numpy as np
 import torch
@@ -50,8 +50,8 @@ class SharedSensorMetadata:
     history_lengths: list[int] = field(default_factory=list)
     # Per-sensor: interpolate delayed reads (aligned with cache_sizes). Appended in Sensor.build.
     interpolate: list[bool] = field(default_factory=list)
-    # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build (and latched True
-    # by `set_delay`) so the per-step fast path in SensorManager._apply_delay_to_shared_cache can avoid a GPU-syncing reduction.
+    # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build (and latched True by
+    # `set_delay`) so the per-step fast path in `_apply_delay_to_shared_cache` can avoid a GPU-syncing reduction.
     has_any_delay: bool = False
     # True iff at least one sensor in the class has a nonzero jitter option. Stays False for non-noisy sensor classes
     # (Contact, Raycaster) since they never sample jitter. Same precompute-and-latch contract as `has_any_delay`.
@@ -275,6 +275,73 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         return self._is_built
 
     # =============================== private shared methods ===============================
+
+    @classmethod
+    def _apply_delay_to_shared_cache(
+        cls,
+        shared_metadata: SharedSensorMetadataT,
+        shared_cache: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
+        interpolate: Sequence[bool] | None = None,
+    ):
+        """
+        Applies the read delay (and jitter, if any) to the shared cache tensor by copying the buffered data at the
+        appropriate index. When the class has neither delay nor jitter, takes a fast path that writes the most
+        recent ring frame to the cache class-wide.
+
+        Parameters
+        ----------
+        shared_metadata : SharedSensorMetadata
+            The shared metadata for the sensor.
+        shared_cache : torch.Tensor
+            The shared cache tensor.
+        measured_data_timeline : TensorRingBuffer
+            Pre-delay measured timeline ring for this sensor class slice (current step already written by
+            ``_update_shared_cache``).
+        interpolate : Sequence[bool] | None
+            Whether to interpolate the sensor data for the read delay + jitter. Defaults to False.
+        """
+        # Fast path: when no sensor in the class has any delay or jitter, this is equivalent to copying the most
+        # recent ring frame to the measured cache class-wide. Avoids a Python loop over every sensor. Both flags
+        # are precomputed Python bools (no GPU sync) latched at build / by setters.
+        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
+            shared_cache.copy_(measured_data_timeline.at(0))
+            return
+
+        # Sample uniform jitter in [0, jitter_ts) per env per sensor. One-sided so samples are non-negative;
+        # combined with the `jitter < dt` option constraint, the effective per-step shift is strictly bounded
+        # within [0, 1) steps and cannot wrap the ring.
+        if shared_metadata.has_any_jitter:
+            shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
+            cur_jitter_ts = shared_metadata.cur_jitter_ts
+        else:
+            cur_jitter_ts = None
+
+        if interpolate is None:
+            interpolate = [False for _ in shared_metadata.cache_sizes]
+
+        tensor_start = 0
+        for sensor_idx, (tensor_size, interp) in enumerate(zip(shared_metadata.cache_sizes, interpolate)):
+            # Compute the current delay of the sensor, taking into account jitter if any
+            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
+            if cur_jitter_ts is not None:
+                cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
+
+            # Get int for indexing into ring buffer (0 = most recent, 1 = delayed by one timestep, etc.)
+            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
+
+            # Update shared cached with left data (Zero Order Hold) or linearly interpolated data (First Order)
+            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
+            sensor_cache = shared_cache[:, tensor_slice]
+            data_left = measured_data_timeline.at(cur_delay_ts_int, tensor_slice, per_row=True)
+            if interp:
+                ratio = torch.frac(cur_delay_ts)
+                data_right = measured_data_timeline.at(cur_delay_ts_int + 1, tensor_slice, per_row=True)
+                torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
+            else:
+                sensor_cache.copy_(data_left)
+
+            tensor_start += tensor_size
 
     def _get_formatted_data(self, tensor: torch.Tensor, envs_idx=None) -> torch.Tensor:
         """

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, Sequence, TypeVar, get_args, get_origin
+from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, TypeVar, get_args, get_origin
 
 import numpy as np
 import torch
@@ -48,8 +48,10 @@ class SharedSensorMetadata:
     cache_sizes: list[int] = field(default_factory=list)
     delays_ts: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
     history_lengths: list[int] = field(default_factory=list)
+    # Per-sensor: interpolate delayed reads (aligned with cache_sizes). Appended in Sensor.build.
+    interpolate: list[bool] = field(default_factory=list)
     # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build (and latched True
-    # by `set_delay`) so the per-step fast path in `_apply_delay_to_shared_cache` can avoid a GPU-syncing reduction.
+    # by `set_delay`) so the per-step fast path in SensorManager._apply_delay_to_shared_cache can avoid a GPU-syncing reduction.
     has_any_delay: bool = False
     # True iff at least one sensor in the class has a nonzero jitter option. Stays False for non-noisy sensor classes
     # (Contact, Raycaster) since they never sample jitter. Same precompute-and-latch contract as `has_any_delay`.
@@ -174,6 +176,7 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         )
         self._shared_metadata.cache_sizes.append(self._cache_size)
         self._shared_metadata.history_lengths.append(self._options.history_length)
+        self._shared_metadata.interpolate.append(getattr(self._options, "interpolate", False))
         if self._delay_ts > 0:
             self._shared_metadata.has_any_delay = True
 
@@ -208,29 +211,18 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         raise NotImplementedError(f"{type(self).__name__} has not implemented `get_return_format()`.")
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: SharedSensorMetadataT, shared_ground_truth_cache: torch.Tensor
-    ):
-        """
-        Update the shared sensor ground truth cache for all sensors of this class using metadata in SensorManager.
-        """
-        raise NotImplementedError(f"{cls.__name__} has not implemented `update_shared_ground_truth_cache()`.")
-
-    @classmethod
     def _update_shared_cache(
         cls,
         shared_metadata: SharedSensorMetadataT,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         """
-        Update the shared sensor cache for all sensors of this class using metadata in SensorManager.
-
-        The information in shared_cache should be the final measured sensor data after all noise and post-processing.
-        ``buffered_data`` is a sliced view of the per-dtype ground-truth ring: SensorManager has already written this
-        step's GT into the current slot; use ``_apply_delay_to_shared_cache(..., buffered_data, ...)`` for read delay
-        (do not call ``set`` on it for that GT block).
+        Update the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows) and write this physics
+        step's pre-delay measured values into ``measured_data_timeline``. The current write slot is
+        ``measured_data_timeline.at(0, copy=False)`` (shape ``(B, cols)``); sensors may read older slots via
+        ``at(k, ...)`` (for example first-order filtering). SensorManager applies read delay/jitter from this timeline
+        into ``read()``.
         """
         raise NotImplementedError(f"{cls.__name__} has not implemented `update_shared_cache()`.")
 
@@ -283,72 +275,6 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         return self._is_built
 
     # =============================== private shared methods ===============================
-
-    @classmethod
-    def _apply_delay_to_shared_cache(
-        cls,
-        shared_metadata: SharedSensorMetadataT,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-        interpolate: Sequence[bool] | None = None,
-    ):
-        """
-        Applies the read delay (and jitter, if any) to the shared cache tensor by copying the buffered data at the
-        appropriate index. When the class has neither delay nor jitter, takes a fast path that writes the most
-        recent ring frame to the cache class-wide.
-
-        Parameters
-        ----------
-        shared_metadata : SharedSensorMetadata
-            The shared metadata for the sensor.
-        shared_cache : torch.Tensor
-            The shared cache tensor.
-        buffered_data : TensorRingBuffer
-            Ground-truth timeline ring for this sensor class slice (current step already written by SensorManager).
-        interpolate : Sequence[bool] | None
-            Whether to interpolate the sensor data for the read delay + jitter. Defaults to False.
-        """
-        # Fast path: when no sensor in the class has any delay or jitter, this is equivalent to copying the most
-        # recent ring frame to the measured cache class-wide. Avoids a Python loop over every sensor. Both flags
-        # are precomputed Python bools (no GPU sync) latched at build / by setters.
-        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
-            shared_cache.copy_(buffered_data.at(0))
-            return
-
-        # Sample uniform jitter in [0, jitter_ts) per env per sensor. One-sided so samples are non-negative;
-        # combined with the `jitter < dt` option constraint, the effective per-step shift is strictly bounded
-        # within [0, 1) steps and cannot wrap the ring.
-        if shared_metadata.has_any_jitter:
-            shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
-            cur_jitter_ts = shared_metadata.cur_jitter_ts
-        else:
-            cur_jitter_ts = None
-
-        if interpolate is None:
-            interpolate = [False for _ in shared_metadata.cache_sizes]
-
-        tensor_start = 0
-        for sensor_idx, (tensor_size, interp) in enumerate(zip(shared_metadata.cache_sizes, interpolate)):
-            # Compute the current delay of the sensor, taking into account jitter if any
-            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
-            if cur_jitter_ts is not None:
-                cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
-
-            # Get int for indexing into ring buffer (0 = most recent, 1 = delayed by one timestep, etc.)
-            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
-
-            # Update shared cached with left data (Zero Order Hold) or linearly interpolated data (First Order)
-            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
-            sensor_cache = shared_cache[:, tensor_slice]
-            data_left = buffered_data.at(cur_delay_ts_int, tensor_slice, per_row=True)
-            if interp:
-                ratio = torch.frac(cur_delay_ts)
-                data_right = buffered_data.at(cur_delay_ts_int + 1, tensor_slice, per_row=True)
-                torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
-            else:
-                sensor_cache.copy_(data_left)
-
-            tensor_start += tensor_size
 
     def _get_formatted_data(self, tensor: torch.Tensor, envs_idx=None) -> torch.Tensor:
         """
@@ -528,7 +454,6 @@ class ImperfectSensorMetadataMixin:
     noise: torch.Tensor = make_tensor_field((0, 0))
     jitter_ts: torch.Tensor = make_tensor_field((0, 0))
     cur_jitter_ts: torch.Tensor = make_tensor_field((0, 0))
-    interpolate: list[bool] = field(default_factory=list)
     # Precomputed Python bool flags gate the per-step noise/bias/quantize work without GPU sync. Set at build
     # from options and refreshed by the corresponding setters. Conservatively True once any sensor has nonzero
     # value; never flipped back to False (avoids tracking per-sensor state).
@@ -619,7 +544,6 @@ class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
             self._shared_metadata.jitter_ts, to_tuple(self._options.jitter / self._dt), expand=(batch_size, -1), dim=-1
         )
         self._shared_metadata.cur_jitter_ts = torch.zeros_like(self._shared_metadata.jitter_ts, device=gs.device)
-        self._shared_metadata.interpolate.append(self._options.interpolate)
         if np.any(jitter_np > gs.EPS):
             self._shared_metadata.has_any_jitter = True
         if np.any(np.asarray(self._options.noise, dtype=gs.np_float) > gs.EPS):

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
-from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, Sequence, TypeVar, get_args, get_origin
+from functools import cached_property, partial
+from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, TypeVar, get_args, get_origin
 
 import numpy as np
 import torch
@@ -42,7 +42,7 @@ def _to_tuple(*values: NumArrayType, length_per_value: int = 3) -> tuple[Numeric
 @dataclass
 class SharedSensorMetadata:
     """
-    Shared metadata between all sensors of the same class.
+    Shared metadata between all sensors of the same class. Time-related state only — visible to SensorManager.
     """
 
     cache_sizes: list[int] = field(default_factory=list)
@@ -50,12 +50,16 @@ class SharedSensorMetadata:
     history_lengths: list[int] = field(default_factory=list)
     # Per-sensor: interpolate delayed reads (aligned with cache_sizes). Appended in Sensor.build.
     interpolate: list[bool] = field(default_factory=list)
+    jitter_ts: torch.Tensor = make_tensor_field((0, 0))
+    cur_jitter_ts: torch.Tensor = make_tensor_field((0, 0))
     # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build (and latched True by
-    # `set_delay`) so the per-step fast path in `_apply_delay_to_shared_cache` can avoid a GPU-syncing reduction.
+    # `set_delay`) so the per-step fast path can avoid a GPU-syncing reduction.
     has_any_delay: bool = False
-    # True iff at least one sensor in the class has a nonzero jitter option. Stays False for non-noisy sensor classes
-    # (Contact, Raycaster) since they never sample jitter. Same precompute-and-latch contract as `has_any_delay`.
+    # True iff at least one sensor in the class has a nonzero jitter option. Same precompute-and-latch contract as
+    # `has_any_delay`.
     has_any_jitter: bool = False
+    # Cached reference to scene._envs_idx (arange(B)); populated by SensorManager.build for the delay-sampling loop.
+    envs_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
 
     def __del__(self):
         try:
@@ -72,9 +76,39 @@ class SharedSensorMetadata:
         """
 
 
+@dataclass
+class SimpleSensorMetadata(SharedSensorMetadata):
+    """
+    SimpleSensor's per-class state for the imperfection parameters (noise/bias/random_walk/resolution). Opaque to
+    SensorManager (which only uses ``SharedSensorMetadata`` fields). Per-sensor-class metadata subclasses inherit
+    this when the sensor derives from ``SimpleSensor``; sensors deriving from ``Sensor`` directly (Camera) inherit
+    ``SharedSensorMetadata`` instead.
+    """
+
+    resolution: torch.Tensor = make_tensor_field((0, 0))
+    bias: torch.Tensor = make_tensor_field((0, 0))
+    cur_random_walk: torch.Tensor = make_tensor_field((0, 0))
+    random_walk: torch.Tensor = make_tensor_field((0, 0))
+    cur_noise: torch.Tensor = make_tensor_field((0, 0))
+    noise: torch.Tensor = make_tensor_field((0, 0))
+    has_any_noise: bool = False
+    has_any_random_walk: bool = False
+    has_any_bias: bool = False
+    has_any_resolution: bool = False
+
+
 SharedSensorMetadataT = TypeVar("SharedSensorMetadataT", bound=SharedSensorMetadata)
 OptionsT = TypeVar("OptionsT", bound="SensorOptions")
 DataT = TypeVarWithDefault("DataT", default=tuple, covariant=True)
+
+
+class SensorDataSpec(NamedTuple):
+    """Shape + dtype for a per-sensor cache buffer. ``shape`` follows the existing convention: a single tuple
+    ``(N,)`` for a single-tensor return, or a tuple-of-tuples ``((3,), (3,), (3,))`` for multi-tensor returns
+    (e.g. IMU's ``NamedTuple(lin_acc, ang_vel, mag)``)."""
+
+    shape: tuple[int, ...] | tuple[tuple[int, ...], ...]
+    dtype: torch.dtype
 
 
 class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
@@ -113,6 +147,15 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
                 if len(args) >= 3 and not isinstance(args[2], TypeVar):
                     cls._return_data_class = args[2]
                 break
+        # Strict contract: overriding `_post_process` requires overriding `intermediate_spec` too. The intermediate
+        # buffer must be a distinct buffer regardless of whether the intermediate values happen to coincide with
+        # return values (the timeline ring is in intermediate space; mixing data spaces breaks `_apply_transform`
+        # filter overrides that read previous slots).
+        if "_post_process" in cls.__dict__ and "intermediate_spec" not in cls.__dict__:
+            raise TypeError(
+                f"{cls.__name__} overrides `_post_process` but not `intermediate_spec`; declare the intermediate "
+                f"shape/dtype explicitly (e.g. `intermediate_spec = self.return_spec` when they coincide)."
+            )
         # Auto-register if this class defines its own options (not inherited).
         # Enforce that concrete sensor classes also specify the metadata type parameter.
         if "_options_cls" in cls.__dict__:
@@ -133,10 +176,9 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         self._delay_ts = round(self._options.delay / self._dt)
 
         self._cache_slices: list[slice] = []
-        return_format = self._get_return_format()
-        assert len(return_format) > 0
+        return_shape = self.return_spec.shape
         intrinsic_shapes: tuple[tuple[int, ...], ...] = (
-            (return_format,) if isinstance(return_format[0], int) else return_format
+            (return_shape,) if isinstance(return_shape[0], int) else return_shape
         )
 
         history_length = self._options.history_length
@@ -176,7 +218,7 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         )
         self._shared_metadata.cache_sizes.append(self._cache_size)
         self._shared_metadata.history_lengths.append(self._options.history_length)
-        self._shared_metadata.interpolate.append(getattr(self._options, "interpolate", False))
+        self._shared_metadata.interpolate.append(self._options.interpolate)
         if self._delay_ts > 0:
             self._shared_metadata.has_any_delay = True
 
@@ -198,40 +240,63 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         """
         pass
 
-    def _get_return_format(self) -> tuple[int | tuple[int, ...], ...]:
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
         """
-        Get the data format of the read() return value.
+        Shape + dtype of what ``read()`` returns. Abstract — every concrete sensor declares it.
 
-        Returns
-        -------
-        return_format : tuple[tuple[int, ...], ...]
-            The output shape(s) of the tensor data returned by read(), e.g. (2, 3) means read() will return a single
-            tensor of shape (2, 3) and ((3,), (3,)) would return two tensors of shape (3,).
+        Cached on the instance: shape may depend on options (e.g. Raycaster's pattern, IMU's multi-tensor return),
+        dtype is typically a class-level constant but cached on the instance for uniform access.
         """
-        raise NotImplementedError(f"{type(self).__name__} has not implemented `get_return_format()`.")
+        raise NotImplementedError(f"{type(self).__name__} must declare `return_spec`.")
+
+    @cached_property
+    def intermediate_spec(self) -> SensorDataSpec:
+        """
+        Shape + dtype of the pipeline-internal cache. Defaults to ``return_spec``; when ``_post_process`` is identity,
+        the manager allocates a single buffer and aliases intermediate == return. Override together with
+        ``_post_process`` when the projection changes shape and/or dtype (``__init_subclass__`` enforces this
+        contract).
+        """
+        return self.return_spec
 
     @classmethod
     def _update_shared_cache(
         cls,
         shared_metadata: SharedSensorMetadataT,
         current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
+        measured_data_timeline: "TensorRingBuffer | None",
+        intermediate_cache: torch.Tensor,
+        return_cache: torch.Tensor,
     ):
         """
-        Update the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows) and write this physics
-        step's pre-delay measured values into ``measured_data_timeline``. The current write slot is
-        ``measured_data_timeline.at(0, copy=False)`` (shape ``(B, cols)``); sensors may read older slots via
-        ``at(k, ...)`` (for example first-order filtering). SensorManager applies read delay/jitter from this timeline
-        into ``read()``.
+        Update the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows), the pre-delay measured
+        timeline ring (``measured_data_timeline.at(0)`` is the current write slot), the per-dtype
+        ``intermediate_cache`` (shape ``(B, cols)``, post-delay sample in intermediate space), and the per-class
+        ``return_cache`` (shape ``(B, cols)``, post-``_post_process`` user-facing space). When the sensor opts out
+        of the measured pipeline (e.g. Camera), ``measured_data_timeline`` is ``None`` and the implementation writes
+        directly to ``intermediate_cache``; if ``_post_process`` is identity, ``return_cache is intermediate_cache``.
         """
         raise NotImplementedError(f"{cls.__name__} has not implemented `update_shared_cache()`.")
 
     @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
+    def _post_process(cls, shared_metadata: SharedSensorMetadataT, tensor: torch.Tensor) -> torch.Tensor:
         """
-        The dtype of the cache for this sensor.
+        Write-time projection from per-class intermediate cache to per-class return cache. Applied eagerly once per
+        step by the orchestrator. Default: identity (intermediate IS return; no separate allocation).
+
+        ``tensor`` is the full per-class intermediate cache ``[B, total_cache_size]``. Per-instance reads slice the
+        return cache directly; no ``cache_slice`` keyword needed. Override authors must be stateless: same input +
+        same metadata produces same output.
         """
-        raise NotImplementedError(f"{cls.__name__} has not implemented `get_cache_dtype()`.")
+        return tensor
+
+    @property
+    def uses_measured_pipeline(self) -> bool:
+        """Opt-in: False by default. A plain ``Sensor`` derivative (e.g. Camera) writes its result directly into
+        the per-class return cache and skips the measured-timeline ring entirely. ``SimpleSensor`` overrides with a
+        smart heuristic."""
+        return False
 
     def _draw_debug(self, context: "RasterizerContext"):
         """
@@ -244,14 +309,15 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
     @gs.assert_built
     def read(self, envs_idx=None) -> DataT:
         """
-        Read the sensor data (with noise applied if applicable).
+        Read the sensor data (with noise applied if applicable). Pure view into the per-class return cache
+        (post-``_post_process``); `_post_process` was applied eagerly once per step by the orchestrator.
         """
         return self._get_formatted_data(self._manager.get_cloned_from_cache(self), envs_idx)
 
     @gs.assert_built
     def read_ground_truth(self, envs_idx=None) -> DataT:
         """
-        Read the ground truth sensor data (without noise).
+        Read the ground truth sensor data (without noise). Pure view into the per-class ground-truth return cache.
         """
         return self._get_formatted_data(self._manager.get_cloned_from_cache(self, is_ground_truth=True), envs_idx)
 
@@ -275,73 +341,6 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         return self._is_built
 
     # =============================== private shared methods ===============================
-
-    @classmethod
-    def _apply_delay_to_shared_cache(
-        cls,
-        shared_metadata: SharedSensorMetadataT,
-        shared_cache: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-        interpolate: Sequence[bool] | None = None,
-    ):
-        """
-        Applies the read delay (and jitter, if any) to the shared cache tensor by copying the buffered data at the
-        appropriate index. When the class has neither delay nor jitter, takes a fast path that writes the most
-        recent ring frame to the cache class-wide.
-
-        Parameters
-        ----------
-        shared_metadata : SharedSensorMetadata
-            The shared metadata for the sensor.
-        shared_cache : torch.Tensor
-            The shared cache tensor.
-        measured_data_timeline : TensorRingBuffer
-            Pre-delay measured timeline ring for this sensor class slice (current step already written by
-            ``_update_shared_cache``).
-        interpolate : Sequence[bool] | None
-            Whether to interpolate the sensor data for the read delay + jitter. Defaults to False.
-        """
-        # Fast path: when no sensor in the class has any delay or jitter, this is equivalent to copying the most
-        # recent ring frame to the measured cache class-wide. Avoids a Python loop over every sensor. Both flags
-        # are precomputed Python bools (no GPU sync) latched at build / by setters.
-        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
-            shared_cache.copy_(measured_data_timeline.at(0))
-            return
-
-        # Sample uniform jitter in [0, jitter_ts) per env per sensor. One-sided so samples are non-negative;
-        # combined with the `jitter < dt` option constraint, the effective per-step shift is strictly bounded
-        # within [0, 1) steps and cannot wrap the ring.
-        if shared_metadata.has_any_jitter:
-            shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
-            cur_jitter_ts = shared_metadata.cur_jitter_ts
-        else:
-            cur_jitter_ts = None
-
-        if interpolate is None:
-            interpolate = [False for _ in shared_metadata.cache_sizes]
-
-        tensor_start = 0
-        for sensor_idx, (tensor_size, interp) in enumerate(zip(shared_metadata.cache_sizes, interpolate)):
-            # Compute the current delay of the sensor, taking into account jitter if any
-            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
-            if cur_jitter_ts is not None:
-                cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
-
-            # Get int for indexing into ring buffer (0 = most recent, 1 = delayed by one timestep, etc.)
-            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
-
-            # Update shared cached with left data (Zero Order Hold) or linearly interpolated data (First Order)
-            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
-            sensor_cache = shared_cache[:, tensor_slice]
-            data_left = measured_data_timeline.at(cur_delay_ts_int, tensor_slice, per_row=True)
-            if interp:
-                ratio = torch.frac(cur_delay_ts)
-                data_right = measured_data_timeline.at(cur_delay_ts_int + 1, tensor_slice, per_row=True)
-                torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
-            else:
-                sensor_cache.copy_(data_left)
-
-            tensor_start += tensor_size
 
     def _get_formatted_data(self, tensor: torch.Tensor, envs_idx=None) -> torch.Tensor:
         """
@@ -507,35 +506,17 @@ class KinematicSensorMixin(_LinkAttachedSensorMixin, Generic[KinematicSensorMeta
             )
 
 
-@dataclass
-class ImperfectSensorMetadataMixin:
+class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
     """
-    Base shared metadata class for analog sensors that are attached to a RigidEntity.
-    """
+    Standard sensor pipeline: produce raw data into both ground-truth and measured buffers, optionally transform
+    each (and filter the measured branch with stateful history), apply hardware imperfections on the measured
+    timeline slot (PRE-delay snapshot time), sample delay/jitter into ``intermediate_cache``, then post-process
+    into ``return_cache``. Concrete sensors override hooks (``_update_raw_data``, ``_update_current_timestep_data``,
+    ``_apply_transform``, ``_apply_hardware_imperfections``) rather than ``_update_shared_cache`` itself.
 
-    resolution: torch.Tensor = make_tensor_field((0, 0))
-    bias: torch.Tensor = make_tensor_field((0, 0))
-    cur_random_walk: torch.Tensor = make_tensor_field((0, 0))
-    random_walk: torch.Tensor = make_tensor_field((0, 0))
-    cur_noise: torch.Tensor = make_tensor_field((0, 0))
-    noise: torch.Tensor = make_tensor_field((0, 0))
-    jitter_ts: torch.Tensor = make_tensor_field((0, 0))
-    cur_jitter_ts: torch.Tensor = make_tensor_field((0, 0))
-    # Precomputed Python bool flags gate the per-step noise/bias/quantize work without GPU sync. Set at build
-    # from options and refreshed by the corresponding setters. Conservatively True once any sensor has nonzero
-    # value; never flipped back to False (avoids tracking per-sensor state).
-    has_any_noise: bool = False
-    has_any_random_walk: bool = False
-    has_any_bias: bool = False
-    has_any_resolution: bool = False
-
-
-ImperfectSensorMetadataMixinT = TypeVar("ImperfectSensorMetadataMixinT", bound=ImperfectSensorMetadataMixin)
-
-
-class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
-    """
-    Base sensor class for analog sensors that are attached to a RigidEntity.
+    v17: imperfections are applied at snapshot time (PRE-delay) inside the timeline ring's slot 0; the same ring
+    serves both delay sampling and ``read(history_length)`` history. ``_post_process`` is eager (applied once per
+    step at the end of the orchestrator).
     """
 
     @gs.assert_built
@@ -575,7 +556,8 @@ class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
 
     def build(self):
         """
-        Initialize all shared metadata needed to update all noisy sensors.
+        Initialize all shared metadata needed to update all noisy sensors. Time-related state (delays_ts, interpolate)
+        is pushed by ``Sensor.build()``; this method adds the imperfection-parameter state.
         """
         super().build()
         to_tuple = partial(_to_tuple, length_per_value=self._cache_size)
@@ -623,28 +605,142 @@ class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
             self._shared_metadata.has_any_resolution = True
 
     @classmethod
-    def reset(cls, shared_metadata: ImperfectSensorMetadataMixin, shared_ground_truth_cache: torch.Tensor, envs_idx):
+    def reset(cls, shared_metadata: SharedSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
         super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
         shared_metadata.cur_random_walk[envs_idx, ...].fill_(0.0)
 
     @classmethod
-    def _apply_imperfections(cls, shared_metadata: "ImperfectSensorMetadataMixin", output: torch.Tensor):
-        """Transform ground truth into realistic measured data in-place: apply random_walk drift, Gaussian noise,
-        bias, then quantize to the configured resolution. Each contribution is gated by a precomputed Python bool
-        flag (`has_any_*`) so sensor classes with all-zero values pay no GPU work."""
+    def _update_shared_cache(
+        cls,
+        shared_metadata: SharedSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer | None",
+        intermediate_cache: torch.Tensor,
+        return_cache: torch.Tensor,
+    ):
+        # `intermediate_cache` is the pipeline-internal buffer (shape/dtype from `intermediate_spec`).
+        # `return_cache` is in `return_spec` space. When `_post_process` is identity (default), the manager passes
+        # the same buffer for both (zero-copy alias); when overridden, they're distinct buffers and `_post_process`
+        # is applied at the end.
+        if measured_data_timeline is None:
+            cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
+            cls._apply_transform(shared_metadata, current_ground_truth_data_T.T, timeline=None)
+            intermediate_cache.copy_(current_ground_truth_data_T.T)
+        else:
+            cls._update_current_timestep_data(shared_metadata, current_ground_truth_data_T, measured_data_timeline)
+            cls._apply_transform(shared_metadata, current_ground_truth_data_T.T, timeline=None)
+            measured_slot_0 = measured_data_timeline.at(0, copy=False)
+            cls._apply_transform(shared_metadata, measured_slot_0, timeline=measured_data_timeline)
+            # v17: imperfections applied PRE-delay so the timeline ring stores post-noise values that serve both
+            # delay sampling below AND `read(history_length=N)`. Timeline stays in intermediate space — required
+            # for `_apply_transform` filter correctness (previous slots must be in the same data space as `data`).
+            cls._apply_hardware_imperfections(shared_metadata, measured_slot_0)
+            # Inlined delay sampling: writes intermediate_cache from measured_data_timeline.
+            if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
+                intermediate_cache.copy_(measured_slot_0)
+            else:
+                if shared_metadata.has_any_jitter:
+                    shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
+                    cur_jitter_ts = shared_metadata.cur_jitter_ts
+                else:
+                    cur_jitter_ts = None
+                envs_idx = shared_metadata.envs_idx
+                tensor_start = 0
+                for sensor_idx, (tensor_size, interp) in enumerate(
+                    zip(shared_metadata.cache_sizes, shared_metadata.interpolate)
+                ):
+                    cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
+                    if cur_jitter_ts is not None:
+                        cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
+                    cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
+                    tensor_slice = slice(tensor_start, tensor_start + tensor_size)
+                    sensor_cache = intermediate_cache[:, tensor_slice]
+                    data_left = measured_data_timeline.at(cur_delay_ts_int, envs_idx, tensor_slice)
+                    if interp:
+                        ratio = torch.frac(cur_delay_ts)
+                        data_right = measured_data_timeline.at(cur_delay_ts_int + 1, envs_idx, tensor_slice)
+                        torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
+                    else:
+                        sensor_cache.copy_(data_left)
+                    tensor_start += tensor_size
+
+        # v17: eager post-processing. Applied once per step here; `read()` is then a pure view into `return_cache`.
+        # When `_post_process` is the identity default, intermediate_cache IS return_cache (same buffer alias) and
+        # this line is a no-op.
+        if return_cache is not intermediate_cache:
+            return_cache.copy_(cls._post_process(shared_metadata, intermediate_cache))
+
+    @classmethod
+    def _update_current_timestep_data(
+        cls,
+        shared_metadata: SharedSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
+    ):
+        """Write the current timestep's raw signal into both buffers. Default: compute raw GT, then copy to
+        the measured ring's current slot. Override for sensors with kernel-internal physical-response noise."""
+        cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
+        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+
+    @classmethod
+    def _update_raw_data(cls, shared_metadata: SharedSensorMetadata, raw_data_T: torch.Tensor):
+        """Sensor-specific kernel computing raw data into ``raw_data_T`` (shape ``(cols, B)``)."""
+        raise NotImplementedError(f"{cls.__name__} has not implemented `_update_raw_data()`.")
+
+    @classmethod
+    def _apply_transform(
+        cls,
+        shared_metadata: SharedSensorMetadata,
+        data: torch.Tensor,
+        *,
+        timeline: "TensorRingBuffer | None" = None,
+    ):
+        """Coordinate transform + optional stateful filter. Receives ``data`` as a batch-first view
+        ``[B, cache_size, ...]`` and must mutate it in place. ``timeline`` is ``None`` on the GT branch and the
+        measured ring on the measured branch; gate filter logic on ``timeline is not None``."""
+
+    @classmethod
+    def _apply_hardware_imperfections(cls, shared_metadata: SimpleSensorMetadata, measured_slot_0: torch.Tensor):
+        """SimpleSensor's opinionated interpretation of the imperfection parameters (noise, bias, random_walk,
+        resolution) as the perturbations introduced by the embedded sampling layer at snapshot time.
+
+        Applied in-place at slot 0 of the measured timeline (PRE-delay sampling). Each contribution is gated by a
+        precomputed Python bool flag (``has_any_*``) so sensor classes with all-zero values pay no GPU work."""
         if shared_metadata.has_any_random_walk:
             shared_metadata.cur_random_walk += torch.normal(0.0, shared_metadata.random_walk)
-            output += shared_metadata.cur_random_walk
+            measured_slot_0 += shared_metadata.cur_random_walk
         if shared_metadata.has_any_noise:
             torch.normal(0.0, shared_metadata.noise, out=shared_metadata.cur_noise)
-            output += shared_metadata.cur_noise
+            measured_slot_0 += shared_metadata.cur_noise
         if shared_metadata.has_any_bias:
-            output += shared_metadata.bias
+            measured_slot_0 += shared_metadata.bias
         if shared_metadata.has_any_resolution:
             resolution = shared_metadata.resolution
             mask = resolution > gs.EPS
-            output[mask] = torch.round(output[mask] / resolution[mask]) * resolution[mask]
+            measured_slot_0[mask] = torch.round(measured_slot_0[mask] / resolution[mask]) * resolution[mask]
 
-    @classmethod
-    def get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
+    @property
+    def uses_measured_pipeline(self) -> bool:
+        """Smart heuristic for SimpleSensor. Two conditions for opt-out:
+          1. All imperfection parameters are zero AND delay/jitter are zero.
+          2. None of the default pipeline hooks (`_update_current_timestep_data`, `_apply_transform`,
+             `_apply_hardware_imperfections`) are overridden. Once a sensor author overrides any of these,
+             the assumption "measured == transformed GT, no ring needed" can no longer be trusted.
+        The `__func__` identity check is required for classmethods; `cls.method is SimpleSensor.method` always
+        evaluates False because each attribute access creates a new bound-method instance."""
+        cls = type(self)
+        if (
+            cls._update_current_timestep_data.__func__ is not SimpleSensor._update_current_timestep_data.__func__
+            or cls._apply_transform.__func__ is not SimpleSensor._apply_transform.__func__
+            or cls._apply_hardware_imperfections.__func__ is not SimpleSensor._apply_hardware_imperfections.__func__
+        ):
+            return True
+        opts = self._options
+        return (
+            opts.delay > 0.0
+            or opts.jitter > 0.0
+            or np.any(np.asarray(opts.noise, dtype=gs.np_float) > 0.0)
+            or np.any(np.asarray(opts.bias, dtype=gs.np_float) != 0.0)
+            or np.any(np.asarray(opts.random_walk, dtype=gs.np_float) > 0.0)
+            or np.any(np.asarray(opts.resolution, dtype=gs.np_float) > 0.0)
+        )

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -247,20 +247,11 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
         return torch.uint8
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls,
-        shared_metadata: SharedSensorMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-    ):
-        pass
-
-    @classmethod
     def _update_shared_cache(
         cls,
         shared_metadata: SharedSensorMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         # No per-step measured-cache update for cameras (handled lazily on read()).
         pass

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -4,6 +4,7 @@ Camera sensors for rendering: Rasterizer, Raytracer, and Batch Renderer.
 
 import sys
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Type
 
 import numpy as np
@@ -36,6 +37,7 @@ from .base_sensor import (
     KinematicSensorMetadataMixin,
     KinematicSensorMixin,
     Sensor,
+    SensorDataSpec,
     SharedSensorMetadata,
 )
 
@@ -238,22 +240,22 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
 
     # ========================== Cache Integration (shared) ==========================
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
         w, h = self._options.res
-        return ((h, w, 3),)
-
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return torch.uint8
+        return SensorDataSpec(shape=((h, w, 3),), dtype=torch.uint8)
 
     @classmethod
     def _update_shared_cache(
         cls,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
+        measured_data_timeline: "TensorRingBuffer | None",
+        intermediate_cache: torch.Tensor,
+        return_cache: torch.Tensor,
     ):
-        # No per-step measured-cache update for cameras (handled lazily on read()).
+        # No per-step measured-cache update for cameras (handled lazily on read()). Camera inherits
+        # `uses_measured_pipeline = False` from the Sensor base default, so `measured_data_timeline` is always None.
         pass
 
     def _draw_debug(self, context: "RasterizerContext"):

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Type
 
 import numpy as np
@@ -17,12 +18,12 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_torc
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SensorDataSpec,
+    SimpleSensor,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -71,7 +72,7 @@ def _kernel_get_contacts_forces(
 
 
 @dataclass
-class ContactSensorMetadata(SharedSensorMetadata):
+class ContactSensorMetadata(SimpleSensorMetadata):
     """
     Metadata for all rigid contact sensors.
     """
@@ -83,9 +84,11 @@ class ContactSensorMetadata(SharedSensorMetadata):
     # Indices into expanded_links_idx of sensors that have at least one filter link. Lets the GT update skip the
     # 4D contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
     filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    # Per-sensor bool threshold (broadcast over B); _post_process returns `tensor > thresholds`.
+    thresholds: torch.Tensor = make_tensor_field((0,))
 
 
-class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
+class ContactSensor(SimpleSensor[ContactSensorOptions, ContactSensorMetadata]):
     """
     Sensor that returns bool based on whether associated RigidLink is in contact.
     """
@@ -124,35 +127,37 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
                 self._shared_metadata.filtered_sensor_idx, num_sensors, expand=(1,), dim=0
             )
 
-    def _get_return_format(self) -> tuple[int, ...]:
-        return (1,)
+        self._shared_metadata.thresholds = concat_with_tensor(
+            self._shared_metadata.thresholds, float(self._options.threshold), expand=(1,)
+        )
+
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=(1,), dtype=gs.tc_bool)
+
+    @cached_property
+    def intermediate_spec(self) -> SensorDataSpec:
+        # Float kernel output; bool projection happens in `_post_process`. Required override because
+        # `_post_process` is overridden (the dtype differs from return_spec).
+        return SensorDataSpec(shape=(1,), dtype=gs.tc_float)
 
     @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_bool
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ContactSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: ContactSensorMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
         all_contacts = shared_metadata.solver.collider.get_contacts(as_tensor=True, to_torch=True)
         link_a, link_b = all_contacts["link_a"], all_contacts["link_b"]
         if link_a.shape[-1] == 0:
-            current_ground_truth_data_T.zero_()
-            measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+            raw_data_T.zero_()
             return
         if shared_metadata.solver.n_envs == 0:
             link_a, link_b = link_a[None], link_b[None]
 
         is_contact_a = link_a[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         is_contact_b = link_b[..., None, :] == shared_metadata.expanded_links_idx[..., None]
-        result = (is_contact_a | is_contact_b).any(dim=-1)
-        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors
-        # keep the cheap any() result above.
+        # Float-valued contact count per sensor (intermediate cache is float; bool projection in `_post_process`).
+        result = (is_contact_a | is_contact_b).sum(dim=-1).to(dtype=gs.tc_float)
+        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors keep
+        # the cheap aggregate result above.
         if shared_metadata.filtered_sensor_idx.numel() > 0:
             filt = shared_metadata.filtered_sensor_idx
             sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
@@ -160,9 +165,12 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
             filtered_b = (link_a[:, None, :, None] == sub_filter).any(dim=-1)
             sub_is_a = is_contact_a[:, filt, :]
             sub_is_b = is_contact_b[:, filt, :]
-            result[:, filt] = ((sub_is_a & ~filtered_a) | (sub_is_b & ~filtered_b)).any(dim=-1)
-        current_ground_truth_data_T[:] = result.T
-        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+            result[:, filt] = ((sub_is_a & ~filtered_a) | (sub_is_b & ~filtered_b)).sum(dim=-1).to(dtype=gs.tc_float)
+        raw_data_T[:] = result.T
+
+    @classmethod
+    def _post_process(cls, shared_metadata: ContactSensorMetadata, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor > shared_metadata.thresholds
 
     def _draw_debug(self, context: "RasterizerContext"):
         """
@@ -189,7 +197,7 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
 
 
 @dataclass
-class ContactForceSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata):
+class ContactForceSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     """
     Shared metadata for all contact force sensors.
     """
@@ -200,8 +208,7 @@ class ContactForceSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMetada
 
 class ContactForceSensor(
     RigidSensorMixin[ContactForceSensorMetadata],
-    ImperfectSensorMixin[ContactForceSensorMetadata],
-    Sensor[ContactForceSensorOptions, ContactForceSensorMetadata],
+    SimpleSensor[ContactForceSensorOptions, ContactForceSensorMetadata],
 ):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
@@ -225,20 +232,18 @@ class ContactForceSensor(
             self._shared_metadata.max_force, self._options.max_force, expand=(1, 3)
         )
 
-    def _get_return_format(self) -> tuple[int, ...]:
-        return (3,)
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=(3,), dtype=gs.tc_float)
+
+    @cached_property
+    def intermediate_spec(self) -> SensorDataSpec:
+        # Required override because `_post_process` is overridden, even though shape+dtype coincide with return.
+        # The intermediate buffer must be a distinct buffer (the timeline ring is in intermediate space).
+        return self.return_spec
 
     @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ContactForceSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: ContactForceSensorMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
 
         # Note that forcing GPU sync to operate on `slice(0, max(n_contacts))` is usually faster overall.
@@ -249,43 +254,42 @@ class ContactForceSensor(
 
         # Short-circuit if no contacts
         if link_a.shape[-1] == 0:
-            current_ground_truth_data_T.zero_()
-            measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+            raw_data_T.zero_()
+            return
+
+        links_quat = shared_metadata.solver.get_links_quat()
+        if shared_metadata.solver.n_envs == 0:
+            links_quat = links_quat[None]
+
+        if gs.use_zerocopy:
+            force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
+            force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
+            force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
+            sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
+            sensors_quat = links_quat[:, shared_metadata.links_idx]
+            n_envs = max(shared_metadata.solver.n_envs, 1)
+            result = inv_transform_by_quat(sensors_force, sensors_quat)  # (B, n_sensors, 3)
+            raw_data_T[:] = result.permute(1, 2, 0).reshape(-1, n_envs)
         else:
-            links_quat = shared_metadata.solver.get_links_quat()
-            if shared_metadata.solver.n_envs == 0:
-                links_quat = links_quat[None]
+            raw_data_T.zero_()
+            _kernel_get_contacts_forces(
+                force.contiguous(),
+                link_a.contiguous(),
+                link_b.contiguous(),
+                links_quat.contiguous(),
+                shared_metadata.links_idx,
+                raw_data_T,
+            )
 
-            if gs.use_zerocopy:
-                # Forces are aggregated BEFORE moving them in local frame for efficiency
-                force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
-                force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
-                force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
-                sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
-                sensors_quat = links_quat[:, shared_metadata.links_idx]
-                n_envs = max(shared_metadata.solver.n_envs, 1)
-                result = inv_transform_by_quat(sensors_force, sensors_quat)  # (B, n_sensors, 3)
-                current_ground_truth_data_T[:] = result.permute(1, 2, 0).reshape(-1, n_envs)
-            else:
-                current_ground_truth_data_T.zero_()
-                _kernel_get_contacts_forces(
-                    force.contiguous(),
-                    link_a.contiguous(),
-                    link_b.contiguous(),
-                    links_quat.contiguous(),
-                    shared_metadata.links_idx,
-                    current_ground_truth_data_T,
-                )
-
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
-        # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization; for
-        # max_force values that are not multiples of resolution this produces a non-quantized saturation value,
-        # accepted as minor drift in that edge case.
-        measured_per_sensor_view = measured.reshape((measured.shape[0], -1, 3))
-        measured_per_sensor_view.clamp_(min=-shared_metadata.max_force, max=shared_metadata.max_force)
-        measured_per_sensor_view.masked_fill_(torch.abs(measured_per_sensor_view) < shared_metadata.min_force, 0.0)
+    @classmethod
+    def _post_process(cls, shared_metadata: ContactForceSensorMetadata, tensor: torch.Tensor) -> torch.Tensor:
+        # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization (which
+        # happens upstream in `_apply_hardware_imperfections`); for max_force values that are not multiples of
+        # resolution this produces a non-quantized saturation value, accepted as minor drift in that edge case.
+        per_sensor = tensor.reshape((tensor.shape[0], -1, 3))
+        out = per_sensor.clamp(min=-shared_metadata.max_force, max=shared_metadata.max_force)
+        out = out.masked_fill(out.abs() < shared_metadata.min_force, 0.0)
+        return out.reshape(tensor.shape)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -151,6 +151,8 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
         is_contact_a = link_a[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         is_contact_b = link_b[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         result = (is_contact_a | is_contact_b).any(dim=-1)
+        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors
+        # keep the cheap any() result above.
         if shared_metadata.filtered_sensor_idx.numel() > 0:
             filt = shared_metadata.filtered_sensor_idx
             sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
@@ -239,11 +241,13 @@ class ContactForceSensor(
     ):
         assert shared_metadata.solver is not None
 
+        # Note that forcing GPU sync to operate on `slice(0, max(n_contacts))` is usually faster overall.
         all_contacts = shared_metadata.solver.collider.get_contacts(as_tensor=True, to_torch=True)
         force, link_a, link_b = all_contacts["force"], all_contacts["link_a"], all_contacts["link_b"]
         if shared_metadata.solver.n_envs == 0:
             force, link_a, link_b = force[None], link_a[None], link_b[None]
 
+        # Short-circuit if no contacts
         if link_a.shape[-1] == 0:
             current_ground_truth_data_T.zero_()
             measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
@@ -253,6 +257,7 @@ class ContactForceSensor(
                 links_quat = links_quat[None]
 
             if gs.use_zerocopy:
+                # Forces are aggregated BEFORE moving them in local frame for efficiency
                 force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
                 force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
                 force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
@@ -275,6 +280,9 @@ class ContactForceSensor(
         measured = measured_data_timeline.at(0, copy=False)
         measured.copy_(current_ground_truth_data_T.T)
         cls._apply_imperfections(shared_metadata, measured)
+        # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization; for
+        # max_force values that are not multiples of resolution this produces a non-quantized saturation value,
+        # accepted as minor drift in that edge case.
         measured_per_sensor_view = measured.reshape((measured.shape[0], -1, 3))
         measured_per_sensor_view.clamp_(min=-shared_metadata.max_force, max=shared_metadata.max_force)
         measured_per_sensor_view.masked_fill_(torch.abs(measured_per_sensor_view) < shared_metadata.min_force, 0.0)

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -14,6 +14,7 @@ from genesis.options.sensors import (
 )
 from genesis.utils.geom import inv_transform_by_quat, qd_inv_transform_by_quat, transform_by_quat
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_torch, tensor_to_array
+from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import (
     ImperfectSensorMetadataMixin,
@@ -28,7 +29,6 @@ if TYPE_CHECKING:
     from genesis.engine.entities.rigid_entity.rigid_link import RigidLink
     from genesis.engine.solvers import RigidSolver
     from genesis.ext.pyrender.mesh import Mesh
-    from genesis.utils.ring_buffer import TensorRingBuffer
     from genesis.vis.rasterizer_context import RasterizerContext
 
     from .sensor_manager import SensorManager
@@ -132,14 +132,18 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
         return gs.tc_bool
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: ContactSensorMetadata, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: ContactSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         assert shared_metadata.solver is not None
         all_contacts = shared_metadata.solver.collider.get_contacts(as_tensor=True, to_torch=True)
         link_a, link_b = all_contacts["link_a"], all_contacts["link_b"]
         if link_a.shape[-1] == 0:
-            shared_ground_truth_cache.zero_()
+            current_ground_truth_data_T.zero_()
+            measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
             return
         if shared_metadata.solver.n_envs == 0:
             link_a, link_b = link_a[None], link_b[None]
@@ -147,8 +151,6 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
         is_contact_a = link_a[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         is_contact_b = link_b[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         result = (is_contact_a | is_contact_b).any(dim=-1)
-        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors
-        # keep the cheap result computed above.
         if shared_metadata.filtered_sensor_idx.numel() > 0:
             filt = shared_metadata.filtered_sensor_idx
             sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
@@ -157,17 +159,8 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
             sub_is_a = is_contact_a[:, filt, :]
             sub_is_b = is_contact_b[:, filt, :]
             result[:, filt] = ((sub_is_a & ~filtered_a) | (sub_is_b & ~filtered_b)).any(dim=-1)
-        shared_ground_truth_cache[:] = result.T
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ContactSensorMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        cls._apply_delay_to_shared_cache(shared_metadata, shared_cache, buffered_data)
+        current_ground_truth_data_T[:] = result.T
+        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """
@@ -238,69 +231,53 @@ class ContactForceSensor(
         return gs.tc_float
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: ContactForceSensorMetadata, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: ContactForceSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         assert shared_metadata.solver is not None
 
-        # Note that forcing GPU sync to operate on `slice(0, max(n_contacts))` is usually faster overall
         all_contacts = shared_metadata.solver.collider.get_contacts(as_tensor=True, to_torch=True)
         force, link_a, link_b = all_contacts["force"], all_contacts["link_a"], all_contacts["link_b"]
         if shared_metadata.solver.n_envs == 0:
             force, link_a, link_b = force[None], link_a[None], link_b[None]
 
-        # Short-circuit if no contacts
         if link_a.shape[-1] == 0:
-            shared_ground_truth_cache.zero_()
-            return
+            current_ground_truth_data_T.zero_()
+            measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+        else:
+            links_quat = shared_metadata.solver.get_links_quat()
+            if shared_metadata.solver.n_envs == 0:
+                links_quat = links_quat[None]
 
-        links_quat = shared_metadata.solver.get_links_quat()
-        if shared_metadata.solver.n_envs == 0:
-            links_quat = links_quat[None]
+            if gs.use_zerocopy:
+                force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
+                force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
+                force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
+                sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
+                sensors_quat = links_quat[:, shared_metadata.links_idx]
+                n_envs = max(shared_metadata.solver.n_envs, 1)
+                result = inv_transform_by_quat(sensors_force, sensors_quat)  # (B, n_sensors, 3)
+                current_ground_truth_data_T[:] = result.permute(1, 2, 0).reshape(-1, n_envs)
+            else:
+                current_ground_truth_data_T.zero_()
+                _kernel_get_contacts_forces(
+                    force.contiguous(),
+                    link_a.contiguous(),
+                    link_b.contiguous(),
+                    links_quat.contiguous(),
+                    shared_metadata.links_idx,
+                    current_ground_truth_data_T,
+                )
 
-        if gs.use_zerocopy:
-            # Forces are aggregated BEFORE moving them in local frame for efficiency
-            force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
-            force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
-            force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
-            sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
-            sensors_quat = links_quat[:, shared_metadata.links_idx]
-            n_envs = max(shared_metadata.solver.n_envs, 1)
-            result = inv_transform_by_quat(sensors_force, sensors_quat)  # (B, n_sensors, 3)
-            shared_ground_truth_cache[:] = result.permute(1, 2, 0).reshape(-1, n_envs)
-            return
-
-        shared_ground_truth_cache.zero_()
-        _kernel_get_contacts_forces(
-            force.contiguous(),
-            link_a.contiguous(),
-            link_b.contiguous(),
-            links_quat.contiguous(),
-            shared_metadata.links_idx,
-            shared_ground_truth_cache,
-        )
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ContactForceSensorMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        cls._apply_delay_to_shared_cache(
-            shared_metadata,
-            shared_cache,
-            buffered_data,
-            shared_metadata.interpolate,
-        )
-        cls._apply_imperfections(shared_metadata, shared_cache)
-        shared_cache_per_sensor = shared_cache.reshape((shared_cache.shape[0], -1, 3))  # B, n_sensors * 3
-        # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization;
-        # for max_force values that are not multiples of resolution this produces a non-quantized saturation
-        # value, accepted as minor drift in that edge case.
-        shared_cache_per_sensor.clamp_(min=-shared_metadata.max_force, max=shared_metadata.max_force)
-        shared_cache_per_sensor.masked_fill_(torch.abs(shared_cache_per_sensor) < shared_metadata.min_force, 0.0)
+        measured = measured_data_timeline.at(0, copy=False)
+        measured.copy_(current_ground_truth_data_T.T)
+        cls._apply_imperfections(shared_metadata, measured)
+        measured_per_sensor_view = measured.reshape((measured.shape[0], -1, 3))
+        measured_per_sensor_view.clamp_(min=-shared_metadata.max_force, max=shared_metadata.max_force)
+        measured_per_sensor_view.masked_fill_(torch.abs(measured_per_sensor_view) < shared_metadata.min_force, 0.0)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/imu.py
+++ b/genesis/engine/sensors/imu.py
@@ -162,11 +162,14 @@ class IMUSensor(
         return gs.tc_float
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: IMUSharedMetadata, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: IMUSharedMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         """
-        Update the current ground truth values for all IMU sensors.
+        Update ground truth and pre-delay measured IMU values for all sensors of this class.
         """
         # Extract acceleration and gravity in world frame
         assert shared_metadata.solver is not None
@@ -201,36 +204,17 @@ class IMUSensor(
 
         # cache layout: (n_imus * 9, B)
         *batch_size, n_imus, _ = local_acc.shape
-        strided_ground_truth_cache = shared_ground_truth_cache.view(n_imus, 3, 3, *batch_size)
+        strided_ground_truth_cache = current_ground_truth_data_T.view(n_imus, 3, 3, *batch_size)
         strided_ground_truth_cache[:, 0].copy_(local_acc.permute(1, 2, 0))
         strided_ground_truth_cache[:, 1].copy_(local_ang.permute(1, 2, 0))
         strided_ground_truth_cache[:, 2].copy_(local_mag.permute(1, 2, 0))
 
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: IMUSharedMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        """
-        Update the current measured sensor data for all IMU sensors.
-        """
-        cls._apply_delay_to_shared_cache(
-            shared_metadata,
-            shared_cache,
-            buffered_data,
-            shared_metadata.interpolate,
-        )
-
-        # apply rotation matrix to the shared cache
-        shared_cache_xyz_view = shared_cache.view(shared_cache.shape[0], -1, 3)
-        shared_cache_xyz_view.copy_(
-            torch.matmul(shared_metadata.alignment_rot_matrix, shared_cache_xyz_view.unsqueeze(-1)).squeeze(-1)
-        )
-
-        cls._apply_imperfections(shared_metadata, shared_cache)
+        # apply alignment rotation and imperfections to the measured data
+        measured = measured_data_timeline.at(0, copy=False)
+        measured.copy_(current_ground_truth_data_T.T)
+        measured_xyz = measured.view(measured.shape[0], -1, 3)
+        measured_xyz.copy_(torch.matmul(shared_metadata.alignment_rot_matrix, measured_xyz.unsqueeze(-1)).squeeze(-1))
+        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/imu.py
+++ b/genesis/engine/sensors/imu.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, NamedTuple, Type
 
 import numpy as np
@@ -16,12 +17,12 @@ from genesis.utils.geom import (
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SensorDataSpec,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -63,7 +64,7 @@ def _get_cross_axis_coupling_to_alignment_matrix(
 
 
 @dataclass
-class IMUSharedMetadata(RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata):
+class IMUSharedMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     """
     Shared metadata between all IMU sensors.
     """
@@ -83,8 +84,7 @@ class IMUData(NamedTuple):
 
 class IMUSensor(
     RigidSensorMixin[IMUSharedMetadata],
-    ImperfectSensorMixin[IMUSharedMetadata],
-    Sensor[IMUOptions, IMUSharedMetadata, IMUData],
+    SimpleSensor[IMUOptions, IMUSharedMetadata, IMUData],
 ):
     def __init__(self, options: IMUOptions, shared_metadata: IMUSharedMetadata, manager: "SensorManager"):
         # FIXME: Resolution should be made private in mixin, so that it cannot be set by the user directly.
@@ -154,24 +154,12 @@ class IMUSensor(
             self.quat_offset = self._shared_metadata.offsets_quat[0, self._idx]
             self.pos_offset = self._shared_metadata.offsets_pos[0, self._idx]
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (3,), (3,), (3,)
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=((3,), (3,), (3,)), dtype=gs.tc_float)
 
     @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: IMUSharedMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
-        """
-        Update ground truth and pre-delay measured IMU values for all sensors of this class.
-        """
-        # Extract acceleration and gravity in world frame
+    def _update_raw_data(cls, shared_metadata: IMUSharedMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
         gravity = shared_metadata.solver.get_gravity()
         quats = shared_metadata.solver.get_links_quat(links_idx=shared_metadata.links_idx)
@@ -198,23 +186,24 @@ class IMUSensor(
         # acc/ang shape: (B, n_imus, 3)
         local_acc = inv_transform_by_quat(acc - gravity[..., None, :], offset_quats)
         local_ang = inv_transform_by_quat(ang, offset_quats)
-
-        # is now already (n_envs, n_imus, 3), no need for a reshape
         local_mag = inv_transform_by_quat(shared_metadata.magnetic_field_vector, offset_quats)
 
-        # cache layout: (n_imus * 9, B)
         *batch_size, n_imus, _ = local_acc.shape
-        strided_ground_truth_cache = current_ground_truth_data_T.view(n_imus, 3, 3, *batch_size)
-        strided_ground_truth_cache[:, 0].copy_(local_acc.permute(1, 2, 0))
-        strided_ground_truth_cache[:, 1].copy_(local_ang.permute(1, 2, 0))
-        strided_ground_truth_cache[:, 2].copy_(local_mag.permute(1, 2, 0))
+        strided = raw_data_T.view(n_imus, 3, 3, *batch_size)
+        strided[:, 0].copy_(local_acc.permute(1, 2, 0))
+        strided[:, 1].copy_(local_ang.permute(1, 2, 0))
+        strided[:, 2].copy_(local_mag.permute(1, 2, 0))
 
-        # apply alignment rotation and imperfections to the measured data
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        measured_xyz = measured.view(measured.shape[0], -1, 3)
-        measured_xyz.copy_(torch.matmul(shared_metadata.alignment_rot_matrix, measured_xyz.unsqueeze(-1)).squeeze(-1))
-        cls._apply_imperfections(shared_metadata, measured)
+    @classmethod
+    def _apply_transform(
+        cls,
+        shared_metadata: IMUSharedMetadata,
+        data: torch.Tensor,
+        *,
+        timeline=None,
+    ):
+        data_xyz = data.view(data.shape[0], -1, 3)
+        data_xyz.copy_(torch.matmul(shared_metadata.alignment_rot_matrix, data_xyz.unsqueeze(-1)).squeeze(-1))
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -1,5 +1,6 @@
 import math
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import TYPE_CHECKING, Callable, Generic, NamedTuple, Type, TypeVar
 
 import numpy as np
@@ -17,12 +18,12 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 from genesis.utils.raycast_qd import get_triangle_vertices, ray_triangle_intersection
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SensorDataSpec,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -784,7 +785,7 @@ KinematicTactileSensorMetadataMixinT = TypeVar(
 
 class KinematicTactileSensorMixin(Generic[KinematicTactileSensorMetadataMixinT]):
     def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
-        # Store n_probes before super().__init__() since _get_return_format() is called there
+        # Store n_probes before super().__init__() since `return_spec` is read there
         self._probe_local_pos = torch.tensor(sensor_options.probe_local_pos, dtype=gs.tc_float, device=gs.device)
         self._n_probes = int(np.prod(self._probe_local_pos.shape[:-1]))
 
@@ -843,10 +844,6 @@ class KinematicTactileSensorMixin(Generic[KinematicTactileSensorMetadataMixinT])
             self._shared_metadata.probe_radius, probe_radius_tensor, expand=(self._n_probes,)
         )
 
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
-
     def _draw_debug_probes(self, context: "RasterizerContext", get_magnitude: Callable[[int], float]):
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None
 
@@ -904,7 +901,7 @@ class KinematicContactProbeData(NamedTuple):
 
 @dataclass
 class KinematicContactProbeMetadata(
-    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata
+    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata
 ):
     stiffness: torch.Tensor = make_tensor_field((0,))
 
@@ -912,16 +909,16 @@ class KinematicContactProbeMetadata(
 class KinematicContactProbe(
     KinematicTactileSensorMixin[KinematicContactProbeMetadata],
     RigidSensorMixin[KinematicContactProbeMetadata],
-    ImperfectSensorMixin[KinematicContactProbeMetadata],
-    Sensor[KinematicContactProbeOptions, KinematicContactProbeMetadata, KinematicContactProbeData],
+    SimpleSensor[KinematicContactProbeOptions, KinematicContactProbeMetadata, KinematicContactProbeData],
 ):
     """Kinematic contact probe measuring penetration depth along the probe normal on collisions."""
 
     def __init__(self, sensor_options: KinematicContactProbeOptions, sensor_idx: int, sensor_manager: "SensorManager"):
         super().__init__(sensor_options, sensor_idx, sensor_manager)
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._n_probes,), (self._n_probes, 3)
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=((self._n_probes,), (self._n_probes, 3)), dtype=gs.tc_float)
 
     def build(self):
         super().build()
@@ -931,16 +928,11 @@ class KinematicContactProbe(
         )
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: KinematicTactileSensorMetadataMixinT,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: KinematicContactProbeMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
         collider_state = solver.collider._collider_state
 
-        current_ground_truth_data_T.zero_()
+        raw_data_T.zero_()
         _kernel_kinematic_contact_probe(
             shared_metadata.probe_positions,
             shared_metadata.probe_normals,
@@ -962,11 +954,8 @@ class KinematicContactProbe(
             solver.verts_info,
             solver.faces_info,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(context, lambda data: data.penetration)
@@ -974,7 +963,7 @@ class KinematicContactProbe(
 
 @dataclass
 class ElastomerDisplacementSensorMetadata(
-    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata
+    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata
 ):
     contact_buf: torch.Tensor = make_tensor_field((0, 0, 4))
     contact_link_buf: torch.Tensor = make_tensor_field((0, 0))
@@ -1001,8 +990,7 @@ class ElastomerDisplacementSensorMetadata(
 class ElastomerDisplacementSensor(
     KinematicTactileSensorMixin[ElastomerDisplacementSensorMetadata],
     RigidSensorMixin[ElastomerDisplacementSensorMetadata],
-    ImperfectSensorMixin[ElastomerDisplacementSensorMetadata],
-    Sensor[ElastomerDisplacementSensorOptions, ElastomerDisplacementSensorMetadata],
+    SimpleSensor[ElastomerDisplacementSensorOptions, ElastomerDisplacementSensorMetadata],
 ):
     def __init__(
         self, sensor_options: ElastomerDisplacementSensorOptions, sensor_idx: int, sensor_manager: "SensorManager"
@@ -1013,8 +1001,9 @@ class ElastomerDisplacementSensor(
         self._shape = self._probe_local_pos.shape[:-1]
         self._probe_local_pos = self._probe_local_pos.reshape(-1, 3)
 
-    def _get_return_format(self) -> tuple[int, ...]:
-        return (self._n_probes, 3)
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=(self._n_probes, 3), dtype=gs.tc_float)
 
     def build(self):
         super().build()
@@ -1088,12 +1077,7 @@ class ElastomerDisplacementSensor(
         self._shared_metadata.fft_kernel_list.append(kernel_fft)
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ElastomerDisplacementSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: ElastomerDisplacementSensorMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
 
         # Zero buffers allocated with torch.empty to avoid stale data if the kernel
@@ -1126,7 +1110,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.contact_buf,
             shared_metadata.contact_link_buf,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
         _elastomer_displacement_grid_fft_dilate(
             shared_metadata.is_grid,
@@ -1139,7 +1123,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.dilate_coefficient,
             shared_metadata.dilate_max_delta,
             shared_metadata.grid_dilate_out_buffer,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
         _kernel_elastomer_displacement_grid_shear_twist(
             shared_metadata.probe_positions,
@@ -1157,11 +1141,8 @@ class ElastomerDisplacementSensor(
             solver.links_state,
             solver._sim.dt,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(context, lambda data: torch.linalg.norm(data, dim=-1))

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -847,22 +847,6 @@ class KinematicTactileSensorMixin(Generic[KinematicTactileSensorMetadataMixinT])
     def _get_cache_dtype(cls) -> torch.dtype:
         return gs.tc_float
 
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: KinematicTactileSensorMetadataMixinT,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        cls._apply_delay_to_shared_cache(
-            shared_metadata,
-            shared_cache,
-            buffered_data,
-            shared_metadata.interpolate,
-        )
-        cls._apply_imperfections(shared_metadata, shared_cache)
-
     def _draw_debug_probes(self, context: "RasterizerContext", get_magnitude: Callable[[int], float]):
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None
 
@@ -947,13 +931,16 @@ class KinematicContactProbe(
         )
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: KinematicTactileSensorMetadataMixinT, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: KinematicTactileSensorMetadataMixinT,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
         collider_state = solver.collider._collider_state
 
-        shared_ground_truth_cache.zero_()
+        current_ground_truth_data_T.zero_()
         _kernel_kinematic_contact_probe(
             shared_metadata.probe_positions,
             shared_metadata.probe_normals,
@@ -975,8 +962,11 @@ class KinematicContactProbe(
             solver.verts_info,
             solver.faces_info,
             gs.EPS,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
+        measured = measured_data_timeline.at(0, copy=False)
+        measured.copy_(current_ground_truth_data_T.T)
+        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(context, lambda data: data.penetration)
@@ -1098,10 +1088,11 @@ class ElastomerDisplacementSensor(
         self._shared_metadata.fft_kernel_list.append(kernel_fft)
 
     @classmethod
-    def _update_shared_ground_truth_cache(
+    def _update_shared_cache(
         cls,
         shared_metadata: ElastomerDisplacementSensorMetadata,
-        shared_ground_truth_cache: torch.Tensor,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
 
@@ -1135,9 +1126,9 @@ class ElastomerDisplacementSensor(
             shared_metadata.contact_buf,
             shared_metadata.contact_link_buf,
             gs.EPS,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
-
+        # use torch for fft
         _elastomer_displacement_grid_fft_dilate(
             shared_metadata.is_grid,
             shared_metadata.contact_buf,
@@ -1149,7 +1140,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.dilate_coefficient,
             shared_metadata.dilate_max_delta,
             shared_metadata.grid_dilate_out_buffer,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
         _kernel_elastomer_displacement_grid_shear_twist(
             shared_metadata.probe_positions,
@@ -1167,8 +1158,11 @@ class ElastomerDisplacementSensor(
             solver.links_state,
             solver._sim.dt,
             gs.EPS,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
+        measured = measured_data_timeline.at(0, copy=False)
+        measured.copy_(current_ground_truth_data_T.T)
+        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(context, lambda data: torch.linalg.norm(data, dim=-1))

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -1128,7 +1128,6 @@ class ElastomerDisplacementSensor(
             gs.EPS,
             current_ground_truth_data_T,
         )
-        # use torch for fft
         _elastomer_displacement_grid_fft_dilate(
             shared_metadata.is_grid,
             shared_metadata.contact_buf,

--- a/genesis/engine/sensors/proximity.py
+++ b/genesis/engine/sensors/proximity.py
@@ -212,16 +212,19 @@ class ProximitySensor(
         self._nearest_points_slice = slice(slice_start, slice_start + self._n_probes)
 
     @classmethod
-    def reset(cls, shared_metadata: ProximityMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
-        super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
+    def reset(cls, shared_metadata: ProximityMetadata, current_ground_truth_data_T: torch.Tensor, envs_idx):
+        super().reset(shared_metadata, current_ground_truth_data_T, envs_idx)
         shared_metadata.nearest_positions[envs_idx] = shared_metadata.probe_positions
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: ProximityMetadata, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: ProximityMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
-        shared_ground_truth_cache.zero_()
+        current_ground_truth_data_T.zero_()
         _kernel_proximity(
             shared_metadata.probe_positions,
             shared_metadata.probe_sensor_idx,
@@ -243,24 +246,11 @@ class ProximitySensor(
             solver.fixed_verts_state,
             solver.free_verts_state,
             shared_metadata.nearest_positions,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ProximityMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        cls._apply_delay_to_shared_cache(
-            shared_metadata,
-            shared_cache,
-            buffered_data,
-            shared_metadata.interpolate,
-        )
-        cls._apply_imperfections(shared_metadata, shared_cache)
+        measured = measured_data_timeline.at(0, copy=False)
+        measured.copy_(current_ground_truth_data_T.T)
+        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None

--- a/genesis/engine/sensors/proximity.py
+++ b/genesis/engine/sensors/proximity.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
@@ -14,12 +15,12 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 from genesis.utils.raycast_qd import get_triangle_vertices
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SensorDataSpec,
+    SimpleSensorMetadata,
 )
 from .kinematic_tactile import _func_closest_point_on_triangle
 
@@ -131,16 +132,13 @@ class ProximitySensorMetadataMixin:
 
 
 @dataclass
-class ProximityMetadata(
-    ProximitySensorMetadataMixin, RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata
-):
+class ProximityMetadata(ProximitySensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata):
     """Shared metadata for the Proximity sensor class."""
 
 
 class ProximitySensor(
     RigidSensorMixin[ProximityMetadata],
-    ImperfectSensorMixin[ProximityMetadata],
-    Sensor[ProximityOptions, ProximityMetadata, tuple],
+    SimpleSensor[ProximityOptions, ProximityMetadata, tuple],
 ):
     """Proximity sensor: distance and nearest point from probe positions to tracked mesh surfaces."""
 
@@ -151,12 +149,9 @@ class ProximitySensor(
         self._debug_objects: list = []
         self._nearest_points_slice: slice = slice(None)
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._n_probes,)
-
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=(self._n_probes,), dtype=gs.tc_float)
 
     def build(self):
         super().build()
@@ -217,14 +212,9 @@ class ProximitySensor(
         shared_metadata.nearest_positions[envs_idx] = shared_metadata.probe_positions
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ProximityMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: ProximityMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
-        current_ground_truth_data_T.zero_()
+        raw_data_T.zero_()
         _kernel_proximity(
             shared_metadata.probe_positions,
             shared_metadata.probe_sensor_idx,
@@ -246,11 +236,8 @@ class ProximitySensor(
             solver.fixed_verts_state,
             solver.free_verts_state,
             shared_metadata.nearest_positions,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -230,8 +230,8 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
             )
 
     @classmethod
-    def reset(cls, shared_metadata: RaycasterSharedMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
-        super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
+    def reset(cls, shared_metadata: RaycasterSharedMetadata, current_ground_truth_data_T: torch.Tensor, envs_idx):
+        super().reset(shared_metadata, current_ground_truth_data_T, envs_idx)
         cls._update_bvh(shared_metadata)
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
@@ -243,8 +243,11 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
         return gs.tc_float
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: RaycasterSharedMetadata, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: RaycasterSharedMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         cls._update_bvh(shared_metadata)
 
@@ -292,7 +295,7 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
                 shared_metadata.sensor_cache_offsets,
                 shared_metadata.sensor_point_offsets,
                 shared_metadata.sensor_point_counts,
-                shared_ground_truth_cache,
+                current_ground_truth_data_T,
                 gs.EPS,
                 i > 0,
             )
@@ -313,15 +316,7 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
                     *args_common,
                 )
 
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: RaycasterSharedMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        cls._apply_delay_to_shared_cache(shared_metadata, shared_cache, buffered_data)
+        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -1,5 +1,6 @@
 import math
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
@@ -28,7 +29,9 @@ from .base_sensor import (
     KinematicSensorMetadataMixin,
     KinematicSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SensorDataSpec,
+    SimpleSensorMetadata,
+    SimpleSensor,
 )
 
 if TYPE_CHECKING:
@@ -50,7 +53,7 @@ class _SolverBVH(NamedTuple):
 
 
 @dataclass
-class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMetadata):
+class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata):
     # All BVHs (one per active solver per mesh type) cast against each frame. The first is written into the output
     # cache with is_merge=False (initializes hits or no_hit_value), the rest merge in closer hits. Per-sensor link
     # poses are gathered via KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
@@ -85,7 +88,7 @@ class RaycasterData(NamedTuple):
     distances: torch.Tensor
 
 
-class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSharedMetadata, RaycasterData]):
+class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, RaycasterSharedMetadata, RaycasterData]):
     def __init__(self, options: RaycasterOptions, sensor_idx: int, manager: "SensorManager"):
         super().__init__(options, sensor_idx, manager)
         self.debug_objects: list["Mesh"] = []
@@ -234,21 +237,13 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
         super().reset(shared_metadata, current_ground_truth_data_T, envs_idx)
         cls._update_bvh(shared_metadata)
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
         shape = self._options.pattern.return_shape
-        return (*shape, 3), shape
+        return SensorDataSpec(shape=((*shape, 3), shape), dtype=gs.tc_float)
 
     @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
-
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: RaycasterSharedMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: RaycasterSharedMetadata, raw_data_T: torch.Tensor):
         cls._update_bvh(shared_metadata)
 
         # Allocate the link-pose scratch buffers on first cast (B and n_sensors are known here). Identity quat is
@@ -264,8 +259,6 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
             )
             shared_metadata.links_quat[:, :, 0] = 1.0
 
-        # Gather link poses per sensor. Sensors are pre-bucketed into shared_metadata.solver_groups at build time so
-        # this loop issues one bulk get_links_pos / get_links_quat per solver with already-tensor-typed indices.
         links_pos = shared_metadata.links_pos
         links_quat = shared_metadata.links_quat
         for group in shared_metadata.solver_groups:
@@ -295,7 +288,7 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
                 shared_metadata.sensor_cache_offsets,
                 shared_metadata.sensor_point_offsets,
                 shared_metadata.sensor_point_counts,
-                current_ground_truth_data_T,
+                raw_data_T,
                 gs.EPS,
                 i > 0,
             )
@@ -315,8 +308,6 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
                     solver.vgeoms_state,
                     *args_common,
                 )
-
-        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -28,15 +28,16 @@ class SensorManager:
         self._sensors_metadata: dict[type["Sensor"], SharedSensorMetadata | None] = {}
         self._ground_truth_cache: dict[type[torch.dtype], torch.Tensor] = {}
         self._cache: dict[type[torch.dtype], torch.Tensor] = {}
-        self._gt_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Pre-delay instantaneous measured timeline; shares ring idx with _gt_timeline_ring per dtype.
+        self._ground_truth_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
+        # Pre-delay instantaneous measured timeline; shares ring idx with _ground_truth_timeline_ring per dtype.
         self._measured_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
         self._measured_history_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
         # Linearized per-class history of shape (B, max_history_for_class, class_cache_size). Refreshed every step.
         # Lets read_sensors and per-sensor history reads return views instead of re-gathering from the ring.
-        self._linearized_gt_history: dict[type["Sensor"], torch.Tensor] = {}
+        self._linearized_ground_truth_history: dict[type["Sensor"], torch.Tensor] = {}
         self._linearized_measured_history: dict[type["Sensor"], torch.Tensor] = {}
-        # Per-class precomputed history index tensor [0, 1, ..., max_history-1]. Used to fancy-index the rings each step.
+        # Per-class precomputed history index tensor [0, 1, ..., max_history-1]. Used to fancy-index the rings each
+        # step.
         self._hist_idx_by_class: dict[type["Sensor"], torch.Tensor] = {}
         self._cache_slices_by_type: dict[type["Sensor"], slice] = {}
         # (sensor class, entity_idx) -> slice within the class cache. entity_idx == -1 means static sensors.
@@ -153,10 +154,10 @@ class SensorManager:
             }
             self._max_history_by_class[sensor_cls] = cls_max_history
 
-        self._gt_timeline_ring.clear()
+        self._ground_truth_timeline_ring.clear()
         self._measured_timeline_ring.clear()
         self._measured_history_ring.clear()
-        self._linearized_gt_history.clear()
+        self._linearized_ground_truth_history.clear()
         self._linearized_measured_history.clear()
         self._hist_idx_by_class.clear()
 
@@ -171,9 +172,9 @@ class SensorManager:
             delay_n = max(delay_depth_per_dtype.get(dtype, 1), 1)
             hist_n = max_history_per_dtype.get(dtype, 0)
             ring_n = max(delay_n, hist_n)
-            self._gt_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
+            self._ground_truth_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
             self._measured_timeline_ring[dtype] = TensorRingBuffer(
-                ring_n, cache_shape, dtype=dtype, idx=self._gt_timeline_ring[dtype]._idx
+                ring_n, cache_shape, dtype=dtype, idx=self._ground_truth_timeline_ring[dtype]._idx
             )
             if hist_n > 0:
                 self._measured_history_ring[dtype] = TensorRingBuffer(hist_n, cache_shape, dtype=dtype)
@@ -186,7 +187,7 @@ class SensorManager:
             cache_slice = self._cache_slices_by_type[sensor_cls]
             cls_size = cache_slice.stop - cache_slice.start
             shape = (self._sim._B, cls_max_history, cls_size)
-            self._linearized_gt_history[sensor_cls] = torch.zeros(shape, dtype=dtype, device=gs.device)
+            self._linearized_ground_truth_history[sensor_cls] = torch.zeros(shape, dtype=dtype, device=gs.device)
             self._linearized_measured_history[sensor_cls] = torch.zeros(shape, dtype=dtype, device=gs.device)
             self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
 
@@ -211,7 +212,7 @@ class SensorManager:
         for dtype in self._ground_truth_cache.keys():
             self._ground_truth_cache[dtype][:, envs_idx] = 0.0
             self._cache[dtype][envs_idx] = 0.0
-            self._gt_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
+            self._ground_truth_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
             self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
             if dtype in self._measured_history_ring:
                 self._measured_history_ring[dtype].buffer[:, envs_idx] = 0.0
@@ -219,7 +220,7 @@ class SensorManager:
                 key = (is_ground_truth, dtype)
                 self._is_last_cache_cloned[key] = False
 
-        for linearized in self._linearized_gt_history.values():
+        for linearized in self._linearized_ground_truth_history.values():
             linearized[envs_idx] = 0.0
         for linearized in self._linearized_measured_history.values():
             linearized[envs_idx] = 0.0
@@ -229,47 +230,8 @@ class SensorManager:
             cache_slice = self._cache_slices_by_type[sensor_cls]
             sensor_cls.reset(self._sensors_metadata[sensor_cls], self._ground_truth_cache[dtype][cache_slice], envs_idx)
 
-    def _apply_delay_to_shared_cache(
-        self,
-        shared_metadata: SharedSensorMetadata,
-        shared_cache: torch.Tensor,
-        source_ring: TensorRingBuffer,
-    ) -> None:
-        """Sample ``source_ring`` (pre-delay measured timeline) into ``shared_cache`` using delay_ts and jitter."""
-        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
-            shared_cache.copy_(source_ring.at(0))
-            return
-
-        if shared_metadata.has_any_jitter:
-            shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
-            cur_jitter_ts = shared_metadata.cur_jitter_ts
-        else:
-            cur_jitter_ts = None
-
-        interpolate = shared_metadata.interpolate
-        tensor_start = 0
-        envs_idx = self._sim._scene._envs_idx
-        for sensor_idx, (tensor_size, interp) in enumerate(zip(shared_metadata.cache_sizes, interpolate)):
-            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
-            if cur_jitter_ts is not None:
-                cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
-
-            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
-
-            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
-            sensor_cache = shared_cache[:, tensor_slice]
-            data_left = source_ring.at(cur_delay_ts_int, envs_idx, tensor_slice)
-            if interp:
-                ratio = torch.frac(cur_delay_ts)
-                data_right = source_ring.at(cur_delay_ts_int + 1, envs_idx, tensor_slice)
-                torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
-            else:
-                sensor_cache.copy_(data_left)
-
-            tensor_start += tensor_size
-
     def step(self):
-        for ring in self._gt_timeline_ring.values():
+        for ring in self._ground_truth_timeline_ring.values():
             ring.rotate()
         for ring in self._measured_history_ring.values():
             ring.rotate()
@@ -277,14 +239,18 @@ class SensorManager:
         for sensor_cls in self._sensors_by_type.keys():
             dtype = sensor_cls._get_cache_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
-            gt_slice = self._ground_truth_cache[dtype][cache_slice]
+            ground_truth_slice = self._ground_truth_cache[dtype][cache_slice]
             measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
-            sensor_cls._update_shared_cache(self._sensors_metadata[sensor_cls], gt_slice, measured_data_timeline)
-            self._gt_timeline_ring[dtype][:, cache_slice].set(gt_slice.T)
-            self._apply_delay_to_shared_cache(
-                self._sensors_metadata[sensor_cls],
+            shared_metadata = self._sensors_metadata[sensor_cls]
+            sensor_cls._update_shared_cache(shared_metadata, ground_truth_slice, measured_data_timeline)
+            # GT timeline ring write is required: history reads access older slots even at delay=0, so the slot
+            # for the current step must be populated independent of the delay sampling that follows.
+            self._ground_truth_timeline_ring[dtype][:, cache_slice].set(ground_truth_slice.T)
+            sensor_cls._apply_delay_to_shared_cache(
+                shared_metadata,
                 self._cache[dtype][:, cache_slice],
                 measured_data_timeline,
+                shared_metadata.interpolate,
             )
             if dtype in self._measured_history_ring:
                 self._measured_history_ring[dtype][:, cache_slice].set(self._cache[dtype][:, cache_slice])
@@ -299,8 +265,8 @@ class SensorManager:
             dtype = sensor_cls._get_cache_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
             hist_idx = self._hist_idx_by_class[sensor_cls]
-            gt_view = self._gt_timeline_ring[dtype].at(hist_idx, slice(None), cache_slice)
-            self._linearized_gt_history[sensor_cls].copy_(gt_view.transpose(0, 1))
+            ground_truth_view = self._ground_truth_timeline_ring[dtype].at(hist_idx, slice(None), cache_slice)
+            self._linearized_ground_truth_history[sensor_cls].copy_(ground_truth_view.transpose(0, 1))
             meas_view = self._measured_history_ring[dtype].at(hist_idx, slice(None), cache_slice)
             self._linearized_measured_history[sensor_cls].copy_(meas_view.transpose(0, 1))
 
@@ -315,7 +281,7 @@ class SensorManager:
         if history_length > 0:
             sensor_cls = type(sensor)
             linearized = (
-                self._linearized_gt_history[sensor_cls]
+                self._linearized_ground_truth_history[sensor_cls]
                 if is_ground_truth
                 else self._linearized_measured_history[sensor_cls]
             )
@@ -394,7 +360,7 @@ class SensorManager:
             cls_max_history = self._max_history_by_class[sensor_cls]
             if cls_max_history > 0:
                 linearized = (
-                    self._linearized_gt_history[sensor_cls]
+                    self._linearized_ground_truth_history[sensor_cls]
                     if is_ground_truth
                     else self._linearized_measured_history[sensor_cls]
                 )

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -10,10 +10,12 @@ from genesis.options.sensors import types as _sensor_types_namespace
 from genesis.options.sensors.options import SensorOptions
 from genesis.utils.ring_buffer import TensorRingBuffer
 
+from .base_sensor import SharedSensorMetadata
+
 if TYPE_CHECKING:
     from genesis.vis.rasterizer_context import RasterizerContext
 
-    from .base_sensor import Sensor, SharedSensorMetadata
+    from .base_sensor import Sensor
 
 
 class SensorManager:
@@ -27,6 +29,8 @@ class SensorManager:
         self._ground_truth_cache: dict[type[torch.dtype], torch.Tensor] = {}
         self._cache: dict[type[torch.dtype], torch.Tensor] = {}
         self._gt_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
+        # Pre-delay instantaneous measured timeline; shares ring idx with _gt_timeline_ring per dtype.
+        self._measured_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
         self._measured_history_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
         # Linearized per-class history of shape (B, max_history_for_class, class_cache_size). Refreshed every step.
         # Lets read_sensors and per-sensor history reads return views instead of re-gathering from the ring.
@@ -150,6 +154,7 @@ class SensorManager:
             self._max_history_by_class[sensor_cls] = cls_max_history
 
         self._gt_timeline_ring.clear()
+        self._measured_timeline_ring.clear()
         self._measured_history_ring.clear()
         self._linearized_gt_history.clear()
         self._linearized_measured_history.clear()
@@ -165,7 +170,11 @@ class SensorManager:
             self._cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
             delay_n = max(delay_depth_per_dtype.get(dtype, 1), 1)
             hist_n = max_history_per_dtype.get(dtype, 0)
-            self._gt_timeline_ring[dtype] = TensorRingBuffer(max(delay_n, hist_n), cache_shape, dtype=dtype)
+            ring_n = max(delay_n, hist_n)
+            self._gt_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
+            self._measured_timeline_ring[dtype] = TensorRingBuffer(
+                ring_n, cache_shape, dtype=dtype, idx=self._gt_timeline_ring[dtype]._idx
+            )
             if hist_n > 0:
                 self._measured_history_ring[dtype] = TensorRingBuffer(hist_n, cache_shape, dtype=dtype)
 
@@ -203,6 +212,7 @@ class SensorManager:
             self._ground_truth_cache[dtype][:, envs_idx] = 0.0
             self._cache[dtype][envs_idx] = 0.0
             self._gt_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
+            self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
             if dtype in self._measured_history_ring:
                 self._measured_history_ring[dtype].buffer[:, envs_idx] = 0.0
             for is_ground_truth in (False, True):
@@ -219,6 +229,45 @@ class SensorManager:
             cache_slice = self._cache_slices_by_type[sensor_cls]
             sensor_cls.reset(self._sensors_metadata[sensor_cls], self._ground_truth_cache[dtype][cache_slice], envs_idx)
 
+    def _apply_delay_to_shared_cache(
+        self,
+        shared_metadata: SharedSensorMetadata,
+        shared_cache: torch.Tensor,
+        source_ring: TensorRingBuffer,
+    ) -> None:
+        """Sample ``source_ring`` (pre-delay measured timeline) into ``shared_cache`` using delay_ts and jitter."""
+        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
+            shared_cache.copy_(source_ring.at(0))
+            return
+
+        if shared_metadata.has_any_jitter:
+            shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
+            cur_jitter_ts = shared_metadata.cur_jitter_ts
+        else:
+            cur_jitter_ts = None
+
+        interpolate = shared_metadata.interpolate
+        tensor_start = 0
+        envs_idx = self._sim._scene._envs_idx
+        for sensor_idx, (tensor_size, interp) in enumerate(zip(shared_metadata.cache_sizes, interpolate)):
+            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
+            if cur_jitter_ts is not None:
+                cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
+
+            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
+
+            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
+            sensor_cache = shared_cache[:, tensor_slice]
+            data_left = source_ring.at(cur_delay_ts_int, envs_idx, tensor_slice)
+            if interp:
+                ratio = torch.frac(cur_delay_ts)
+                data_right = source_ring.at(cur_delay_ts_int + 1, envs_idx, tensor_slice)
+                torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
+            else:
+                sensor_cache.copy_(data_left)
+
+            tensor_start += tensor_size
+
     def step(self):
         for ring in self._gt_timeline_ring.values():
             ring.rotate()
@@ -229,15 +278,13 @@ class SensorManager:
             dtype = sensor_cls._get_cache_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
             gt_slice = self._ground_truth_cache[dtype][cache_slice]
-            sensor_cls._update_shared_ground_truth_cache(self._sensors_metadata[sensor_cls], gt_slice)
-            # GT timeline ring write is required: _apply_delay_to_shared_cache reads from the ring even at delay=0,
-            # so even noiseless/no-delay sensor classes need the current frame written each step.
+            measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
+            sensor_cls._update_shared_cache(self._sensors_metadata[sensor_cls], gt_slice, measured_data_timeline)
             self._gt_timeline_ring[dtype][:, cache_slice].set(gt_slice.T)
-            sensor_cls._update_shared_cache(
+            self._apply_delay_to_shared_cache(
                 self._sensors_metadata[sensor_cls],
-                gt_slice.T,
                 self._cache[dtype][:, cache_slice],
-                self._gt_timeline_ring[dtype][:, cache_slice],
+                measured_data_timeline,
             )
             if dtype in self._measured_history_ring:
                 self._measured_history_ring[dtype][:, cache_slice].set(self._cache[dtype][:, cache_slice])

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -26,12 +26,19 @@ class SensorManager:
         self._sim = sim
         self._sensors_by_type: dict[type["Sensor"], list["Sensor"]] = {}
         self._sensors_metadata: dict[type["Sensor"], SharedSensorMetadata | None] = {}
-        self._ground_truth_cache: dict[type[torch.dtype], torch.Tensor] = {}
-        self._cache: dict[type[torch.dtype], torch.Tensor] = {}
+        # Per-dtype intermediate caches: pre-`_post_process` storage in intermediate space. The transposed GT cache
+        # is `(cols, B)` for C-contiguous per-class row slices required by kernel writes.
+        self._ground_truth_intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
+        self._intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
+        # Per-class return caches: post-`_post_process` storage in return space. When `_post_process` is identity,
+        # alias-views into the per-dtype intermediate cache; when overridden, separate buffers in return shape/dtype.
+        self._return_cache: dict[type["Sensor"], torch.Tensor] = {}
+        self._ground_truth_return_cache: dict[type["Sensor"], torch.Tensor] = {}
         self._ground_truth_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Pre-delay instantaneous measured timeline; shares ring idx with _ground_truth_timeline_ring per dtype.
+        # Measured timeline: post-imperfection, pre-delay snapshots. Shares ring idx with _ground_truth_timeline_ring
+        # per dtype. v17 has no separate measured-history ring (history is served from this ring's slots or from the
+        # per-class linearized history buffer).
         self._measured_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        self._measured_history_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
         # Linearized per-class history of shape (B, max_history_for_class, class_cache_size). Refreshed every step.
         # Lets read_sensors and per-sensor history reads return views instead of re-gathering from the ring.
         self._linearized_ground_truth_history: dict[type["Sensor"], torch.Tensor] = {}
@@ -43,8 +50,6 @@ class SensorManager:
         # (sensor class, entity_idx) -> slice within the class cache. entity_idx == -1 means static sensors.
         self._entity_slice_in_class: dict[type["Sensor"], dict[int, slice]] = {}
         self._max_history_by_class: dict[type["Sensor"], int] = {}
-        self._is_last_cache_cloned: dict[tuple[bool, type[torch.dtype]], bool] = {}
-        self._cloned_cache: dict[tuple[bool, type[torch.dtype]], torch.Tensor] = {}
 
     def create_sensor(self, sensor_options: "SensorOptions") -> "Sensor":
         sensor_options.validate_scene(self._sim.scene)
@@ -117,28 +122,36 @@ class SensorManager:
             for new_idx, sensor in enumerate(sensors):
                 sensor._idx = new_idx
 
-        cache_size_per_dtype = {}
-        delay_depth_per_dtype: dict[type[torch.dtype], int] = {}
-        max_history_per_dtype: dict[type[torch.dtype], int] = {}
+        # Per-class intermediate dtype is the dtype of `sensor.intermediate_spec`. Per-class return dtype is the
+        # dtype of `sensor.return_spec`. All instances of a sensor class share the same intermediate / return
+        # dtypes (specs may vary by shape per-instance but dtype is class-uniform); use any-instance's spec.
+        cache_size_per_dtype: dict[torch.dtype, int] = {}
+        delay_depth_per_dtype: dict[torch.dtype, int] = {}
+        max_history_per_dtype: dict[torch.dtype, int] = {}
+        intermediate_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
+        return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
-            dtype = sensor_cls._get_cache_dtype()
+            intermediate_dtype = sensors[0].intermediate_spec.dtype
+            return_dtype = sensors[0].return_spec.dtype
+            intermediate_dtype_by_class[sensor_cls] = intermediate_dtype
+            return_dtype_by_class[sensor_cls] = return_dtype
 
-            for is_ground_truth in (False, True):
-                key = (is_ground_truth, dtype)
-                self._is_last_cache_cloned[key] = False
-
-            cache_size_per_dtype.setdefault(dtype, 0)
-            cls_cache_start_idx = cache_size_per_dtype[dtype]
+            cache_size_per_dtype.setdefault(intermediate_dtype, 0)
+            cls_cache_start_idx = cache_size_per_dtype[intermediate_dtype]
             entity_offsets: dict[int, list[int]] = {}
             cls_offset = 0
             cls_max_history = 0
             for sensor in sensors:
-                sensor._cache_idx = cache_size_per_dtype[dtype]
-                cache_size_per_dtype[dtype] += sensor._cache_size
-                delay_depth_per_dtype[dtype] = max(delay_depth_per_dtype.get(dtype, 0), sensor._delay_ts + 1)
+                sensor._cache_idx = cache_size_per_dtype[intermediate_dtype]
+                cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
+                delay_depth_per_dtype[intermediate_dtype] = max(
+                    delay_depth_per_dtype.get(intermediate_dtype, 0), sensor._delay_ts + 1
+                )
                 hist = sensor._options.history_length
                 if hist > 0:
-                    max_history_per_dtype[dtype] = max(max_history_per_dtype.get(dtype, 0), hist)
+                    max_history_per_dtype[intermediate_dtype] = max(
+                        max_history_per_dtype.get(intermediate_dtype, 0), hist
+                    )
                     cls_max_history = max(cls_max_history, hist)
                 eid = sensor._options.entity_idx
                 if eid in entity_offsets:
@@ -147,7 +160,7 @@ class SensorManager:
                     entity_offsets[eid] = [cls_offset, cls_offset + sensor._cache_size]
                 cls_offset += sensor._cache_size
 
-            cls_cache_end_idx = cache_size_per_dtype[dtype]
+            cls_cache_end_idx = cache_size_per_dtype[intermediate_dtype]
             self._cache_slices_by_type[sensor_cls] = slice(cls_cache_start_idx, cls_cache_end_idx)
             self._entity_slice_in_class[sensor_cls] = {
                 eid: slice(start, stop) for eid, (start, stop) in entity_offsets.items()
@@ -156,34 +169,65 @@ class SensorManager:
 
         self._ground_truth_timeline_ring.clear()
         self._measured_timeline_ring.clear()
-        self._measured_history_ring.clear()
+        self._return_cache.clear()
+        self._ground_truth_return_cache.clear()
         self._linearized_ground_truth_history.clear()
         self._linearized_measured_history.clear()
         self._hist_idx_by_class.clear()
 
-        for dtype in cache_size_per_dtype.keys():
-            cache_shape = (self._sim._B, cache_size_per_dtype[dtype])
+        dtype_uses_measured: dict[torch.dtype, bool] = {}
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = intermediate_dtype_by_class[sensor_cls]
+            cur = dtype_uses_measured.get(dtype, False)
+            dtype_uses_measured[dtype] = cur or any(sensor.uses_measured_pipeline for sensor in sensors)
+
+        for dtype, total_cols in cache_size_per_dtype.items():
+            cache_shape = (self._sim._B, total_cols)
             # Ground truth cache is stored transposed (cols, B) so that per-class row slices are C-contiguous,
             # which is required for kernel writes. The cache and ring buffer stay (B, cols) since they only
             # receive data via .copy_() / torch.lerp which handle non-contiguous targets.
-            gt_cache_shape = (cache_size_per_dtype[dtype], self._sim._B)
-            self._ground_truth_cache[dtype] = torch.zeros(gt_cache_shape, dtype=dtype, device=gs.device)
-            self._cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
+            gt_cache_shape = (total_cols, self._sim._B)
+            self._ground_truth_intermediate_cache[dtype] = torch.zeros(gt_cache_shape, dtype=dtype, device=gs.device)
+            self._intermediate_cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
             delay_n = max(delay_depth_per_dtype.get(dtype, 1), 1)
             hist_n = max_history_per_dtype.get(dtype, 0)
             ring_n = max(delay_n, hist_n)
             self._ground_truth_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
-            self._measured_timeline_ring[dtype] = TensorRingBuffer(
-                ring_n, cache_shape, dtype=dtype, idx=self._ground_truth_timeline_ring[dtype]._idx
-            )
-            if hist_n > 0:
-                self._measured_history_ring[dtype] = TensorRingBuffer(hist_n, cache_shape, dtype=dtype)
+            if dtype_uses_measured[dtype]:
+                self._measured_timeline_ring[dtype] = TensorRingBuffer(
+                    ring_n, cache_shape, dtype=dtype, idx=self._ground_truth_timeline_ring[dtype]._idx
+                )
 
-        # Per-class linearized history buffers. Refreshed every step from the ring.
+        # Per-class return caches. View alias into intermediate when `_post_process` is identity; separate buffer
+        # when overridden.
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            intermediate_dtype = intermediate_dtype_by_class[sensor_cls]
+            return_dtype = return_dtype_by_class[sensor_cls]
+            cls_slice = self._cache_slices_by_type[sensor_cls]
+            if self._post_process_is_overridden(sensor_cls):
+                # Separate return buffer in return dtype.
+                cls_size = cls_slice.stop - cls_slice.start
+                self._return_cache[sensor_cls] = torch.zeros(
+                    (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
+                )
+                self._ground_truth_return_cache[sensor_cls] = torch.zeros(
+                    (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
+                )
+            else:
+                # Alias view of the intermediate cache's class slice. Same dtype/shape; no extra allocation.
+                self._return_cache[sensor_cls] = self._intermediate_cache[intermediate_dtype][:, cls_slice]
+                self._ground_truth_return_cache[sensor_cls] = self._ground_truth_intermediate_cache[intermediate_dtype][
+                    cls_slice, :
+                ].T
+
+        for sensor_cls in self._sensors_by_type.keys():
+            self._sensors_metadata[sensor_cls].envs_idx = self._sim._scene._envs_idx
+
+        # Per-class linearized history buffers. Refreshed every step from the timeline ring.
         for sensor_cls, cls_max_history in self._max_history_by_class.items():
             if cls_max_history == 0:
                 continue
-            dtype = sensor_cls._get_cache_dtype()
+            dtype = intermediate_dtype_by_class[sensor_cls]
             cache_slice = self._cache_slices_by_type[sensor_cls]
             cls_size = cache_slice.stop - cache_slice.start
             shape = (self._sim._B, cls_max_history, cls_size)
@@ -195,6 +239,12 @@ class SensorManager:
             for sensor in sensors:
                 sensor.build()
                 sensor._is_built = True
+
+    @staticmethod
+    def _post_process_is_overridden(sensor_cls: type["Sensor"]) -> bool:
+        from .base_sensor import Sensor as _Sensor
+
+        return sensor_cls._post_process.__func__ is not _Sensor._post_process.__func__
 
     def destroy(self):
         for sensors_metadata in self._sensors_metadata.values():
@@ -209,66 +259,75 @@ class SensorManager:
 
         envs_idx = self._sim._scene._sanitize_envs_idx(envs_idx)
 
-        for dtype in self._ground_truth_cache.keys():
-            self._ground_truth_cache[dtype][:, envs_idx] = 0.0
-            self._cache[dtype][envs_idx] = 0.0
+        for dtype in self._ground_truth_intermediate_cache.keys():
+            self._ground_truth_intermediate_cache[dtype][:, envs_idx] = 0.0
+            self._intermediate_cache[dtype][envs_idx] = 0.0
             self._ground_truth_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
-            self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
-            if dtype in self._measured_history_ring:
-                self._measured_history_ring[dtype].buffer[:, envs_idx] = 0.0
-            for is_ground_truth in (False, True):
-                key = (is_ground_truth, dtype)
-                self._is_last_cache_cloned[key] = False
+            if dtype in self._measured_timeline_ring:
+                self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
+
+        # Reset per-class return caches that are distinct buffers (overridden `_post_process`); alias views are
+        # already cleared via the intermediate-cache zero above.
+        for sensor_cls, return_cache in self._return_cache.items():
+            if self._post_process_is_overridden(sensor_cls):
+                return_cache[envs_idx] = 0
+                self._ground_truth_return_cache[sensor_cls][envs_idx] = 0
 
         for linearized in self._linearized_ground_truth_history.values():
             linearized[envs_idx] = 0.0
         for linearized in self._linearized_measured_history.values():
             linearized[envs_idx] = 0.0
 
-        for sensor_cls in self._sensors_by_type.keys():
-            dtype = sensor_cls._get_cache_dtype()
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = sensors[0].intermediate_spec.dtype
             cache_slice = self._cache_slices_by_type[sensor_cls]
-            sensor_cls.reset(self._sensors_metadata[sensor_cls], self._ground_truth_cache[dtype][cache_slice], envs_idx)
+            sensor_cls.reset(
+                self._sensors_metadata[sensor_cls],
+                self._ground_truth_intermediate_cache[dtype][cache_slice],
+                envs_idx,
+            )
 
     def step(self):
         for ring in self._ground_truth_timeline_ring.values():
             ring.rotate()
-        for ring in self._measured_history_ring.values():
-            ring.rotate()
 
-        for sensor_cls in self._sensors_by_type.keys():
-            dtype = sensor_cls._get_cache_dtype()
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = sensors[0].intermediate_spec.dtype
             cache_slice = self._cache_slices_by_type[sensor_cls]
-            ground_truth_slice = self._ground_truth_cache[dtype][cache_slice]
-            measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
-            shared_metadata = self._sensors_metadata[sensor_cls]
-            sensor_cls._update_shared_cache(shared_metadata, ground_truth_slice, measured_data_timeline)
-            # GT timeline ring write is required: history reads access older slots even at delay=0, so the slot
-            # for the current step must be populated independent of the delay sampling that follows.
-            self._ground_truth_timeline_ring[dtype][:, cache_slice].set(ground_truth_slice.T)
-            sensor_cls._apply_delay_to_shared_cache(
-                shared_metadata,
-                self._cache[dtype][:, cache_slice],
+            ground_truth_slice = self._ground_truth_intermediate_cache[dtype][cache_slice]
+            if dtype in self._measured_timeline_ring:
+                measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
+            else:
+                measured_data_timeline = None
+            sensor_cls._update_shared_cache(
+                self._sensors_metadata[sensor_cls],
+                ground_truth_slice,
                 measured_data_timeline,
-                shared_metadata.interpolate,
+                self._intermediate_cache[dtype][:, cache_slice],
+                self._return_cache[sensor_cls],
             )
-            if dtype in self._measured_history_ring:
-                self._measured_history_ring[dtype][:, cache_slice].set(self._cache[dtype][:, cache_slice])
-            for is_ground_truth in (False, True):
-                key = (is_ground_truth, dtype)
-                self._is_last_cache_cloned[key] = False
+            # GT timeline ring write is required: history reads access older slots even at delay=0, so the slot for
+            # the current step must be populated independent of the delay sampling done inside `_update_shared_cache`.
+            self._ground_truth_timeline_ring[dtype][:, cache_slice].set(ground_truth_slice.T)
+            # Mirror eager `_post_process` for the GT path. The orchestrator handles the measured path; here we
+            # populate the GT return cache from the GT intermediate slice. No-op when buffers alias.
+            if self._post_process_is_overridden(sensor_cls):
+                gt_return = self._ground_truth_return_cache[sensor_cls]
+                gt_return.copy_(sensor_cls._post_process(self._sensors_metadata[sensor_cls], ground_truth_slice.T))
 
-        # Linearize per-class history once per step so that per-sensor and bulk reads are pure views.
+        # Linearize per-class history once per step so that per-sensor and bulk reads are pure views. Stored in
+        # intermediate space; sensors with overridden `_post_process` apply it per-slot on retrieval (rare path).
         for sensor_cls, cls_max_history in self._max_history_by_class.items():
             if cls_max_history == 0:
                 continue
-            dtype = sensor_cls._get_cache_dtype()
+            dtype = self._sensors_by_type[sensor_cls][0].intermediate_spec.dtype
             cache_slice = self._cache_slices_by_type[sensor_cls]
             hist_idx = self._hist_idx_by_class[sensor_cls]
             ground_truth_view = self._ground_truth_timeline_ring[dtype].at(hist_idx, slice(None), cache_slice)
             self._linearized_ground_truth_history[sensor_cls].copy_(ground_truth_view.transpose(0, 1))
-            meas_view = self._measured_history_ring[dtype].at(hist_idx, slice(None), cache_slice)
-            self._linearized_measured_history[sensor_cls].copy_(meas_view.transpose(0, 1))
+            if dtype in self._measured_timeline_ring:
+                meas_view = self._measured_timeline_ring[dtype].at(hist_idx, slice(None), cache_slice)
+                self._linearized_measured_history[sensor_cls].copy_(meas_view.transpose(0, 1))
 
     def draw_debug(self, context: "RasterizerContext"):
         for sensor in self.sensors:
@@ -276,31 +335,35 @@ class SensorManager:
                 sensor._draw_debug(context)
 
     def get_cloned_from_cache(self, sensor: "Sensor", is_ground_truth: bool = False) -> torch.Tensor:
-        dtype = sensor._get_cache_dtype()
+        sensor_cls = type(sensor)
+        cls_slice = self._cache_slices_by_type[sensor_cls]
+        rel_start = sensor._cache_idx - cls_slice.start
         history_length = sensor._options.history_length
+
         if history_length > 0:
-            sensor_cls = type(sensor)
             linearized = (
                 self._linearized_ground_truth_history[sensor_cls]
                 if is_ground_truth
                 else self._linearized_measured_history[sensor_cls]
             )
-            cls_slice = self._cache_slices_by_type[sensor_cls]
-            rel_start = sensor._cache_idx - cls_slice.start
             sensor_hist = linearized[:, :history_length, rel_start : rel_start + sensor._cache_size]
+            # When `_post_process` is overridden, the linearized buffer is in intermediate space; apply per-slot.
+            if self._post_process_is_overridden(sensor_cls):
+                metadata = self._sensors_metadata[sensor_cls]
+                # sensor_hist: (B, H, n) — flatten H into B for per-call _post_process, then unflatten.
+                B, H, n = sensor_hist.shape
+                projected = sensor_cls._post_process(metadata, sensor_hist.reshape(B * H, n)).reshape(B, H, -1)
+                sensor_hist = projected
             blocks = [sensor_hist[..., rel_slice].flatten(1, 2) for rel_slice in sensor._cache_slices]
             if len(blocks) == 1:
                 return blocks[0]
             return torch.cat(blocks, dim=1)
 
-        key = (is_ground_truth, dtype)
-        if not self._is_last_cache_cloned[key]:
-            self._is_last_cache_cloned[key] = True
-            if is_ground_truth:
-                self._cloned_cache[key] = self._ground_truth_cache[dtype].T.contiguous()
-            else:
-                self._cloned_cache[key] = self._cache[dtype].clone()
-        return self._cloned_cache[key][:, sensor._cache_idx : sensor._cache_idx + sensor._cache_size]
+        # Pure view into the per-class return cache. Eager `_post_process` already populated it during step().
+        return_cache = (
+            self._ground_truth_return_cache[sensor_cls] if is_ground_truth else self._return_cache[sensor_cls]
+        )
+        return return_cache[:, rel_start : rel_start + sensor._cache_size]
 
     def read_sensors(
         self,
@@ -323,7 +386,8 @@ class SensorManager:
             (fancy) indexing produces a copy along the batch axis.
         copy : bool
             When True, returned tensors are cloned. When False (default), returned tensors are views into the
-            shared cache wherever possible. Note that fancy-indexed `envs_idx` always copies along B.
+            per-class return cache. Honest for every sensor class — including ContactSensor and ContactForceSensor
+            whose `_post_process` overrides write into real per-class storage at step end.
         is_ground_truth : bool
             When True, return ground-truth tensors instead of measured tensors.
 
@@ -356,7 +420,6 @@ class SensorManager:
                     continue
                 within_cls_slice = entity_slice_map[eid]
 
-            dtype = sensor_cls._get_cache_dtype()
             cls_max_history = self._max_history_by_class[sensor_cls]
             if cls_max_history > 0:
                 linearized = (
@@ -365,21 +428,21 @@ class SensorManager:
                     else self._linearized_measured_history[sensor_cls]
                 )
                 tensor = linearized[env_index, :, within_cls_slice]
+                # When `_post_process` is overridden, the linearized buffer is in intermediate space; apply per-step.
+                if self._post_process_is_overridden(sensor_cls):
+                    metadata = self._sensors_metadata[sensor_cls]
+                    B, H, n = tensor.shape
+                    tensor = sensor_cls._post_process(metadata, tensor.reshape(B * H, n)).reshape(B, H, -1)
             else:
-                cls_cache_slice = self._cache_slices_by_type[sensor_cls]
-                abs_slice = slice(
-                    cls_cache_slice.start + within_cls_slice.start,
-                    cls_cache_slice.start + within_cls_slice.stop,
+                return_cache = (
+                    self._ground_truth_return_cache[sensor_cls] if is_ground_truth else self._return_cache[sensor_cls]
                 )
-                if is_ground_truth:
-                    tensor = self._ground_truth_cache[dtype][abs_slice, :].T[env_index]
-                else:
-                    tensor = self._cache[dtype][env_index, abs_slice]
+                tensor = return_cache[env_index, within_cls_slice]
 
-            if self._sim.n_envs == 0:
-                tensor = tensor[0]
             if copy:
                 tensor = tensor.clone()
+            if self._sim.n_envs == 0:
+                tensor = tensor[0]
             options_cls = type(sensors[0]._options)
             type_id = getattr(_sensor_types_namespace, options_cls.__name__)
             result[type_id] = tensor

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -1,7 +1,6 @@
-import math
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 import numpy as np
 import quadrants as qd
@@ -13,8 +12,8 @@ import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 from genesis.options.sensors import TemperatureGrid as TemperatureGridOptions
 from genesis.options.sensors import TemperatureProperties
-from genesis.utils import mesh as mu
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
+from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import (
     ImperfectSensorMetadataMixin,
@@ -27,7 +26,6 @@ from .base_sensor import (
 
 if TYPE_CHECKING:
     from genesis.engine.entities.rigid_entity.rigid_link import RigidLink
-    from genesis.utils.ring_buffer import TensorRingBuffer
     from genesis.vis.rasterizer_context import RasterizerContext
 
     from .sensor_manager import SensorManager
@@ -684,14 +682,14 @@ class TemperatureGridSensor(
         return gs.tc_float
 
     @classmethod
-    def reset(cls, shared_metadata: TemperatureGridSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
-        super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
+    def reset(cls, shared_metadata: TemperatureGridSensorMetadata, current_ground_truth_data_T: torch.Tensor, envs_idx):
+        super().reset(shared_metadata, current_ground_truth_data_T, envs_idx)
         for i_s in range(shared_metadata.sensor_cache_start.shape[0]):
             link_idx = shared_metadata.links_idx[i_s].item()
             mat_idx = shared_metadata.link_to_material_idx[link_idx].item()
             base_T = shared_metadata.link_material_properties[_PropIdx.BASE_TEMP][mat_idx].item()
             start = shared_metadata.sensor_cache_start[i_s].item()
-            shared_ground_truth_cache[start : start + shared_metadata.cache_sizes[i_s], envs_idx] = base_T
+            current_ground_truth_data_T[start : start + shared_metadata.cache_sizes[i_s], envs_idx] = base_T
         if shared_metadata.link_temps.numel() > 0:
             ambient_T = shared_metadata.ambient_temperature
             link_base_T = shared_metadata.link_material_properties[_PropIdx.BASE_TEMP]
@@ -705,8 +703,11 @@ class TemperatureGridSensor(
             shared_metadata.link_temps[envs_idx, :] = base_T_per_link.unsqueeze(0).expand(n_envs, -1)
 
     @classmethod
-    def _update_shared_ground_truth_cache(
-        cls, shared_metadata: TemperatureGridSensorMetadata, shared_ground_truth_cache: torch.Tensor
+    def _update_shared_cache(
+        cls,
+        shared_metadata: TemperatureGridSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
         dt = solver._sim.dt
@@ -730,7 +731,7 @@ class TemperatureGridSensor(
             shared_metadata.K2_spectral,
             dt,
             gs.EPS,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
         # 3) Contact heat transfer
         collider_state = solver.collider._collider_state
@@ -761,9 +762,9 @@ class TemperatureGridSensor(
             shared_metadata.contact_area_buffer,
             dt,
             gs.EPS,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
-        shared_ground_truth_cache.clamp_(-MAX_TEMP, MAX_TEMP)
+        current_ground_truth_data_T.clamp_(-MAX_TEMP, MAX_TEMP)
         # 4) Radiation and convection
         _apply_radiation_convection(
             shared_metadata.sensor_cache_start,
@@ -779,28 +780,21 @@ class TemperatureGridSensor(
             shared_metadata.ambient_temperature,
             shared_metadata.convection_coeff,
             dt,
-            shared_ground_truth_cache,
+            current_ground_truth_data_T,
         )
 
-    @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: TemperatureGridSensorMetadata,
-        shared_ground_truth_cache: torch.Tensor,
-        shared_cache: torch.Tensor,
-        buffered_data: "TensorRingBuffer",
-    ):
-        dt = shared_metadata.solver._sim.dt
+        t_actual = current_ground_truth_data_T.T
+        work = measured_data_timeline.at(1).clone()
         _apply_T_measured_filter(
             shared_metadata.sensor_cache_start,
             shared_metadata.cache_sizes,
             shared_metadata.sensor_time_const,
             dt,
-            shared_ground_truth_cache,
-            buffered_data.at(0),
+            t_actual,
+            work,
         )
-        cls._apply_delay_to_shared_cache(shared_metadata, shared_cache, buffered_data)
-        cls._apply_imperfections(shared_metadata, shared_cache)
+        cls._apply_imperfections(shared_metadata, work)
+        measured_data_timeline.at(0, copy=False).copy_(work)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import IntEnum
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -16,12 +17,12 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SensorDataSpec,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -491,7 +492,7 @@ def _apply_T_measured_filter(
 
 
 @dataclass
-class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata):
+class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     """Shared metadata for all temperature grid sensors."""
 
     ambient_temperature: float = 21.0
@@ -521,7 +522,7 @@ class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMet
 
 class TemperatureGridSensor(
     RigidSensorMixin[TemperatureGridSensorMetadata],
-    ImperfectSensorMixin[TemperatureGridSensorMetadata],
+    SimpleSensor,
     Sensor[TemperatureGridOptions, TemperatureGridSensorMetadata, TemperatureGridSensorMetadata],
 ):
     def __init__(self, sensor_options: TemperatureGridOptions, sensor_idx: int, sensor_manager: "SensorManager"):
@@ -674,12 +675,9 @@ class TemperatureGridSensor(
             (solver._B, n_c_max, len(_ScratchIdx)), device=gs.device, dtype=gs.tc_float
         )
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._options.grid_size,)
-
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
+    @cached_property
+    def return_spec(self) -> SensorDataSpec:
+        return SensorDataSpec(shape=(self._options.grid_size,), dtype=gs.tc_float)
 
     @classmethod
     def reset(cls, shared_metadata: TemperatureGridSensorMetadata, current_ground_truth_data_T: torch.Tensor, envs_idx):
@@ -703,12 +701,7 @@ class TemperatureGridSensor(
             shared_metadata.link_temps[envs_idx, :] = base_T_per_link.unsqueeze(0).expand(n_envs, -1)
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: TemperatureGridSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: TemperatureGridSensorMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
         dt = solver._sim.dt
         props = shared_metadata.link_material_properties
@@ -731,7 +724,7 @@ class TemperatureGridSensor(
             shared_metadata.K2_spectral,
             dt,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
         # 3) Contact heat transfer
         collider_state = solver.collider._collider_state
@@ -762,9 +755,9 @@ class TemperatureGridSensor(
             shared_metadata.contact_area_buffer,
             dt,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        current_ground_truth_data_T.clamp_(-MAX_TEMP, MAX_TEMP)
+        raw_data_T.clamp_(-MAX_TEMP, MAX_TEMP)
         # 4) Radiation and convection
         _apply_radiation_convection(
             shared_metadata.sensor_cache_start,
@@ -780,21 +773,32 @@ class TemperatureGridSensor(
             shared_metadata.ambient_temperature,
             shared_metadata.convection_coeff,
             dt,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
 
-        t_actual = current_ground_truth_data_T.T
-        work = measured_data_timeline.at(1).clone()
+    @classmethod
+    def _apply_transform(
+        cls,
+        shared_metadata: TemperatureGridSensorMetadata,
+        data: torch.Tensor,
+        *,
+        timeline=None,
+    ):
+        if timeline is None:
+            return
+        # First-order RC filter: data <- prev_measured + (dt/tau) * (raw - prev_measured), where data initially
+        # holds the raw seed copied by the default `_update_current_timestep_data`.
+        raw = data.clone()
+        filtered = timeline.at(1).clone()
         _apply_T_measured_filter(
             shared_metadata.sensor_cache_start,
             shared_metadata.cache_sizes,
             shared_metadata.sensor_time_const,
-            dt,
-            t_actual,
-            work,
+            shared_metadata.solver._sim.dt,
+            raw,
+            filtered,
         )
-        cls._apply_imperfections(shared_metadata, work)
-        measured_data_timeline.at(0, copy=False).copy_(work)
+        data.copy_(filtered)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -60,16 +60,24 @@ class SensorOptions(Options, Generic[SensorT]):
 
     Parameters
     ----------
-    history_length: NonNegativeInt
+    history_length : NonNegativeInt
         The length of the history to store. Defaults to 0 (no history).
-    delay : float
+    delay : float, optional
         The read delay time in seconds. Data read will be outdated by this amount. Defaults to 0.0 (no delay).
+    jitter : float, optional
+        The jitter in seconds modeled as a random additive delay sampled from a normal distribution.
+        Jitter cannot be greater than delay. `interpolate` should be True when `jitter` is greater than 0.
+    interpolate : bool, optional
+        If True, the sensor data is interpolated between data points for delay + jitter.
+        Otherwise, the sensor data at the closest time step will be used. Default is False.
     draw_debug : bool
         If True and visualizer is active, the sensor will draw debug shapes in the scene. Defaults to False.
     """
 
     history_length: NonNegativeInt = 0
     delay: NonNegativeFloat = 0.0
+    jitter: NonNegativeFloat = 0.0
+    interpolate: StrictBool = False
     draw_debug: StrictBool = False
     # -1 means not link-attached. None is accepted from users and normalized to -1 so SensorManager can sort uniformly.
     entity_idx: StrictInt = Field(default=-1, ge=-1)
@@ -79,6 +87,12 @@ class SensorOptions(Options, Generic[SensorT]):
     def _normalize_entity_idx(cls, value):
         return -1 if value is None else value
 
+    def model_post_init(self, context: Any) -> None:
+        if self.jitter > 0 and not self.interpolate:
+            gs.raise_exception(f"{type(self).__name__}: `interpolate` should be True when `jitter` is greater than 0.")
+        if self.jitter > self.delay:
+            gs.raise_exception(f"{type(self).__name__}: Jitter must be less than or equal to read delay.")
+
     def validate_scene(self, scene: "Scene"):
         """
         Validate the sensor options values before the sensor is added to the scene.
@@ -86,12 +100,13 @@ class SensorOptions(Options, Generic[SensorT]):
         Use pydantic's model_post_init() for validation that does not require scene context.
         """
         assert scene.sim is not None
-        delay_hz = self.delay / scene.sim.dt
-        if not np.isclose(delay_hz, round(delay_hz), atol=gs.EPS):
-            gs.logger.warning(
-                f"{type(self).__name__}: Read delay should be a multiple of the simulation time step. Got {self.delay}"
-                f" and {scene.sim.dt}. Actual read delay will be {1 / round(delay_hz)}."
-            )
+        if self.delay > 0:
+            delay_hz = self.delay / scene.sim.dt
+            if not np.isclose(delay_hz, round(delay_hz), atol=gs.EPS):
+                gs.logger.warning(
+                    f"{type(self).__name__}: Read delay should be a multiple of the simulation time step. Got "
+                    f"{self.delay} and {scene.sim.dt}. Actual read delay will be {1 / round(delay_hz)}."
+                )
 
 
 class KinematicSensorOptionsMixin(SensorOptions[SensorT]):
@@ -146,9 +161,12 @@ class RigidSensorOptionsMixin(KinematicSensorOptionsMixin[SensorT]):
                 gs.raise_exception(f"Entity at index {self.entity_idx} is not a RigidEntity.")
 
 
-class ImperfectSensorOptionsMixin(SensorOptions[SensorT]):
+class SimpleSensorOptions(SensorOptions[SensorT]):
     """
-    Base options class for analog sensors that are attached to a RigidEntity.
+    Options carrying SimpleSensor's imperfection parameters (interpreted by ``_apply_hardware_imperfections`` as
+    perturbations introduced by the embedded sampler when it snapshots the sensor into shared memory). Inherited
+    by every ``SimpleSensor``-derived options class; Camera (deriving from ``Sensor`` directly) stays on plain
+    ``SensorOptions``.
 
     Parameters
     ----------
@@ -161,29 +179,15 @@ class ImperfectSensorOptionsMixin(SensorOptions[SensorT]):
         The standard deviation of the additive white noise.
     random_walk : float | array-like[float, ...], optional
         The standard deviation of the random walk, which acts as accumulated bias drift.
-    jitter : float, optional
-        The jitter in seconds modeled as a a random additive delay sampled from a normal distribution.
-        Jitter cannot be greater than delay. `interpolate` should be True when `jitter` is greater than 0.
-    interpolate : bool, optional
-        If True, the sensor data is interpolated between data points for delay + jitter.
-        Otherwise, the sensor data at the closest time step will be used. Default is False.
     """
 
     resolution: FArrayType | float = 0.0
     bias: FArrayType | float = 0.0
     noise: FArrayType | float = 0.0
     random_walk: FArrayType | float = 0.0
-    jitter: NonNegativeFloat = 0.0
-    interpolate: StrictBool = False
-
-    def model_post_init(self, context: Any) -> None:
-        if self.jitter > 0 and not self.interpolate:
-            gs.raise_exception(f"{type(self).__name__}: `interpolate` should be True when `jitter` is greater than 0.")
-        if self.jitter > self.delay:
-            gs.raise_exception(f"{type(self).__name__}: Jitter must be less than or equal to read delay.")
 
 
-class Contact(RigidSensorOptionsMixin["ContactSensor"]):
+class Contact(RigidSensorOptionsMixin["ContactSensor"], SimpleSensorOptions["ContactSensor"]):
     """
     Sensor that returns bool based on whether associated RigidLink is in contact.
 
@@ -192,6 +196,10 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"]):
     filter_link_idx : array-like[int], optional
         Global rigid link indices (solver link space). Contacts with the sensor link where the other
         participant is one of these links are ignored. Default is empty (no filtering).
+    threshold : float, optional
+        The bool-conversion threshold applied at read time to the underlying float contact magnitude
+        (kernel produces float). A bin reads ``True`` iff its magnitude exceeds this value. Default
+        ``0.0`` (any positive magnitude registers as contact, preserving pre-v16 semantics).
     debug_sphere_radius : float, optional
         The radius of the debug sphere. Defaults to 0.05.
     debug_color : array-like[float, float, float, float], optional
@@ -199,6 +207,7 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"]):
     """
 
     filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
+    threshold: NonNegativeFloat = 0.0
     debug_sphere_radius: PositiveFloat = 0.05
     debug_color: UnitIntervalVec4Type = (1.0, 0.0, 1.0, 0.5)
 
@@ -212,7 +221,7 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"]):
                 )
 
 
-class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], ImperfectSensorOptionsMixin["ContactForceSensor"]):
+class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOptions["ContactForceSensor"]):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
 
@@ -267,9 +276,7 @@ class TemperatureProperties(NamedTuple):
     emissivity: float = 0.9
 
 
-class TemperatureGrid(
-    RigidSensorOptionsMixin["TemperatureGridSensor"], ImperfectSensorOptionsMixin["TemperatureGridSensor"]
-):
+class TemperatureGrid(RigidSensorOptionsMixin["TemperatureGridSensor"], SimpleSensorOptions["TemperatureGridSensor"]):
     """
     Sensor that returns the temperature in Celsius of the associated RigidLink in its local frame.
     Temperature is computed based on object contacts and their material properties provided to these options.
@@ -315,7 +322,7 @@ class TemperatureGrid(
     debug_temperature_range: Vec2FType = (0.0, 100.0)
 
 
-class IMU(RigidSensorOptionsMixin["IMUSensor"], ImperfectSensorOptionsMixin["IMUSensor"]):
+class IMU(RigidSensorOptionsMixin["IMUSensor"], SimpleSensorOptions["IMUSensor"]):
     """
     IMU sensor returns the linear acceleration (accelerometer) and angular velocity (gyroscope)
     of the associated entity link.
@@ -412,7 +419,7 @@ class IMU(RigidSensorOptionsMixin["IMUSensor"], ImperfectSensorOptionsMixin["IMU
         self.noise = self.acc_noise + self.gyro_noise + self.mag_noise
 
 
-class Proximity(RigidSensorOptionsMixin["ProximitySensor"], ImperfectSensorOptionsMixin["ProximitySensor"]):
+class Proximity(RigidSensorOptionsMixin["ProximitySensor"], SimpleSensorOptions["ProximitySensor"]):
     """
     Proximity sensor that reports the nearest distances from probe positions to tracked mesh surfaces.
     The read() output will provide the distances, and the nearest points can be accessed with `sensor.nearest_points`.
@@ -452,7 +459,7 @@ class Proximity(RigidSensorOptionsMixin["ProximitySensor"], ImperfectSensorOptio
                 gs.raise_exception(f"Proximity sensor track_link_idx[{i}]={link_idx} is out of range [0, {n_links}).")
 
 
-class Raycaster(KinematicSensorOptionsMixin["RaycasterSensor"]):
+class Raycaster(KinematicSensorOptionsMixin["RaycasterSensor"], SimpleSensorOptions["RaycasterSensor"]):
     """
     Raycaster sensor that performs ray casting to get distance measurements and point clouds.
 

--- a/genesis/options/sensors/tactile.py
+++ b/genesis/options/sensors/tactile.py
@@ -14,7 +14,7 @@ from genesis.typing import (
     NonNegativeFloat,
 )
 
-from .options import ImperfectSensorOptionsMixin, RigidSensorOptionsMixin, SensorOptions, SensorT
+from .options import SimpleSensorOptions, RigidSensorOptionsMixin, SensorOptions, SensorT
 
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ class KinematicTactileSensorMixin(SensorOptions[SensorT]):
 
 class KinematicContactProbe(
     RigidSensorOptionsMixin["KinematicContactProbeSensor"],
-    ImperfectSensorOptionsMixin["KinematicContactProbeSensor"],
+    SimpleSensorOptions["KinematicContactProbeSensor"],
     KinematicTactileSensorMixin["KinematicContactProbeSensor"],
 ):
     """
@@ -96,7 +96,7 @@ class KinematicContactProbe(
 
 class ElastomerDisplacement(
     RigidSensorOptionsMixin["ElastomerDisplacementSensor"],
-    ImperfectSensorOptionsMixin["ElastomerDisplacementSensor"],
+    SimpleSensorOptions["ElastomerDisplacementSensor"],
     KinematicTactileSensorMixin["ElastomerDisplacementSensor"],
 ):
     """

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -77,11 +77,11 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
                 return gs.tc_float
 
             @classmethod
-            def _update_shared_ground_truth_cache(cls, metadata, cache):
+            def _update_current_ground_truth_data_T(cls, metadata, cache):
                 pass
 
             @classmethod
-            def _update_shared_cache(cls, metadata, gt_cache, cache, buffer):
+            def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline):
                 pass
 
             @classmethod
@@ -442,10 +442,13 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
     GRAVITY = -10.0
     BIAS = (0.1, 0.2, 0.3)
     NOISE = 0.01
+    DT = 1e-2
+    DELAY_STEPS = 2
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             gravity=(0.0, 0.0, GRAVITY),
+            dt=DT,
         ),
         profiling_options=gs.options.ProfilingOptions(
             show_FPS=False,
@@ -468,7 +471,7 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
     box = scene.add_entity(
         morph=gs.morphs.Box(
             size=(1.0, 1.0, 1.0),  # volume = 1 m^3
-            pos=(0.0, 0.0, 0.51),
+            pos=(0.0, 0.0, 0.55),
         ),
         material=gs.materials.Rigid(
             rho=1.0,  # mass = 1.0 kg
@@ -530,7 +533,7 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
             noise=NOISE,
             bias=BIAS,
             random_walk=(NOISE * 0.01, NOISE * 0.02, NOISE * 0.03),
-            delay=0.05,
+            delay=DT * DELAY_STEPS,
             jitter=0.01,
             interpolate=True,
         )
@@ -555,7 +558,8 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
     box_3.set_dofs_position((-np.pi / 2, -np.pi / 4, -np.pi / 2), dofs_idx_local=slice(3, None))
 
     # Note that it is necessary to do a first step, because the initial state right after reset is not valid
-    scene.step()
+    for _ in range(DELAY_STEPS + 1):
+        scene.step()
 
     # Make sure that box CoM is valid
     assert_allclose(box.get_links_pos(ref="root_com")[..., :2], box_com_offset[:2], tol=tol)
@@ -566,14 +570,14 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
     assert_allclose(force_sensor.read(), force_sensor_noisy.read_ground_truth(), tol=gs.EPS)
     assert_allclose(force_sensor_noisy.read(), BIAS, tol=NOISE * 3)
 
-    for _ in range(10):
+    for _ in range(20):
         scene.step()
 
     assert bool_sensor_floor.read().all(), "ContactSensor for floor should detect contact with the ground"
     assert not bool_sensor_box_2.read().any(), "ContactSensor for box_2 should not detect any contact yet."
     assert_allclose(force_sensor_noisy.read(), force_sensor_noisy.read(), tol=gs.EPS)
 
-    for _ in range(90):
+    for _ in range(80):
         scene.step()
 
     assert bool_sensor_box_2.read().all(), "ContactSensor for box_2 should detect contact with the ground"

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -56,9 +56,10 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
         textwrap.dedent(
             """\
         from dataclasses import dataclass
+        from functools import cached_property
 
         import genesis as gs
-        from genesis.engine.sensors.base_sensor import Sensor, SharedSensorMetadata
+        from genesis.engine.sensors.base_sensor import Sensor, SensorDataSpec, SharedSensorMetadata
 
         from .options import FakeSensorOptions
 
@@ -69,15 +70,12 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
 
 
         class FakeSensor(Sensor[FakeSensorOptions, FakeSensorMetadata]):
-            def _get_return_format(self):
-                return (1,)
+            @cached_property
+            def return_spec(self):
+                return SensorDataSpec(shape=(1,), dtype=gs.tc_float)
 
             @classmethod
-            def _get_cache_dtype(cls):
-                return gs.tc_float
-
-            @classmethod
-            def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline):
+            def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline, intermediate_cache, return_cache):
                 pass
 
             @classmethod
@@ -120,6 +118,26 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
             if mod_name.startswith("fake_sensor_plugin"):
                 del sys.modules[mod_name]
         SensorManager.SENSOR_TYPES_MAP.pop(FakeSensorOptions, None)
+
+
+@pytest.mark.required
+def test_post_process_requires_intermediate_spec():
+    # Strict-override rule: a subclass overriding `_post_process` without also overriding `intermediate_spec` must
+    # raise TypeError at class-definition time. Prevents silent guessing about the intermediate data space.
+    from functools import cached_property
+
+    from genesis.engine.sensors.base_sensor import Sensor, SensorDataSpec, SharedSensorMetadata
+
+    with pytest.raises(TypeError, match="intermediate_spec"):
+
+        class BadSensor(Sensor):
+            @cached_property
+            def return_spec(self):
+                return SensorDataSpec(shape=(1,), dtype=gs.tc_float)
+
+            @classmethod
+            def _post_process(cls, shared_metadata, tensor):
+                return tensor * 2
 
 
 @pytest.mark.required
@@ -581,8 +599,10 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
     # Moving force back in world frame because box is not perfectly flat on the ground due to CoM offset
     with np.testing.assert_raises(AssertionError):
         assert_allclose(box.get_quat(), 0.0, atol=tol)
+    # Unsaturated GT physics check uses force_sensor (no max_force). force_sensor_noisy clamps in _post_process,
+    # which applies uniformly to read() and read_ground_truth().
     assert_allclose(
-        gu.transform_by_quat(force_sensor_noisy.read_ground_truth(), box.get_quat()), (0.0, 0.0, -GRAVITY), tol=tol
+        gu.transform_by_quat(force_sensor.read_ground_truth(), box.get_quat()), (0.0, 0.0, -GRAVITY), tol=tol
     )
 
     # FIXME: Adding CoM offset on box is disturbing contact force computations on box_2 for some reason...
@@ -1869,7 +1889,8 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
         scene.step()
 
     # Scene-wide read returns every sensor class. Per-entity reads restrict to classes present on that entity, so the
-    # static camera class is excluded from both box_a and box_b reads.
+    # static camera class is excluded from both box_a and box_b reads. `copy=False` (the default) returns views into
+    # each per-class return cache — honest for every sensor class under v17's eager `_post_process`.
     scene_data = scene.read_sensors()
     a_data = box_a.read_sensors()
     b_data = box_b.read_sensors()
@@ -1920,7 +1941,8 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
 
     # View vs copy: storage data_ptr is the discriminating metadata. Two copy=False reads must share storage (both
     # views into the same backing cache), and the scene-level and entity-level views must share storage too. copy=True
-    # must always allocate fresh storage. Verified for both the float (IMU) and bool (Contact) dtypes.
+    # must always allocate fresh storage. Verified on both IMU (identity `_post_process`, return cache aliases the
+    # intermediate slice) and Contact (overridden `_post_process`, return cache is its own per-class bool buffer).
     for type_tag in (gs.sensors.types.IMU, gs.sensors.types.Contact):
         scene_view = scene.read_sensors(copy=False)[type_tag]
         entity_view = box_a.read_sensors(copy=False)[type_tag]

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -77,10 +77,6 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
                 return gs.tc_float
 
             @classmethod
-            def _update_current_ground_truth_data_T(cls, metadata, cache):
-                pass
-
-            @classmethod
             def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline):
                 pass
 


### PR DESCRIPTION
## Summary

Builds on @Milotrince's #2770 (consolidate `_update_shared_cache`) to introduce the v17 sensor base hierarchy. This PR is **stacked on #2770** and should land after it.

Key changes:

- **`Sensor` / `SimpleSensor` split.** `Sensor` is the minimal customization contract (4 entry-points: `_update_shared_cache`, `_post_process`, `return_spec`/`intermediate_spec`, `uses_measured_pipeline`). `SimpleSensor` is the standard pipeline that most Genesis sensors derive from, with four hooks (`_update_raw_data`, `_update_current_timestep_data`, `_apply_transform`, `_apply_hardware_imperfections`).

- **No `Imperfect*` classes.** Options-side: time-related (`delay`, `jitter`, `interpolate`, `history_length`) on `SensorOptions` base; imperfection parameters (`noise`, `bias`, `random_walk`, `resolution`) on `SimpleSensorOptions(SensorOptions)`. Metadata-side: time-related on `SharedSensorMetadata`; imperfection-parameter state on `SimpleSensorMetadata(SharedSensorMetadata)`. Behavior: `ImperfectSensorMixin` folded into `SimpleSensor`.

- **`SensorDataSpec` API.** Self-contained `return_spec` and `intermediate_spec` cached_properties (public, no underscore prefix), each a `SensorDataSpec(shape, dtype)` NamedTuple. Replaces the old `_get_return_format` / `_get_cache_dtype` method pair. Overriding `_post_process` REQUIRES overriding `intermediate_spec` — `Sensor.__init_subclass__` enforces this at class-definition time.

- **Snapshot-time imperfections.** Hardware imperfections (noise, bias, random_walk, resolution) apply at the embedded-sampler snapshot (PRE-delay), inside the timeline ring's slot 0 — not at read time. This matches the abstraction: `read()` is a query into shared memory, idempotent within a sampling period; delayed reads return stale snapshots with their original imperfection state. v16's "fresh noise per `read()`" framing implicitly modeled an analog amplifier on the wire — wrong abstraction once you cross into the digital embedded layer.

- **Eager `_post_process`.** Applied once per step by the orchestrator into a per-class return cache; `read()` is then a pure memory-lookup view. Per-class `_return_cache[sensor_cls]` alias-views the per-dtype `_intermediate_cache[dtype]` when `_post_process` is identity, separate buffer when overridden. `read_sensors(copy=False)` is honest for every sensor class.

- **Per-sensor migrations.** All Genesis sensors except Camera derive from `SimpleSensor` and inherit the standard pipeline. IMU's body-frame rotation moves to `_apply_transform`. Temperature's RC filter moves to `_apply_transform` with `if timeline is not None` gating. ContactSensor refactored to float intermediate + bool return; ContactForceSensor deadband + saturation moved to `_post_process`. Camera derives from `Sensor` directly and inherits `uses_measured_pipeline = False`.

- **Single measured ring.** v17 merges the v16 `_measured_timeline_ring` and `_measured_history_ring` (imperfections were AFTER delay sampling, requiring a separate post-noise ring for history). Now the timeline ring stores post-noise values directly; `read(history_length=N)` reads from the per-class linearized history snapshots of the return cache.

## User-observable behavior changes

- `Contact` options gains a new `threshold` field (default 0.0 preserves current behavior).
- `ContactSensor`'s internal intermediate cache is now `float` (kernel writes a contact count); read paths still return `bool` via `_post_process`.
- `ContactForceSensor`'s deadband + saturation runs at read time (eagerly into the return cache) instead of at write time. No user-facing read behavior change; internal cache may transiently contain values outside the deadband.
- Temperature's hardware imperfections move from inside the seed/filter step to snapshot time (PRE-delay) — delayed reads correctly return stale snapshots with their original noise state, and `read(history_length=N)` is consistent with prior `read()` values.
- `SensorManager.read_sensors(copy=False)` (the default) returns honest views for every sensor class, including `ContactSensor` / `ContactForceSensor` which now have real per-class return-cache storage. No three-valued `copy=None` semantics.
- `return_spec` / `intermediate_spec` are public properties — users may inspect the spec of any sensor instance.

## Test plan
- [ ] `pytest tests/test_sensors.py` — 34/34 passing (33 pre-existing + 1 new test for the `intermediate_spec` strict-override rule).
- [ ] `pytest tests/test_viewer.py` — 6/6 passing.
- [ ] `pytest tests/test_rigid_physics.py` — no sensor-specific tests; verified no spillover.