### PR TITLE
rigid/constraint/solver: uptake quadrants subgroup _tiled rename

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1864,7 +1864,7 @@ def func_cholesky_and_solve_fused_tiled(
             while j < i_d:
                 dot = dot + L_sh[i_d, j] * v_sh[j]
                 j = j + 16
-            dot = qd.simt.subgroup.reduce_all_add(dot, 4)
+            dot = qd.simt.subgroup.reduce_all_add_tiled(dot, 4)
             if tid == 0:
                 v_sh[i_d] = (v_sh[i_d] - dot) / L_sh[i_d, i_d]
             qd.simt.block.sync()
@@ -1877,7 +1877,7 @@ def func_cholesky_and_solve_fused_tiled(
             while j < n_dofs:
                 dot = dot + L_sh[j, i_d] * v_sh[j]
                 j = j + 16
-            dot = qd.simt.subgroup.reduce_all_add(dot, 4)
+            dot = qd.simt.subgroup.reduce_all_add_tiled(dot, 4)
             if tid == 0:
                 v_sh[i_d] = (v_sh[i_d] - dot) / L_sh[i_d, i_d]
             qd.simt.block.sync()


### PR DESCRIPTION
## Summary

`qd.simt.subgroup` recently moved to the suffix convention where the sized form is `<op>_tiled(v, log2_size)` and the no-suffix form `<op>(v)` operates over the full subgroup (quadrants commit [d07644e4](https://github.com/Genesis-Embodied-AI/quadrants/commit/d07644e4), *"rename to _tiled suffix convention"*).

`solver._kernel_mass_factor_solve_chol_subgroup_16` was still calling the old `reduce_all_add(dot, 4)` two-arg form, which no longer exists on the new API. The 1-arg `reduce_all_add(dot)` would silently reduce over the full subgroup (32 lanes on CUDA / 64 on AMDGPU) instead of the intended 2**4 = 16-lane tile, giving wrong results for the kernel's 16-thread parallel dot.

Switch the two call sites to `reduce_all_add_tiled(dot, 4)` to preserve the original semantics.

## Test plan

- [ ] CI passes (rigid solver tests exercising the Cholesky path)
- [ ] Manual smoke: rigid-body sim with constraint solver matches pre-rename behaviour

Made with [Cursor](https://cursor.com)