### PR TITLE
[MISC] Refactor sensor pipeline (cont'd).

### DIFF
--- a/examples/sensors/imu_franka.py
+++ b/examples/sensors/imu_franka.py
@@ -62,7 +62,6 @@ def main():
             gyro_random_walk=(0.001, 0.001, 0.001),
             delay=0.01,
             jitter=0.01,
-            interpolate=True,
             # visualize
             draw_debug=True,
         )

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -48,11 +48,9 @@ class SharedSensorMetadata:
     cache_sizes: list[int] = field(default_factory=list)
     delays_ts: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
     history_lengths: list[int] = field(default_factory=list)
-    # Per-sensor: interpolate delayed reads (aligned with cache_sizes). Appended in Sensor.build.
-    interpolate: list[bool] = field(default_factory=list)
     jitter_ts: torch.Tensor = make_tensor_field((0, 0))
-    # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build so the per-step fast
-    # path can avoid a GPU-syncing reduction.
+    # True iff at least one sensor in the class has a nonzero read delay. Precomputed at build so the per-step fast path
+    # can avoid a GPU-syncing reduction.
     has_any_delay: bool = False
     # True iff at least one sensor in the class has a nonzero jitter. Latched True by `set_jitter`; same
     # precompute-and-latch contract as `has_any_delay`.
@@ -68,7 +66,7 @@ class SharedSensorMetadata:
         """
         Destroy shared metadata.
 
-        This method is called by SensorManager when the scene is destroyed. his should remove any references to the
+        This method is called by SensorManager when the scene is destroyed. This should remove any references to the
         sensors from the shared metadata, and clean up any resources associated with the sensors.
         """
 
@@ -89,8 +87,8 @@ class SimpleSensorMetadata(SharedSensorMetadata):
     random_walk: torch.Tensor = make_tensor_field((0, 0))
     noise: torch.Tensor = make_tensor_field((0, 0))
     # Precomputed Python bool flags gate the per-step noise/bias/quantize work without GPU sync. Set at build from
-    # options and refreshed by the corresponding setters. Conservatively True once any sensor has nonzero value;
-    # never flipped back to False (avoids tracking per-sensor state).
+    # options and refreshed by the corresponding setters. Conservatively True once any sensor has nonzero value; never
+    # flipped back to False (avoids tracking per-sensor state).
     has_any_noise: bool = False
     has_any_random_walk: bool = False
     has_any_bias: bool = False
@@ -124,10 +122,11 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
     _options_cls: ClassVar[type]
     _metadata_cls: ClassVar[type]
     _return_data_class: ClassVar[type] = tuple
-    # Whether instances of this class read or write the measured-timeline ring inside `_update_shared_cache`. Drives
-    # ring allocation in `SensorManager.build`. Subclasses whose `_update_shared_cache` bypasses the ring (e.g.
-    # cameras handling rendering lazily) explicitly set this to ``False``.
-    uses_measured_pipeline: ClassVar[bool] = True
+    # Whether instances of this class participate in the ring-based per-step pipeline (delay sampling, transform
+    # recurrence, history snapshots). Drives allocation of the GT + measured timeline rings in `SensorManager.build`.
+    # Subclasses whose `_update_shared_cache` bypasses the rings (e.g. cameras handling rendering lazily) explicitly set
+    # this to ``False``.
+    uses_ring_pipeline: ClassVar[bool] = True
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -144,10 +143,9 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
                 break
         # Strict contract: overriding `_post_process` requires overriding `_get_intermediate_format` and/or
         # `_get_intermediate_dtype`. The intermediate buffer must be a distinct buffer regardless of whether its
-        # shape/dtype happen to coincide with the return space (the timeline ring is in intermediate space; mixing
-        # data spaces breaks `_apply_transform` filter overrides that read previous slots). When the intermediate
-        # shape and dtype both coincide with return, override one method as a no-op to make the structural
-        # distinction explicit.
+        # shape/dtype happen to coincide with the return space (the timeline ring is in intermediate space; mixing data
+        # spaces breaks `_apply_transform` filter overrides that read previous slots). When the intermediate shape and
+        # dtype both coincide with return, override one method as a no-op to make the structural distinction explicit.
         if "_post_process" in cls.__dict__ and not (
             "_get_intermediate_format" in cls.__dict__ or "_get_intermediate_dtype" in cls.__dict__
         ):
@@ -156,8 +154,8 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
                 f"`_get_intermediate_dtype`; declare the intermediate buffer explicitly (no-op override returning "
                 f"the return-space value is acceptable when they coincide)."
             )
-        # Auto-register if this class defines its own options (not inherited).
-        # Enforce that concrete sensor classes also specify the metadata type parameter.
+        # Auto-register if this class defines its own options (not inherited). Enforce that concrete sensor classes also
+        # specify the metadata type parameter.
         if "_options_cls" in cls.__dict__:
             if "_metadata_cls" not in cls.__dict__:
                 raise TypeError(f"{cls.__name__} must specify Sensor[OptionsT, MetadataT, DataT=tuple].")
@@ -171,6 +169,22 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         self._manager: "SensorManager" = sensor_manager
         self._shared_metadata: SharedSensorMetadataT = sensor_manager._sensors_metadata[type(self)]
         self._is_built = False
+
+        # Classes that opt out of the ring pipeline (e.g. cameras handling rendering lazily on read) cannot honor delay
+        # / jitter / history because those features depend on the per-class return-space ring. Reject the inputs at
+        # construction so the user picks a different sensor or drops the option rather than silently getting no-ops.
+        if not self.uses_ring_pipeline:
+            if sensor_options.delay > 0.0:
+                gs.raise_exception(f"{type(self).__name__} does not support `delay`; got delay={sensor_options.delay}.")
+            if sensor_options.jitter > 0.0:
+                gs.raise_exception(
+                    f"{type(self).__name__} does not support `jitter`; got jitter={sensor_options.jitter}."
+                )
+            if sensor_options.history_length > 0:
+                gs.raise_exception(
+                    f"{type(self).__name__} does not support `history_length`; got "
+                    f"history_length={sensor_options.history_length}."
+                )
 
         self._dt = self._manager._sim.dt
         self._delay_ts = round(self._options.delay / self._dt)
@@ -208,18 +222,14 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         """
         Build the sensor.
 
-        This method is called by SensorManager during the scene build phase.
-        This is where any shared metadata should be initialized.
+        This method is called by SensorManager during the scene build phase. This is where any shared metadata should be
+        initialized.
         """
         self._shared_metadata.delays_ts = concat_with_tensor(
-            self._shared_metadata.delays_ts,
-            self._delay_ts,
-            expand=(self._manager._sim._B, 1),
-            dim=1,
+            self._shared_metadata.delays_ts, self._delay_ts, expand=(self._manager._sim._B, 1), dim=1
         )
         self._shared_metadata.cache_sizes.append(self._cache_size)
         self._shared_metadata.history_lengths.append(self._options.history_length)
-        self._shared_metadata.interpolate.append(self._options.interpolate)
         if self._delay_ts > 0:
             self._shared_metadata.has_any_delay = True
 
@@ -247,8 +257,8 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
 
         Sensor options are free to affect the returned shape (Raycaster's pattern, Camera's resolution, Proximity's
         probe positions, etc.) - this is supported by design. Returns a single tuple ``(N,)`` for a single-tensor
-        return, or a tuple-of-tuples ``((3,), (3,), (3,))`` for a multi-tensor return (e.g. IMU's
-        ``NamedTuple(lin_acc, ang_vel, mag)``).
+        return, or a tuple-of-tuples ``((3,), (3,), (3,))`` for a multi-tensor return (e.g. IMU's ``NamedTuple(lin_acc,
+        ang_vel, mag)``).
         """
         raise NotImplementedError(f"{type(self).__name__} has not implemented `_get_return_format()`.")
 
@@ -257,10 +267,10 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         """
         Dtype of what ``read()`` returns; classmethod because the dtype is class-uniform across all instances.
 
-        The manager allocates one per-dtype intermediate cache buffer and uses a per-class slice within it; if
-        instances of the same class returned different dtypes, the per-class slice would no longer be a single
-        contiguous range, breaking the per-class batched ``_update_shared_cache`` and ``_apply_transform`` contract.
-        Dtype is therefore class-uniform by design.
+        The manager allocates one per-dtype intermediate cache buffer and uses a per-class slice within it; if instances
+        of the same class returned different dtypes, the per-class slice would no longer be a single contiguous range,
+        breaking the per-class batched ``_update_shared_cache`` and ``_apply_transform`` contract. Dtype is therefore
+        class-uniform by design.
         """
         raise NotImplementedError(f"{cls.__name__} has not implemented `_get_cache_dtype()`.")
 
@@ -268,8 +278,8 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         """
         Shape(s) of the pipeline-internal cache; defaults to ``_get_return_format()``.
 
-        Override together with ``_post_process`` when the projection changes shape. Same instance-method semantics
-        as ``_get_return_format``: the shape may depend on options.
+        Override together with ``_post_process`` when the projection changes shape. Same instance-method semantics as
+        ``_get_return_format``: the shape may depend on options.
         """
         return self._get_return_format()
 
@@ -288,33 +298,94 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         cls,
         shared_metadata: SharedSensorMetadataT,
         current_ground_truth_data_T: torch.Tensor,
+        ground_truth_data_timeline: "TensorRingBuffer | None",
         measured_data_timeline: "TensorRingBuffer | None",
         intermediate_cache: torch.Tensor,
-        return_cache: torch.Tensor,
     ):
         """
-        Compute one step of sensor data into the shared caches.
+        Compute one step of sensor data into the shared caches up to the per-step working buffer.
 
-        Updates the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows), the pre-delay
-        measured timeline ring (``measured_data_timeline.at(0)`` is the current write slot), the per-dtype
-        ``intermediate_cache`` (shape ``(B, cols)``, post-delay sample in intermediate space), and the per-class
-        ``return_cache`` (shape ``(B, cols)``, post-``_post_process`` user-facing space). When the sensor opts
-        out of the measured pipeline (e.g. Camera), ``measured_data_timeline`` is ``None`` and the
-        implementation writes directly to ``intermediate_cache``; if ``_post_process`` is identity,
-        ``return_cache is intermediate_cache``.
+        Updates the shared ground-truth cache slice (shape ``(cols, B)``, C-contiguous rows), the GT timeline ring
+        (``ground_truth_data_timeline.at(0)`` is the current GT write slot, post-transform), the measured timeline ring
+        (``measured_data_timeline.at(0)`` is the current measured write slot, post-physics-imperfections /
+        post-transform / PRE-hardware-imperfections), and the per-dtype ``intermediate_cache`` (shape ``(B, cols)``, the
+        per-step measured working buffer in intermediate space: post-HW-imperfections, pre-``_post_process``,
+        pre-delay-sample). When the sensor opts out of the ring pipeline (e.g. Camera), both timeline rings are ``None``
+        and the implementation writes directly to ``intermediate_cache``. The manager handles ``_post_process``
+        projection, return-space ring writes, and delay sampling after this hook returns.
         """
         raise NotImplementedError(f"{cls.__name__} has not implemented `update_shared_cache()`.")
 
     @classmethod
-    def _post_process(cls, shared_metadata: SharedSensorMetadataT, tensor: torch.Tensor) -> torch.Tensor:
+    def _apply_delay(
+        cls, shared_metadata: SharedSensorMetadataT, return_ring: "TensorRingBuffer", return_cache: torch.Tensor
+    ):
         """
-        Write-time projection from per-class intermediate cache to per-class return cache.
+        Sample stale slots of the measured return-space ring into the user-visible measured return cache.
 
-        Applied eagerly once per step by the orchestrator. Default: identity (intermediate IS return; no separate
-        allocation). ``tensor`` is the full per-class intermediate cache ``[B, total_cache_size]``. Per-instance reads
-        slice the return cache directly; no ``cache_slice`` keyword needed. Stateful overrides are allowed because the
-        orchestrator calls this exactly once per simulation step (a natural place for software-level signal processing
-        such as a complementary, Mahony, or Kalman filter on top of the raw measurement).
+        Default implementation: per-sensor zero-order-hold (ZOH) lookup at ``delay + jitter`` steps back. ZOH is the
+        only sampling strategy that is dtype-safe for arbitrary return types (bool, int, uint8, quantized float), which
+        is why it is the default. Override on the sensor class if you have a return space where a smoother sampling rule
+        is appropriate (e.g. linear interpolation between adjacent slots for a continuous-valued sensor whose return
+        dtype is float).
+
+        ``return_ring`` is the per-class measured return-space ring (slot 0 = current step's post-everything value;
+        slots 1.. are previous steps in increasing age). ``return_cache`` is the per-class measured return cache to
+        populate; it is in return space (same shape and dtype as the ring).
+        """
+        if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
+            # Fast path: no per-sensor delay loop, just copy the most recent slot class-wide.
+            return_cache.copy_(return_ring.at(0, copy=False))
+            return
+
+        if shared_metadata.has_any_jitter:
+            # Uniform jitter in [0, jitter_ts) per env per sensor. Combined with the `jitter <= delay` and `jitter < dt`
+            # option constraints, the effective per-step shift cannot wrap the ring.
+            cur_jitter_ts = torch.rand_like(shared_metadata.jitter_ts).mul_(shared_metadata.jitter_ts)
+        else:
+            cur_jitter_ts = None
+
+        tensor_start = 0
+        for sensor_idx, tensor_size in enumerate(shared_metadata.cache_sizes):
+            cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
+            if cur_jitter_ts is not None:
+                # Probabilistic rounding of the continuous-time delay onto integer ring slots: with `jitter < dt` (one
+                # slot), the realized jitter sample `j` is in `[0, 1)`; adding `uniform[0, 1)` then flooring picks the
+                # next slot (`D + 1`) with probability `j`, preserving the expected jitter shift while staying
+                # dtype-safe (no interpolation between adjacent slots).
+                cur_delay_ts = (
+                    cur_delay_ts + cur_jitter_ts[:, sensor_idx] + torch.rand_like(cur_jitter_ts[:, sensor_idx])
+                )
+            cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
+            tensor_slice = slice(tensor_start, tensor_start + tensor_size)
+            return_cache[:, tensor_slice].copy_(return_ring.at(cur_delay_ts_int, tensor_slice, per_row=True))
+            tensor_start += tensor_size
+
+    @classmethod
+    def _post_process(
+        cls,
+        shared_metadata: SharedSensorMetadataT,
+        tensor: torch.Tensor,
+        timeline: "TensorRingBuffer",
+        *,
+        is_measured: bool,
+    ) -> torch.Tensor:
+        """
+        Project from intermediate space to return space. Applied once per branch per step.
+
+        ``tensor`` is the full per-class intermediate cache ``[B, total_cache_size]`` (post-physics / post-transform /
+        post-hardware for measured; post-transform for GT). Return the post-cast value (any return-space dtype); the
+        orchestrator writes the return into slot 0 of the per-class return-space ring, and the user-visible read is then
+        produced by delay-sampling the ring. ``timeline`` is that ring (post-``_post_process`` snapshots); the return
+        ring is rotated AFTER this call returns, so during the override ``timeline.at(0)`` is the previous step's
+        post-output (the most recent valid value), ``timeline.at(1)`` is the step before that, and so on.
+        ``is_measured`` is ``True`` on the measured branch call and ``False`` on the GT branch call, so an override can
+        apply readout-stage contributions on only one side.
+
+        Designed for cast / clamp / threshold / mask / deadband / simple reductions and (optionally) stateful HW
+        responses that should not contaminate ``_apply_transform`` recurrence. Default: identity (return ``tensor``
+        unchanged - valid because the strict-override contract enforces matching intermediate / return dtypes when
+        ``_post_process`` is not overridden).
         """
         return tensor
 
@@ -331,8 +402,8 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         """
         Read the sensor data (with noise applied if applicable).
 
-        Pure view into the per-class return cache (post-``_post_process``); ``_post_process`` was applied
-        eagerly once per step by the orchestrator.
+        Pure view into the per-class return cache (post-``_post_process``); ``_post_process`` was applied eagerly once
+        per step by the orchestrator.
         """
         return self._get_formatted_data(self._manager.get_cloned_from_cache(self), envs_idx)
 
@@ -415,9 +486,9 @@ class KinematicSensorMetadataMixin:
     """
     Shared metadata for sensors attached to a KinematicEntity (or any subclass, including RigidEntity).
 
-    Sensors are bucketed at build time into per-solver ``_SolverLinkGroup`` entries so the per-step gather is one
-    bulk read per solver. Static sensors (``entity_idx<0``) are not bucketed and keep an identity link pose,
-    leaving the kernel to apply ``pos_offset`` / ``euler_offset`` in world frame.
+    Sensors are bucketed at build time into per-solver ``_SolverLinkGroup`` entries so the per-step gather is one bulk
+    read per solver. Static sensors (``entity_idx<0``) are not bucketed and keep an identity link pose, leaving the
+    kernel to apply ``pos_offset`` / ``euler_offset`` in world frame.
     """
 
     offsets_pos: torch.Tensor = make_tensor_field((0, 0, 3))
@@ -449,10 +520,10 @@ class _LinkAttachedSensorMixin:
     """
     Common boilerplate for sensors attached to a link.
 
-    Holds the python-side ``_link`` reference, concatenates per-sensor pos/euler offsets into shared metadata at
-    build time, and exposes ``set_{pos,quat}_offset``. Subclasses implement ``_register_link`` to record the link
-    mapping in solver-specific shared-metadata shape (single tensor for ``RigidSensorMixin``, per-solver buckets
-    for ``KinematicSensorMixin``).
+    Holds the python-side ``_link`` reference, concatenates per-sensor pos/euler offsets into shared metadata at build
+    time, and exposes ``set_{pos,quat}_offset``. Subclasses implement ``_register_link`` to record the link mapping in
+    solver-specific shared-metadata shape (single tensor for ``RigidSensorMixin``, per-solver buckets for
+    ``KinematicSensorMixin``).
     """
 
     _link: "RigidLink | None" = None
@@ -468,10 +539,7 @@ class _LinkAttachedSensorMixin:
             self._register_link(entity, link_idx)
 
         self._shared_metadata.offsets_pos = concat_with_tensor(
-            self._shared_metadata.offsets_pos,
-            self._options.pos_offset,
-            expand=(batch_size, 1, 3),
-            dim=1,
+            self._shared_metadata.offsets_pos, self._options.pos_offset, expand=(batch_size, 1, 3), dim=1
         )
         self._shared_metadata.offsets_quat = concat_with_tensor(
             self._shared_metadata.offsets_quat,
@@ -508,8 +576,8 @@ class KinematicSensorMixin(_LinkAttachedSensorMixin, Generic[KinematicSensorMeta
     """
     Base sensor class for sensors that may attach to entities across solvers (rigid or kinematic).
 
-    Bucketing into ``shared_metadata.solver_groups`` happens at build time so the per-step gather is one bulk
-    read per solver.
+    Bucketing into ``shared_metadata.solver_groups`` happens at build time so the per-step gather is one bulk read per
+    solver.
     """
 
     def _register_link(self, entity, link_idx: int):
@@ -537,18 +605,33 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
     """
     Base class for sensors that use the standard per-step pipeline.
 
-    The pipeline produces raw data into both ground-truth and measured buffers, optionally transforms each (and
-    filters the measured branch with stateful history), applies hardware imperfections on the measured timeline
-    slot (PRE-delay snapshot time), samples delay/jitter into ``intermediate_cache``, then post-processes into
-    ``return_cache``. Concrete sensors override hooks (``_update_raw_data``, ``_update_current_timestep_data``,
-    ``_apply_transform``, ``_apply_hardware_imperfections``) rather than ``_update_shared_cache`` itself.
+    Pipeline (per branch, in execution order):
 
-    Imperfections are applied at snapshot time (PRE-delay) inside the timeline ring's slot 0; the same ring
-    serves both delay sampling and ``read(history_length)`` history. ``_post_process`` is eager (applied once
-    per step at the end of the orchestrator).
+    - GT branch: ``raw -> _apply_transform(is_measured=False) -> _post_process(is_measured=False) -> ground truth``.
+    - Measured branch: ``raw -> _apply_physics_imperfections -> _apply_transform(is_measured=True) ->
+      _apply_hardware_imperfections -> _post_process(is_measured=True) -> delay sampling -> measured``.
+
+    ``_update_raw_data`` and ``_apply_physics_imperfections`` are packaged inside ``_update_current_timestep_data``;
+    override the latter to fuse them in a single kernel pass.
+
+    Both branches keep their own intermediate-space timeline ring (``ground_truth_data_timeline`` /
+    ``measured_data_timeline``). The timeline rings store post-transform, PRE-hardware-imperfections data, so
+    ``_apply_transform`` recurrence reads clean previous slots and stateful filters (e.g. thermal dissipation) are not
+    contaminated by hardware noise. Hardware imperfections mutate a per-step working buffer (the intermediate cache),
+    never a timeline ring. The post-``_post_process`` snapshot of that working buffer is then frozen into slot 0 of the
+    per-class return-space ring, and delay sampling reads stale slots of the return-space ring to produce the
+    user-visible value - so each delayed read returns the post-everything signal observed at the step of capture.
+
+    Concrete sensors override hooks (``_update_raw_data``, ``_update_current_timestep_data``,
+    ``_apply_physics_imperfections``, ``_apply_transform``, ``_apply_hardware_imperfections``, ``_post_process``) rather
+    than ``_update_shared_cache`` itself.
+
+    History reads gather post-everything snapshots from the per-class return-space ring, so ``read(history_length=N)``
+    returns the final measured values that were observed at each past step. ``_post_process`` is eager (applied once per
+    branch per step by the orchestrator).
     """
 
-    uses_measured_pipeline: ClassVar[bool] = True
+    uses_ring_pipeline: ClassVar[bool] = True
 
     @gs.assert_built
     def set_resolution(self, resolution, envs_idx=None):
@@ -581,26 +664,26 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
                 f"jitter={tuple(jitter_np.ravel())}."
             )
         self._set_metadata_field(jitter_np / self._dt, self._shared_metadata.jitter_ts, 1, envs_idx)
-        # Recompute the slow-path flag from the freshly-written class metadata. One GPU->CPU sync at setter
-        # call time; setters are not hot path. The check covers partial envs_idx writes and other sensors.
+        # Recompute the slow-path flag from the freshly-written class metadata. One GPU->CPU sync at setter call time;
+        # setters are not hot path. The check covers partial envs_idx writes and other sensors.
         self._shared_metadata.has_any_jitter = bool((self._shared_metadata.jitter_ts > gs.EPS).any().item())
 
     def build(self):
         """
         Initialize all shared metadata needed to update all noisy sensors.
 
-        Time-related state (``delays_ts``, ``interpolate``) is pushed by ``Sensor.build()``; this method adds
-        the imperfection-parameter state.
+        Time-related state (``delays_ts``, ``jitter_ts``) is pushed by ``Sensor.build()``; this method adds the
+        imperfection-parameter state.
         """
         super().build()
         to_tuple = partial(_to_tuple, length_per_value=self._cache_size)
 
         batch_size = self._manager._sim._B
 
-        # Jitter must not exceed the simulation step so it can only shift a read by at most one extra ring slot.
-        # The shared GT ring is sized at build to accommodate `max_delay + 1` slots; a larger jitter would wrap
-        # modulo the ring depth and silently return wrong-frame data. An EPS slack lets jitter == dt pass cleanly
-        # despite float quantization.
+        # Jitter must not exceed the simulation step so a single jittered read can only shift by at most one extra ring
+        # slot. The per-class return-space ring is sized at build to accommodate `max_delay + 1` slots; a larger jitter
+        # would wrap modulo the ring depth and silently return wrong-frame data. An EPS slack lets `jitter == dt` pass
+        # cleanly despite float quantization.
         jitter_np = np.asarray(self._options.jitter, dtype=gs.np_float)
         if np.any(jitter_np >= self._dt + gs.EPS):
             gs.raise_exception(
@@ -645,86 +728,95 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
         cls,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
+        ground_truth_data_timeline: "TensorRingBuffer | None",
         measured_data_timeline: "TensorRingBuffer | None",
         intermediate_cache: torch.Tensor,
-        return_cache: torch.Tensor,
     ):
-        # `intermediate_cache` is the pipeline-internal buffer (shape/dtype from `_get_intermediate_format` /
-        # `_get_intermediate_dtype`). `return_cache` is in `_get_return_format` / `_get_cache_dtype` space. When
-        # `_post_process` is identity (default), the manager passes the same buffer for both (zero-copy alias); when
-        # overridden, they're distinct buffers and `_post_process` is applied at the end.
+        # Both branches share the same raw signal. The GT and measured timeline rings (paired, same size, shared
+        # rotation idx) store post-transform, PRE-hardware-imperfections data; `_apply_transform` reads previous ring
+        # slots cleanly and hardware imperfections never write back to the ring, so transform recurrence stays clean.
+
         if measured_data_timeline is None:
+            # No measured pipeline for this dtype (only non-SimpleSensor classes); shouldn't happen for SimpleSensor
+            # instances but keep the path correct: raw GT -> intermediate cache.
             cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
-            cls._apply_transform(shared_metadata, current_ground_truth_data_T.T, timeline=None)
             intermediate_cache.copy_(current_ground_truth_data_T.T)
         else:
-            cls._update_current_timestep_data(shared_metadata, current_ground_truth_data_T, measured_data_timeline)
-            cls._apply_transform(shared_metadata, current_ground_truth_data_T.T, timeline=None)
+            gt_slot_0 = ground_truth_data_timeline.at(0, copy=False)
             measured_slot_0 = measured_data_timeline.at(0, copy=False)
-            cls._apply_transform(shared_metadata, measured_slot_0, timeline=measured_data_timeline)
-            # Imperfections applied PRE-delay so the timeline ring stores post-noise values that serve both delay
-            # sampling below AND `read(history_length=N)`. Timeline stays in intermediate space - required for
-            # `_apply_transform` filter correctness (previous slots must be in the same data space as `data`).
-            cls._apply_hardware_imperfections(shared_metadata, measured_slot_0)
-            # Inlined delay sampling: writes intermediate_cache from measured_data_timeline.
-            # Fast path: when no sensor in the class has any delay or jitter, this is equivalent to copying the most
-            # recent ring frame to the measured cache class-wide. Avoids a Python loop over every sensor. Both flags
-            # are precomputed Python bools (no GPU sync) latched at build / by setters.
-            if not shared_metadata.has_any_delay and not shared_metadata.has_any_jitter:
-                intermediate_cache.copy_(measured_slot_0)
-            else:
-                if shared_metadata.has_any_jitter:
-                    # Sample uniform jitter in [0, jitter_ts) per env per sensor. One-sided so samples are
-                    # non-negative; combined with the `jitter < dt` option constraint, the effective per-step shift
-                    # is strictly bounded within [0, 1) steps and cannot wrap the ring.
-                    cur_jitter_ts = torch.rand_like(shared_metadata.jitter_ts).mul_(shared_metadata.jitter_ts)
-                else:
-                    cur_jitter_ts = None
-                tensor_start = 0
-                for sensor_idx, (tensor_size, interp) in enumerate(
-                    zip(shared_metadata.cache_sizes, shared_metadata.interpolate)
-                ):
-                    # Compute the current delay of the sensor, taking into account jitter if any.
-                    cur_delay_ts = shared_metadata.delays_ts[:, sensor_idx]
-                    if cur_jitter_ts is not None:
-                        cur_delay_ts = cur_delay_ts + cur_jitter_ts[:, sensor_idx]
-                    # Get int for indexing into ring buffer (0 = most recent, 1 = delayed by one timestep, etc.)
-                    cur_delay_ts_int = cur_delay_ts.to(dtype=torch.int64)
-                    tensor_slice = slice(tensor_start, tensor_start + tensor_size)
-                    sensor_cache = intermediate_cache[:, tensor_slice]
-                    data_left = measured_data_timeline.at(cur_delay_ts_int, tensor_slice, per_row=True)
-                    # Update intermediate cache with left data (Zero Order Hold) or linearly interpolated data
-                    # (First Order Hold).
-                    if interp:
-                        ratio = torch.frac(cur_delay_ts)
-                        data_right = measured_data_timeline.at(cur_delay_ts_int + 1, tensor_slice, per_row=True)
-                        torch.lerp(data_left, data_right, ratio[:, None], out=sensor_cache)
-                    else:
-                        sensor_cache.copy_(data_left)
-                    tensor_start += tensor_size
 
-        # Eager post-processing: applied once per step so `read()` is a pure view into the per-class return cache.
-        # When `_post_process` is the identity default, the manager passes `intermediate_cache` as `return_cache`
-        # (zero-copy alias); the buffer-identity check skips the redundant copy in that case.
-        if return_cache is not intermediate_cache:
-            return_cache.copy_(cls._post_process(shared_metadata, intermediate_cache))
+            # Raw signal and measured-only physics imperfections in one hook so an override can fuse them in a single
+            # kernel pass. Default writes raw GT to slot 0 of both rings and then applies `_apply_physics_imperfections`
+            # in place on the measured ring slot only - GT keeps the raw simulated phenomenon, measured carries the
+            # noised value.
+            cls._update_current_timestep_data(
+                shared_metadata, current_ground_truth_data_T, ground_truth_data_timeline, measured_data_timeline
+            )
+
+            # GT branch transform. `is_measured=False` lets sensor-element-specific effects (RC filter, mechanical
+            # bandwidth) skip on the GT path while branch-symmetric coordinate transforms still run.
+            cls._apply_transform(shared_metadata, gt_slot_0, ground_truth_data_timeline, is_measured=False)
+            current_ground_truth_data_T.copy_(gt_slot_0.T)
+
+            # Measured branch transform - same hook, on the measured ring with `is_measured=True`. Recurrence is
+            # independent of the GT branch because each branch has its own timeline ring.
+            cls._apply_transform(shared_metadata, measured_slot_0, measured_data_timeline, is_measured=True)
+
+            # Copy post-transform value from the measured ring slot 0 into the per-step intermediate cache (the working
+            # buffer), then apply hardware imperfections in place. The ring stays clean of HW noise so
+            # `_apply_transform` recurrence next step sees uncontaminated previous slots; the working buffer holds the
+            # per-step post-HW value that the orchestrator will project via `_post_process` and write into the
+            # return-space ring slot 0. Delay sampling reads from the return-space ring, so each delayed slot carries
+            # its own frozen noise sample (embedded-sampler semantics).
+            intermediate_cache.copy_(measured_slot_0)
+            cls._apply_hardware_imperfections(shared_metadata, intermediate_cache)
+
+        # `_post_process`, write to return ring slot 0, and delay sampling are handled by the manager after this hook
+        # returns.
 
     @classmethod
     def _update_current_timestep_data(
         cls,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
+        ground_truth_data_timeline: "TensorRingBuffer | None",
         measured_data_timeline: "TensorRingBuffer",
     ):
         """
-        Write the current timestep's raw signal into both buffers.
+        Pack the raw signal and measured-only physics imperfections into one hook.
 
-        Default behavior: compute raw GT into ``current_ground_truth_data_T`` via ``_update_raw_data``, then copy
-        it into the measured ring's current slot. Override for sensors with kernel-internal physical-response
-        noise (one kernel writes both GT and the noised measured value in one pass).
+        Default behavior: compute raw GT into ``current_ground_truth_data_T`` (shape ``(cols, B)``, C-contiguous, the
+        kernel-friendly target) via ``_update_raw_data``, mirror it into slot 0 of the GT and measured timeline rings,
+        then call ``_apply_physics_imperfections`` in place on the measured ring slot. Override this method to fuse
+        ``_update_raw_data`` and ``_apply_physics_imperfections`` in a single kernel pass: write the raw GT to
+        ``current_ground_truth_data_T`` and to the GT ring slot, and write the noised value directly to the measured
+        ring slot.
         """
         cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
-        measured_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+        if ground_truth_data_timeline is not None:
+            ground_truth_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
+        measured_slot_0 = measured_data_timeline.at(0, copy=False)
+        measured_slot_0.copy_(current_ground_truth_data_T.T)
+        cls._apply_physics_imperfections(shared_metadata, measured_slot_0, measured_data_timeline)
+
+    @classmethod
+    def _apply_physics_imperfections(
+        cls, shared_metadata: SharedSensorMetadata, data: torch.Tensor, timeline: "TensorRingBuffer"
+    ):
+        """
+        Apply physics-level perturbations in place on the current measured-timeline slot, BEFORE ``_apply_transform``.
+
+        Physics-level means random fluctuations of the underlying physical phenomenon the simulator does not model
+        (genuine drift, random walk of the quantity, fine-scale turbulence on top of the deterministic field, etc.).
+        These shape what the sensor *sees* beyond the simulated GT, but they are NOT the sensor element's response
+        (thermal mass / RC time constant, mechanical bandwidth -> ``_apply_transform`` with ``is_measured=True``) and
+        they are NOT the sensor's electronics (ADC, ethercat, embedded buffering -> ``_apply_hardware_imperfections``).
+        Measured-only by construction (GT keeps the raw simulated phenomenon).
+
+        ``data IS timeline.at(0)`` (the measured ring's slot 0). Stateful overrides read previous slots with
+        ``timeline.at(1)``, etc. Default: no-op. Sensors that fuse this with ``_update_raw_data`` in a single kernel
+        should override ``_update_current_timestep_data`` instead of this hook.
+        """
 
     @classmethod
     def _update_raw_data(cls, shared_metadata: SharedSensorMetadata, raw_data_T: torch.Tensor):
@@ -736,26 +828,41 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
         cls,
         shared_metadata: SharedSensorMetadata,
         data: torch.Tensor,
+        timeline: "TensorRingBuffer",
         *,
-        timeline: "TensorRingBuffer | None" = None,
+        is_measured: bool,
     ):
         """
-        Coordinate transform + optional stateful filter; mutates ``data`` in place.
+        Pre-acquisition transform + optional stateful filter; mutates ``data`` in place.
 
-        Receives ``data`` as a batch-first view ``[B, cache_size, ...]`` and must mutate it in place. ``timeline``
-        is ``None`` on the GT branch and the measured ring on the measured branch; gate filter logic on
-        ``timeline is not None`` and read previous slots with ``timeline.at(1)``, ``timeline.at(2)``, etc.
+        Receives ``data`` as a batch-first view ``[B, cache_size, ...]`` (the current slot 0 of ``timeline``) and must
+        mutate it in place. ``timeline`` is the branch's ring - the GT ring on the GT branch call, the measured ring on
+        the measured branch call - and is always non-``None``. Read previous slots with ``timeline.at(1)``,
+        ``timeline.at(2)``, etc. for stateful filters. Ring contents are clean of hardware imperfections, so recurrence
+        state never accumulates hardware noise.
+
+        ``is_measured`` indicates which branch is currently active. The hook runs on both branches by default so
+        branch-symmetric effects (coordinate transforms, frame change) happen uniformly. Gate on ``is_measured`` for
+        sensor-element-specific pre-acquisition effects that must NOT appear in GT (RC time constant, mechanical
+        bandwidth, etc.).
         """
 
     @classmethod
     def _apply_hardware_imperfections(cls, shared_metadata: SimpleSensorMetadata, measured_slot_0: torch.Tensor):
         """
-        Apply SimpleSensor's imperfection model in-place at the current measured-timeline slot.
+        Apply SimpleSensor's imperfection model in-place on the per-step measured working buffer.
 
         Opinionated interpretation of the imperfection parameters (noise, bias, random_walk, resolution) as the
-        perturbations introduced by the embedded sampling layer at snapshot time. Applied at slot 0 of the
-        measured timeline (PRE-delay sampling). Each contribution is gated by a precomputed Python bool flag
-        (``has_any_*``) so sensor classes with all-zero values pay no GPU work.
+        perturbations introduced by the embedded sampling layer at the sensor output. Each contribution is gated by a
+        precomputed Python bool flag (``has_any_*``) so sensor classes with all-zero values pay no GPU work.
+
+        ``measured_slot_0`` is the per-dtype intermediate cache (the working buffer about to be projected by
+        ``_post_process``), not a ring slot - mutations here are local to the current step and never bleed into
+        ``_apply_transform`` recurrence. The post-projection result is written by the orchestrator into the return-space
+        ring slot 0, so each delayed read picks up a frozen noise sample captured at that step.
+
+        Designed for stateless per-step perturbations. Stateful HW responses (sensor-element bandwidth, signal-dependent
+        gain with memory) belong in ``_post_process``, which sees the return-space ring and can read its previous slots.
         """
         if shared_metadata.has_any_random_walk:
             shared_metadata._cur_random_walk += torch.normal(0.0, shared_metadata.random_walk)

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -31,13 +31,7 @@ from genesis.vis.batch_renderer import BatchRenderer
 from genesis.vis.rasterizer import Rasterizer
 from genesis.vis.rasterizer_context import RasterizerContext
 
-from .base_sensor import (
-    OptionsT,
-    KinematicSensorMetadataMixin,
-    KinematicSensorMixin,
-    Sensor,
-    SharedSensorMetadata,
-)
+from .base_sensor import OptionsT, KinematicSensorMetadataMixin, KinematicSensorMixin, Sensor, SharedSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.utils.ring_buffer import TensorRingBuffer
@@ -62,10 +56,9 @@ class MinimalVisualizerWrapper:
     """
     Minimal visualizer wrapper for BatchRenderer camera sensors.
 
-    BatchRenderer requires a visualizer-like object to provide camera information and context,
-    but camera sensors don't need the full visualizer functionality (viewer, UI, etc.).
-    This wrapper provides just the minimal interface expected by BatchRenderer while
-    avoiding the overhead of creating a full visualizer instance.
+    BatchRenderer requires a visualizer-like object to provide camera information and context, but camera sensors don't
+    need the full visualizer functionality (viewer, UI, etc.). This wrapper provides just the minimal interface expected
+    by BatchRenderer while avoiding the overhead of creating a full visualizer instance.
     """
 
     def __init__(self, scene, sensors, vis_options):
@@ -73,8 +66,8 @@ class MinimalVisualizerWrapper:
         self._cameras = []  # Will be populated with camera wrappers
         self._sensors = sensors  # Keep reference to sensors
 
-        # Create a minimal rasterizer context for camera frustum visualization
-        # (required by BatchRenderer even though cameras don't render frustums)
+        # Create a minimal rasterizer context for camera frustum visualization (required by BatchRenderer even though
+        # cameras don't render frustums)
         self._context = RasterizerContext(vis_options)
         self._context.build(scene)
         self._context.reset()
@@ -232,20 +225,10 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
     - Shared read() method returning torch tensors
     """
 
-    uses_measured_pipeline: ClassVar[bool] = False
+    uses_ring_pipeline: ClassVar[bool] = False
 
     def __init__(self, options: "SensorOptions", idx: int, manager: "SensorManager"):
-        # Camera bypasses the measured pipeline (lazy render on read); any feature relying on the timeline ring
-        # would silently no-op. Reject the inputs at construction so the user is forced to drop the option or pick a
-        # different sensor.
-        if options.delay > 0.0:
-            gs.raise_exception(f"{type(self).__name__} does not support `delay`; got delay={options.delay}.")
-        if options.jitter > 0.0:
-            gs.raise_exception(f"{type(self).__name__} does not support `jitter`; got jitter={options.jitter}.")
-        if options.history_length > 0:
-            gs.raise_exception(
-                f"{type(self).__name__} does not support `history_length`; got history_length={options.history_length}."
-            )
+        # `uses_ring_pipeline = False` triggers the generic delay / jitter / history rejection in `Sensor.__init__`.
         super().__init__(options, idx, manager)
         self._stale: bool = True
 
@@ -264,12 +247,12 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
         cls,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
+        ground_truth_data_timeline: "TensorRingBuffer | None",
         measured_data_timeline: "TensorRingBuffer | None",
         intermediate_cache: torch.Tensor,
-        return_cache: torch.Tensor,
     ):
-        # No per-step measured-cache update for cameras (handled lazily on read()). `BaseCameraSensor` declares
-        # `uses_measured_pipeline = False`, so the manager passes `measured_data_timeline=None` here.
+        # No per-step cache update for cameras (handled lazily on read()). `BaseCameraSensor` declares
+        # `uses_ring_pipeline = False`, so the manager passes both timeline rings as ``None`` here.
         pass
 
     def _draw_debug(self, context: "RasterizerContext"):
@@ -322,7 +305,6 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
 
     def _ensure_rendered_for_current_state(self):
         """Ensure this camera has an up-to-date render before reading.
-
         Base handles staleness and timestamps; subclasses implement _render_current_state().
         """
         scene = self._manager._sim.scene
@@ -400,8 +382,8 @@ class RasterizerCameraSensor(
     """
     Rasterizer camera sensor using OpenGL-based rendering.
 
-    This sensor renders RGB images using the existing Rasterizer backend,
-    but operates independently from the scene visualizer.
+    This sensor renders RGB images using the existing Rasterizer backend, but operates independently from the scene
+    visualizer.
     """
 
     def __init__(self, options: RasterizerCameraOptions, idx: int, manager: "SensorManager"):
@@ -425,8 +407,8 @@ class RasterizerCameraSensor(
             self._shared_metadata.lights = gs.List()
             self._shared_metadata.image_cache = {}
 
-            # If a viewer is active, reuse its windowed OpenGL context for both offscreen and onscreen
-            # rendering, rather than creating a separate headless context which is fragile.
+            # If a viewer is active, reuse its windowed OpenGL context for both offscreen and onscreen rendering, rather
+            # than creating a separate headless context which is fragile.
             if scene.viewer is not None:
                 self._shared_metadata.context = scene.visualizer.context
                 self._shared_metadata.renderer = scene.visualizer.rasterizer
@@ -524,8 +506,8 @@ class RasterizerCameraSensor(
             pos_world = transform_by_quat(pos, link_quat) + link_pos
             pos = pos_world
         elif self._link is not None:
-            # Link exists but not built yet - use configured pose as-is (treat as world coordinates for now)
-            # This will be corrected when move_to_attach is called
+            # Link exists but not built yet - use configured pose as-is (treat as world coordinates for now) This will
+            # be corrected when move_to_attach is called
             pass
 
         transform = pos_lookat_up_to_T(pos, lookat, up)
@@ -544,18 +526,16 @@ class RasterizerCameraSensor(
 
         context = self._shared_metadata.context
 
-        # When env_separate_rigid is enabled, geometry render transforms include env_spacing
-        # offsets (baked in by kernel_update_geoms_render_T). For per-env sensor rendering,
-        # these offsets must be temporarily removed so each env's geometry renders at local
-        # origin relative to the camera. The offsets are restored after rendering to preserve
-        # the correct layout for the interactive viewer which shares the same context.
+        # When env_separate_rigid is enabled, geometry render transforms include env_spacing offsets (baked in by
+        # kernel_update_geoms_render_T). For per-env sensor rendering, these offsets must be temporarily removed so each
+        # env's geometry renders at local origin relative to the camera. The offsets are restored after rendering to
+        # preserve the correct layout for the interactive viewer which shares the same context.
         context.update(force_render=True)
 
-        # When env_separate_rigid is enabled, geometry render transforms include env_spacing
-        # offsets (baked in by kernel_update_geoms_render_T). For per-env sensor rendering,
-        # these offsets must be temporarily removed so each env's geometry renders at local
-        # origin relative to the camera. The offsets are restored after rendering to preserve
-        # the correct layout for the interactive viewer which shares the same context.
+        # When env_separate_rigid is enabled, geometry render transforms include env_spacing offsets (baked in by
+        # kernel_update_geoms_render_T). For per-env sensor rendering, these offsets must be temporarily removed so each
+        # env's geometry renders at local origin relative to the camera. The offsets are restored after rendering to
+        # preserve the correct layout for the interactive viewer which shares the same context.
         envs_offset = context.scene.envs_offset
         saved_poses = {}
         if context.env_separate_rigid and (envs_offset != 0).any():
@@ -569,11 +549,7 @@ class RasterizerCameraSensor(
                         context.jit.update_buffer(buf_id, poses.transpose((0, 2, 1)))
 
         rgb_arr, _, _, _ = self._shared_metadata.renderer.render_camera(
-            self._camera_wrapper,
-            rgb=True,
-            depth=False,
-            segmentation=False,
-            normal=False,
+            self._camera_wrapper, rgb=True, depth=False, segmentation=False, normal=False
         )
 
         # Restore original geometry transforms with offsets for the interactive viewer
@@ -658,8 +634,8 @@ class RaytracerCameraSensor(
             lookat = transform_by_trans_quat(lookat, link_pos, link_quat)
             up = transform_by_quat(up, link_quat)
         elif self._link is not None:
-            # Link exists but not built yet - use configured pose as-is (treat as world coordinates for now)
-            # This will be corrected when move_to_attach is called
+            # Link exists but not built yet - use configured pose as-is (treat as world coordinates for now) This will
+            # be corrected when move_to_attach is called
             pass
 
         self._camera_obj = visualizer.add_camera(
@@ -780,9 +756,7 @@ class BatchRendererCameraSensor(
                     f"All BatchRendererCameraSensor instances must have the same resolution. Found: {set(resolutions)}"
                 )
 
-            br_options = BatchRendererOptions(
-                use_rasterizer=self._options.use_rasterizer,
-            )
+            br_options = BatchRendererOptions(use_rasterizer=self._options.use_rasterizer)
 
             vis_options = VisOptions(
                 show_world_frame=False,
@@ -824,12 +798,7 @@ class BatchRendererCameraSensor(
         self._shared_metadata.renderer.update_scene(force_render=True)
 
         rgb_arr, *_ = self._shared_metadata.renderer.render(
-            rgb=True,
-            depth=False,
-            segmentation=False,
-            normal=False,
-            antialiasing=False,
-            force_render=True,
+            rgb=True, depth=False, segmentation=False, normal=False, antialiasing=False, force_render=True
         )
 
         # rgb_arr might be a tuple of arrays (one per camera) or a single array

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -6,23 +6,13 @@ import quadrants as qd
 import torch
 
 import genesis as gs
-from genesis.options.sensors import (
-    Contact as ContactSensorOptions,
-)
-from genesis.options.sensors import (
-    ContactForce as ContactForceSensorOptions,
-)
+from genesis.options.sensors import Contact as ContactSensorOptions
+from genesis.options.sensors import ContactForce as ContactForceSensorOptions
 from genesis.utils.geom import inv_transform_by_quat, qd_inv_transform_by_quat, transform_by_quat
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_torch, tensor_to_array
 from genesis.utils.ring_buffer import TensorRingBuffer
 
-from .base_sensor import (
-    RigidSensorMetadataMixin,
-    RigidSensorMixin,
-    Sensor,
-    SimpleSensor,
-    SimpleSensorMetadata,
-)
+from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, Sensor, SimpleSensor, SimpleSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.engine.entities.rigid_entity.rigid_link import RigidLink
@@ -79,8 +69,8 @@ class ContactSensorMetadata(SimpleSensorMetadata):
     expanded_links_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     # (num_contact_sensors, max_num_filter_links); unused slots are -1.
     filter_links_idx: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
-    # Indices into expanded_links_idx of sensors that have at least one filter link. Lets the GT update skip the
-    # 4D contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
+    # Indices into expanded_links_idx of sensors that have at least one filter link. Lets the GT update skip the 4D
+    # contact-vs-filter comparison for the (typically larger) subset of sensors with no filter.
     filtered_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     # Per-sensor bool threshold (broadcast over B); _post_process returns `tensor > thresholds`.
     thresholds: torch.Tensor = make_tensor_field((0,))
@@ -156,8 +146,8 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, ContactSensorMetadata]):
         is_contact_b = link_b[..., None, :] == shared_metadata.expanded_links_idx[..., None]
         # Float-valued contact count per sensor (intermediate cache is float; bool projection in `_post_process`).
         result = (is_contact_a | is_contact_b).sum(dim=-1).to(dtype=gs.tc_float)
-        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors keep
-        # the cheap aggregate result above.
+        # Apply the (more expensive) filter-aware update only on sensors that declared a filter; other sensors keep the
+        # cheap aggregate result above.
         if shared_metadata.filtered_sensor_idx.numel() > 0:
             filt = shared_metadata.filtered_sensor_idx
             sub_filter = shared_metadata.filter_links_idx[filt][None, :, None, :]
@@ -169,7 +159,9 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, ContactSensorMetadata]):
         raw_data_T[:] = result.T
 
     @classmethod
-    def _post_process(cls, shared_metadata: ContactSensorMetadata, tensor: torch.Tensor) -> torch.Tensor:
+    def _post_process(
+        cls, shared_metadata: ContactSensorMetadata, tensor: torch.Tensor, timeline, *, is_measured: bool
+    ) -> torch.Tensor:
         return tensor > shared_metadata.thresholds
 
     def _draw_debug(self, context: "RasterizerContext"):
@@ -207,8 +199,7 @@ class ContactForceSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata)
 
 
 class ContactForceSensor(
-    RigidSensorMixin[ContactForceSensorMetadata],
-    SimpleSensor[ContactForceSensorOptions, ContactForceSensorMetadata],
+    RigidSensorMixin[ContactForceSensorMetadata], SimpleSensor[ContactForceSensorOptions, ContactForceSensorMetadata]
 ):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
@@ -241,8 +232,8 @@ class ContactForceSensor(
 
     @classmethod
     def _get_intermediate_dtype(cls) -> torch.dtype:
-        # Required override because `_post_process` is overridden, even though shape and dtype coincide with return.
-        # The intermediate buffer must be a distinct buffer (the timeline ring is in intermediate space).
+        # Required override because `_post_process` is overridden, even though shape and dtype coincide with return. The
+        # intermediate buffer must be a distinct buffer (the timeline ring is in intermediate space).
         return cls._get_cache_dtype()
 
     @classmethod
@@ -286,7 +277,9 @@ class ContactForceSensor(
             )
 
     @classmethod
-    def _post_process(cls, shared_metadata: ContactForceSensorMetadata, tensor: torch.Tensor) -> torch.Tensor:
+    def _post_process(
+        cls, shared_metadata: ContactForceSensorMetadata, tensor: torch.Tensor, timeline, *, is_measured: bool
+    ) -> torch.Tensor:
         # Saturate at max_force and zero out values below the min_force dead band. Applied after quantization (which
         # happens upstream in `_apply_hardware_imperfections`); for max_force values that are not multiples of
         # resolution this produces a non-quantized saturation value, accepted as minor drift in that edge case.

--- a/genesis/engine/sensors/imu.py
+++ b/genesis/engine/sensors/imu.py
@@ -8,20 +8,10 @@ import torch
 import genesis as gs
 from genesis.options.sensors import IMU as IMUOptions
 from genesis.options.sensors import CrossCouplingAxisType
-from genesis.utils.geom import (
-    inv_transform_by_quat,
-    transform_by_quat,
-    transform_quat_by_quat,
-)
+from genesis.utils.geom import inv_transform_by_quat, transform_by_quat, transform_quat_by_quat
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 
-from .base_sensor import (
-    SimpleSensor,
-    RigidSensorMetadataMixin,
-    RigidSensorMixin,
-    Sensor,
-    SimpleSensorMetadata,
-)
+from .base_sensor import SimpleSensor, RigidSensorMetadataMixin, RigidSensorMixin, Sensor, SimpleSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.ext.pyrender.mesh import Mesh
@@ -80,10 +70,7 @@ class IMUData(NamedTuple):
     mag: torch.Tensor  # added magnetometer to complete 9-axis IMU
 
 
-class IMUSensor(
-    RigidSensorMixin[IMUSharedMetadata],
-    SimpleSensor[IMUOptions, IMUSharedMetadata, IMUData],
-):
+class IMUSensor(RigidSensorMixin[IMUSharedMetadata], SimpleSensor[IMUOptions, IMUSharedMetadata, IMUData]):
     def __init__(self, options: IMUOptions, shared_metadata: IMUSharedMetadata, manager: "SensorManager"):
         # FIXME: Resolution should be made private in mixin, so that it cannot be set by the user directly.
         options.resolution = options.acc_resolution + options.gyro_resolution + options.mag_resolution
@@ -130,7 +117,7 @@ class IMUSensor(
                     _get_cross_axis_coupling_to_alignment_matrix(self._options.acc_cross_axis_coupling),
                     _get_cross_axis_coupling_to_alignment_matrix(self._options.gyro_cross_axis_coupling),
                     _get_cross_axis_coupling_to_alignment_matrix(self._options.mag_cross_axis_coupling),
-                ],
+                ]
             ),
             expand=(self._manager._sim._B, 3, 3, 3),  # 3 sub-matrices after adding mag
             dim=1,
@@ -142,10 +129,7 @@ class IMUSensor(
             default_field = torch.tensor(default_field, device=gs.device, dtype=gs.tc_float)
 
         self._shared_metadata.magnetic_field_vector = concat_with_tensor(
-            self._shared_metadata.magnetic_field_vector,
-            default_field,
-            expand=(self._manager._sim._B, 1, 3),
-            dim=1,
+            self._shared_metadata.magnetic_field_vector, default_field, expand=(self._manager._sim._B, 1, 3), dim=1
         )
 
         if self._options.draw_debug:
@@ -184,8 +168,8 @@ class IMUSensor(
             centripetal_acc = torch.cross(ang, torch.cross(ang, offset_pos_world, dim=-1), dim=-1)
             acc += tangential_acc + centripetal_acc
 
-        # Subtract gravity then move to local frame. acc/ang shape: (B, n_imus, 3); local_mag is already
-        # (B, n_imus, 3) after the inverse transform, no reshape needed.
+        # Subtract gravity then move to local frame. acc/ang shape: (B, n_imus, 3); local_mag is already (B, n_imus, 3)
+        # after the inverse transform, no reshape needed.
         local_acc = inv_transform_by_quat(acc - gravity[..., None, :], offset_quats)
         local_ang = inv_transform_by_quat(ang, offset_quats)
         local_mag = inv_transform_by_quat(shared_metadata.magnetic_field_vector, offset_quats)
@@ -198,15 +182,10 @@ class IMUSensor(
         strided_raw[:, 2].copy_(local_mag.permute(1, 2, 0))
 
     @classmethod
-    def _apply_transform(
-        cls,
-        shared_metadata: IMUSharedMetadata,
-        data: torch.Tensor,
-        *,
-        timeline=None,
-    ):
+    def _apply_transform(cls, shared_metadata: IMUSharedMetadata, data: torch.Tensor, timeline, *, is_measured: bool):
         # Apply alignment rotation to the (lin_acc, ang_vel, mag) triplet. View the flat cache as a stack of 3-vectors
-        # and rotate them in place with the per-sensor `alignment_rot_matrix`.
+        # and rotate them in place with the per-sensor `alignment_rot_matrix`. Branch-symmetric stateless transform:
+        # `timeline` and `is_measured` are received for API uniformity but not read.
         data_xyz = data.view(data.shape[0], -1, 3)
         data_xyz.copy_(torch.matmul(shared_metadata.alignment_rot_matrix, data_xyz.unsqueeze(-1)).squeeze(-1))
 

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -16,13 +16,7 @@ from genesis.options.sensors import KinematicContactProbe as KinematicContactPro
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 from genesis.utils.raycast_qd import get_triangle_vertices, ray_triangle_intersection
 
-from .base_sensor import (
-    SimpleSensor,
-    RigidSensorMetadataMixin,
-    RigidSensorMixin,
-    Sensor,
-    SimpleSensorMetadata,
-)
+from .base_sensor import SimpleSensor, RigidSensorMetadataMixin, RigidSensorMixin, Sensor, SimpleSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.ext.pyrender.mesh import Mesh
@@ -81,12 +75,7 @@ def _func_probe_geom_penetration(
 
 
 @qd.func
-def _func_closest_point_on_triangle(
-    point: gs.qd_vec3,
-    v0: gs.qd_vec3,
-    v1: gs.qd_vec3,
-    v2: gs.qd_vec3,
-) -> gs.qd_vec3:
+def _func_closest_point_on_triangle(point: gs.qd_vec3, v0: gs.qd_vec3, v1: gs.qd_vec3, v2: gs.qd_vec3) -> gs.qd_vec3:
     """
     Find the point on the surface of a triangle closest to a given point.
 
@@ -245,14 +234,7 @@ def _func_shear_twist_displacement(
         shear_decay = qd.exp(-shear_coeff * mg_dist_sq)
         delta_s_mag = qd.sqrt(delta_s_local[0] * delta_s_local[0] + delta_s_local[1] * delta_s_local[1] + eps * eps)
         shear_scale = qd.min(delta_s_mag, shear_max_delta) * shear_decay / (delta_s_mag + eps)
-        shear_local = qd.Vector(
-            [
-                shear_scale * delta_s_local[0],
-                shear_scale * delta_s_local[1],
-                0.0,
-            ],
-            dt=gs.qd_float,
-        )
+        shear_local = qd.Vector([shear_scale * delta_s_local[0], shear_scale * delta_s_local[1], 0.0], dt=gs.qd_float)
         displacement_world += gu.qd_transform_by_quat(shear_local, link_quat)
 
     # twist_displacement = min(twist_max_delta, twist_angle) * (M - G) * exp(-λt ||M - G||²)
@@ -643,8 +625,8 @@ def _elastomer_displacement_grid_fft_dilate(
     output: torch.Tensor,
 ) -> None:
     """
-    Grid dilate via 2D FFT. Uses in-plane distance only in the kernel; scale by exp(-λ*H²)
-    so magnitude matches non-grid formulation which uses full 3D distance (r²_2D + Δz²).
+    Grid dilate via 2D FFT. Uses in-plane distance only in the kernel; scale by exp(-λ*H²) so magnitude matches non-grid
+    formulation which uses full 3D distance (r²_2D + Δz²).
     """
     n_batches = contact_buf.shape[0]
     n_sensors = grid_n.shape[0]
@@ -665,8 +647,8 @@ def _elastomer_displacement_grid_fft_dilate(
         Ky = fft_kernel_list[i_s][1]
         fft_nx, fft_ny = Kx.shape[0], Kx.shape[1]
 
-        # H = contact depth grid (ix, iy); zero-pad to fft size for linear convolution.
-        # Probes from generate_grid_points_on_plane flat as iy*nx+ix; view (g_ny, g_nx) then transpose -> (g_nx, g_ny).
+        # H = contact depth grid (ix, iy); zero-pad to fft size for linear convolution. Probes from
+        # generate_grid_points_on_plane flat as iy*nx+ix; view (g_ny, g_nx) then transpose -> (g_nx, g_ny).
         contact_slice = contact_buf[:, probe_start : probe_start + g_nx * g_ny, 3]
         H_buf = fft_depth_buffer[:, i_s, :fft_nx, :fft_ny]
         H_buf.zero_()
@@ -814,9 +796,7 @@ class KinematicTactileSensorMixin(Generic[KinematicTactileSensorMetadataMixinT])
             expand=(1,),
         )
         self._shared_metadata.sensor_probe_start = concat_with_tensor(
-            self._shared_metadata.sensor_probe_start,
-            self._shared_metadata.total_n_probes,
-            expand=(1,),
+            self._shared_metadata.sensor_probe_start, self._shared_metadata.total_n_probes, expand=(1,)
         )
         self._shared_metadata.probe_sensor_idx = concat_with_tensor(
             self._shared_metadata.probe_sensor_idx,
@@ -1062,9 +1042,7 @@ class ElastomerDisplacementSensor(
             prev = self._shared_metadata.fft_depth_buffer.shape
             max_fft_n = (max(fft_n[0], prev[2]), max(fft_n[1], prev[3]))
             self._shared_metadata.fft_depth_buffer = torch.zeros(
-                (self._manager._sim._B, n_sensors, max_fft_n[0], max_fft_n[1]),
-                dtype=gs.tc_float,
-                device=gs.device,
+                (self._manager._sim._B, n_sensors, max_fft_n[0], max_fft_n[1]), dtype=gs.tc_float, device=gs.device
             )
             grid_size = nx * ny * 3
             out_buf = self._shared_metadata.grid_dilate_out_buffer
@@ -1084,8 +1062,8 @@ class ElastomerDisplacementSensor(
     def _update_raw_data(cls, shared_metadata: ElastomerDisplacementSensorMetadata, raw_data_T: torch.Tensor):
         solver = shared_metadata.solver
 
-        # Zero buffers allocated with torch.empty to avoid stale data if the kernel
-        # fails to write some entries (e.g. after a backend switch within the same process).
+        # Zero buffers allocated with torch.empty to avoid stale data if the kernel fails to write some entries (e.g.
+        # after a backend switch within the same process).
         shared_metadata.contact_buf.zero_()
         shared_metadata.contact_link_buf.fill_(-1)
 

--- a/genesis/engine/sensors/proximity.py
+++ b/genesis/engine/sensors/proximity.py
@@ -13,13 +13,7 @@ from genesis.options.sensors import Proximity as ProximityOptions
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 from genesis.utils.raycast_qd import get_triangle_vertices
 
-from .base_sensor import (
-    SimpleSensor,
-    RigidSensorMetadataMixin,
-    RigidSensorMixin,
-    Sensor,
-    SimpleSensorMetadata,
-)
+from .base_sensor import SimpleSensor, RigidSensorMetadataMixin, RigidSensorMixin, Sensor, SimpleSensorMetadata
 from .kinematic_tactile import _func_closest_point_on_triangle
 
 if TYPE_CHECKING:
@@ -134,10 +128,7 @@ class ProximityMetadata(ProximitySensorMetadataMixin, RigidSensorMetadataMixin, 
     """Shared metadata for the Proximity sensor class."""
 
 
-class ProximitySensor(
-    RigidSensorMixin[ProximityMetadata],
-    SimpleSensor[ProximityOptions, ProximityMetadata, tuple],
-):
+class ProximitySensor(RigidSensorMixin[ProximityMetadata], SimpleSensor[ProximityOptions, ProximityMetadata, tuple]):
     """Proximity sensor: distance and nearest point from probe positions to tracked mesh surfaces."""
 
     def __init__(self, sensor_options: ProximityOptions, sensor_idx: int, sensor_manager: "SensorManager"):
@@ -169,9 +160,7 @@ class ProximitySensor(
             expand=(1,),
         )
         self._shared_metadata.sensor_probe_start = concat_with_tensor(
-            self._shared_metadata.sensor_probe_start,
-            self._shared_metadata.total_n_probes,
-            expand=(1,),
+            self._shared_metadata.sensor_probe_start, self._shared_metadata.total_n_probes, expand=(1,)
         )
         self._shared_metadata.probe_sensor_idx = concat_with_tensor(
             self._shared_metadata.probe_sensor_idx,

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -8,12 +8,8 @@ import torch
 import genesis as gs
 from genesis.engine.bvh import AABB, LBVH
 from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
-from genesis.options.sensors import (
-    Raycaster as RaycasterOptions,
-)
-from genesis.options.sensors import (
-    RaycastPattern,
-)
+from genesis.options.sensors import Raycaster as RaycasterOptions
+from genesis.options.sensors import RaycastPattern
 from genesis.utils.geom import transform_by_quat, transform_by_trans_quat
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_numpy
 from genesis.utils.raycast_qd import (
@@ -24,13 +20,7 @@ from genesis.utils.raycast_qd import (
 )
 from genesis.vis.rasterizer_context import RasterizerContext
 
-from .base_sensor import (
-    KinematicSensorMetadataMixin,
-    KinematicSensorMixin,
-    Sensor,
-    SimpleSensorMetadata,
-    SimpleSensor,
-)
+from .base_sensor import KinematicSensorMetadataMixin, KinematicSensorMixin, Sensor, SimpleSensorMetadata, SimpleSensor
 
 if TYPE_CHECKING:
     from genesis.engine.solvers.kinematic_solver import KinematicSolver
@@ -44,8 +34,8 @@ class _SolverBVH(NamedTuple):
     """
     One BVH built against a solver's mesh.
 
-    ``raycast_mask`` is ``None`` for a collision BVH (``faces_info`` / ``verts_info``, no per-face mask),
-    otherwise an int8 array of shape ``(n_vfaces,)`` selecting which visual faces contribute.
+    ``raycast_mask`` is ``None`` for a collision BVH (``faces_info`` / ``verts_info``, no per-face mask), otherwise an
+    int8 array of shape ``(n_vfaces,)`` selecting which visual faces contribute.
     """
 
     solver: "KinematicSolver"
@@ -56,9 +46,9 @@ class _SolverBVH(NamedTuple):
 
 @dataclass
 class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata):
-    # All BVHs (one per active solver per mesh type) cast against each frame. The first is written into the output
-    # cache with is_merge=False (initializes hits or no_hit_value), the rest merge in closer hits. Per-sensor link
-    # poses are gathered via KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
+    # All BVHs (one per active solver per mesh type) cast against each frame. The first is written into the output cache
+    # with is_merge=False (initializes hits or no_hit_value), the rest merge in closer hits. Per-sensor link poses are
+    # gathered via KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
     solver_bvhs: list[_SolverBVH] = field(default_factory=list)
 
     # Per-step scratch tensors for sensor link poses, lazily allocated on the first cast (B and n_sensors known).
@@ -99,9 +89,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
     @staticmethod
     def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
         """Build a per-vface mask (int8, shape (n_vfaces,)) selecting vfaces opted into visual raycasting.
-
-        A vface is opted in iff its owning vgeom belongs to an entity whose material has
-        use_visual_raycasting=True.
+        A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
         """
         n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
         if n_vfaces == 0:
@@ -132,11 +120,10 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                 )
                 entry.bvh.build()
             else:
-                # Reads vverts_state.pos as the source of vvert positions. The buffer is seeded by FK at
-                # scene.build() and refreshed for each user-driven entity via set_vverts; entries set via
-                # set_vverts survive across calls until set_vverts(None) re-runs FK over the entity's vgeoms.
-                # raycast_mask gates which vfaces contribute to the BVH; masked-out vfaces keep an inverted
-                # AABB and are skipped by ray queries.
+                # Reads vverts_state.pos as the source of vvert positions. The buffer is seeded by FK at scene.build()
+                # and refreshed for each user-driven entity via set_vverts; entries set via set_vverts survive across
+                # calls until set_vverts(None) re-runs FK over the entity's vgeoms. raycast_mask gates which vfaces
+                # contribute to the BVH; masked-out vfaces keep an inverted AABB and are skipped by ray queries.
                 entry.solver.update_forward_pos()
                 entry.solver.update_vgeoms()
                 kernel_update_visual_aabbs(
@@ -152,10 +139,10 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
     def build(self):
         super().build()
 
-        # First raycast sensor: build the per-(solver, mesh-type) BVHs once. Rigid solvers get a collision BVH
-        # covering all collision faces; any solver with entities opting in via material.use_visual_raycasting gets
-        # a visual BVH masked to those entities' vfaces. Collision and visual entries coexist transparently because
-        # the cast kernels merge in place via is_merge.
+        # First raycast sensor: build the per-(solver, mesh-type) BVHs once. Rigid solvers get a collision BVH covering
+        # all collision faces; any solver with entities opting in via material.use_visual_raycasting gets a visual BVH
+        # masked to those entities' vfaces. Collision and visual entries coexist transparently because the cast kernels
+        # merge in place via is_merge.
         if not self._shared_metadata.solver_bvhs:
             self._shared_metadata.sensor_cache_offsets = concat_with_tensor(
                 self._shared_metadata.sensor_cache_offsets, 0
@@ -226,8 +213,8 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
             self._shared_metadata.no_hit_values, self._options.no_hit_value
         )
 
-        # Multi-BVH merge passes use raw distance comparison to pick the closer hit; this only works if
-        # no_hit_value >= max_range. The negated form also rejects NaN (every IEEE 754 comparison with NaN is False).
+        # Multi-BVH merge passes use raw distance comparison to pick the closer hit; this only works if no_hit_value >=
+        # max_range. The negated form also rejects NaN (every IEEE 754 comparison with NaN is False).
         if len(self._shared_metadata.solver_bvhs) > 1 and not (self._options.no_hit_value >= self._options.max_range):
             gs.raise_exception(
                 f"no_hit_value ({self._options.no_hit_value}) must be >= max_range ({self._options.max_range}) "
@@ -251,9 +238,9 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
     def _update_raw_data(cls, shared_metadata: RaycasterSharedMetadata, raw_data_T: torch.Tensor):
         cls._update_bvh(shared_metadata)
 
-        # Allocate the link-pose scratch buffers on first cast (B and n_sensors are known here). Identity quat is
-        # baked into the initial allocation so static sensors (entity_idx<0) leave their rows at identity, letting
-        # the cast kernel apply pos_offset / euler_offset in world frame.
+        # Allocate the link-pose scratch buffers on first cast (B and n_sensors are known here). Identity quat is baked
+        # into the initial allocation so static sensors (entity_idx<0) leave their rows at identity, letting the cast
+        # kernel apply pos_offset / euler_offset in world frame.
         if shared_metadata.links_pos is None:
             B = shared_metadata.solver_bvhs[0].solver._B
             shared_metadata.links_pos = torch.zeros(
@@ -309,11 +296,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                 )
             else:
                 kernel_cast_rays_visual(
-                    solver.vverts_info,
-                    solver.vverts_state,
-                    solver.vfaces_info,
-                    solver.vgeoms_state,
-                    *args_common,
+                    solver.vverts_info, solver.vverts_state, solver.vfaces_info, solver.vgeoms_state, *args_common
                 )
 
     def _draw_debug(self, context: "RasterizerContext"):
@@ -343,13 +326,9 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
 
         self.debug_objects += [
             context.draw_debug_spheres(
-                ray_starts,
-                radius=self._options.debug_sphere_radius,
-                color=self._options.debug_ray_start_color,
+                ray_starts, radius=self._options.debug_sphere_radius, color=self._options.debug_ray_start_color
             ),
             context.draw_debug_spheres(
-                points,
-                radius=self._options.debug_sphere_radius,
-                color=self._options.debug_ray_hit_color,
+                points, radius=self._options.debug_sphere_radius, color=self._options.debug_ray_hit_color
             ),
         ]

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -24,24 +24,26 @@ class SensorManager:
         self._sim = sim
         self._sensors_by_type: dict[type["Sensor"], list["Sensor"]] = {}
         self._sensors_metadata: dict[type["Sensor"], SharedSensorMetadata | None] = {}
-        # Per-dtype intermediate caches: pre-`_post_process` storage in intermediate space. The transposed GT cache
-        # is `(cols, B)` for C-contiguous per-class row slices required by kernel writes.
+        # Per-dtype intermediate caches: pre-`_post_process` storage in intermediate space. The transposed GT cache is
+        # `(cols, B)` for C-contiguous per-class row slices required by kernel writes.
         self._ground_truth_intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
         self._intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
-        # Per-class return caches: post-`_post_process` storage in return space. When `_post_process` is identity,
-        # alias-views into the per-dtype intermediate cache; when overridden, separate buffers in return shape/dtype.
+        # Per-class return caches in return space - what `read()` and `read_ground_truth()` slice into. Separate buffers
+        # when a per-class return-space ring is allocated (the orchestrator delay-samples the ring into the cache);
+        # alias-views into the per-dtype intermediate cache otherwise (identity `_post_process`, no delay, no history -
+        # the per-step write inside `_update_shared_cache` is then directly visible to `read()`).
         self._return_cache: dict[type["Sensor"], torch.Tensor] = {}
         self._ground_truth_return_cache: dict[type["Sensor"], torch.Tensor] = {}
+        # Paired GT and measured timeline rings (post-transform, PRE-hardware-imperfections data). Allocated together
+        # per dtype when any sensor in the dtype declares `uses_ring_pipeline = True`. They share the same rotation idx
+        # so a single `rotate()` per step advances both.
         self._ground_truth_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Measured timeline: post-imperfection, pre-delay snapshots. Shares ring idx with _ground_truth_timeline_ring
-        # per dtype. No separate measured-history ring - history reads are served from this ring's slots or from the
-        # per-class linearized history buffer.
         self._measured_timeline_ring: dict[type[torch.dtype], TensorRingBuffer] = {}
-        # Per-class return-space rings, only allocated when `_post_process` is overridden AND any sensor of the class
-        # has `history_length > 0`. Each step the eager `_post_process` result is written to slot 0; history reads
-        # gather from here so the projection is computed once at write time (correct for stateful `_post_process`)
-        # and history reads avoid re-projecting older slots. For identity `_post_process` the intermediate ring is
-        # already in return space, so no extra ring is needed.
+        # Per-class return-space rings (post-everything: post-hardware-imperfections, post-`_post_process`,
+        # pre-delay-sample). Allocated together when any sensor in the class has `delay > 0`, OR `history_length > 0`,
+        # OR the class overrides `_post_process`. Each step the post-everything snapshot is written to slot 0; the
+        # source for delay sampling (into the per-class return cache) and for history reads. GT and measured rings share
+        # their rotation idx so a single `rotate()` per step advances both.
         self._ground_truth_return_timeline_ring: dict[type["Sensor"], TensorRingBuffer] = {}
         self._measured_return_timeline_ring: dict[type["Sensor"], TensorRingBuffer] = {}
         # Per-class precomputed history index tensor [0, 1, ..., max_history-1]. Used to fancy-index the rings on
@@ -69,8 +71,8 @@ class SensorManager:
         if sensor_cls is not None:
             return sensor_cls
 
-        # Not registered yet — check that the options class specifies its sensor type, then try to discover it.
-        # The sensor class name is extracted from the generic metadata on the options class bases.
+        # Not registered yet — check that the options class specifies its sensor type, then try to discover it. The
+        # sensor class name is extracted from the generic metadata on the options class bases.
         is_parameterized = False
         for base in options_cls.__bases__:
             meta = base.__pydantic_generic_metadata__
@@ -115,23 +117,24 @@ class SensorManager:
         )
 
     def build(self):
-        # Sort each class by entity_idx so sensors attached to the same entity occupy a contiguous slice of the
-        # class cache. Static sensors have entity_idx=-1 and group together. Python's sort is stable, so
-        # registration order is preserved within each entity bucket.
+        # Sort each class by entity_idx so sensors attached to the same entity occupy a contiguous slice of the class
+        # cache. Static sensors have entity_idx=-1 and group together. Python's sort is stable, so registration order is
+        # preserved within each entity bucket.
         for sensors in self._sensors_by_type.values():
             sensors.sort(key=lambda s: s._options.entity_idx)
             for new_idx, sensor in enumerate(sensors):
                 sensor._idx = new_idx
 
         # Per-class intermediate / return dtypes come from `_get_intermediate_dtype` / `_get_cache_dtype`. Dtype is
-        # class-uniform by design (the per-class slice into the per-dtype intermediate buffer must be contiguous, so
-        # all instances of a class share one dtype). Shape is per-instance via `_get_intermediate_format` /
+        # class-uniform by design (the per-class slice into the per-dtype intermediate buffer must be contiguous, so all
+        # instances of a class share one dtype). Shape is per-instance via `_get_intermediate_format` /
         # `_get_return_format` and contributes to the class slice size below.
         cache_size_per_dtype: dict[torch.dtype, int] = {}
-        delay_depth_per_dtype: dict[torch.dtype, int] = {}
         max_history_per_dtype: dict[torch.dtype, int] = {}
         intermediate_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
         return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
+        # Per-class delay-depth (max sensor `_delay_ts + 1`) drives the return-space ring sizing for delay sampling.
+        delay_depth_by_class: dict[type["Sensor"], int] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
             intermediate_dtype = sensor_cls._get_intermediate_dtype()
             return_dtype = sensor_cls._get_cache_dtype()
@@ -143,12 +146,11 @@ class SensorManager:
             entity_offsets: dict[int, list[int]] = {}
             cls_offset = 0
             cls_max_history = 0
+            cls_delay_depth = 1
             for sensor in sensors:
                 sensor._cache_idx = cache_size_per_dtype[intermediate_dtype]
                 cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
-                delay_depth_per_dtype[intermediate_dtype] = max(
-                    delay_depth_per_dtype.get(intermediate_dtype, 0), sensor._delay_ts + 1
-                )
+                cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + 1)
                 hist = sensor._options.history_length
                 if hist > 0:
                     max_history_per_dtype[intermediate_dtype] = max(
@@ -168,6 +170,7 @@ class SensorManager:
                 eid: slice(start, stop) for eid, (start, stop) in entity_offsets.items()
             }
             self._max_history_by_class[sensor_cls] = cls_max_history
+            delay_depth_by_class[sensor_cls] = cls_delay_depth
 
         self._ground_truth_timeline_ring.clear()
         self._measured_timeline_ring.clear()
@@ -177,38 +180,55 @@ class SensorManager:
         self._measured_return_timeline_ring.clear()
         self._hist_idx_by_class.clear()
 
-        dtype_uses_measured: dict[torch.dtype, bool] = {}
-        for sensor_cls, sensors in self._sensors_by_type.items():
+        # Per-dtype flag: at least one class in this dtype uses the ring-based per-step pipeline. Drives allocation of
+        # the paired GT + measured timeline rings.
+        dtype_uses_rings: dict[torch.dtype, bool] = {}
+        for sensor_cls in self._sensors_by_type:
             dtype = intermediate_dtype_by_class[sensor_cls]
-            cur = dtype_uses_measured.get(dtype, False)
-            dtype_uses_measured[dtype] = cur or sensor_cls.uses_measured_pipeline
+            dtype_uses_rings[dtype] = dtype_uses_rings.get(dtype, False) or sensor_cls.uses_ring_pipeline
 
         for dtype, total_cols in cache_size_per_dtype.items():
             cache_shape = (self._sim._B, total_cols)
-            # Ground truth cache is stored transposed (cols, B) so that per-class row slices are C-contiguous,
-            # which is required for kernel writes. The cache and ring buffer stay (B, cols) since they only
-            # receive data via .copy_() / torch.lerp which handle non-contiguous targets.
+            # Ground truth cache is stored transposed (cols, B) so that per-class row slices are C-contiguous, which is
+            # required for kernel writes. The cache and ring buffer stay (B, cols) since they only receive data via
+            # .copy_() / torch.lerp which handle non-contiguous targets.
             gt_cache_shape = (total_cols, self._sim._B)
             self._ground_truth_intermediate_cache[dtype] = torch.zeros(gt_cache_shape, dtype=dtype, device=gs.device)
             self._intermediate_cache[dtype] = torch.zeros(cache_shape, dtype=dtype, device=gs.device)
-            delay_n = max(delay_depth_per_dtype.get(dtype, 1), 1)
-            hist_n = max_history_per_dtype.get(dtype, 0)
-            ring_n = max(delay_n, hist_n)
-            self._ground_truth_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
-            if dtype_uses_measured[dtype]:
-                self._measured_timeline_ring[dtype] = TensorRingBuffer(
-                    ring_n, cache_shape, dtype=dtype, idx=self._ground_truth_timeline_ring[dtype]._idx
+            if dtype_uses_rings[dtype]:
+                # Timeline rings serve `_apply_transform` recurrence. Two slots cover the canonical one-step recurrence;
+                # the ring is grown to `max_history` when any sensor in the dtype requests history, so a multi-tap
+                # stateful filter inside `_apply_transform` can read deeper without keeping its own state.
+                ring_n = max(2, max_history_per_dtype.get(dtype, 0))
+                self._measured_timeline_ring[dtype] = TensorRingBuffer(ring_n, cache_shape, dtype=dtype)
+                self._ground_truth_timeline_ring[dtype] = TensorRingBuffer(
+                    ring_n, cache_shape, dtype=dtype, idx=self._measured_timeline_ring[dtype]._idx
                 )
 
-        # Per-class return caches. View alias into intermediate when `_post_process` is identity; separate buffer
-        # when overridden.
+        # Per-class return-space caches + rings. The return-space ring is the single per-class buffer that records each
+        # step's post-`_post_process` snapshot; it is the source for delay sampling and history reads, and provides the
+        # `timeline` argument that stateful `_post_process` overrides see. Allocated whenever any sensor in the class
+        # has delay > 0, OR history > 0, OR the class overrides `_post_process`. Sized to fit the deepest demand. When
+        # no return-space ring is needed (no delay, no history, identity `_post_process`), the return cache is a
+        # zero-copy alias-view of the intermediate cache so per-step writes propagate without extra work.
         for sensor_cls, sensors in self._sensors_by_type.items():
             intermediate_dtype = intermediate_dtype_by_class[sensor_cls]
             return_dtype = return_dtype_by_class[sensor_cls]
             cls_slice = self._cache_slices_by_type[sensor_cls]
-            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
-                # Separate return buffer in return dtype.
-                cls_size = cls_slice.stop - cls_slice.start
+            cls_size = cls_slice.stop - cls_slice.start
+            cls_max_history = self._max_history_by_class[sensor_cls]
+            cls_delay_depth = delay_depth_by_class[sensor_cls]
+            pp_overridden = sensor_cls._post_process.__func__ is not Sensor._post_process.__func__
+            needs_ring = cls_delay_depth > 1 or cls_max_history > 0 or pp_overridden
+            if needs_ring:
+                ring_n = max(cls_delay_depth, cls_max_history, 2 if pp_overridden else 1)
+                ring_shape = (self._sim._B, cls_size)
+                self._ground_truth_return_timeline_ring[sensor_cls] = TensorRingBuffer(
+                    ring_n, ring_shape, dtype=return_dtype
+                )
+                self._measured_return_timeline_ring[sensor_cls] = TensorRingBuffer(
+                    ring_n, ring_shape, dtype=return_dtype, idx=self._ground_truth_return_timeline_ring[sensor_cls]._idx
+                )
                 self._return_cache[sensor_cls] = torch.zeros(
                     (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
                 )
@@ -216,34 +236,12 @@ class SensorManager:
                     (self._sim._B, cls_size), dtype=return_dtype, device=gs.device
                 )
             else:
-                # Alias view of the intermediate cache's class slice. Same dtype/shape; no extra allocation.
                 self._return_cache[sensor_cls] = self._intermediate_cache[intermediate_dtype][:, cls_slice]
                 self._ground_truth_return_cache[sensor_cls] = self._ground_truth_intermediate_cache[intermediate_dtype][
                     cls_slice, :
                 ].T
-
-        # Per-class precomputed history index + (overridden `_post_process` only) per-class return-space rings. The
-        # return rings record each step's eager `_post_process` snapshot so history reads gather post-processed
-        # values directly, instead of re-projecting older slots from the intermediate ring (which would be wrong for
-        # stateful `_post_process`).
-        for sensor_cls, cls_max_history in self._max_history_by_class.items():
-            if cls_max_history == 0:
-                continue
-            intermediate_dtype = intermediate_dtype_by_class[sensor_cls]
-            self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
-            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
-                cache_slice = self._cache_slices_by_type[sensor_cls]
-                cls_size = cache_slice.stop - cache_slice.start
-                return_dtype = return_dtype_by_class[sensor_cls]
-                ring_n = max(delay_depth_per_dtype.get(intermediate_dtype, 1), cls_max_history)
-                ring_shape = (self._sim._B, cls_size)
-                shared_idx = self._ground_truth_timeline_ring[intermediate_dtype]._idx
-                self._ground_truth_return_timeline_ring[sensor_cls] = TensorRingBuffer(
-                    ring_n, ring_shape, dtype=return_dtype, idx=shared_idx
-                )
-                self._measured_return_timeline_ring[sensor_cls] = TensorRingBuffer(
-                    ring_n, ring_shape, dtype=return_dtype, idx=shared_idx
-                )
+            if cls_max_history > 0:
+                self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
 
         for sensor_cls, sensors in self._sensors_by_type.items():
             for sensor in sensors:
@@ -266,16 +264,17 @@ class SensorManager:
         for dtype in self._ground_truth_intermediate_cache.keys():
             self._ground_truth_intermediate_cache[dtype][:, envs_idx] = 0.0
             self._intermediate_cache[dtype][envs_idx] = 0.0
-            self._ground_truth_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
+            if dtype in self._ground_truth_timeline_ring:
+                self._ground_truth_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
             if dtype in self._measured_timeline_ring:
                 self._measured_timeline_ring[dtype].buffer[:, envs_idx] = 0.0
 
-        # Reset per-class return caches that are distinct buffers (overridden `_post_process`); alias views are
-        # already cleared via the intermediate-cache zero above. Same logic for the per-class return-space rings.
-        for sensor_cls, return_cache in self._return_cache.items():
-            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
-                return_cache[envs_idx] = 0
-                self._ground_truth_return_cache[sensor_cls][envs_idx] = 0
+        # Reset per-class return caches. When the return cache is an alias-view of the intermediate cache the clear is
+        # redundant (the intermediate clear above already wrote zeros to the same memory) but harmless. Per-class
+        # return-space rings are always distinct buffers.
+        for sensor_cls in self._return_cache:
+            self._return_cache[sensor_cls][envs_idx] = 0
+            self._ground_truth_return_cache[sensor_cls][envs_idx] = 0
         for ring in self._ground_truth_return_timeline_ring.values():
             ring.buffer[:, envs_idx] = 0
         for ring in self._measured_return_timeline_ring.values():
@@ -285,44 +284,64 @@ class SensorManager:
             dtype = sensor_cls._get_intermediate_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
             sensor_cls.reset(
-                self._sensors_metadata[sensor_cls],
-                self._ground_truth_intermediate_cache[dtype][cache_slice],
-                envs_idx,
+                self._sensors_metadata[sensor_cls], self._ground_truth_intermediate_cache[dtype][cache_slice], envs_idx
             )
 
     def step(self):
-        for ring in self._ground_truth_timeline_ring.values():
+        # Timeline rings must rotate before `_update_shared_cache` because `_apply_transform` mutates `at(0)` of the
+        # timeline ring and needs a fresh write slot. Return-space rings, by contrast, are read during `_post_process`
+        # (past post-output values) and written afterward; their rotation is deferred to inside the per-class loop so
+        # `at(0)` during `_post_process` is the previous step's post-output (a meaningful "previous value") rather than
+        # stale data from the slot about to be overwritten.
+        for ring in self._measured_timeline_ring.values():
             ring.rotate()
 
         for sensor_cls, sensors in self._sensors_by_type.items():
             dtype = sensor_cls._get_intermediate_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
             ground_truth_slice = self._ground_truth_intermediate_cache[dtype][cache_slice]
-            if dtype in self._measured_timeline_ring:
-                measured_data_timeline = self._measured_timeline_ring[dtype][:, cache_slice]
-            else:
-                measured_data_timeline = None
-            sensor_cls._update_shared_cache(
-                self._sensors_metadata[sensor_cls],
-                ground_truth_slice,
-                measured_data_timeline,
-                self._intermediate_cache[dtype][:, cache_slice],
-                self._return_cache[sensor_cls],
+            intermediate = self._intermediate_cache[dtype][:, cache_slice]
+            ground_truth_data_timeline = (
+                self._ground_truth_timeline_ring[dtype][:, cache_slice]
+                if dtype in self._ground_truth_timeline_ring
+                else None
             )
-            # GT timeline ring write is required: history reads access older slots even at delay=0, so the slot for
-            # the current step must be populated independent of the delay sampling done inside `_update_shared_cache`.
-            self._ground_truth_timeline_ring[dtype][:, cache_slice].set(ground_truth_slice.T)
-            # Mirror eager `_post_process` for the GT path. The orchestrator handles the measured path; here we
-            # populate the GT return cache from the GT intermediate slice. No-op when buffers alias.
-            if sensor_cls._post_process.__func__ is not Sensor._post_process.__func__:
-                gt_return = self._ground_truth_return_cache[sensor_cls]
-                gt_return.copy_(sensor_cls._post_process(self._sensors_metadata[sensor_cls], ground_truth_slice.T))
-                # Record both eager projections in the per-class return-space rings so history reads pull
-                # post-processed snapshots directly (correct for stateful `_post_process`). Identity-projection
-                # classes don't allocate these rings; their history reads gather from the intermediate ring instead.
-                if sensor_cls in self._ground_truth_return_timeline_ring:
-                    self._ground_truth_return_timeline_ring[sensor_cls].set(gt_return)
-                    self._measured_return_timeline_ring[sensor_cls].set(self._return_cache[sensor_cls])
+            measured_data_timeline = (
+                self._measured_timeline_ring[dtype][:, cache_slice] if dtype in self._measured_timeline_ring else None
+            )
+            metadata = self._sensors_metadata[sensor_cls]
+            sensor_cls._update_shared_cache(
+                metadata, ground_truth_slice, ground_truth_data_timeline, measured_data_timeline, intermediate
+            )
+
+            gt_return_ring = self._ground_truth_return_timeline_ring.get(sensor_cls)
+            if gt_return_ring is None:
+                # No return-space ring: identity `_post_process`, no delay, no history. Return cache aliases
+                # intermediate (the per-step write inside `_update_shared_cache` is already visible to `read()`).
+                continue
+            measured_return_ring = self._measured_return_timeline_ring[sensor_cls]
+
+            # Project both branches into the return-space ring slot 0. `_post_process` returns the post-cast tensor. The
+            # ring has not yet been rotated this step, so during the override `timeline.at(0)` is the previous step's
+            # post-output (the most recent valid value) and `timeline.at(1)`, `at(2)`, etc. are older. `is_measured`
+            # lets the override apply readout-stage contributions on only one branch.
+            measured_projected = sensor_cls._post_process(
+                metadata, intermediate, measured_return_ring, is_measured=True
+            )
+            gt_projected = sensor_cls._post_process(metadata, ground_truth_slice.T, gt_return_ring, is_measured=False)
+
+            # Rotate now, after `_post_process` reads finished and before writing this step's projections into slot 0.
+            # Only one rotate per pair since GT and measured return rings share idx.
+            gt_return_ring.rotate()
+            measured_return_ring.set(measured_projected)
+            gt_return_ring.set(gt_projected)
+
+            # GT has no readout delay (delay is a measured-only effect), so the GT read is just the current ring slot.
+            self._ground_truth_return_cache[sensor_cls].copy_(gt_return_ring.at(0, copy=False))
+            # Measured: per-sensor delay + jitter sampling from the return-space ring into the per-class return cache.
+            # `_apply_delay` is an overrideable classmethod on `Sensor` whose default ZOH implementation is dtype-safe
+            # for any return space (bool, uint8, quantized float, ...).
+            sensor_cls._apply_delay(metadata, measured_return_ring, self._return_cache[sensor_cls])
 
     def draw_debug(self, context: "RasterizerContext"):
         for sensor in self.sensors:
@@ -351,28 +370,20 @@ class SensorManager:
         return return_cache[:, rel_start : rel_start + sensor._cache_size]
 
     def _gather_history(self, sensor_cls: type["Sensor"], history_length: int, is_ground_truth: bool) -> torch.Tensor:
-        # Gather the last `history_length` snapshots for the whole class into a fresh `(B, H, cls_size)` tensor.
-        # For overridden `_post_process` we read from the per-class return-space ring (snapshots are already
-        # post-processed at write time). For identity `_post_process` we read from the per-dtype intermediate ring,
-        # since intermediate == return there.
+        # Gather the last `history_length` snapshots for the whole class into a fresh `(B, H, cls_size)` tensor. Always
+        # reads from the per-class return-space ring: it records the post-everything snapshot at each step, so history
+        # reads return the final measured (or GT) values observed in the past. The intermediate ring is in
+        # pre-hardware-imperfection space and would yield wrong history.
         hist_idx = self._hist_idx_by_class[sensor_cls][:history_length]
-        if sensor_cls in self._ground_truth_return_timeline_ring:
-            ring = (
-                self._ground_truth_return_timeline_ring[sensor_cls]
-                if is_ground_truth
-                else self._measured_return_timeline_ring[sensor_cls]
-            )
-            return ring.at(hist_idx).transpose(0, 1)
-        dtype = sensor_cls._get_intermediate_dtype()
-        cache_slice = self._cache_slices_by_type[sensor_cls]
-        ring = self._ground_truth_timeline_ring[dtype] if is_ground_truth else self._measured_timeline_ring[dtype]
-        return ring.at(hist_idx, slice(None), cache_slice).transpose(0, 1)
+        ring = (
+            self._ground_truth_return_timeline_ring[sensor_cls]
+            if is_ground_truth
+            else self._measured_return_timeline_ring[sensor_cls]
+        )
+        return ring.at(hist_idx).transpose(0, 1)
 
     def read_sensors(
-        self,
-        entity_idx: int | None = None,
-        envs_idx=None,
-        is_ground_truth: bool = False,
+        self, entity_idx: int | None = None, envs_idx=None, is_ground_truth: bool = False
     ) -> dict[int, torch.Tensor]:
         """
         Read the latest data of every sensor class in scope as a single tensor per class.
@@ -398,8 +409,8 @@ class SensorManager:
             (B, [history,] class_or_entity_cache_size). For sensors without history, the history
             dimension is omitted.
         """
-        # Sanitize envs_idx to a 1D tensor so fancy-indexing the batch axis always allocates a fresh tensor; this
-        # is what gives the function its mutation-safe contract.
+        # Sanitize envs_idx to a 1D tensor so fancy-indexing the batch axis always allocates a fresh tensor; this is
+        # what gives the function its mutation-safe contract.
         env_index = self._sim._scene._sanitize_envs_idx(envs_idx)
 
         result: dict[int, torch.Tensor] = {}

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -15,12 +15,7 @@ from genesis.options.sensors import TemperatureProperties
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 from genesis.utils.ring_buffer import TensorRingBuffer
 
-from .base_sensor import (
-    SimpleSensor,
-    RigidSensorMetadataMixin,
-    RigidSensorMixin,
-    SimpleSensorMetadata,
-)
+from .base_sensor import SimpleSensor, RigidSensorMetadataMixin, RigidSensorMixin, SimpleSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.engine.entities.rigid_entity.rigid_link import RigidLink
@@ -83,10 +78,7 @@ def _compute_K2_rfft3(
 def _compute_surface_mask(nx: int, ny: int, nz: int, device: torch.device) -> torch.Tensor:
     """Boolean mask of boundary voxels (at least one face on grid boundary). Shape (nx, ny, nz)."""
     ix, iy, iz = torch.meshgrid(
-        torch.arange(nx, device=device),
-        torch.arange(ny, device=device),
-        torch.arange(nz, device=device),
-        indexing="ij",
+        torch.arange(nx, device=device), torch.arange(ny, device=device), torch.arange(nz, device=device), indexing="ij"
     )
     return (ix == 0) | (ix == nx - 1) | (iy == 0) | (iy == ny - 1) | (iz == 0) | (iz == nz - 1)
 
@@ -139,12 +131,7 @@ def _apply_diffusion_and_heat_generation(
 
 
 @qd.func
-def _qd_polygon_area_from_points_3d(
-    n: int,
-    scratch: qd.types.ndarray(),
-    i_b: int,
-    eps: float,
-) -> float:
+def _qd_polygon_area_from_points_3d(n: int, scratch: qd.types.ndarray(), i_b: int, eps: float) -> float:
     """Area of polygon from scratch buffer."""
     area = gs.qd_float(0.0)
     if n >= 3:
@@ -336,11 +323,7 @@ def _kernel_contact_heat(
 
         k_sensor = link_conductivity[mat_idx_sensor]
         amin = qd.math.vec3(aabb_min[i_s, 0], aabb_min[i_s, 1], aabb_min[i_s, 2])
-        vs = qd.math.vec3(
-            voxel_size[i_s, 0] + eps,
-            voxel_size[i_s, 1] + eps,
-            voxel_size[i_s, 2] + eps,
-        )
+        vs = qd.math.vec3(voxel_size[i_s, 0] + eps, voxel_size[i_s, 1] + eps, voxel_size[i_s, 2] + eps)
         n_c = collider_state.n_contacts[i_b]
         for i_c in range(n_c):
             la = collider_state.contact_data.link_a[i_c, i_b]
@@ -439,9 +422,8 @@ def _apply_radiation_convection(
     output: torch.Tensor,
 ) -> None:
     """Radiation + convection on surface voxels and (when allocated) on link temperatures.
-
-    For link_temps, links with link_to_material_idx == -1 are treated as material index 0
-    (default properties) for emissivity/rho_cp; only links with valid material are updated.
+    For link_temps, links with link_to_material_idx == -1 are treated as material index 0 (default properties) for
+    emissivity/rho_cp; only links with valid material are updated.
     """
     for i_s in range(sensor_cache_start.shape[0]):
         start = sensor_cache_start[i_s].item()
@@ -780,24 +762,28 @@ class TemperatureGridSensor(
         cls,
         shared_metadata: TemperatureGridSensorMetadata,
         data: torch.Tensor,
+        timeline: "TensorRingBuffer",
         *,
-        timeline=None,
+        is_measured: bool,
     ):
-        if timeline is None:
+        # First-order RC filter modelling the sensor element's thermal response time. The thermal mass is a property of
+        # the sensor element only, so the filter is measured-only - ground truth exposes the raw simulated temperature
+        # unchanged so that `read_ground_truth()` returns the underlying physical phenomenon. `data IS timeline.at(0)`
+        # (the measured ring slot 0), pre-populated with the current raw temperature by `_update_current_timestep_data`;
+        # the previous filtered value lives in `timeline.at(1)`.
+        if not is_measured:
             return
-        # First-order RC filter: data <- prev_measured + (dt/tau) * (raw - prev_measured), where data initially
-        # holds the raw seed copied by the default `_update_current_timestep_data`.
         raw = data.clone()
-        filtered = timeline.at(1).clone()
+        previous = timeline.at(1).clone()
         _apply_T_measured_filter(
             shared_metadata.sensor_cache_start,
             shared_metadata.cache_sizes,
             shared_metadata.sensor_time_const,
             shared_metadata.solver._sim.dt,
             raw,
-            filtered,
+            previous,
         )
-        data.copy_(filtered)
+        data.copy_(previous)
 
     def _draw_debug(self, context: "RasterizerContext"):
         """

--- a/genesis/options/sensors/camera.py
+++ b/genesis/options/sensors/camera.py
@@ -20,11 +20,7 @@ from genesis.typing import (
 from .options import KinematicSensorOptionsMixin, SensorT
 
 if TYPE_CHECKING:
-    from genesis.engine.sensors.camera import (
-        BatchRendererCameraSensor,
-        RasterizerCameraSensor,
-        RaytracerCameraSensor,
-    )
+    from genesis.engine.sensors.camera import BatchRendererCameraSensor, RasterizerCameraSensor, RaytracerCameraSensor
 
 
 class BaseCameraOptions(KinematicSensorOptionsMixin[SensorT]):

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -65,11 +65,8 @@ class SensorOptions(Options, Generic[SensorT]):
     delay : float, optional
         The read delay time in seconds. Data read will be outdated by this amount. Defaults to 0.0 (no delay).
     jitter : float, optional
-        The jitter in seconds modeled as a random additive delay sampled from a normal distribution.
-        Jitter cannot be greater than delay. `interpolate` should be True when `jitter` is greater than 0.
-    interpolate : bool, optional
-        If True, the sensor data is interpolated between data points for delay + jitter.
-        Otherwise, the sensor data at the closest time step will be used. Default is False.
+        The jitter in seconds modeled as a random additive delay sampled uniformly in ``[0, jitter)`` each step.
+        Jitter cannot be greater than delay.
     draw_debug : bool
         If True and visualizer is active, the sensor will draw debug shapes in the scene. Defaults to False.
     """
@@ -77,7 +74,6 @@ class SensorOptions(Options, Generic[SensorT]):
     history_length: NonNegativeInt = 0
     delay: NonNegativeFloat = 0.0
     jitter: NonNegativeFloat = 0.0
-    interpolate: StrictBool = False
     draw_debug: StrictBool = False
     # -1 means not link-attached. None is accepted from users and normalized to -1 so SensorManager can sort uniformly.
     entity_idx: StrictInt = Field(default=-1, ge=-1)
@@ -88,8 +84,6 @@ class SensorOptions(Options, Generic[SensorT]):
         return -1 if value is None else value
 
     def model_post_init(self, context: Any) -> None:
-        if self.jitter > 0 and not self.interpolate:
-            gs.raise_exception(f"{type(self).__name__}: `interpolate` should be True when `jitter` is greater than 0.")
         if self.jitter > self.delay:
             gs.raise_exception(f"{type(self).__name__}: Jitter must be less than or equal to read delay.")
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -78,7 +78,9 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
                 return gs.tc_float
 
             @classmethod
-            def _update_shared_cache(cls, metadata, gt_cache, measured_data_timeline, intermediate_cache, return_cache):
+            def _update_shared_cache(
+                cls, metadata, gt_cache, ground_truth_data_timeline, measured_data_timeline, intermediate_cache,
+            ):
                 pass
 
             @classmethod
@@ -147,6 +149,276 @@ def test_post_process_requires_intermediate_override():
             @classmethod
             def _post_process(cls, shared_metadata, tensor):
                 return tensor * 2
+
+
+@pytest.mark.required
+def test_pipeline_contract(tol):
+    # Two synthetic sensor families share a single scene/build:
+    #   * `FakePipelineSensor` is a vector sensor whose components each take a different
+    #     (physics_imp, measured_only_imp, transform_alpha, hardware_imp) path, so GT-cleanliness, physics
+    #     propagation through transform recurrence, the `is_measured` gate on `_apply_transform`, and HW non-
+    #     compounding are all verified in one batched pass.
+    #   * `FakeSimpleSensor` instances cover the three return-space ring allocation paths: no-ring (delay=0,
+    #     history=0), history-only ring, and delay+history ring. All four instances of `FakeSimpleSensor` share
+    #     the same per-class step counter, so they all see the same raw value at each step and the expected
+    #     outputs are simple shifts / windows of that sequence.
+    from dataclasses import dataclass
+
+    from genesis.engine.sensors.base_sensor import SimpleSensor, SimpleSensorMetadata
+    from genesis.options.sensors.options import SimpleSensorOptions
+
+    @dataclass
+    class FakeMetadata(SimpleSensorMetadata):
+        # Per-component knob vectors, shape `(1, vec_size)` so they broadcast over the batch dim of slot 0.
+        step_counter: int = 0
+        physics_imp: torch.Tensor = None
+        measured_only_imp: torch.Tensor = None
+        transform_alpha: torch.Tensor = None
+        hardware_imp: torch.Tensor = None
+
+    class FakeOptions(SimpleSensorOptions["FakePipelineSensor"]):
+        physics_imp: tuple[float, ...] = (0.0,)
+        measured_only_imp: tuple[float, ...] = (0.0,)
+        transform_alpha: tuple[float, ...] = (0.0,)
+        hardware_imp: tuple[float, ...] = (0.0,)
+
+    class FakePipelineSensor(SimpleSensor[FakeOptions, FakeMetadata]):
+        def _get_return_format(self):
+            return (len(self._options.physics_imp),)
+
+        @classmethod
+        def _get_cache_dtype(cls):
+            return gs.tc_float
+
+        def build(self):
+            super().build()
+            self._shared_metadata.physics_imp = torch.tensor(
+                [self._options.physics_imp], device=gs.device, dtype=gs.tc_float
+            )
+            self._shared_metadata.measured_only_imp = torch.tensor(
+                [self._options.measured_only_imp], device=gs.device, dtype=gs.tc_float
+            )
+            self._shared_metadata.transform_alpha = torch.tensor(
+                [self._options.transform_alpha], device=gs.device, dtype=gs.tc_float
+            )
+            self._shared_metadata.hardware_imp = torch.tensor(
+                [self._options.hardware_imp], device=gs.device, dtype=gs.tc_float
+            )
+
+        @classmethod
+        def reset(cls, shared_metadata, ground_truth_cache, envs_idx):
+            super().reset(shared_metadata, ground_truth_cache, envs_idx)
+            shared_metadata.step_counter = 0
+
+        @classmethod
+        def _update_raw_data(cls, metadata, raw_data_T):
+            # Same scalar raw value across all components and envs; per-component divergence is introduced by the
+            # downstream hook vectors. 1-indexed step.
+            metadata.step_counter += 1
+            raw_data_T.fill_(float(metadata.step_counter))
+
+        @classmethod
+        def _apply_physics_imperfections(cls, metadata, slot_0, timeline):
+            slot_0.add_(metadata.physics_imp)
+
+        @classmethod
+        def _apply_transform(cls, metadata, data, timeline, *, is_measured):
+            # Measured-only pre-acquisition contribution: exercises the `is_measured` gate.
+            if is_measured:
+                data.add_(metadata.measured_only_imp)
+            # Stateful linear recurrence per component, branch-symmetric. `timeline.at(1)` is the previous step's
+            # post-transform value on this branch (clean of hardware noise - the load-bearing invariant under test).
+            data.add_(timeline.at(1) * metadata.transform_alpha)
+
+        @classmethod
+        def _apply_hardware_imperfections(cls, metadata, working_buf):
+            working_buf.add_(metadata.hardware_imp)
+
+    # Each row is one (physics_imp, measured_only_imp, transform_alpha, hardware_imp) tuple. Components are
+    # independent.
+    paths = [
+        (0.0, 0.0, 0.0, 0.0),  # identity pipeline
+        (0.0, 0.0, 0.0, 100.0),  # hardware only: GT must stay clean, measured = raw + H
+        (0.0, 0.0, 1.0, 0.0),  # stateful transform on both branches
+        (0.0, 0.0, 1.0, 100.0),  # stateful transform + large H: HW must NOT compound through recurrence
+        (5.0, 0.0, 0.0, 0.0),  # physics imperfection measured-only, no transform
+        (0.0, 5.0, 0.0, 0.0),  # measured-only pre-acquisition (transform with is_measured)
+        (5.0, 0.0, 1.0, 0.0),  # physics imperfection compounds through transform recurrence
+        (5.0, 5.0, 1.0, 100.0),  # all four together
+    ]
+    P = np.array([row[0] for row in paths], dtype=np.float32)
+    M = np.array([row[1] for row in paths], dtype=np.float32)
+    A = np.array([row[2] for row in paths], dtype=np.float32)
+    H = np.array([row[3] for row in paths], dtype=np.float32)
+
+    # Companion simple sensor for the ring-allocation paths. No knobs, no overrides beyond raw write - the read
+    # just echoes the shared per-class step counter. Four instances cover (delay=0, history=0), history-only,
+    # delay-only, and (delay + history).
+    @dataclass
+    class FakeSimpleMetadata(SimpleSensorMetadata):
+        step_counter: int = 0
+
+    class FakeSimpleOptions(SimpleSensorOptions["FakeSimpleSensor"]):
+        pass
+
+    class FakeSimpleSensor(SimpleSensor[FakeSimpleOptions, FakeSimpleMetadata]):
+        def _get_return_format(self):
+            return (1,)
+
+        @classmethod
+        def _get_cache_dtype(cls):
+            return gs.tc_float
+
+        @classmethod
+        def reset(cls, shared_metadata, ground_truth_cache, envs_idx):
+            super().reset(shared_metadata, ground_truth_cache, envs_idx)
+            shared_metadata.step_counter = 0
+
+        @classmethod
+        def _update_raw_data(cls, metadata, raw_data_T):
+            metadata.step_counter += 1
+            raw_data_T.fill_(float(metadata.step_counter))
+
+    DT = 1e-2
+    DELAY_STEPS = 2
+    HISTORY_LEN = 3
+    scene = gs.Scene(sim_options=gs.options.SimOptions(dt=DT), show_viewer=False)
+    scene.add_entity(gs.morphs.Plane())  # minimum scene; the sensors do not depend on any physics.
+    sensor = scene.add_sensor(
+        FakeOptions(
+            physics_imp=tuple(P.tolist()),
+            measured_only_imp=tuple(M.tolist()),
+            transform_alpha=tuple(A.tolist()),
+            hardware_imp=tuple(H.tolist()),
+        )
+    )
+    s_baseline = scene.add_sensor(FakeSimpleOptions())
+    s_history = scene.add_sensor(FakeSimpleOptions(history_length=HISTORY_LEN))
+    s_delay = scene.add_sensor(FakeSimpleOptions(delay=DELAY_STEPS * DT))
+    s_both = scene.add_sensor(FakeSimpleOptions(history_length=HISTORY_LEN, delay=DELAY_STEPS * DT))
+    scene.build()
+    scene.reset()  # zero the build-warmup counter increment so step 1 sees raw = 1.
+
+    n_steps = 8
+    gt_observed = np.zeros((n_steps, len(paths)), dtype=np.float32)
+    measured_observed = np.zeros((n_steps, len(paths)), dtype=np.float32)
+    baseline_observed = np.zeros(n_steps, dtype=np.float32)
+    history_observed = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
+    delay_observed = np.zeros(n_steps, dtype=np.float32)
+    both_observed = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
+    for i in range(n_steps):
+        scene.step()
+        gt_observed[i] = tensor_to_array(sensor.read_ground_truth()).reshape(-1)
+        measured_observed[i] = tensor_to_array(sensor.read()).reshape(-1)
+        baseline_observed[i] = tensor_to_array(s_baseline.read()).item()
+        history_observed[i] = tensor_to_array(s_history.read()).reshape(-1)
+        delay_observed[i] = tensor_to_array(s_delay.read()).item()
+        both_observed[i] = tensor_to_array(s_both.read()).reshape(-1)
+
+    # Analytical expectation for the vector sensor, per component. Let raw[k] = k, and (P, M, A, H) be the per-
+    # component vectors.
+    # GT ring:    gt[k]  = k + A * gt[k-1]                       (raw -> transform with is_measured=False)
+    # Meas ring:  m[k]   = (k + P + M) + A * m[k-1]              (raw -> physics_imp -> transform is_measured=True)
+    # Measured:   meas[k] = m[k] + H                             (working buffer adds H; no compounding into m)
+    gt_expected = np.zeros_like(gt_observed)
+    measured_expected = np.zeros_like(measured_observed)
+    gt_prev = np.zeros(len(paths), dtype=np.float32)
+    m_prev = np.zeros(len(paths), dtype=np.float32)
+    for k in range(1, n_steps + 1):
+        gt_k = k + A * gt_prev
+        m_k = (k + P + M) + A * m_prev
+        gt_expected[k - 1] = gt_k
+        measured_expected[k - 1] = m_k + H
+        gt_prev, m_prev = gt_k, m_k
+
+    assert_allclose(gt_observed, gt_expected, tol=tol)
+    assert_allclose(measured_observed, measured_expected, tol=tol)
+
+    # Ring-allocation paths. raw[k] = k for every FakeSimpleSensor instance (shared step counter); delayed reads
+    # before slot D has been filled return zero (ring initialized to zero on reset). History reads source slots
+    # `at(0..H-1)` of the return-space ring directly - i.e. the last H post-`_post_process` snapshots - without
+    # additional delay shift. A sensor that configures both `delay > 0` and `history_length > 0` therefore sees
+    # undelayed history alongside a delayed non-history read; this matches the implementation and is what the
+    # combined test asserts.
+    raw = np.arange(1, n_steps + 1, dtype=np.float32)
+    expected_baseline = raw
+    expected_delay = np.where(raw - DELAY_STEPS >= 1, raw - DELAY_STEPS, 0.0)
+    expected_history = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
+    for k in range(1, n_steps + 1):
+        for h in range(HISTORY_LEN):
+            past_step = k - h
+            expected_history[k - 1, h] = past_step if past_step >= 1 else 0.0
+
+    assert_allclose(baseline_observed, expected_baseline, tol=tol)
+    assert_allclose(delay_observed, expected_delay, tol=tol)
+    assert_allclose(history_observed, expected_history, tol=tol)
+    # The combined delay + history sensor returns the same history as the history-only sensor (delay is bypassed
+    # by the ring-gather history path); verify they match.
+    assert_allclose(both_observed, expected_history, tol=tol)
+
+
+@pytest.mark.required
+def test_pipeline_contract_uint8_delay(tol):
+    # ZOH delay sampling must work on non-float return dtypes. A sensor whose `_post_process` casts a float
+    # intermediate to a `uint8` return stores `uint8` snapshots in the per-class return-space ring; delay
+    # sampling reads those slots verbatim (the dtype-safe ZOH default). Verifies the slot is correctly typed
+    # and the delayed values match the cast of `raw[k - delay]`.
+    from dataclasses import dataclass
+
+    from genesis.engine.sensors.base_sensor import SimpleSensor, SimpleSensorMetadata
+    from genesis.options.sensors.options import SimpleSensorOptions
+
+    @dataclass
+    class FakeQuantizedMetadata(SimpleSensorMetadata):
+        step_counter: int = 0
+
+    class FakeQuantizedOptions(SimpleSensorOptions["FakeQuantizedSensor"]):
+        pass
+
+    class FakeQuantizedSensor(SimpleSensor[FakeQuantizedOptions, FakeQuantizedMetadata]):
+        def _get_return_format(self):
+            return (1,)
+
+        @classmethod
+        def _get_cache_dtype(cls):
+            return torch.uint8
+
+        @classmethod
+        def _get_intermediate_dtype(cls):
+            return gs.tc_float
+
+        @classmethod
+        def reset(cls, shared_metadata, ground_truth_cache, envs_idx):
+            super().reset(shared_metadata, ground_truth_cache, envs_idx)
+            shared_metadata.step_counter = 0
+
+        @classmethod
+        def _update_raw_data(cls, metadata, raw_data_T):
+            metadata.step_counter += 1
+            raw_data_T.fill_(float(metadata.step_counter))
+
+        @classmethod
+        def _post_process(cls, shared_metadata, tensor, timeline, *, is_measured):
+            return tensor.clamp(0, 255).to(torch.uint8)
+
+    DT = 1e-2
+    DELAY_STEPS = 2
+    scene = gs.Scene(sim_options=gs.options.SimOptions(dt=DT), show_viewer=False)
+    scene.add_entity(gs.morphs.Plane())
+    sensor = scene.add_sensor(FakeQuantizedOptions(delay=DELAY_STEPS * DT))
+    scene.build()
+    scene.reset()
+
+    n_steps = 8
+    observed = np.zeros(n_steps, dtype=np.uint8)
+    for i in range(n_steps):
+        scene.step()
+        observed[i] = tensor_to_array(sensor.read()).item()
+
+    raw = np.arange(1, n_steps + 1, dtype=np.float32)
+    expected = np.where(raw - DELAY_STEPS >= 1, raw - DELAY_STEPS, 0.0).astype(np.uint8)
+    assert observed.dtype == np.uint8
+    assert_equal(observed, expected)
 
 
 @pytest.mark.required
@@ -270,7 +542,6 @@ def test_imu_sensor(show_viewer, tol, n_envs):
             delay=DT,
             magnetic_field=MAG_FIELD,
             jitter=DT * 0.1,
-            interpolate=True,
         )
     )
 
@@ -558,7 +829,6 @@ def test_contact_sensors_gravity_force(n_envs, show_viewer, tol):
             random_walk=(NOISE * 0.01, NOISE * 0.02, NOISE * 0.03),
             delay=DT * DELAY_STEPS,
             jitter=0.01,
-            interpolate=True,
         )
     )
     # Adding extra sensor sharing same dtype to force discontinuous memory layout for ground truth when batched


### PR DESCRIPTION
## Summary

Continuation of #2786. Restores the physics-vs-hardware imperfection split that the abstraction calls for, and reworks the buffer scheme around two ring layers so delay sampling and history reads both source from a single per-class return-space ring.

### Pipeline-level changes

- **New \`_apply_physics_imperfections\` hook.** Lives between raw and \`_apply_transform\` on the measured branch only; in-ring contribution that propagates through transform recurrence (e.g. physics-level drift / random walk of the sensed phenomenon).
- **\`_apply_hardware_imperfections\` no longer writes to the timeline ring.** It mutates a per-step working buffer (the intermediate cache) before \`_post_process\`, so transform recurrence stays clean of hardware noise. The post-\`_post_process\` snapshot is what ends up in the return-space ring, where delay sampling later reads it.
- **Two-layer ring storage.**
  - Per-dtype timeline rings (GT + measured) - \`_apply_transform\` recurrence source. Sized \`max(2, max_history)\`; deeper recurrence is supported via the history sizing.
  - Per-class return-space rings - post-\`_post_process\` snapshots, source for delay sampling, history reads, and stateful \`_post_process\` overrides. Allocated when \`delay > 0\` OR \`history_length > 0\` OR \`_post_process\` is overridden.
- **Delay sampling moves to after \`_post_process\`** and reads from the return-space ring. Each delayed slot carries its own frozen imperfection state - the embedded-sampler semantics.
- **Default delay is ZOH** (zero-order hold), dtype-safe for any return space (bool, uint8, quantized float). The \`interpolate\` option is removed (it broke for non-float dtypes). Sensors that want a smoother sampling rule override the new \`_apply_delay\` classmethod.
- **\`_post_process\` signature gains \`timeline\` and \`is_measured\`.** The return-space ring rotates after \`_post_process\` returns, so \`timeline.at(0)\` inside the override is the previous step's post-output (clean recurrence semantics; no stale-slot footgun).
- **Rename: \`uses_measured_pipeline\` -> \`uses_ring_pipeline\`.** The flag now gates both GT and measured timeline rings; the old name implied a measured-side-only concern.
- **\`Sensor.__init__\` enforces the ring-pipeline opt-out:** classes that declare \`uses_ring_pipeline = False\` (cameras) now reject \`delay > 0\`, \`jitter > 0\`, and \`history_length > 0\` at construction. The duplicated rejection on \`BaseCameraSensor\` is gone.

### Regression test

\`test_pipeline_contract\` exercises every pipeline stage on a single scene/build:

- A synthetic 7-component vector sensor where each component takes a different \`(physics_imp, transform_alpha, hardware_imp)\` triplet. Verifies GT-cleanliness, physics propagation through transform recurrence, and HW non-compounding in one batched pass.
- Four \`FakeSimpleSensor\` instances cover the return-space ring allocation paths: no-ring, history-only, delay-only, delay+history.

\`test_pipeline_contract_uint8_delay\` adds a sensor with \`uint8\` return / float intermediate / \`delay > 0\` to confirm ZOH on non-float dtypes.

### Doc

Submodule bumped to \`Genesis-Embodied-AI/genesis-doc#113\` (already merged) which rewrites \`sensor_pipeline.md\` and \`custom_sensors.md\` to match the new hook signatures and ring scheme.