### PR TITLE
[BUG FIX] Fix ImGui interactive viewer plugin.

### DIFF
--- a/genesis/ext/pyrender/overlay/plugin.py
+++ b/genesis/ext/pyrender/overlay/plugin.py
@@ -193,7 +193,7 @@ class ImGuiOverlayPlugin(ViewerPlugin):
         rigid_solver.update_geoms_render_T()
         rigid_solver.update_vgeoms()
         rigid_solver.update_vgeoms_render_T()
-        ctx = self.viewer.context
+        ctx = self.viewer.gs_context
         ctx.update_link_frame()
         ctx.update_rigid()
 
@@ -210,7 +210,7 @@ class ImGuiOverlayPlugin(ViewerPlugin):
             return
 
         with self.viewer.render_lock:
-            ctx = self.viewer.context
+            ctx = self.viewer.gs_context
             rigid_solver = self.scene.rigid_solver
 
             old_geoms = entity.vgeoms if old_mode == "visual" else entity.geoms
@@ -539,7 +539,7 @@ class ImGuiOverlayPlugin(ViewerPlugin):
         if imgui.button("Reset", size=button_size_with_min(imgui, "Reset", 60.0)):
             with self.viewer.render_lock:
                 self.scene.reset()
-                self.viewer.context.clear_dynamic_nodes(only_outdated=False)
+                self.viewer.gs_context.clear_dynamic_nodes(only_outdated=False)
                 self._refresh_visuals()
 
         # Time display (frame count * dt = simulation time)
@@ -993,7 +993,7 @@ class ImGuiOverlayPlugin(ViewerPlugin):
             changed_wf, new_wf = imgui.checkbox(f"Wireframe##wf_{entity_idx}", is_wireframe)
             if changed_wf:
                 self._wireframe_state[entity_idx] = new_wf
-                ctx = self.viewer.context
+                ctx = self.viewer.gs_context
                 geoms = entity.vgeoms if entity.surface.vis_mode == "visual" else entity.geoms
                 for geom in geoms:
                     node = ctx.rigid_nodes.get(geom.uid)


### PR DESCRIPTION
## Summary

`ImGuiOverlayPlugin` reaches into `self.viewer.context` in four places where it should use `self.viewer.gs_context`. The two attributes are not the same:

- `viewer.context` — pyglet `Window`'s GL context (e.g. `XlibContext` on Linux). Used for `make_current`, `get_info`, etc.
- `viewer.gs_context` — Genesis `RasterizerContext` set up in `Viewer.__init__`. The thing that owns `rigid_nodes`, `add_rigid_node`, `clear_dynamic_nodes`, `update_rigid`, `update_link_frame`, etc.

`_render_visualization` already reads `self.viewer.gs_context` correctly (line 567), which is why the Visualization tab works.

## Repro

Run the bundled example and toggle Vis Mode on any entity:

```bash
python examples/gui/imgui_joint_control.py
```

Drop down the panel under any entity → switch ``visual`` → ``collision``. Console:

```
AttributeError: 'XlibContext' object has no attribute 'rigid_nodes'
```

raised from `plugin.py:218` (inside `_apply_entity_vis_mode`). The exception fires between `imgui.new_frame()` and `imgui.render()` inside `on_draw`, so the frame is never rendered and ImGui's frame state stays open. Every subsequent `new_frame` asserts, and the panel silently disappears for the rest of the session.

The Reset button (`_render_sim_controls`, line 542) and the Wireframe checkbox (`_render_entity_browser`, line 996) hit the same crash via the same attribute mismatch.

## Fix

Mechanical: swap `self.viewer.context` → `self.viewer.gs_context` at the four affected lines (`_refresh_visuals`, `_apply_entity_vis_mode`, the Reset button, and the wireframe toggle). Four lines, no behavior change beyond making the code reach the context it has always meant to reach.

## Test plan

- [x] Reproduced the original `AttributeError: 'XlibContext' object has no attribute 'rigid_nodes'` on `main` (db84b8e).
- [x] On the fix branch, called `plugin._apply_entity_vis_mode(entity, "collision")` then `_apply_entity_vis_mode(entity, "visual")` programmatically on both a `Plane` and an MJCF Panda — both directions succeed; `entity.surface.vis_mode` updates as expected; `gs_context.rigid_nodes` is correctly populated (59 entries on the test scene).
- [x] Existing `tests/test_imgui_overlay.py` (panel screenshot) does not exercise these code paths, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)