### PR TITLE
[FEATURE] Refactor sensor pipeline (cont'd).

### DIFF
--- a/genesis/engine/entities/base_entity.py
+++ b/genesis/engine/entities/base_entity.py
@@ -111,17 +111,17 @@ class Entity(RBC):
         return self._sim._sensor_manager.get_sensors_by_entity(self._idx)
 
     @gs.assert_built
-    def read_sensors(self, envs_idx=None, copy: bool = False) -> "dict[type[Sensor], torch.Tensor]":
+    def read_sensors(self, envs_idx=None) -> "dict[type[Sensor], torch.Tensor]":
         """
         Read every sensor attached to this entity as a tensor per sensor class.
+
+        Always returns a fresh tensor independent of the internal sensor storage; the caller is free to mutate the
+        result.
 
         Parameters
         ----------
         envs_idx : array-like | int | slice | None
-            Environment selection. Integer/slice indexing returns a view along the batch axis; list/tensor
-            (fancy) indexing returns a copy.
-        copy : bool
-            When True, returned tensors are cloned. When False (default), they are views into the shared cache.
+            Environment selection. Defaults to all environments.
 
         Returns
         -------
@@ -129,7 +129,7 @@ class Entity(RBC):
             For each sensor class with at least one sensor on this entity, a tensor of shape
             (B, [history,] entity_cache_size_for_class).
         """
-        return self._sim._sensor_manager.read_sensors(entity_idx=self._idx, envs_idx=envs_idx, copy=copy)
+        return self._sim._sensor_manager.read_sensors(entity_idx=self._idx, envs_idx=envs_idx)
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- naming methods -----------------------------------

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -636,24 +636,24 @@ class Scene(RBC):
         return self._sim._sensor_manager.create_sensor(sensor_options)
 
     @gs.assert_built
-    def read_sensors(self, envs_idx=None, copy: bool = False) -> "dict[type[Sensor], torch.Tensor]":
+    def read_sensors(self, envs_idx=None) -> "dict[type[Sensor], torch.Tensor]":
         """
         Read every sensor in the scene as a tensor per sensor class.
+
+        Always returns a fresh tensor independent of the internal sensor storage; the caller is free to mutate the
+        result.
 
         Parameters
         ----------
         envs_idx : array-like | int | slice | None
-            Environment selection. Integer/slice indexing returns a view along the batch axis; list/tensor
-            (fancy) indexing returns a copy.
-        copy : bool
-            When True, returned tensors are cloned. When False (default), they are views into the shared cache.
+            Environment selection. Defaults to all environments.
 
         Returns
         -------
         dict[Type[Sensor], torch.Tensor]
             For each sensor class present in the scene, a tensor of shape (B, [history,] class_cache_size).
         """
-        return self._sim._sensor_manager.read_sensors(entity_idx=None, envs_idx=envs_idx, copy=copy)
+        return self._sim._sensor_manager.read_sensors(entity_idx=None, envs_idx=envs_idx)
 
     @gs.assert_unbuilt
     def start_recording(self, data_func: Callable, rec_options: "RecorderOptions") -> "Recorder":

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from functools import partial
-from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, Sequence, TypeVar, get_args, get_origin
+from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, TypeVar, get_args, get_origin
 
 import numpy as np
 import torch
@@ -42,7 +42,7 @@ def _to_tuple(*values: NumArrayType, length_per_value: int = 3) -> tuple[Numeric
 @dataclass
 class SharedSensorMetadata:
     """
-    Shared metadata between all sensors of the same class.
+    Shared metadata between all sensors of the same class. Time-related state only - visible to SensorManager.
     """
 
     cache_sizes: list[int] = field(default_factory=list)
@@ -50,11 +50,12 @@ class SharedSensorMetadata:
     history_lengths: list[int] = field(default_factory=list)
     # Per-sensor: interpolate delayed reads (aligned with cache_sizes). Appended in Sensor.build.
     interpolate: list[bool] = field(default_factory=list)
-    # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build (and latched True by
-    # `set_delay`) so the per-step fast path in `_apply_delay_to_shared_cache` can avoid a GPU-syncing reduction.
+    jitter_ts: torch.Tensor = make_tensor_field((0, 0))
+    # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build so the per-step fast
+    # path can avoid a GPU-syncing reduction.
     has_any_delay: bool = False
-    # True iff at least one sensor in the class has a nonzero jitter option. Stays False for non-noisy sensor classes
-    # (Contact, Raycaster) since they never sample jitter. Same precompute-and-latch contract as `has_any_delay`.
+    # True iff at least one sensor in the class has a nonzero jitter. Latched True by `set_jitter`; same
+    # precompute-and-latch contract as `has_any_delay`.
     has_any_jitter: bool = False
 
     def __del__(self):
@@ -70,6 +71,30 @@ class SharedSensorMetadata:
         This method is called by SensorManager when the scene is destroyed. his should remove any references to the
         sensors from the shared metadata, and clean up any resources associated with the sensors.
         """
+
+
+@dataclass
+class SimpleSensorMetadata(SharedSensorMetadata):
+    """
+    SimpleSensor's per-class state for the imperfection parameters (noise/bias/random_walk/resolution).
+
+    Opaque to SensorManager (which only uses ``SharedSensorMetadata`` fields). Per-sensor-class metadata subclasses
+    inherit this when the sensor derives from ``SimpleSensor``; sensors deriving from ``Sensor`` directly (Camera)
+    inherit ``SharedSensorMetadata`` instead.
+    """
+
+    resolution: torch.Tensor = make_tensor_field((0, 0))
+    bias: torch.Tensor = make_tensor_field((0, 0))
+    _cur_random_walk: torch.Tensor = make_tensor_field((0, 0))
+    random_walk: torch.Tensor = make_tensor_field((0, 0))
+    noise: torch.Tensor = make_tensor_field((0, 0))
+    # Precomputed Python bool flags gate the per-step noise/bias/quantize work without GPU sync. Set at build from
+    # options and refreshed by the corresponding setters. Conservatively True once any sensor has nonzero value;
+    # never flipped back to False (avoids tracking per-sensor state).
+    has_any_noise: bool = False
+    has_any_random_walk: bool = False
+    has_any_bias: bool = False
+    has_any_resolution: bool = False
 
 
 SharedSensorMetadataT = TypeVar("SharedSensorMetadataT", bound=SharedSensorMetadata)
@@ -99,6 +124,10 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
     _options_cls: ClassVar[type]
     _metadata_cls: ClassVar[type]
     _return_data_class: ClassVar[type] = tuple
+    # Whether instances of this class read or write the measured-timeline ring inside `_update_shared_cache`. Drives
+    # ring allocation in `SensorManager.build`. Subclasses whose `_update_shared_cache` bypasses the ring (e.g.
+    # cameras handling rendering lazily) explicitly set this to ``False``.
+    uses_measured_pipeline: ClassVar[bool] = True
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -113,6 +142,20 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
                 if len(args) >= 3 and not isinstance(args[2], TypeVar):
                     cls._return_data_class = args[2]
                 break
+        # Strict contract: overriding `_post_process` requires overriding `_get_intermediate_format` and/or
+        # `_get_intermediate_dtype`. The intermediate buffer must be a distinct buffer regardless of whether its
+        # shape/dtype happen to coincide with the return space (the timeline ring is in intermediate space; mixing
+        # data spaces breaks `_apply_transform` filter overrides that read previous slots). When the intermediate
+        # shape and dtype both coincide with return, override one method as a no-op to make the structural
+        # distinction explicit.
+        if "_post_process" in cls.__dict__ and not (
+            "_get_intermediate_format" in cls.__dict__ or "_get_intermediate_dtype" in cls.__dict__
+        ):
+            raise TypeError(
+                f"{cls.__name__} overrides `_post_process` but neither `_get_intermediate_format` nor "
+                f"`_get_intermediate_dtype`; declare the intermediate buffer explicitly (no-op override returning "
+                f"the return-space value is acceptable when they coincide)."
+            )
         # Auto-register if this class defines its own options (not inherited).
         # Enforce that concrete sensor classes also specify the metadata type parameter.
         if "_options_cls" in cls.__dict__:
@@ -176,7 +219,7 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         )
         self._shared_metadata.cache_sizes.append(self._cache_size)
         self._shared_metadata.history_lengths.append(self._options.history_length)
-        self._shared_metadata.interpolate.append(getattr(self._options, "interpolate", False))
+        self._shared_metadata.interpolate.append(self._options.interpolate)
         if self._delay_ts > 0:
             self._shared_metadata.has_any_delay = True
 
@@ -200,38 +243,80 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
 
     def _get_return_format(self) -> tuple[int | tuple[int, ...], ...]:
         """
-        Get the data format of the read() return value.
+        Shape(s) of what ``read()`` returns; instance method because the shape may depend on options.
 
-        Returns
-        -------
-        return_format : tuple[tuple[int, ...], ...]
-            The output shape(s) of the tensor data returned by read(), e.g. (2, 3) means read() will return a single
-            tensor of shape (2, 3) and ((3,), (3,)) would return two tensors of shape (3,).
+        Sensor options are free to affect the returned shape (Raycaster's pattern, Camera's resolution, Proximity's
+        probe positions, etc.) - this is supported by design. Returns a single tuple ``(N,)`` for a single-tensor
+        return, or a tuple-of-tuples ``((3,), (3,), (3,))`` for a multi-tensor return (e.g. IMU's
+        ``NamedTuple(lin_acc, ang_vel, mag)``).
         """
-        raise NotImplementedError(f"{type(self).__name__} has not implemented `get_return_format()`.")
+        raise NotImplementedError(f"{type(self).__name__} has not implemented `_get_return_format()`.")
+
+    @classmethod
+    def _get_cache_dtype(cls) -> torch.dtype:
+        """
+        Dtype of what ``read()`` returns; classmethod because the dtype is class-uniform across all instances.
+
+        The manager allocates one per-dtype intermediate cache buffer and uses a per-class slice within it; if
+        instances of the same class returned different dtypes, the per-class slice would no longer be a single
+        contiguous range, breaking the per-class batched ``_update_shared_cache`` and ``_apply_transform`` contract.
+        Dtype is therefore class-uniform by design.
+        """
+        raise NotImplementedError(f"{cls.__name__} has not implemented `_get_cache_dtype()`.")
+
+    def _get_intermediate_format(self) -> tuple[int | tuple[int, ...], ...]:
+        """
+        Shape(s) of the pipeline-internal cache; defaults to ``_get_return_format()``.
+
+        Override together with ``_post_process`` when the projection changes shape. Same instance-method semantics
+        as ``_get_return_format``: the shape may depend on options.
+        """
+        return self._get_return_format()
+
+    @classmethod
+    def _get_intermediate_dtype(cls) -> torch.dtype:
+        """
+        Dtype of the pipeline-internal cache; defaults to ``_get_cache_dtype()``.
+
+        Override together with ``_post_process`` when the projection changes dtype (e.g. ContactSensor's float
+        intermediate vs. bool return). Same class-uniform semantics as ``_get_cache_dtype``.
+        """
+        return cls._get_cache_dtype()
 
     @classmethod
     def _update_shared_cache(
         cls,
         shared_metadata: SharedSensorMetadataT,
         current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
+        measured_data_timeline: "TensorRingBuffer | None",
+        intermediate_cache: torch.Tensor,
+        return_cache: torch.Tensor,
     ):
         """
-        Update the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows) and write this physics
-        step's pre-delay measured values into ``measured_data_timeline``. The current write slot is
-        ``measured_data_timeline.at(0, copy=False)`` (shape ``(B, cols)``); sensors may read older slots via
-        ``at(k, ...)`` (for example first-order filtering). SensorManager applies read delay/jitter from this timeline
-        into ``read()``.
+        Compute one step of sensor data into the shared caches.
+
+        Updates the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows), the pre-delay
+        measured timeline ring (``measured_data_timeline.at(0)`` is the current write slot), the per-dtype
+        ``intermediate_cache`` (shape ``(B, cols)``, post-delay sample in intermediate space), and the per-class
+        ``return_cache`` (shape ``(B, cols)``, post-``_post_process`` user-facing space). When the sensor opts
+        out of the measured pipeline (e.g. Camera), ``measured_data_timeline`` is ``None`` and the
+        implementation writes directly to ``intermediate_cache``; if ``_post_process`` is identity,
+        ``return_cache is intermediate_cache``.
         """
         raise NotImplementedError(f"{cls.__name__} has not implemented `update_shared_cache()`.")
 
     @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
+    def _post_process(cls, shared_metadata: SharedSensorMetadataT, tensor: torch.Tensor) -> torch.Tensor:
         """
-        The dtype of the cache for this sensor.
+        Write-time projection from per-class intermediate cache to per-class return cache.
+
+        Applied eagerly once per step by the orchestrator. Default: identity (intermediate IS return; no separate
+        allocation). ``tensor`` is the full per-class intermediate cache ``[B, total_cache_size]``. Per-instance reads
+        slice the return cache directly; no ``cache_slice`` keyword needed. Stateful overrides are allowed because the
+        orchestrator calls this exactly once per simulation step (a natural place for software-level signal processing
+        such as a complementary, Mahony, or Kalman filter on top of the raw measurement).
         """
-        raise NotImplementedError(f"{cls.__name__} has not implemented `get_cache_dtype()`.")
+        return tensor
 
     def _draw_debug(self, context: "RasterizerContext"):
         """
@@ -245,13 +330,16 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
     def read(self, envs_idx=None) -> DataT:
         """
         Read the sensor data (with noise applied if applicable).
+
+        Pure view into the per-class return cache (post-``_post_process``); ``_post_process`` was applied
+        eagerly once per step by the orchestrator.
         """
         return self._get_formatted_data(self._manager.get_cloned_from_cache(self), envs_idx)
 
     @gs.assert_built
     def read_ground_truth(self, envs_idx=None) -> DataT:
         """
-        Read the ground truth sensor data (without noise).
+        Read the ground truth sensor data (without noise). Pure view into the per-class ground-truth return cache.
         """
         return self._get_formatted_data(self._manager.get_cloned_from_cache(self, is_ground_truth=True), envs_idx)
 
@@ -275,73 +363,6 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         return self._is_built
 
     # =============================== private shared methods ===============================
-
-    @classmethod
-    def _apply_delay_to_shared_cache(
-        cls,
-        shared_metadata: SharedSensorMetadataT,
-        shared_cache: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-        interpolate: Sequence[bool] | None = None,
-    ):
-        """
-        Applies the read delay (and jitter, if any) to the shared cache tensor by copying the buffered data at the
-        appropriate index. When the class has neither delay nor jitter, takes a fast path that writes the most
-        recent ring frame to the cache class-wide.
-
-        Parameters
-        ----------
-        shared_metadata : SharedSensorMetadata
-            The shared metadata for the sensor.
-        shared_cache : torch.Tensor
-            The shared cache tensor.
-        measured_data_timeline : TensorRingBuffer
-            Pre-delay measured timeline ring for this sensor class slice (current step already written by
-            ``_update_shared_cache``).
-        interpolate : Sequence[bool] | None
-            Whether to interpolate the sensor data for the read delay + jitter. Defaults to False.
-        """
-        # Fast path: when no sensor in the class has any delay or jitter, this is equivalent to copying the most
-        # recent ring frame to the measured cache class-wide. Avoids a Python loop over every sensor. Both flags
-        # are precomputed Python bools (no GPU sync) latched at build / by setters.
-        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
-            shared_cache.copy_(measured_data_timeline.at(0))
-            return
-
-        # Sample uniform jitter in [0, jitter_ts) per env per sensor. One-sided so samples are non-negative;
-        # combined with the `jitter < dt` option constraint, the effective per-step shift is strictly bounded
-        # within [0, 1) steps and cannot wrap the ring.
-        if shared_metadata.has_any_jitter:
-            shared_metadata.cur_jitter_ts.uniform_(0.0, 1.0).mul_(shared_metadata.jitter_ts)
-            cur_jitter_ts = shared_metadata.cur_jitter_ts
-        else:
-            cur_jitter_ts = None
-
-        if interpolate is None:
-            interpolate = [False for _ in shared_metadata.cache_sizes]
-
-        tensor_start = 0
-        for sensor_idx, (tensor_size, interp) in enumerate(zip(shared_metadata.cache_sizes, interpolate)):
-            # Compute the current delay of the sensor, taking into account jitter if any
-            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
-            if cur_jitter_ts is not None:
-                cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
-
-            # Get int for indexing into ring buffer (0 = most recent, 1 = delayed by one timestep, etc.)
-            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
-
-            # Update shared cached with left data (Zero Order Hold) or linearly interpolated data (First Order)
-            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
-            sensor_cache = shared_cache[:, tensor_slice]
-            data_left = measured_data_timeline.at(cur_delay_ts_int, tensor_slice, per_row=True)
-            if interp:
-                ratio = torch.frac(cur_delay_ts)
-                data_right = measured_data_timeline.at(cur_delay_ts_int + 1, tensor_slice, per_row=True)
-                torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
-            else:
-                sensor_cache.copy_(data_left)
-
-            tensor_start += tensor_size
 
     def _get_formatted_data(self, tensor: torch.Tensor, envs_idx=None) -> torch.Tensor:
         """
@@ -392,10 +413,11 @@ class _SolverLinkGroup(NamedTuple):
 @dataclass
 class KinematicSensorMetadataMixin:
     """
-    Shared metadata for sensors attached to a KinematicEntity (or any subclass, including RigidEntity). Sensors are
-    bucketed at build time into per-solver _SolverLinkGroup entries so the per-step gather is one bulk read per solver.
-    Static sensors (entity_idx<0) are not bucketed and keep an identity link pose, leaving the kernel to apply
-    pos_offset / euler_offset in world frame.
+    Shared metadata for sensors attached to a KinematicEntity (or any subclass, including RigidEntity).
+
+    Sensors are bucketed at build time into per-solver ``_SolverLinkGroup`` entries so the per-step gather is one
+    bulk read per solver. Static sensors (``entity_idx<0``) are not bucketed and keep an identity link pose,
+    leaving the kernel to apply ``pos_offset`` / ``euler_offset`` in world frame.
     """
 
     offsets_pos: torch.Tensor = make_tensor_field((0, 0, 3))
@@ -425,10 +447,12 @@ KinematicSensorMetadataMixinT = TypeVar("KinematicSensorMetadataMixinT", bound=K
 
 class _LinkAttachedSensorMixin:
     """
-    Common boilerplate for sensors attached to a link: holds the python-side `_link` reference, concatenates
-    per-sensor pos/euler offsets into shared metadata at build time, and exposes `set_{pos,quat}_offset`. Subclasses
-    implement `_register_link` to record the link mapping in solver-specific shared-metadata shape (single tensor
-    for RigidSensorMixin, per-solver buckets for KinematicSensorMixin).
+    Common boilerplate for sensors attached to a link.
+
+    Holds the python-side ``_link`` reference, concatenates per-sensor pos/euler offsets into shared metadata at
+    build time, and exposes ``set_{pos,quat}_offset``. Subclasses implement ``_register_link`` to record the link
+    mapping in solver-specific shared-metadata shape (single tensor for ``RigidSensorMixin``, per-solver buckets
+    for ``KinematicSensorMixin``).
     """
 
     _link: "RigidLink | None" = None
@@ -482,8 +506,10 @@ class RigidSensorMixin(_LinkAttachedSensorMixin, Generic[RigidSensorMetadataMixi
 
 class KinematicSensorMixin(_LinkAttachedSensorMixin, Generic[KinematicSensorMetadataMixinT]):
     """
-    Base sensor class for sensors that may attach to entities across solvers (rigid or kinematic). Bucketing into
-    shared_metadata.solver_groups happens at build time so the per-step gather is one bulk read per solver.
+    Base sensor class for sensors that may attach to entities across solvers (rigid or kinematic).
+
+    Bucketing into ``shared_metadata.solver_groups`` happens at build time so the per-step gather is one bulk
+    read per solver.
     """
 
     def _register_link(self, entity, link_idx: int):
@@ -507,36 +533,22 @@ class KinematicSensorMixin(_LinkAttachedSensorMixin, Generic[KinematicSensorMeta
             )
 
 
-@dataclass
-class ImperfectSensorMetadataMixin:
+class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
     """
-    Base shared metadata class for analog sensors that are attached to a RigidEntity.
+    Base class for sensors that use the standard per-step pipeline.
+
+    The pipeline produces raw data into both ground-truth and measured buffers, optionally transforms each (and
+    filters the measured branch with stateful history), applies hardware imperfections on the measured timeline
+    slot (PRE-delay snapshot time), samples delay/jitter into ``intermediate_cache``, then post-processes into
+    ``return_cache``. Concrete sensors override hooks (``_update_raw_data``, ``_update_current_timestep_data``,
+    ``_apply_transform``, ``_apply_hardware_imperfections``) rather than ``_update_shared_cache`` itself.
+
+    Imperfections are applied at snapshot time (PRE-delay) inside the timeline ring's slot 0; the same ring
+    serves both delay sampling and ``read(history_length)`` history. ``_post_process`` is eager (applied once
+    per step at the end of the orchestrator).
     """
 
-    resolution: torch.Tensor = make_tensor_field((0, 0))
-    bias: torch.Tensor = make_tensor_field((0, 0))
-    cur_random_walk: torch.Tensor = make_tensor_field((0, 0))
-    random_walk: torch.Tensor = make_tensor_field((0, 0))
-    cur_noise: torch.Tensor = make_tensor_field((0, 0))
-    noise: torch.Tensor = make_tensor_field((0, 0))
-    jitter_ts: torch.Tensor = make_tensor_field((0, 0))
-    cur_jitter_ts: torch.Tensor = make_tensor_field((0, 0))
-    # Precomputed Python bool flags gate the per-step noise/bias/quantize work without GPU sync. Set at build
-    # from options and refreshed by the corresponding setters. Conservatively True once any sensor has nonzero
-    # value; never flipped back to False (avoids tracking per-sensor state).
-    has_any_noise: bool = False
-    has_any_random_walk: bool = False
-    has_any_bias: bool = False
-    has_any_resolution: bool = False
-
-
-ImperfectSensorMetadataMixinT = TypeVar("ImperfectSensorMetadataMixinT", bound=ImperfectSensorMetadataMixin)
-
-
-class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
-    """
-    Base sensor class for analog sensors that are attached to a RigidEntity.
-    """
+    uses_measured_pipeline: ClassVar[bool] = True
 
     @gs.assert_built
     def set_resolution(self, resolution, envs_idx=None):
@@ -576,6 +588,9 @@ class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
     def build(self):
         """
         Initialize all shared metadata needed to update all noisy sensors.
+
+        Time-related state (``delays_ts``, ``interpolate``) is pushed by ``Sensor.build()``; this method adds
+        the imperfection-parameter state.
         """
         super().build()
         to_tuple = partial(_to_tuple, length_per_value=self._cache_size)
@@ -602,15 +617,13 @@ class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
         self._shared_metadata.random_walk = concat_with_tensor(
             self._shared_metadata.random_walk, to_tuple(self._options.random_walk), expand=(batch_size, -1), dim=-1
         )
-        self._shared_metadata.cur_random_walk = torch.zeros_like(self._shared_metadata.random_walk)
+        self._shared_metadata._cur_random_walk = torch.zeros_like(self._shared_metadata.random_walk)
         self._shared_metadata.noise = concat_with_tensor(
             self._shared_metadata.noise, to_tuple(self._options.noise), expand=(batch_size, -1), dim=-1
         )
-        self._shared_metadata.cur_noise = torch.zeros_like(self._shared_metadata.noise)
         self._shared_metadata.jitter_ts = concat_with_tensor(
             self._shared_metadata.jitter_ts, to_tuple(self._options.jitter / self._dt), expand=(batch_size, -1), dim=-1
         )
-        self._shared_metadata.cur_jitter_ts = torch.zeros_like(self._shared_metadata.jitter_ts, device=gs.device)
         if np.any(jitter_np > gs.EPS):
             self._shared_metadata.has_any_jitter = True
         if np.any(np.asarray(self._options.noise, dtype=gs.np_float) > gs.EPS):
@@ -623,28 +636,135 @@ class ImperfectSensorMixin(Generic[ImperfectSensorMetadataMixinT]):
             self._shared_metadata.has_any_resolution = True
 
     @classmethod
-    def reset(cls, shared_metadata: ImperfectSensorMetadataMixin, shared_ground_truth_cache: torch.Tensor, envs_idx):
+    def reset(cls, shared_metadata: SharedSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
         super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
-        shared_metadata.cur_random_walk[envs_idx, ...].fill_(0.0)
+        shared_metadata._cur_random_walk[envs_idx, ...].fill_(0.0)
 
     @classmethod
-    def _apply_imperfections(cls, shared_metadata: "ImperfectSensorMetadataMixin", output: torch.Tensor):
-        """Transform ground truth into realistic measured data in-place: apply random_walk drift, Gaussian noise,
-        bias, then quantize to the configured resolution. Each contribution is gated by a precomputed Python bool
-        flag (`has_any_*`) so sensor classes with all-zero values pay no GPU work."""
+    def _update_shared_cache(
+        cls,
+        shared_metadata: SharedSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer | None",
+        intermediate_cache: torch.Tensor,
+        return_cache: torch.Tensor,
+    ):
+        # `intermediate_cache` is the pipeline-internal buffer (shape/dtype from `_get_intermediate_format` /
+        # `_get_intermediate_dtype`). `return_cache` is in `_get_return_format` / `_get_cache_dtype` space. When
+        # `_post_process` is identity (default), the manager passes the same buffer for both (zero-copy alias); when
+        # overridden, they're distinct buffers and `_post_process` is applied at the end.
+        if measured_data_timeline is None:
+            cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
+            cls._apply_transform(shared_metadata, current_ground_truth_data_T.T, timeline=None)
+            intermediate_cache.copy_(current_ground_truth_data_T.T)
+        else:
+            cls._update_current_timestep_data(shared_metadata, current_ground_truth_data_T, measured_data_timeline)
+            cls._apply_transform(shared_metadata, current_ground_truth_data_T.T, timeline=None)
+            measured_slot_0 = measured_data_timeline.at(0, copy=False)
+            cls._apply_transform(shared_metadata, measured_slot_0, timeline=measured_data_timeline)
+            # Imperfections applied PRE-delay so the timeline ring stores post-noise values that serve both delay
+            # sampling below AND `read(history_length=N)`. Timeline stays in intermediate space - required for
+            # `_apply_transform` filter correctness (previous slots must be in the same data space as `data`).
+            cls._apply_hardware_imperfections(shared_metadata, measured_slot_0)
+            # Inlined delay sampling: writes intermediate_cache from measured_data_timeline.
+            # Fast path: when no sensor in the class has any delay or jitter, this is equivalent to copying the most
+            # recent ring frame to the measured cache class-wide. Avoids a Python loop over every sensor. Both flags
+            # are precomputed Python bools (no GPU sync) latched at build / by setters.
+            if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
+                intermediate_cache.copy_(measured_slot_0)
+            else:
+                if shared_metadata.has_any_jitter:
+                    # Sample uniform jitter in [0, jitter_ts) per env per sensor. One-sided so samples are
+                    # non-negative; combined with the `jitter < dt` option constraint, the effective per-step shift
+                    # is strictly bounded within [0, 1) steps and cannot wrap the ring.
+                    cur_jitter_ts = torch.rand_like(shared_metadata.jitter_ts).mul_(shared_metadata.jitter_ts)
+                else:
+                    cur_jitter_ts = None
+                tensor_start = 0
+                for sensor_idx, (tensor_size, interp) in enumerate(
+                    zip(shared_metadata.cache_sizes, shared_metadata.interpolate)
+                ):
+                    # Compute the current delay of the sensor, taking into account jitter if any.
+                    cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
+                    if cur_jitter_ts is not None:
+                        cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
+                    # Get int for indexing into ring buffer (0 = most recent, 1 = delayed by one timestep, etc.)
+                    cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
+                    tensor_slice = slice(tensor_start, tensor_start + tensor_size)
+                    sensor_cache = intermediate_cache[:, tensor_slice]
+                    data_left = measured_data_timeline.at(cur_delay_ts_int, tensor_slice, per_row=True)
+                    # Update intermediate cache with left data (Zero Order Hold) or linearly interpolated data
+                    # (First Order Hold).
+                    if interp:
+                        ratio = torch.frac(cur_delay_ts)
+                        data_right = measured_data_timeline.at(cur_delay_ts_int + 1, tensor_slice, per_row=True)
+                        torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
+                    else:
+                        sensor_cache.copy_(data_left)
+                    tensor_start += tensor_size
+
+        # Eager post-processing: applied once per step so `read()` is a pure view into the per-class return cache.
+        # When `_post_process` is the identity default, the manager passes `intermediate_cache` as `return_cache`
+        # (zero-copy alias); the buffer-identity check skips the redundant copy in that case.
+        if return_cache is not intermediate_cache:
+            return_cache.copy_(cls._post_process(shared_metadata, intermediate_cache))
+
+    @classmethod
+    def _update_current_timestep_data(
+        cls,
+        shared_metadata: SharedSensorMetadata,
+        current_ground_truth_data_T: torch.Tensor,
+        measured_data_timeline: "TensorRingBuffer",
+    ):
+        """
+        Write the current timestep's raw signal into both buffers.
+
+        Default behavior: compute raw GT into ``current_ground_truth_data_T`` via ``_update_raw_data``, then copy
+        it into the measured ring's current slot. Override for sensors with kernel-internal physical-response
+        noise (one kernel writes both GT and the noised measured value in one pass).
+        """
+        cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
+        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+
+    @classmethod
+    def _update_raw_data(cls, shared_metadata: SharedSensorMetadata, raw_data_T: torch.Tensor):
+        """Sensor-specific kernel computing raw data into ``raw_data_T`` (shape ``(cols, B)``)."""
+        raise NotImplementedError(f"{cls.__name__} has not implemented `_update_raw_data()`.")
+
+    @classmethod
+    def _apply_transform(
+        cls,
+        shared_metadata: SharedSensorMetadata,
+        data: torch.Tensor,
+        *,
+        timeline: "TensorRingBuffer | None" = None,
+    ):
+        """
+        Coordinate transform + optional stateful filter; mutates ``data`` in place.
+
+        Receives ``data`` as a batch-first view ``[B, cache_size, ...]`` and must mutate it in place. ``timeline``
+        is ``None`` on the GT branch and the measured ring on the measured branch; gate filter logic on
+        ``timeline is not None`` and read previous slots with ``timeline.at(1)``, ``timeline.at(2)``, etc.
+        """
+
+    @classmethod
+    def _apply_hardware_imperfections(cls, shared_metadata: SimpleSensorMetadata, measured_slot_0: torch.Tensor):
+        """
+        Apply SimpleSensor's imperfection model in-place at the current measured-timeline slot.
+
+        Opinionated interpretation of the imperfection parameters (noise, bias, random_walk, resolution) as the
+        perturbations introduced by the embedded sampling layer at snapshot time. Applied at slot 0 of the
+        measured timeline (PRE-delay sampling). Each contribution is gated by a precomputed Python bool flag
+        (``has_any_*``) so sensor classes with all-zero values pay no GPU work.
+        """
         if shared_metadata.has_any_random_walk:
-            shared_metadata.cur_random_walk += torch.normal(0.0, shared_metadata.random_walk)
-            output += shared_metadata.cur_random_walk
+            shared_metadata._cur_random_walk += torch.normal(0.0, shared_metadata.random_walk)
+            measured_slot_0 += shared_metadata._cur_random_walk
         if shared_metadata.has_any_noise:
-            torch.normal(0.0, shared_metadata.noise, out=shared_metadata.cur_noise)
-            output += shared_metadata.cur_noise
+            measured_slot_0 += torch.normal(0.0, shared_metadata.noise)
         if shared_metadata.has_any_bias:
-            output += shared_metadata.bias
+            measured_slot_0 += shared_metadata.bias
         if shared_metadata.has_any_resolution:
             resolution = shared_metadata.resolution
             mask = resolution > gs.EPS
-            output[mask] = torch.round(output[mask] / resolution[mask]) * resolution[mask]
-
-    @classmethod
-    def get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
+            measured_slot_0[mask] = torch.round(measured_slot_0[mask] / resolution[mask]) * resolution[mask]

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -4,7 +4,7 @@ Camera sensors for rendering: Rasterizer, Raytracer, and Batch Renderer.
 
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, NamedTuple, Optional, Type
 
 import numpy as np
 import torch
@@ -232,7 +232,20 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
     - Shared read() method returning torch tensors
     """
 
+    uses_measured_pipeline: ClassVar[bool] = False
+
     def __init__(self, options: "SensorOptions", idx: int, manager: "SensorManager"):
+        # Camera bypasses the measured pipeline (lazy render on read); any feature relying on the timeline ring
+        # would silently no-op. Reject the inputs at construction so the user is forced to drop the option or pick a
+        # different sensor.
+        if options.delay > 0.0:
+            gs.raise_exception(f"{type(self).__name__} does not support `delay`; got delay={options.delay}.")
+        if options.jitter > 0.0:
+            gs.raise_exception(f"{type(self).__name__} does not support `jitter`; got jitter={options.jitter}.")
+        if options.history_length > 0:
+            gs.raise_exception(
+                f"{type(self).__name__} does not support `history_length`; got history_length={options.history_length}."
+            )
         super().__init__(options, idx, manager)
         self._stale: bool = True
 
@@ -251,9 +264,12 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
         cls,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
+        measured_data_timeline: "TensorRingBuffer | None",
+        intermediate_cache: torch.Tensor,
+        return_cache: torch.Tensor,
     ):
-        # No per-step measured-cache update for cameras (handled lazily on read()).
+        # No per-step measured-cache update for cameras (handled lazily on read()). `BaseCameraSensor` declares
+        # `uses_measured_pipeline = False`, so the manager passes `measured_data_timeline=None` here.
         pass
 
     def _draw_debug(self, context: "RasterizerContext"):

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -17,12 +17,11 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_torc
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SimpleSensor,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -71,7 +70,7 @@ def _kernel_get_contacts_forces(
 
 
 @dataclass
-class ContactSensorMetadata(SharedSensorMetadata):
+class ContactSensorMetadata(SimpleSensorMetadata):
     """
     Metadata for all rigid contact sensors.
     """
@@ -83,9 +82,11 @@ class ContactSensorMetadata(SharedSensorMetadata):
     # Indices into expanded_links_idx of sensors that have at least one filter link. Lets the GT update skip the
     # 4D contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
     filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    # Per-sensor bool threshold (broadcast over B); _post_process returns `tensor > thresholds`.
+    thresholds: torch.Tensor = make_tensor_field((0,))
 
 
-class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
+class ContactSensor(SimpleSensor[ContactSensorOptions, ContactSensorMetadata]):
     """
     Sensor that returns bool based on whether associated RigidLink is in contact.
     """
@@ -124,6 +125,10 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
                 self._shared_metadata.filtered_sensor_idx, num_sensors, expand=(1,), dim=0
             )
 
+        self._shared_metadata.thresholds = concat_with_tensor(
+            self._shared_metadata.thresholds, float(self._options.threshold), expand=(1,)
+        )
+
     def _get_return_format(self) -> tuple[int, ...]:
         return (1,)
 
@@ -132,27 +137,27 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
         return gs.tc_bool
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ContactSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _get_intermediate_dtype(cls) -> torch.dtype:
+        # Float kernel output; bool projection happens in `_post_process`. Shape matches `_get_return_format`.
+        return gs.tc_float
+
+    @classmethod
+    def _update_raw_data(cls, shared_metadata: ContactSensorMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
         all_contacts = shared_metadata.solver.collider.get_contacts(as_tensor=True, to_torch=True)
         link_a, link_b = all_contacts["link_a"], all_contacts["link_b"]
         if link_a.shape[-1] == 0:
-            current_ground_truth_data_T.zero_()
-            measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+            raw_data_T.zero_()
             return
         if shared_metadata.solver.n_envs == 0:
             link_a, link_b = link_a[None], link_b[None]
 
         is_contact_a = link_a[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         is_contact_b = link_b[..., None, :] == shared_metadata.expanded_links_idx[..., None]
-        result = (is_contact_a | is_contact_b).any(dim=-1)
-        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors
-        # keep the cheap any() result above.
+        # Float-valued contact count per sensor (intermediate cache is float; bool projection in `_post_process`).
+        result = (is_contact_a | is_contact_b).sum(dim=-1).to(dtype=gs.tc_float)
+        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors keep
+        # the cheap aggregate result above.
         if shared_metadata.filtered_sensor_idx.numel() > 0:
             filt = shared_metadata.filtered_sensor_idx
             sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
@@ -160,9 +165,12 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
             filtered_b = (link_a[:, None, :, None] == sub_filter).any(dim=-1)
             sub_is_a = is_contact_a[:, filt, :]
             sub_is_b = is_contact_b[:, filt, :]
-            result[:, filt] = ((sub_is_a & ~filtered_a) | (sub_is_b & ~filtered_b)).any(dim=-1)
-        current_ground_truth_data_T[:] = result.T
-        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+            result[:, filt] = ((sub_is_a & ~filtered_a) | (sub_is_b & ~filtered_b)).sum(dim=-1).to(dtype=gs.tc_float)
+        raw_data_T[:] = result.T
+
+    @classmethod
+    def _post_process(cls, shared_metadata: ContactSensorMetadata, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor > shared_metadata.thresholds
 
     def _draw_debug(self, context: "RasterizerContext"):
         """
@@ -189,7 +197,7 @@ class ContactSensor(Sensor[ContactSensorOptions, ContactSensorMetadata]):
 
 
 @dataclass
-class ContactForceSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata):
+class ContactForceSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     """
     Shared metadata for all contact force sensors.
     """
@@ -200,8 +208,7 @@ class ContactForceSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMetada
 
 class ContactForceSensor(
     RigidSensorMixin[ContactForceSensorMetadata],
-    ImperfectSensorMixin[ContactForceSensorMetadata],
-    Sensor[ContactForceSensorOptions, ContactForceSensorMetadata],
+    SimpleSensor[ContactForceSensorOptions, ContactForceSensorMetadata],
 ):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
@@ -233,12 +240,13 @@ class ContactForceSensor(
         return gs.tc_float
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ContactForceSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _get_intermediate_dtype(cls) -> torch.dtype:
+        # Required override because `_post_process` is overridden, even though shape and dtype coincide with return.
+        # The intermediate buffer must be a distinct buffer (the timeline ring is in intermediate space).
+        return cls._get_cache_dtype()
+
+    @classmethod
+    def _update_raw_data(cls, shared_metadata: ContactForceSensorMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
 
         # Note that forcing GPU sync to operate on `slice(0, max(n_contacts))` is usually faster overall.
@@ -249,43 +257,43 @@ class ContactForceSensor(
 
         # Short-circuit if no contacts
         if link_a.shape[-1] == 0:
-            current_ground_truth_data_T.zero_()
-            measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+            raw_data_T.zero_()
+            return
+
+        links_quat = shared_metadata.solver.get_links_quat()
+        if shared_metadata.solver.n_envs == 0:
+            links_quat = links_quat[None]
+
+        if gs.use_zerocopy:
+            # Forces are aggregated BEFORE moving them in local frame for efficiency.
+            force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
+            force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
+            force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
+            sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
+            sensors_quat = links_quat[:, shared_metadata.links_idx]
+            n_envs = max(shared_metadata.solver.n_envs, 1)
+            result = inv_transform_by_quat(sensors_force, sensors_quat)  # (B, n_sensors, 3)
+            raw_data_T[:] = result.permute(1, 2, 0).reshape(-1, n_envs)
         else:
-            links_quat = shared_metadata.solver.get_links_quat()
-            if shared_metadata.solver.n_envs == 0:
-                links_quat = links_quat[None]
+            raw_data_T.zero_()
+            _kernel_get_contacts_forces(
+                force.contiguous(),
+                link_a.contiguous(),
+                link_b.contiguous(),
+                links_quat.contiguous(),
+                shared_metadata.links_idx,
+                raw_data_T,
+            )
 
-            if gs.use_zerocopy:
-                # Forces are aggregated BEFORE moving them in local frame for efficiency
-                force_mask_a = link_a[:, None] == shared_metadata.links_idx[None, :, None]
-                force_mask_b = link_b[:, None] == shared_metadata.links_idx[None, :, None]
-                force_mask = force_mask_b.to(dtype=gs.tc_float) - force_mask_a.to(dtype=gs.tc_float)
-                sensors_force = (force_mask[..., None] * force[:, None]).sum(dim=2)
-                sensors_quat = links_quat[:, shared_metadata.links_idx]
-                n_envs = max(shared_metadata.solver.n_envs, 1)
-                result = inv_transform_by_quat(sensors_force, sensors_quat)  # (B, n_sensors, 3)
-                current_ground_truth_data_T[:] = result.permute(1, 2, 0).reshape(-1, n_envs)
-            else:
-                current_ground_truth_data_T.zero_()
-                _kernel_get_contacts_forces(
-                    force.contiguous(),
-                    link_a.contiguous(),
-                    link_b.contiguous(),
-                    links_quat.contiguous(),
-                    shared_metadata.links_idx,
-                    current_ground_truth_data_T,
-                )
-
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
-        # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization; for
-        # max_force values that are not multiples of resolution this produces a non-quantized saturation value,
-        # accepted as minor drift in that edge case.
-        measured_per_sensor_view = measured.reshape((measured.shape[0], -1, 3))
-        measured_per_sensor_view.clamp_(min=-shared_metadata.max_force, max=shared_metadata.max_force)
-        measured_per_sensor_view.masked_fill_(torch.abs(measured_per_sensor_view) < shared_metadata.min_force, 0.0)
+    @classmethod
+    def _post_process(cls, shared_metadata: ContactForceSensorMetadata, tensor: torch.Tensor) -> torch.Tensor:
+        # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization (which
+        # happens upstream in `_apply_hardware_imperfections`); for max_force values that are not multiples of
+        # resolution this produces a non-quantized saturation value, accepted as minor drift in that edge case.
+        per_sensor = tensor.reshape((tensor.shape[0], -1, 3))
+        out = per_sensor.clamp(min=-shared_metadata.max_force, max=shared_metadata.max_force)
+        out = out.masked_fill(out.abs() < shared_metadata.min_force, 0.0)
+        return out.reshape(tensor.shape)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/imu.py
+++ b/genesis/engine/sensors/imu.py
@@ -16,12 +16,11 @@ from genesis.utils.geom import (
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -63,7 +62,7 @@ def _get_cross_axis_coupling_to_alignment_matrix(
 
 
 @dataclass
-class IMUSharedMetadata(RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata):
+class IMUSharedMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     """
     Shared metadata between all IMU sensors.
     """
@@ -83,8 +82,7 @@ class IMUData(NamedTuple):
 
 class IMUSensor(
     RigidSensorMixin[IMUSharedMetadata],
-    ImperfectSensorMixin[IMUSharedMetadata],
-    Sensor[IMUOptions, IMUSharedMetadata, IMUData],
+    SimpleSensor[IMUOptions, IMUSharedMetadata, IMUData],
 ):
     def __init__(self, options: IMUOptions, shared_metadata: IMUSharedMetadata, manager: "SensorManager"):
         # FIXME: Resolution should be made private in mixin, so that it cannot be set by the user directly.
@@ -155,24 +153,16 @@ class IMUSensor(
             self.pos_offset = self._shared_metadata.offsets_pos[0, self._idx]
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (3,), (3,), (3,)
+        return ((3,), (3,), (3,))
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
         return gs.tc_float
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: IMUSharedMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
-        """
-        Update ground truth and pre-delay measured IMU values for all sensors of this class.
-        """
-        # Extract acceleration and gravity in world frame
+    def _update_raw_data(cls, shared_metadata: IMUSharedMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
+        # Extract acceleration and gravity in world frame.
         gravity = shared_metadata.solver.get_gravity()
         quats = shared_metadata.solver.get_links_quat(links_idx=shared_metadata.links_idx)
         acc = shared_metadata.solver.get_links_acc(links_idx=shared_metadata.links_idx)
@@ -194,27 +184,31 @@ class IMUSensor(
             centripetal_acc = torch.cross(ang, torch.cross(ang, offset_pos_world, dim=-1), dim=-1)
             acc += tangential_acc + centripetal_acc
 
-        # Subtract gravity then move to local frame
-        # acc/ang shape: (B, n_imus, 3)
+        # Subtract gravity then move to local frame. acc/ang shape: (B, n_imus, 3); local_mag is already
+        # (B, n_imus, 3) after the inverse transform, no reshape needed.
         local_acc = inv_transform_by_quat(acc - gravity[..., None, :], offset_quats)
         local_ang = inv_transform_by_quat(ang, offset_quats)
-
-        # is now already (n_envs, n_imus, 3), no need for a reshape
         local_mag = inv_transform_by_quat(shared_metadata.magnetic_field_vector, offset_quats)
 
-        # cache layout: (n_imus * 9, B)
+        # Raw-data buffer layout: (n_imus * 9, B). View into (n_imus, 3, 3, *batch_size) for the per-channel writes.
         *batch_size, n_imus, _ = local_acc.shape
-        strided_ground_truth_cache = current_ground_truth_data_T.view(n_imus, 3, 3, *batch_size)
-        strided_ground_truth_cache[:, 0].copy_(local_acc.permute(1, 2, 0))
-        strided_ground_truth_cache[:, 1].copy_(local_ang.permute(1, 2, 0))
-        strided_ground_truth_cache[:, 2].copy_(local_mag.permute(1, 2, 0))
+        strided_raw = raw_data_T.view(n_imus, 3, 3, *batch_size)
+        strided_raw[:, 0].copy_(local_acc.permute(1, 2, 0))
+        strided_raw[:, 1].copy_(local_ang.permute(1, 2, 0))
+        strided_raw[:, 2].copy_(local_mag.permute(1, 2, 0))
 
-        # apply alignment rotation and imperfections to the measured data
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        measured_xyz = measured.view(measured.shape[0], -1, 3)
-        measured_xyz.copy_(torch.matmul(shared_metadata.alignment_rot_matrix, measured_xyz.unsqueeze(-1)).squeeze(-1))
-        cls._apply_imperfections(shared_metadata, measured)
+    @classmethod
+    def _apply_transform(
+        cls,
+        shared_metadata: IMUSharedMetadata,
+        data: torch.Tensor,
+        *,
+        timeline=None,
+    ):
+        # Apply alignment rotation to the (lin_acc, ang_vel, mag) triplet. View the flat cache as a stack of 3-vectors
+        # and rotate them in place with the per-sensor `alignment_rot_matrix`.
+        data_xyz = data.view(data.shape[0], -1, 3)
+        data_xyz.copy_(torch.matmul(shared_metadata.alignment_rot_matrix, data_xyz.unsqueeze(-1)).squeeze(-1))
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -17,12 +17,11 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 from genesis.utils.raycast_qd import get_triangle_vertices, ray_triangle_intersection
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -784,7 +783,7 @@ KinematicTactileSensorMetadataMixinT = TypeVar(
 
 class KinematicTactileSensorMixin(Generic[KinematicTactileSensorMetadataMixinT]):
     def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
-        # Store n_probes before super().__init__() since _get_return_format() is called there
+        # Store n_probes before super().__init__() since `_get_return_format` is read there
         self._probe_local_pos = torch.tensor(sensor_options.probe_local_pos, dtype=gs.tc_float, device=gs.device)
         self._n_probes = int(np.prod(self._probe_local_pos.shape[:-1]))
 
@@ -843,10 +842,6 @@ class KinematicTactileSensorMixin(Generic[KinematicTactileSensorMetadataMixinT])
             self._shared_metadata.probe_radius, probe_radius_tensor, expand=(self._n_probes,)
         )
 
-    @classmethod
-    def _get_cache_dtype(cls) -> torch.dtype:
-        return gs.tc_float
-
     def _draw_debug_probes(self, context: "RasterizerContext", get_magnitude: Callable[[int], float]):
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None
 
@@ -904,7 +899,7 @@ class KinematicContactProbeData(NamedTuple):
 
 @dataclass
 class KinematicContactProbeMetadata(
-    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata
+    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata
 ):
     stiffness: torch.Tensor = make_tensor_field((0,))
 
@@ -912,8 +907,7 @@ class KinematicContactProbeMetadata(
 class KinematicContactProbe(
     KinematicTactileSensorMixin[KinematicContactProbeMetadata],
     RigidSensorMixin[KinematicContactProbeMetadata],
-    ImperfectSensorMixin[KinematicContactProbeMetadata],
-    Sensor[KinematicContactProbeOptions, KinematicContactProbeMetadata, KinematicContactProbeData],
+    SimpleSensor[KinematicContactProbeOptions, KinematicContactProbeMetadata, KinematicContactProbeData],
 ):
     """Kinematic contact probe measuring penetration depth along the probe normal on collisions."""
 
@@ -921,7 +915,11 @@ class KinematicContactProbe(
         super().__init__(sensor_options, sensor_idx, sensor_manager)
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._n_probes,), (self._n_probes, 3)
+        return ((self._n_probes,), (self._n_probes, 3))
+
+    @classmethod
+    def _get_cache_dtype(cls) -> torch.dtype:
+        return gs.tc_float
 
     def build(self):
         super().build()
@@ -931,16 +929,11 @@ class KinematicContactProbe(
         )
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: KinematicTactileSensorMetadataMixinT,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: KinematicContactProbeMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
         collider_state = solver.collider._collider_state
 
-        current_ground_truth_data_T.zero_()
+        raw_data_T.zero_()
         _kernel_kinematic_contact_probe(
             shared_metadata.probe_positions,
             shared_metadata.probe_normals,
@@ -962,11 +955,8 @@ class KinematicContactProbe(
             solver.verts_info,
             solver.faces_info,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(context, lambda data: data.penetration)
@@ -974,7 +964,7 @@ class KinematicContactProbe(
 
 @dataclass
 class ElastomerDisplacementSensorMetadata(
-    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata
+    KinematicTactileSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata
 ):
     contact_buf: torch.Tensor = make_tensor_field((0, 0, 4))
     contact_link_buf: torch.Tensor = make_tensor_field((0, 0))
@@ -1001,8 +991,7 @@ class ElastomerDisplacementSensorMetadata(
 class ElastomerDisplacementSensor(
     KinematicTactileSensorMixin[ElastomerDisplacementSensorMetadata],
     RigidSensorMixin[ElastomerDisplacementSensorMetadata],
-    ImperfectSensorMixin[ElastomerDisplacementSensorMetadata],
-    Sensor[ElastomerDisplacementSensorOptions, ElastomerDisplacementSensorMetadata],
+    SimpleSensor[ElastomerDisplacementSensorOptions, ElastomerDisplacementSensorMetadata],
 ):
     def __init__(
         self, sensor_options: ElastomerDisplacementSensorOptions, sensor_idx: int, sensor_manager: "SensorManager"
@@ -1015,6 +1004,10 @@ class ElastomerDisplacementSensor(
 
     def _get_return_format(self) -> tuple[int, ...]:
         return (self._n_probes, 3)
+
+    @classmethod
+    def _get_cache_dtype(cls) -> torch.dtype:
+        return gs.tc_float
 
     def build(self):
         super().build()
@@ -1088,12 +1081,7 @@ class ElastomerDisplacementSensor(
         self._shared_metadata.fft_kernel_list.append(kernel_fft)
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ElastomerDisplacementSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: ElastomerDisplacementSensorMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
 
         # Zero buffers allocated with torch.empty to avoid stale data if the kernel
@@ -1126,7 +1114,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.contact_buf,
             shared_metadata.contact_link_buf,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
         _elastomer_displacement_grid_fft_dilate(
             shared_metadata.is_grid,
@@ -1139,7 +1127,7 @@ class ElastomerDisplacementSensor(
             shared_metadata.dilate_coefficient,
             shared_metadata.dilate_max_delta,
             shared_metadata.grid_dilate_out_buffer,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
         _kernel_elastomer_displacement_grid_shear_twist(
             shared_metadata.probe_positions,
@@ -1157,11 +1145,8 @@ class ElastomerDisplacementSensor(
             solver.links_state,
             solver._sim.dt,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(context, lambda data: torch.linalg.norm(data, dim=-1))

--- a/genesis/engine/sensors/proximity.py
+++ b/genesis/engine/sensors/proximity.py
@@ -14,12 +14,11 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 from genesis.utils.raycast_qd import get_triangle_vertices
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SimpleSensorMetadata,
 )
 from .kinematic_tactile import _func_closest_point_on_triangle
 
@@ -131,16 +130,13 @@ class ProximitySensorMetadataMixin:
 
 
 @dataclass
-class ProximityMetadata(
-    ProximitySensorMetadataMixin, RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata
-):
+class ProximityMetadata(ProximitySensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata):
     """Shared metadata for the Proximity sensor class."""
 
 
 class ProximitySensor(
     RigidSensorMixin[ProximityMetadata],
-    ImperfectSensorMixin[ProximityMetadata],
-    Sensor[ProximityOptions, ProximityMetadata, tuple],
+    SimpleSensor[ProximityOptions, ProximityMetadata, tuple],
 ):
     """Proximity sensor: distance and nearest point from probe positions to tracked mesh surfaces."""
 
@@ -151,7 +147,7 @@ class ProximitySensor(
         self._debug_objects: list = []
         self._nearest_points_slice: slice = slice(None)
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
+    def _get_return_format(self) -> tuple[int, ...]:
         return (self._n_probes,)
 
     @classmethod
@@ -217,14 +213,9 @@ class ProximitySensor(
         shared_metadata.nearest_positions[envs_idx] = shared_metadata.probe_positions
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: ProximityMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: ProximityMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
-        current_ground_truth_data_T.zero_()
+        raw_data_T.zero_()
         _kernel_proximity(
             shared_metadata.probe_positions,
             shared_metadata.probe_sensor_idx,
@@ -246,11 +237,8 @@ class ProximitySensor(
             solver.fixed_verts_state,
             solver.free_verts_state,
             shared_metadata.nearest_positions,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.copy_(current_ground_truth_data_T.T)
-        cls._apply_imperfections(shared_metadata, measured)
 
     def _draw_debug(self, context: "RasterizerContext"):
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -28,7 +28,8 @@ from .base_sensor import (
     KinematicSensorMetadataMixin,
     KinematicSensorMixin,
     Sensor,
-    SharedSensorMetadata,
+    SimpleSensorMetadata,
+    SimpleSensor,
 )
 
 if TYPE_CHECKING:
@@ -40,8 +41,12 @@ if TYPE_CHECKING:
 
 
 class _SolverBVH(NamedTuple):
-    """One BVH built against a solver's mesh. raycast_mask is None for a collision BVH (faces_info / verts_info,
-    no per-face mask), otherwise an int8 array of shape (n_vfaces,) selecting which visual faces contribute."""
+    """
+    One BVH built against a solver's mesh.
+
+    ``raycast_mask`` is ``None`` for a collision BVH (``faces_info`` / ``verts_info``, no per-face mask),
+    otherwise an int8 array of shape ``(n_vfaces,)`` selecting which visual faces contribute.
+    """
 
     solver: "KinematicSolver"
     bvh: LBVH
@@ -50,7 +55,7 @@ class _SolverBVH(NamedTuple):
 
 
 @dataclass
-class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMetadata):
+class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata):
     # All BVHs (one per active solver per mesh type) cast against each frame. The first is written into the output
     # cache with is_merge=False (initializes hits or no_hit_value), the rest merge in closer hits. Per-sensor link
     # poses are gathered via KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
@@ -85,7 +90,7 @@ class RaycasterData(NamedTuple):
     distances: torch.Tensor
 
 
-class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSharedMetadata, RaycasterData]):
+class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, RaycasterSharedMetadata, RaycasterData]):
     def __init__(self, options: RaycasterOptions, sensor_idx: int, manager: "SensorManager"):
         super().__init__(options, sensor_idx, manager)
         self.debug_objects: list["Mesh"] = []
@@ -236,19 +241,14 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
         shape = self._options.pattern.return_shape
-        return (*shape, 3), shape
+        return ((*shape, 3), shape)
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
         return gs.tc_float
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: RaycasterSharedMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: RaycasterSharedMetadata, raw_data_T: torch.Tensor):
         cls._update_bvh(shared_metadata)
 
         # Allocate the link-pose scratch buffers on first cast (B and n_sensors are known here). Identity quat is
@@ -295,7 +295,7 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
                 shared_metadata.sensor_cache_offsets,
                 shared_metadata.sensor_point_offsets,
                 shared_metadata.sensor_point_counts,
-                current_ground_truth_data_T,
+                raw_data_T,
                 gs.EPS,
                 i > 0,
             )
@@ -315,8 +315,6 @@ class RaycasterSensor(KinematicSensorMixin, Sensor[RaycasterOptions, RaycasterSh
                     solver.vgeoms_state,
                     *args_common,
                 )
-
-        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -10,12 +10,10 @@ from genesis.options.sensors import types as _sensor_types_namespace
 from genesis.options.sensors.options import SensorOptions
 from genesis.utils.ring_buffer import TensorRingBuffer
 
-from .base_sensor import SharedSensorMetadata
+from .base_sensor import Sensor, SharedSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.vis.rasterizer_context import RasterizerContext
-
-    from .base_sensor import Sensor
 
 
 class SensorManager:
@@ -26,25 +24,33 @@ class SensorManager:
         self._sim = sim
         self._sensors_by_type: dict[type["Sensor"], list["Sensor"]] = {}
         self._sensors_metadata: dict[type["Sensor"], SharedSensorMetadata | None] = {}
-        self._ground_truth_cache: dict[type[torch.dtype], torch.Tensor] = {}
-        self._cache: dict[type[torch.dtype], torch.Tensor] = {}
+        # Per-dtype intermediate caches: pre-`_post_process` storage in intermediate space. The transposed GT cache
+        # is `(cols, B)` for C-contiguous per-class row slices required by kernel writes.
+        self._ground_truth_intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
+        self._intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
+        # Per-class return caches: post-`_post_process` storage in return space. When `_post_process` is identity,
+        # alias-views into the per-dtype intermediate cache; when overridden, separate buffers in return shape/dtype.
+        self._return_cache: dict[type["Sensor"], torch.Tensor] = {}
+        self._ground_truth_return_cache: dict[type["Sensor"], torch.Tensor] = {}
         self._ground_truth_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Pre-delay instantaneous measured timeline; shares ring idx with _ground_truth_timeline_ring per dtype.
+        # Measured timeline: post-imperfection, pre-delay snapshots. Shares ring idx with _ground_truth_timeline_ring
+        # per dtype. No separate measured-history ring - history reads are served from this ring's slots or from the
+        # per-class linearized history buffer.
         self._measured_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        self._measured_history_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Linearized per-class history of shape (B, max_history_for_class, class_cache_size). Refreshed every step.
-        # Lets read_sensors and per-sensor history reads return views instead of re-gathering from the ring.
-        self._linearized_ground_truth_history: dict[type["Sensor"], torch.Tensor] = {}
-        self._linearized_measured_history: dict[type["Sensor"], torch.Tensor] = {}
-        # Per-class precomputed history index tensor [0, 1, ..., max_history-1]. Used to fancy-index the rings each
-        # step.
+        # Per-class return-space rings, only allocated when `_post_process` is overridden AND any sensor of the class
+        # has `history_length > 0`. Each step the eager `_post_process` result is written to slot 0; history reads
+        # gather from here so the projection is computed once at write time (correct for stateful `_post_process`)
+        # and history reads avoid re-projecting older slots. For identity `_post_process` the intermediate ring is
+        # already in return space, so no extra ring is needed.
+        self._ground_truth_return_timeline_ring: dict[type["Sensor"], TensorRingBuffer] = {}
+        self._measured_return_timeline_ring: dict[type["Sensor"], TensorRingBuffer] = {}
+        # Per-class precomputed history index tensor [0, 1, ..., max_history-1]. Used to fancy-index the rings on
+        # history reads.
         self._hist_idx_by_class: dict[type["Sensor"], torch.Tensor] = {}
         self._cache_slices_by_type: dict[type["Sensor"], slice] = {}
         # (sensor class, entity_idx) -> slice within the class cache. entity_idx == -1 means static sensors.
         self._entity_slice_in_class: dict[type["Sensor"], dict[int, slice]] = {}
         self._max_history_by_class: dict[type["Sensor"], int] = {}
-        self._is_last_cache_cloned: dict[tuple[bool, type[torch.dtype]], bool] = {}
-        self._cloned_cache: dict[tuple[bool, type[torch.dtype]], torch.Tensor] = {}
 
     def create_sensor(self, sensor_options: "SensorOptions") -> "Sensor":
         sensor_options.validate_scene(self._sim.scene)
@@ -117,28 +123,37 @@ class SensorManager:
             for new_idx, sensor in enumerate(sensors):
                 sensor._idx = new_idx
 
-        cache_size_per_dtype = {}
-        delay_depth_per_dtype: dict[type[torch.dtype], int] = {}
-        max_history_per_dtype: dict[type[torch.dtype], int] = {}
+        # Per-class intermediate / return dtypes come from `_get_intermediate_dtype` / `_get_cache_dtype`. Dtype is
+        # class-uniform by design (the per-class slice into the per-dtype intermediate buffer must be contiguous, so
+        # all instances of a class share one dtype). Shape is per-instance via `_get_intermediate_format` /
+        # `_get_return_format` and contributes to the class slice size below.
+        cache_size_per_dtype: dict[torch.dtype, int] = {}
+        delay_depth_per_dtype: dict[torch.dtype, int] = {}
+        max_history_per_dtype: dict[torch.dtype, int] = {}
+        intermediate_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
+        return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
-            dtype = sensor_cls._get_cache_dtype()
+            intermediate_dtype = sensor_cls._get_intermediate_dtype()
+            return_dtype = sensor_cls._get_cache_dtype()
+            intermediate_dtype_by_class[sensor_cls] = intermediate_dtype
+            return_dtype_by_class[sensor_cls] = return_dtype
 
-            for is_ground_truth in (False, True):
-                key = (is_ground_truth, dtype)
-                self._is_last_cache_cloned[key] = False
-
-            cache_size_per_dtype.setdefault(dtype, 0)
-            cls_cache_start_idx = cache_size_per_dtype[dtype]
+            cache_size_per_dtype.setdefault(intermediate_dtype, 0)
+            cls_cache_start_idx = cache_size_per_dtype[intermediate_dtype]
             entity_offsets: dict[int, list[int]] = {}
             cls_offset = 0
             cls_max_history = 0
             for sensor in sensors:
-                sensor._cache_idx = cache_size_per_dtype[dtype]
-                cache_size_per_dtype[dtype] += sensor._cache_size
-                delay_depth_per_dtype[dtype] = max(delay_depth_per_dtype.get(dtype, 0), sensor._delay_ts + 1)
+                sensor._cache_idx = cache_size_per_dtype[intermediate_dtype]
+                cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
+                delay_depth_per_dtype[intermediate_dtype] = max(
+                    delay_depth_per_dtype.get(intermediate_dtype, 0), sensor._delay_ts + 1
+                )
                 hist = sensor._options.history_length
                 if hist > 0:
-                    max_history_per_dtype[dtype] = max(max_history_per_dtype.get(dtype, 0), hist)
+                    max_history_per_dtype[intermediate_dtype] = max(
+                        max_history_per_dtype.get(intermediate_dtype, 0), hist
+                    )
                     cls_max_history = max(cls_max_history, hist)
                 eid = sensor._options.entity_idx
                 if eid in entity_offsets:
@@ -147,7 +162,7 @@ class SensorManager:
                     entity_offsets[eid] = [cls_offset, cls_offset + sensor._cache_size]
                 cls_offset += sensor._cache_size
 
-            cls_cache_end_idx = cache_size_per_dtype[dtype]
+            cls_cache_end_idx = cache_size_per_dtype[intermediate_dtype]
             self._cache_slices_by_type[sensor_cls] = slice(cls_cache_start_idx, cls_cache_end_idx)
             self._entity_slice_in_class[sensor_cls] = {
                 eid: slice(start, stop) for eid, (start, stop) in entity_offsets.items()
@@ -156,40 +171,79 @@ class SensorManager:
 
         self._ground_truth_timeline_ring.clear()
         self._measured_timeline_ring.clear()
-        self._measured_history_ring.clear()
-        self._linearized_ground_truth_history.clear()
-        self._linearized_measured_history.clear()
+        self._return_cache.clear()
+        self._ground_truth_return_cache.clear()
+        self._ground_truth_return_timeline_ring.clear()
+        self._measured_return_timeline_ring.clear()
         self._hist_idx_by_class.clear()
 
-        for dtype in cache_size_per_dtype.keys():
-            cache_shape = (self._sim._B, cache_size_per_dtype[dtype])
+        dtype_uses_measured: dict[torch.dtype, bool] = {}
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = intermediate_dtype_by_class[sensor_cls]
+            cur = dtype_uses_measured.get(dtype, False)
+            dtype_uses_measured[dtype] = cur or sensor_cls.uses_measured_pipeline
+
+        for dtype, total_cols in cache_size_per_dtype.items():
+            cache_shape = (self._sim._B, total_cols)
             # Ground truth cache is stored transposed (cols, B) so that per-class row slices are C-contiguous,
             # which is required for kernel writes. The cache and ring buffer stay (B, cols) since they only
             # receive data via .copy_() / torch.lerp which handle non-contiguous targets.
-            gt_cache_shape = (cache_size_per_dtype[dtype], self._sim._B)
-            self._ground_truth_cache[dtype] = torch.zeros(gt_cache_shape, dtype=dtype, device=gs.device)
-            self._cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
+            gt_cache_shape = (total_cols, self._sim._B)
+            self._ground_truth_intermediate_cache[dtype] = torch.zeros(gt_cache_shape, dtype=dtype, device=gs.device)
+            self._intermediate_cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
             delay_n = max(delay_depth_per_dtype.get(dtype, 1), 1)
             hist_n = max_history_per_dtype.get(dtype, 0)
             ring_n = max(delay_n, hist_n)
             self._ground_truth_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
-            self._measured_timeline_ring[dtype] = TensorRingBuffer(
-                ring_n, cache_shape, dtype=dtype, idx=self._ground_truth_timeline_ring[dtype]._idx
-            )
-            if hist_n > 0:
-                self._measured_history_ring[dtype] = TensorRingBuffer(hist_n, cache_shape, dtype=dtype)
+            if dtype_uses_measured[dtype]:
+                self._measured_timeline_ring[dtype] = TensorRingBuffer(
+                    ring_n, cache_shape, dtype=dtype, idx=self._ground_truth_timeline_ring[dtype]._idx
+                )
 
-        # Per-class linearized history buffers. Refreshed every step from the ring.
+        # Per-class return caches. View alias into intermediate when `_post_process` is identity; separate buffer
+        # when overridden.
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            intermediate_dtype = intermediate_dtype_by_class[sensor_cls]
+            return_dtype = return_dtype_by_class[sensor_cls]
+            cls_slice = self._cache_slices_by_type[sensor_cls]
+            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
+                # Separate return buffer in return dtype.
+                cls_size = cls_slice.stop - cls_slice.start
+                self._return_cache[sensor_cls] = torch.zeros(
+                    (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
+                )
+                self._ground_truth_return_cache[sensor_cls] = torch.zeros(
+                    (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
+                )
+            else:
+                # Alias view of the intermediate cache's class slice. Same dtype/shape; no extra allocation.
+                self._return_cache[sensor_cls] = self._intermediate_cache[intermediate_dtype][:, cls_slice]
+                self._ground_truth_return_cache[sensor_cls] = self._ground_truth_intermediate_cache[intermediate_dtype][
+                    cls_slice, :
+                ].T
+
+        # Per-class precomputed history index + (overridden `_post_process` only) per-class return-space rings. The
+        # return rings record each step's eager `_post_process` snapshot so history reads gather post-processed
+        # values directly, instead of re-projecting older slots from the intermediate ring (which would be wrong for
+        # stateful `_post_process`).
         for sensor_cls, cls_max_history in self._max_history_by_class.items():
             if cls_max_history == 0:
                 continue
-            dtype = sensor_cls._get_cache_dtype()
-            cache_slice = self._cache_slices_by_type[sensor_cls]
-            cls_size = cache_slice.stop - cache_slice.start
-            shape = (self._sim._B, cls_max_history, cls_size)
-            self._linearized_ground_truth_history[sensor_cls] = torch.zeros(shape, dtype=dtype, device=gs.device)
-            self._linearized_measured_history[sensor_cls] = torch.zeros(shape, dtype=dtype, device=gs.device)
+            intermediate_dtype = intermediate_dtype_by_class[sensor_cls]
             self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
+            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
+                cache_slice = self._cache_slices_by_type[sensor_cls]
+                cls_size = cache_slice.stop - cache_slice.start
+                return_dtype = return_dtype_by_class[sensor_cls]
+                ring_n = max(delay_depth_per_dtype.get(intermediate_dtype, 1), cls_max_history)
+                ring_shape = (self._sim._B, cls_size)
+                shared_idx = self._ground_truth_timeline_ring[intermediate_dtype]._idx
+                self._ground_truth_return_timeline_ring[sensor_cls] = TensorRingBuffer(
+                    ring_n, ring_shape, dtype=return_dtype, idx=shared_idx
+                )
+                self._measured_return_timeline_ring[sensor_cls] = TensorRingBuffer(
+                    ring_n, ring_shape, dtype=return_dtype, idx=shared_idx
+                )
 
         for sensor_cls, sensors in self._sensors_by_type.items():
             for sensor in sensors:
@@ -209,66 +263,66 @@ class SensorManager:
 
         envs_idx = self._sim._scene._sanitize_envs_idx(envs_idx)
 
-        for dtype in self._ground_truth_cache.keys():
-            self._ground_truth_cache[dtype][:, envs_idx] = 0.0
-            self._cache[dtype][envs_idx] = 0.0
+        for dtype in self._ground_truth_intermediate_cache.keys():
+            self._ground_truth_intermediate_cache[dtype][:, envs_idx] = 0.0
+            self._intermediate_cache[dtype][envs_idx] = 0.0
             self._ground_truth_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
-            self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
-            if dtype in self._measured_history_ring:
-                self._measured_history_ring[dtype].buffer[:, envs_idx] = 0.0
-            for is_ground_truth in (False, True):
-                key = (is_ground_truth, dtype)
-                self._is_last_cache_cloned[key] = False
+            if dtype in self._measured_timeline_ring:
+                self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
 
-        for linearized in self._linearized_ground_truth_history.values():
-            linearized[envs_idx] = 0.0
-        for linearized in self._linearized_measured_history.values():
-            linearized[envs_idx] = 0.0
+        # Reset per-class return caches that are distinct buffers (overridden `_post_process`); alias views are
+        # already cleared via the intermediate-cache zero above. Same logic for the per-class return-space rings.
+        for sensor_cls, return_cache in self._return_cache.items():
+            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
+                return_cache[envs_idx] = 0
+                self._ground_truth_return_cache[sensor_cls][envs_idx] = 0
+        for ring in self._ground_truth_return_timeline_ring.values():
+            ring.buffer[:, envs_idx] = 0
+        for ring in self._measured_return_timeline_ring.values():
+            ring.buffer[:, envs_idx] = 0
 
-        for sensor_cls in self._sensors_by_type.keys():
-            dtype = sensor_cls._get_cache_dtype()
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = sensor_cls._get_intermediate_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
-            sensor_cls.reset(self._sensors_metadata[sensor_cls], self._ground_truth_cache[dtype][cache_slice], envs_idx)
+            sensor_cls.reset(
+                self._sensors_metadata[sensor_cls],
+                self._ground_truth_intermediate_cache[dtype][cache_slice],
+                envs_idx,
+            )
 
     def step(self):
         for ring in self._ground_truth_timeline_ring.values():
             ring.rotate()
-        for ring in self._measured_history_ring.values():
-            ring.rotate()
 
-        for sensor_cls in self._sensors_by_type.keys():
-            dtype = sensor_cls._get_cache_dtype()
+        for sensor_cls, sensors in self._sensors_by_type.items():
+            dtype = sensor_cls._get_intermediate_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
-            ground_truth_slice = self._ground_truth_cache[dtype][cache_slice]
-            measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
-            shared_metadata = self._sensors_metadata[sensor_cls]
-            sensor_cls._update_shared_cache(shared_metadata, ground_truth_slice, measured_data_timeline)
-            # GT timeline ring write is required: history reads access older slots even at delay=0, so the slot
-            # for the current step must be populated independent of the delay sampling that follows.
-            self._ground_truth_timeline_ring[dtype][:, cache_slice].set(ground_truth_slice.T)
-            sensor_cls._apply_delay_to_shared_cache(
-                shared_metadata,
-                self._cache[dtype][:, cache_slice],
+            ground_truth_slice = self._ground_truth_intermediate_cache[dtype][cache_slice]
+            if dtype in self._measured_timeline_ring:
+                measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
+            else:
+                measured_data_timeline = None
+            sensor_cls._update_shared_cache(
+                self._sensors_metadata[sensor_cls],
+                ground_truth_slice,
                 measured_data_timeline,
-                shared_metadata.interpolate,
+                self._intermediate_cache[dtype][:, cache_slice],
+                self._return_cache[sensor_cls],
             )
-            if dtype in self._measured_history_ring:
-                self._measured_history_ring[dtype][:, cache_slice].set(self._cache[dtype][:, cache_slice])
-            for is_ground_truth in (False, True):
-                key = (is_ground_truth, dtype)
-                self._is_last_cache_cloned[key] = False
-
-        # Linearize per-class history once per step so that per-sensor and bulk reads are pure views.
-        for sensor_cls, cls_max_history in self._max_history_by_class.items():
-            if cls_max_history == 0:
-                continue
-            dtype = sensor_cls._get_cache_dtype()
-            cache_slice = self._cache_slices_by_type[sensor_cls]
-            hist_idx = self._hist_idx_by_class[sensor_cls]
-            ground_truth_view = self._ground_truth_timeline_ring[dtype].at(hist_idx, slice(None), cache_slice)
-            self._linearized_ground_truth_history[sensor_cls].copy_(ground_truth_view.transpose(0, 1))
-            meas_view = self._measured_history_ring[dtype].at(hist_idx, slice(None), cache_slice)
-            self._linearized_measured_history[sensor_cls].copy_(meas_view.transpose(0, 1))
+            # GT timeline ring write is required: history reads access older slots even at delay=0, so the slot for
+            # the current step must be populated independent of the delay sampling done inside `_update_shared_cache`.
+            self._ground_truth_timeline_ring[dtype][:, cache_slice].set(ground_truth_slice.T)
+            # Mirror eager `_post_process` for the GT path. The orchestrator handles the measured path; here we
+            # populate the GT return cache from the GT intermediate slice. No-op when buffers alias.
+            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
+                gt_return = self._ground_truth_return_cache[sensor_cls]
+                gt_return.copy_(sensor_cls._post_process(self._sensors_metadata[sensor_cls], ground_truth_slice.T))
+                # Record both eager projections in the per-class return-space rings so history reads pull
+                # post-processed snapshots directly (correct for stateful `_post_process`). Identity-projection
+                # classes don't allocate these rings; their history reads gather from the intermediate ring instead.
+                if sensor_cls in self._ground_truth_return_timeline_ring:
+                    self._ground_truth_return_timeline_ring[sensor_cls].set(gt_return)
+                    self._measured_return_timeline_ring[sensor_cls].set(self._return_cache[sensor_cls])
 
     def draw_debug(self, context: "RasterizerContext"):
         for sensor in self.sensors:
@@ -276,41 +330,55 @@ class SensorManager:
                 sensor._draw_debug(context)
 
     def get_cloned_from_cache(self, sensor: "Sensor", is_ground_truth: bool = False) -> torch.Tensor:
-        dtype = sensor._get_cache_dtype()
+        sensor_cls = type(sensor)
+        cls_slice = self._cache_slices_by_type[sensor_cls]
+        rel_start = sensor._cache_idx - cls_slice.start
         history_length = sensor._options.history_length
+
         if history_length > 0:
-            sensor_cls = type(sensor)
-            linearized = (
-                self._linearized_ground_truth_history[sensor_cls]
-                if is_ground_truth
-                else self._linearized_measured_history[sensor_cls]
-            )
-            cls_slice = self._cache_slices_by_type[sensor_cls]
-            rel_start = sensor._cache_idx - cls_slice.start
-            sensor_hist = linearized[:, :history_length, rel_start : rel_start + sensor._cache_size]
+            sensor_hist = self._gather_history(sensor_cls, history_length, is_ground_truth)
+            sensor_slice = slice(rel_start, rel_start + sensor._cache_size)
+            sensor_hist = sensor_hist[:, :, sensor_slice]
             blocks = [sensor_hist[..., rel_slice].flatten(1, 2) for rel_slice in sensor._cache_slices]
             if len(blocks) == 1:
                 return blocks[0]
             return torch.cat(blocks, dim=1)
 
-        key = (is_ground_truth, dtype)
-        if not self._is_last_cache_cloned[key]:
-            self._is_last_cache_cloned[key] = True
-            if is_ground_truth:
-                self._cloned_cache[key] = self._ground_truth_cache[dtype].T.contiguous()
-            else:
-                self._cloned_cache[key] = self._cache[dtype].clone()
-        return self._cloned_cache[key][:, sensor._cache_idx : sensor._cache_idx + sensor._cache_size]
+        # Pure view into the per-class return cache. Eager `_post_process` already populated it during step().
+        return_cache = (
+            self._ground_truth_return_cache[sensor_cls] if is_ground_truth else self._return_cache[sensor_cls]
+        )
+        return return_cache[:, rel_start : rel_start + sensor._cache_size]
+
+    def _gather_history(self, sensor_cls: type["Sensor"], history_length: int, is_ground_truth: bool) -> torch.Tensor:
+        # Gather the last `history_length` snapshots for the whole class into a fresh `(B, H, cls_size)` tensor.
+        # For overridden `_post_process` we read from the per-class return-space ring (snapshots are already
+        # post-processed at write time). For identity `_post_process` we read from the per-dtype intermediate ring,
+        # since intermediate == return there.
+        hist_idx = self._hist_idx_by_class[sensor_cls][:history_length]
+        if sensor_cls in self._ground_truth_return_timeline_ring:
+            ring = (
+                self._ground_truth_return_timeline_ring[sensor_cls]
+                if is_ground_truth
+                else self._measured_return_timeline_ring[sensor_cls]
+            )
+            return ring.at(hist_idx).transpose(0, 1)
+        dtype = sensor_cls._get_intermediate_dtype()
+        cache_slice = self._cache_slices_by_type[sensor_cls]
+        ring = self._ground_truth_timeline_ring[dtype] if is_ground_truth else self._measured_timeline_ring[dtype]
+        return ring.at(hist_idx, slice(None), cache_slice).transpose(0, 1)
 
     def read_sensors(
         self,
         entity_idx: int | None = None,
         envs_idx=None,
-        copy: bool = False,
         is_ground_truth: bool = False,
     ) -> dict[int, torch.Tensor]:
         """
         Read the latest data of every sensor class in scope as a single tensor per class.
+
+        Always returns a fresh tensor per class, independent of the internal sensor storage; the caller is free to
+        mutate the result.
 
         Parameters
         ----------
@@ -319,11 +387,7 @@ class SensorManager:
             - k >= 0: include only sensors whose `entity_idx == k`.
             - -1: include only static sensors (those not attached to any entity).
         envs_idx : array-like | int | slice | None
-            Environment selection. Integer or slice indexing produces a view along the batch axis; list/tensor
-            (fancy) indexing produces a copy along the batch axis.
-        copy : bool
-            When True, returned tensors are cloned. When False (default), returned tensors are views into the
-            shared cache wherever possible. Note that fancy-indexed `envs_idx` always copies along B.
+            Environment selection. Defaults to all environments.
         is_ground_truth : bool
             When True, return ground-truth tensors instead of measured tensors.
 
@@ -334,15 +398,9 @@ class SensorManager:
             (B, [history,] class_or_entity_cache_size). For sensors without history, the history
             dimension is omitted.
         """
-        # Use basic indexing (slice/int) whenever possible to preserve view semantics. Fancy indexing
-        # (list/tensor) on the env axis is only triggered when the user explicitly passes a list/tensor,
-        # and is documented to copy.
-        if envs_idx is None or isinstance(envs_idx, slice):
-            env_index = slice(None) if envs_idx is None else envs_idx
-        elif isinstance(envs_idx, int):
-            env_index = envs_idx
-        else:
-            env_index = self._sim._scene._sanitize_envs_idx(envs_idx)
+        # Sanitize envs_idx to a 1D tensor so fancy-indexing the batch axis always allocates a fresh tensor; this
+        # is what gives the function its mutation-safe contract.
+        env_index = self._sim._scene._sanitize_envs_idx(envs_idx)
 
         result: dict[int, torch.Tensor] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
@@ -356,30 +414,18 @@ class SensorManager:
                     continue
                 within_cls_slice = entity_slice_map[eid]
 
-            dtype = sensor_cls._get_cache_dtype()
             cls_max_history = self._max_history_by_class[sensor_cls]
             if cls_max_history > 0:
-                linearized = (
-                    self._linearized_ground_truth_history[sensor_cls]
-                    if is_ground_truth
-                    else self._linearized_measured_history[sensor_cls]
-                )
-                tensor = linearized[env_index, :, within_cls_slice]
+                sensor_hist = self._gather_history(sensor_cls, cls_max_history, is_ground_truth)
+                tensor = sensor_hist[env_index, :, within_cls_slice]
             else:
-                cls_cache_slice = self._cache_slices_by_type[sensor_cls]
-                abs_slice = slice(
-                    cls_cache_slice.start + within_cls_slice.start,
-                    cls_cache_slice.start + within_cls_slice.stop,
+                return_cache = (
+                    self._ground_truth_return_cache[sensor_cls] if is_ground_truth else self._return_cache[sensor_cls]
                 )
-                if is_ground_truth:
-                    tensor = self._ground_truth_cache[dtype][abs_slice, :].T[env_index]
-                else:
-                    tensor = self._cache[dtype][env_index, abs_slice]
+                tensor = return_cache[env_index, within_cls_slice]
 
             if self._sim.n_envs == 0:
                 tensor = tensor[0]
-            if copy:
-                tensor = tensor.clone()
             options_cls = type(sensors[0]._options)
             type_id = getattr(_sensor_types_namespace, options_cls.__name__)
             result[type_id] = tensor

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -16,12 +16,10 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 from genesis.utils.ring_buffer import TensorRingBuffer
 
 from .base_sensor import (
-    ImperfectSensorMetadataMixin,
-    ImperfectSensorMixin,
+    SimpleSensor,
     RigidSensorMetadataMixin,
     RigidSensorMixin,
-    Sensor,
-    SharedSensorMetadata,
+    SimpleSensorMetadata,
 )
 
 if TYPE_CHECKING:
@@ -491,7 +489,7 @@ def _apply_T_measured_filter(
 
 
 @dataclass
-class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMetadataMixin, SharedSensorMetadata):
+class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     """Shared metadata for all temperature grid sensors."""
 
     ambient_temperature: float = 21.0
@@ -521,8 +519,7 @@ class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, ImperfectSensorMet
 
 class TemperatureGridSensor(
     RigidSensorMixin[TemperatureGridSensorMetadata],
-    ImperfectSensorMixin[TemperatureGridSensorMetadata],
-    Sensor[TemperatureGridOptions, TemperatureGridSensorMetadata, TemperatureGridSensorMetadata],
+    SimpleSensor[TemperatureGridOptions, TemperatureGridSensorMetadata, TemperatureGridSensorMetadata],
 ):
     def __init__(self, sensor_options: TemperatureGridOptions, sensor_idx: int, sensor_manager: "SensorManager"):
         super().__init__(sensor_options, sensor_idx, sensor_manager)
@@ -674,7 +671,7 @@ class TemperatureGridSensor(
             (solver._B, n_c_max, len(_ScratchIdx)), device=gs.device, dtype=gs.tc_float
         )
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
+    def _get_return_format(self) -> tuple[int, ...]:
         return (self._options.grid_size,)
 
     @classmethod
@@ -703,12 +700,7 @@ class TemperatureGridSensor(
             shared_metadata.link_temps[envs_idx, :] = base_T_per_link.unsqueeze(0).expand(n_envs, -1)
 
     @classmethod
-    def _update_shared_cache(
-        cls,
-        shared_metadata: TemperatureGridSensorMetadata,
-        current_ground_truth_data_T: torch.Tensor,
-        measured_data_timeline: "TensorRingBuffer",
-    ):
+    def _update_raw_data(cls, shared_metadata: TemperatureGridSensorMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
         dt = solver._sim.dt
         props = shared_metadata.link_material_properties
@@ -731,7 +723,7 @@ class TemperatureGridSensor(
             shared_metadata.K2_spectral,
             dt,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
         # 3) Contact heat transfer
         collider_state = solver.collider._collider_state
@@ -762,9 +754,9 @@ class TemperatureGridSensor(
             shared_metadata.contact_area_buffer,
             dt,
             gs.EPS,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
-        current_ground_truth_data_T.clamp_(-MAX_TEMP, MAX_TEMP)
+        raw_data_T.clamp_(-MAX_TEMP, MAX_TEMP)
         # 4) Radiation and convection
         _apply_radiation_convection(
             shared_metadata.sensor_cache_start,
@@ -780,21 +772,32 @@ class TemperatureGridSensor(
             shared_metadata.ambient_temperature,
             shared_metadata.convection_coeff,
             dt,
-            current_ground_truth_data_T,
+            raw_data_T,
         )
 
-        t_actual = current_ground_truth_data_T.T
-        work = measured_data_timeline.at(1).clone()
+    @classmethod
+    def _apply_transform(
+        cls,
+        shared_metadata: TemperatureGridSensorMetadata,
+        data: torch.Tensor,
+        *,
+        timeline=None,
+    ):
+        if timeline is None:
+            return
+        # First-order RC filter: data <- prev_measured + (dt/tau) * (raw - prev_measured), where data initially
+        # holds the raw seed copied by the default `_update_current_timestep_data`.
+        raw = data.clone()
+        filtered = timeline.at(1).clone()
         _apply_T_measured_filter(
             shared_metadata.sensor_cache_start,
             shared_metadata.cache_sizes,
             shared_metadata.sensor_time_const,
-            dt,
-            t_actual,
-            work,
+            shared_metadata.solver._sim.dt,
+            raw,
+            filtered,
         )
-        cls._apply_imperfections(shared_metadata, work)
-        measured_data_timeline.at(0, copy=False).copy_(work)
+        data.copy_(filtered)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -60,16 +60,24 @@ class SensorOptions(Options, Generic[SensorT]):
 
     Parameters
     ----------
-    history_length: NonNegativeInt
+    history_length : NonNegativeInt
         The length of the history to store. Defaults to 0 (no history).
-    delay : float
+    delay : float, optional
         The read delay time in seconds. Data read will be outdated by this amount. Defaults to 0.0 (no delay).
+    jitter : float, optional
+        The jitter in seconds modeled as a random additive delay sampled from a normal distribution.
+        Jitter cannot be greater than delay. `interpolate` should be True when `jitter` is greater than 0.
+    interpolate : bool, optional
+        If True, the sensor data is interpolated between data points for delay + jitter.
+        Otherwise, the sensor data at the closest time step will be used. Default is False.
     draw_debug : bool
         If True and visualizer is active, the sensor will draw debug shapes in the scene. Defaults to False.
     """
 
     history_length: NonNegativeInt = 0
     delay: NonNegativeFloat = 0.0
+    jitter: NonNegativeFloat = 0.0
+    interpolate: StrictBool = False
     draw_debug: StrictBool = False
     # -1 means not link-attached. None is accepted from users and normalized to -1 so SensorManager can sort uniformly.
     entity_idx: StrictInt = Field(default=-1, ge=-1)
@@ -79,6 +87,12 @@ class SensorOptions(Options, Generic[SensorT]):
     def _normalize_entity_idx(cls, value):
         return -1 if value is None else value
 
+    def model_post_init(self, context: Any) -> None:
+        if self.jitter > 0 and not self.interpolate:
+            gs.raise_exception(f"{type(self).__name__}: `interpolate` should be True when `jitter` is greater than 0.")
+        if self.jitter > self.delay:
+            gs.raise_exception(f"{type(self).__name__}: Jitter must be less than or equal to read delay.")
+
     def validate_scene(self, scene: "Scene"):
         """
         Validate the sensor options values before the sensor is added to the scene.
@@ -86,12 +100,13 @@ class SensorOptions(Options, Generic[SensorT]):
         Use pydantic's model_post_init() for validation that does not require scene context.
         """
         assert scene.sim is not None
-        delay_hz = self.delay / scene.sim.dt
-        if not np.isclose(delay_hz, round(delay_hz), atol=gs.EPS):
-            gs.logger.warning(
-                f"{type(self).__name__}: Read delay should be a multiple of the simulation time step. Got {self.delay}"
-                f" and {scene.sim.dt}. Actual read delay will be {1 / round(delay_hz)}."
-            )
+        if self.delay > 0:
+            delay_hz = self.delay / scene.sim.dt
+            if not np.isclose(delay_hz, round(delay_hz), atol=gs.EPS):
+                gs.logger.warning(
+                    f"{type(self).__name__}: Read delay should be a multiple of the simulation time step. Got "
+                    f"{self.delay} and {scene.sim.dt}. Actual read delay will be {1 / round(delay_hz)}."
+                )
 
 
 class KinematicSensorOptionsMixin(SensorOptions[SensorT]):
@@ -132,8 +147,10 @@ class KinematicSensorOptionsMixin(SensorOptions[SensorT]):
 
 class RigidSensorOptionsMixin(KinematicSensorOptionsMixin[SensorT]):
     """
-    Options for sensors that require a RigidEntity specifically (e.g. contact, contact force, IMU, tactile). Any
-    sensor whose output depends on physics quantities (contact pairs, friction, inertial dynamics) belongs here.
+    Options for sensors that require a RigidEntity specifically (e.g. contact, contact force, IMU, tactile).
+
+    Any sensor whose output depends on physics quantities (contact pairs, friction, inertial dynamics) belongs
+    here.
     """
 
     def validate_scene(self, scene: "Scene"):
@@ -146,9 +163,13 @@ class RigidSensorOptionsMixin(KinematicSensorOptionsMixin[SensorT]):
                 gs.raise_exception(f"Entity at index {self.entity_idx} is not a RigidEntity.")
 
 
-class ImperfectSensorOptionsMixin(SensorOptions[SensorT]):
+class SimpleSensorOptions(SensorOptions[SensorT]):
     """
-    Base options class for analog sensors that are attached to a RigidEntity.
+    Options carrying SimpleSensor's imperfection parameters.
+
+    Interpreted by ``_apply_hardware_imperfections`` as perturbations introduced by the embedded sampler when it
+    snapshots the sensor into shared memory. Inherited by every ``SimpleSensor``-derived options class; Camera
+    (deriving from ``Sensor`` directly) stays on plain ``SensorOptions``.
 
     Parameters
     ----------
@@ -161,29 +182,15 @@ class ImperfectSensorOptionsMixin(SensorOptions[SensorT]):
         The standard deviation of the additive white noise.
     random_walk : float | array-like[float, ...], optional
         The standard deviation of the random walk, which acts as accumulated bias drift.
-    jitter : float, optional
-        The jitter in seconds modeled as a a random additive delay sampled from a normal distribution.
-        Jitter cannot be greater than delay. `interpolate` should be True when `jitter` is greater than 0.
-    interpolate : bool, optional
-        If True, the sensor data is interpolated between data points for delay + jitter.
-        Otherwise, the sensor data at the closest time step will be used. Default is False.
     """
 
     resolution: FArrayType | float = 0.0
     bias: FArrayType | float = 0.0
     noise: FArrayType | float = 0.0
     random_walk: FArrayType | float = 0.0
-    jitter: NonNegativeFloat = 0.0
-    interpolate: StrictBool = False
-
-    def model_post_init(self, context: Any) -> None:
-        if self.jitter > 0 and not self.interpolate:
-            gs.raise_exception(f"{type(self).__name__}: `interpolate` should be True when `jitter` is greater than 0.")
-        if self.jitter > self.delay:
-            gs.raise_exception(f"{type(self).__name__}: Jitter must be less than or equal to read delay.")
 
 
-class Contact(RigidSensorOptionsMixin["ContactSensor"]):
+class Contact(RigidSensorOptionsMixin["ContactSensor"], SimpleSensorOptions["ContactSensor"]):
     """
     Sensor that returns bool based on whether associated RigidLink is in contact.
 
@@ -192,6 +199,10 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"]):
     filter_link_idx : array-like[int], optional
         Global rigid link indices (solver link space). Contacts with the sensor link where the other
         participant is one of these links are ignored. Default is empty (no filtering).
+    threshold : float, optional
+        The bool-conversion threshold applied at read time to the underlying float contact magnitude
+        (kernel produces float). A bin reads ``True`` iff its magnitude exceeds this value. Default
+        ``0.0`` so any positive magnitude registers as contact.
     debug_sphere_radius : float, optional
         The radius of the debug sphere. Defaults to 0.05.
     debug_color : array-like[float, float, float, float], optional
@@ -199,6 +210,7 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"]):
     """
 
     filter_link_idx: OptionalIArrayType = Field(default_factory=tuple)
+    threshold: NonNegativeFloat = 0.0
     debug_sphere_radius: PositiveFloat = 0.05
     debug_color: UnitIntervalVec4Type = (1.0, 0.0, 1.0, 0.5)
 
@@ -212,7 +224,7 @@ class Contact(RigidSensorOptionsMixin["ContactSensor"]):
                 )
 
 
-class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], ImperfectSensorOptionsMixin["ContactForceSensor"]):
+class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOptions["ContactForceSensor"]):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
 
@@ -267,9 +279,7 @@ class TemperatureProperties(NamedTuple):
     emissivity: float = 0.9
 
 
-class TemperatureGrid(
-    RigidSensorOptionsMixin["TemperatureGridSensor"], ImperfectSensorOptionsMixin["TemperatureGridSensor"]
-):
+class TemperatureGrid(RigidSensorOptionsMixin["TemperatureGridSensor"], SimpleSensorOptions["TemperatureGridSensor"]):
     """
     Sensor that returns the temperature in Celsius of the associated RigidLink in its local frame.
     Temperature is computed based on object contacts and their material properties provided to these options.
@@ -315,7 +325,7 @@ class TemperatureGrid(
     debug_temperature_range: Vec2FType = (0.0, 100.0)
 
 
-class IMU(RigidSensorOptionsMixin["IMUSensor"], ImperfectSensorOptionsMixin["IMUSensor"]):
+class IMU(RigidSensorOptionsMixin["IMUSensor"], SimpleSensorOptions["IMUSensor"]):
     """
     IMU sensor returns the linear acceleration (accelerometer) and angular velocity (gyroscope)
     of the associated entity link.
@@ -412,7 +422,7 @@ class IMU(RigidSensorOptionsMixin["IMUSensor"], ImperfectSensorOptionsMixin["IMU
         self.noise = self.acc_noise + self.gyro_noise + self.mag_noise
 
 
-class Proximity(RigidSensorOptionsMixin["ProximitySensor"], ImperfectSensorOptionsMixin["ProximitySensor"]):
+class Proximity(RigidSensorOptionsMixin["ProximitySensor"], SimpleSensorOptions["ProximitySensor"]):
     """
     Proximity sensor that reports the nearest distances from probe positions to tracked mesh surfaces.
     The read() output will provide the distances, and the nearest points can be accessed with `sensor.nearest_points`.
@@ -452,7 +462,7 @@ class Proximity(RigidSensorOptionsMixin["ProximitySensor"], ImperfectSensorOptio
                 gs.raise_exception(f"Proximity sensor track_link_idx[{i}]={link_idx} is out of range [0, {n_links}).")
 
 
-class Raycaster(KinematicSensorOptionsMixin["RaycasterSensor"]):
+class Raycaster(KinematicSensorOptionsMixin["RaycasterSensor"], SimpleSensorOptions["RaycasterSensor"]):
     """
     Raycaster sensor that performs ray casting to get distance measurements and point clouds.
 

--- a/genesis/options/sensors/tactile.py
+++ b/genesis/options/sensors/tactile.py
@@ -14,7 +14,7 @@ from genesis.typing import (
     NonNegativeFloat,
 )
 
-from .options import ImperfectSensorOptionsMixin, RigidSensorOptionsMixin, SensorOptions, SensorT
+from .options import SimpleSensorOptions, RigidSensorOptionsMixin, SensorOptions, SensorT
 
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ class KinematicTactileSensorMixin(SensorOptions[SensorT]):
 
 class KinematicContactProbe(
     RigidSensorOptionsMixin["KinematicContactProbeSensor"],
-    ImperfectSensorOptionsMixin["KinematicContactProbeSensor"],
+    SimpleSensorOptions["KinematicContactProbeSensor"],
     KinematicTactileSensorMixin["KinematicContactProbeSensor"],
 ):
     """
@@ -96,7 +96,7 @@ class KinematicContactProbe(
 
 class ElastomerDisplacement(
     RigidSensorOptionsMixin["ElastomerDisplacementSensor"],
-    ImperfectSensorOptionsMixin["ElastomerDisplacementSensor"],
+    SimpleSensorOptions["ElastomerDisplacementSensor"],
     KinematicTactileSensorMixin["ElastomerDisplacementSensor"],
 ):
     """

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -58,6 +58,7 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
         from dataclasses import dataclass
 
         import genesis as gs
+        import torch
         from genesis.engine.sensors.base_sensor import Sensor, SharedSensorMetadata
 
         from .options import FakeSensorOptions
@@ -77,7 +78,7 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
                 return gs.tc_float
 
             @classmethod
-            def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline):
+            def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline, intermediate_cache, return_cache):
                 pass
 
             @classmethod
@@ -120,6 +121,32 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
             if mod_name.startswith("fake_sensor_plugin"):
                 del sys.modules[mod_name]
         SensorManager.SENSOR_TYPES_MAP.pop(FakeSensorOptions, None)
+
+
+@pytest.mark.required
+def test_post_process_requires_intermediate_override():
+    # Strict-override rule: a subclass overriding `_post_process` without also overriding `_get_intermediate_format`
+    # or `_get_intermediate_dtype` must raise TypeError at class-definition time. The intermediate buffer is
+    # structurally distinct from the return buffer (timeline ring is in intermediate space); the explicit override
+    # forces the author to declare it - even a no-op override is acceptable when shape/dtype coincide with return.
+    # Local import: importing `genesis.engine.sensors.base_sensor` at module top triggers the sensors package
+    # `__init__.py`, which transitively loads `genesis.utils.sdf` and dereferences `gs.qd_float`. That attribute is
+    # only set by `gs.init(...)`, which runs in the autouse conftest fixture after pytest collection. Defer here.
+    from genesis.engine.sensors.base_sensor import Sensor
+
+    with pytest.raises(TypeError, match="_get_intermediate"):
+
+        class BadSensor(Sensor):
+            def _get_return_format(self):
+                return (1,)
+
+            @classmethod
+            def _get_cache_dtype(cls):
+                return gs.tc_float
+
+            @classmethod
+            def _post_process(cls, shared_metadata, tensor):
+                return tensor * 2
 
 
 @pytest.mark.required
@@ -581,8 +608,10 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
     # Moving force back in world frame because box is not perfectly flat on the ground due to CoM offset
     with np.testing.assert_raises(AssertionError):
         assert_allclose(box.get_quat(), 0.0, atol=tol)
+    # Unsaturated GT physics check uses force_sensor (no max_force). force_sensor_noisy clamps in _post_process,
+    # which applies uniformly to read() and read_ground_truth().
     assert_allclose(
-        gu.transform_by_quat(force_sensor_noisy.read_ground_truth(), box.get_quat()), (0.0, 0.0, -GRAVITY), tol=tol
+        gu.transform_by_quat(force_sensor.read_ground_truth(), box.get_quat()), (0.0, 0.0, -GRAVITY), tol=tol
     )
 
     # FIXME: Adding CoM offset on box is disturbing contact force computations on box_2 for some reason...
@@ -1869,7 +1898,7 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
         scene.step()
 
     # Scene-wide read returns every sensor class. Per-entity reads restrict to classes present on that entity, so the
-    # static camera class is excluded from both box_a and box_b reads.
+    # static camera class is excluded from both box_a and box_b reads. Each call allocates a fresh tensor per class.
     scene_data = scene.read_sensors()
     a_data = box_a.read_sensors()
     b_data = box_b.read_sensors()
@@ -1918,18 +1947,16 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
     assert_equal(a_data[gs.sensors.types.Contact], contact_a.read())
     assert_equal(b_data[gs.sensors.types.Contact], contact_b.read())
 
-    # View vs copy: storage data_ptr is the discriminating metadata. Two copy=False reads must share storage (both
-    # views into the same backing cache), and the scene-level and entity-level views must share storage too. copy=True
-    # must always allocate fresh storage. Verified for both the float (IMU) and bool (Contact) dtypes.
+    # `read_sensors` always returns a fresh tensor independent of internal sensor storage. Two successive calls (at
+    # the scene level or the entity level) must back onto distinct storage. Verified on both IMU (identity
+    # `_post_process`, intermediate-space ring) and Contact (overridden `_post_process`, per-class return-space ring).
     for type_tag in (gs.sensors.types.IMU, gs.sensors.types.Contact):
-        scene_view = scene.read_sensors(copy=False)[type_tag]
-        entity_view = box_a.read_sensors(copy=False)[type_tag]
-        clone_a = scene.read_sensors(copy=True)[type_tag]
-        clone_b = scene.read_sensors(copy=True)[type_tag]
-        assert scene_view.untyped_storage().data_ptr() == entity_view.untyped_storage().data_ptr()
-        assert clone_a.untyped_storage().data_ptr() != scene_view.untyped_storage().data_ptr()
-        assert clone_b.untyped_storage().data_ptr() != scene_view.untyped_storage().data_ptr()
-        assert clone_a.untyped_storage().data_ptr() != clone_b.untyped_storage().data_ptr()
+        scene_a = scene.read_sensors()[type_tag]
+        scene_b = scene.read_sensors()[type_tag]
+        entity_a = box_a.read_sensors()[type_tag]
+        assert scene_a.untyped_storage().data_ptr() != scene_b.untyped_storage().data_ptr()
+        assert scene_a.untyped_storage().data_ptr() != entity_a.untyped_storage().data_ptr()
+        assert_equal(scene_a, scene_b)
 
     # Batching must be exercised end-to-end. For n_envs > 0, every per-env row of the bulk view must equal that env's
     # individual sensor read.


### PR DESCRIPTION
## Summary

Follow-up to #2770 (Trinity's `_update_shared_cache` consolidation). Splits the sensor base hierarchy and reshapes the per-step pipeline so that:

- `Sensor` carries only the time-related plumbing (`delay`, `jitter`, `interpolate`, `history_length`); `SimpleSensor(Sensor)` adds the standard pipeline and the imperfection parameters (`noise`, `bias`, `random_walk`, `resolution`). `SimpleSensorOptions` / `SimpleSensorMetadata` mirror the split on the options and metadata layers. Camera derives from `Sensor` directly and sees only the time-related fields. No `Imperfect*` classes remain.
- Sensor-class spec is declared via four accessors: `_get_return_format(self)` and `_get_intermediate_format(self)` for shape (instance methods, since sensor options may affect shape — Raycaster pattern, Camera resolution, Proximity probes, etc.); `_get_cache_dtype(cls)` and `_get_intermediate_dtype(cls)` for dtype (classmethods, since dtype is class-uniform — the per-class slice into the per-dtype intermediate buffer must be contiguous). The intermediate methods default to the return ones. `__init_subclass__` enforces that overriding `_post_process` also requires overriding `_get_intermediate_format` and/or `_get_intermediate_dtype` (no silent guessing about the intermediate buffer space; a no-op override is acceptable when shape and dtype coincide with return).
- Hardware imperfections (`_apply_hardware_imperfections`) are applied **PRE-delay** at snapshot time inside the SimpleSensor orchestrator. This matches the embedded-sampler abstraction (`read()` is a memory lookup against a snapshot the firmware wrote earlier) and lets a single measured-timeline ring serve both delay sampling and `read(history_length=N)`.
- `_post_process` becomes **eager** (applied once per step into a per-class `_return_cache` in the return space). `read()` returns a pure view into the return cache for non-history reads. Stateful `_post_process` is well-defined under eager placement, opening the door to in-sensor software signal processing (complementary / Mahony / Kalman filters, fused-orientation estimates). For sensors with overridden `_post_process` AND `history_length > 0`, the manager allocates a per-class return-space ring so history reads pull post-processed snapshots directly (correct for stateful projections).
- `_apply_transform`'s signature gains a `timeline` keyword so coordinate transforms and stateful filters live in the same override (transform on both branches; filter portion gated by `if timeline is not None:`). Filter-then-transform is not expressible by design — GT has no hardware response.
- `uses_measured_pipeline: ClassVar[bool] = True` is the class-level capability flag declaring whether the class reads or writes the measured-timeline ring inside `_update_shared_cache`. Default `True` (every `SimpleSensor`-derived class needs the ring); `BaseCameraSensor` explicitly sets it to `False` and raises in `__init__` if any of `delay > 0`, `jitter > 0`, `history_length > 0` is requested (those features depend on the ring it bypasses). Ring allocation is therefore a binary class-level decision, decoupled from runtime imperfection state — setters like `set_noise` / `set_bias` / `set_random_walk` / `set_jitter` always work because the ring is already there. Per-step gating of actual imperfection work is done by the `has_any_*` flags inside `_apply_hardware_imperfections`.
- `read_sensors(envs_idx=..., is_ground_truth=...)` always returns a fresh tensor per class (env axis is sanitized to a 1D tensor, forcing fancy indexing). The `copy` parameter is removed at all three levels (manager / scene / entity); the mutation-safe contract is uniform.
- Per-sensor migrations: ContactSensor moves the bool projection from kernel to `_post_process` (float intermediate, bool return, per-instance `threshold` option); ContactForceSensor's existing stateless deadband + saturation moves from the write path into `_post_process`; IMU gains an `_apply_transform` override (body-frame rotation); TemperatureGrid gains an `_apply_transform` override (RC filter on the measured branch). Other sensors only need `_update_raw_data`.

A complete walkthrough of the runtime pipeline and a custom-sensors how-to are in the user guide under Advanced Topics: [`sensor_pipeline.md`](https://genesis-world.readthedocs.io/en/latest/user_guide/advanced_topics/sensor_pipeline.html) and [`custom_sensors.md`](https://genesis-world.readthedocs.io/en/latest/user_guide/advanced_topics/custom_sensors.html) (merged via Genesis-Embodied-AI/genesis-doc#110).