### PR TITLE
[MISC] Migrate to Quadrants 0.8.0.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -2488,7 +2488,7 @@ def _func_linesearch_eval_constraints_at_n_alphas_coop(
     """Cooperative (32-lane subgroup) variant of ``_func_linesearch_eval_constraints_at_n_alphas_serial``.
 
     All 32 lanes call this with their own ``tid``; the constraint loop is strided by 32, then each
-    accumulator is reduced across the warp via ``subgroup.reduce_all_add(_, 5)`` so every lane ends
+    accumulator is reduced across the warp via ``subgroup.reduce_all_add_tiled(_, 5)`` so every lane ends
     up with identical return values. Returns the same 3 ``qd.Vector(3)``s ``(t0, t1, t2)`` as the serial inner.
     """
     ne = constraint_state.n_constraints_equality[i_b]
@@ -2559,9 +2559,9 @@ def _func_linesearch_eval_constraints_at_n_alphas_coop(
     # Warp-tree reduction: every lane's 9 partial sums collapse into the per-env totals; after this
     # all 32 lanes hold identical scalars. The `5` is log2(32) tree levels.
     for k in qd.static(range(n_alphas)):
-        t_0[k] = qd.simt.subgroup.reduce_all_add(t_0[k], 5)
-        t_1[k] = qd.simt.subgroup.reduce_all_add(t_1[k], 5)
-        t_2[k] = qd.simt.subgroup.reduce_all_add(t_2[k], 5)
+        t_0[k] = qd.simt.subgroup.reduce_all_add_tiled(t_0[k], 5)
+        t_1[k] = qd.simt.subgroup.reduce_all_add_tiled(t_1[k], 5)
+        t_2[k] = qd.simt.subgroup.reduce_all_add_tiled(t_2[k], 5)
 
     t0 = qd.Vector([t_0[0], t_1[0], t_2[0]])
     t1 = qd.Vector([t_0[1], t_1[1], t_2[1]])

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1864,7 +1864,7 @@ def func_cholesky_and_solve_fused_tiled(
             while j < i_d:
                 dot = dot + L_sh[i_d, j] * v_sh[j]
                 j = j + 16
-            dot = qd.simt.subgroup.reduce_all_add(dot, 4)
+            dot = qd.simt.subgroup.reduce_all_add_tiled(dot, 4)
             if tid == 0:
                 v_sh[i_d] = (v_sh[i_d] - dot) / L_sh[i_d, i_d]
             qd.simt.block.sync()
@@ -1877,7 +1877,7 @@ def func_cholesky_and_solve_fused_tiled(
             while j < n_dofs:
                 dot = dot + L_sh[j, i_d] * v_sh[j]
                 j = j + 16
-            dot = qd.simt.subgroup.reduce_all_add(dot, 4)
+            dot = qd.simt.subgroup.reduce_all_add_tiled(dot, 4)
             if tid == 0:
                 v_sh[i_d] = (v_sh[i_d] - dot) / L_sh[i_d, i_d]
             qd.simt.block.sync()

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -598,7 +598,7 @@ def _func_update_constraint_cost_coop(
     static_rigid_sim_config: qd.template(),
 ):
     """Warp-per-env cooperative variant of ``_func_update_constraint_cost``: 32 lanes stride through dofs and
-    constraints, with the final per-env scalar produced by ``subgroup.reduce_all_add``. Per-lane reads of
+    constraints, with the final per-env scalar produced by ``subgroup.reduce_all_add_tiled``. Per-lane reads of
     Jaref/efc_D/active are coalesced under the [_B, len_constraints_] physical layout (i.e. when those
     layout-flippable constraint-state tensors were allocated with ``layout=(1, 0)``)."""
     _B = constraint_state.grad.shape[1]
@@ -648,8 +648,8 @@ def _func_update_constraint_cost_coop(
                     cost_i += linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
                 i_c = i_c + _K
 
-            cost_i = qd.simt.subgroup.reduce_all_add(cost_i, 5)
-            gauss_i = qd.simt.subgroup.reduce_all_add(gauss_i, 5)
+            cost_i = qd.simt.subgroup.reduce_all_add_tiled(cost_i, 5)
+            gauss_i = qd.simt.subgroup.reduce_all_add_tiled(gauss_i, 5)
 
             if tid == 0:
                 constraint_state.gauss[i_b] = gauss_i

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==0.7.8",
+    "quadrants==0.8.0",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",


### PR DESCRIPTION
## Summary

`qd.simt.subgroup` recently moved to the suffix convention where the sized form is `<op>_tiled(v, log2_size)` and the no-suffix form `<op>(v)` operates over the full subgroup (quadrants commit [d07644e4](https://github.com/Genesis-Embodied-AI/quadrants/commit/d07644e4), *"rename to _tiled suffix convention"*).

`solver._kernel_mass_factor_solve_chol_subgroup_16` was still calling the old `reduce_all_add(dot, 4)` two-arg form, which no longer exists on the new API. The 1-arg `reduce_all_add(dot)` would silently reduce over the full subgroup (32 lanes on CUDA / 64 on AMDGPU) instead of the intended 2**4 = 16-lane tile, giving wrong results for the kernel's 16-thread parallel dot.

Switch the two call sites to `reduce_all_add_tiled(dot, 4)` to preserve the original semantics.

