### PR TITLE
[MISC] Raise on ambiguous morph access for heterogeneous entities.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1952,6 +1952,20 @@ class KinematicEntity(Entity):
         return len(self._links)
 
     @property
+    def morph(self):
+        """The morph of the entity.
+
+        Raises an exception for heterogeneous entities, which have multiple morph variants: use morphs for all
+        variants, or main_morph for the first one.
+        """
+        if self._enable_heterogeneous:
+            gs.raise_exception(
+                "Heterogeneous entities have multiple morph variants. Use `.morphs` for all variants, "
+                "or `.main_morph` only when explicitly using the first variant."
+            )
+        return self._morph
+
+    @property
     def main_morph(self):
         """The main morph of the entity (first morph for heterogeneous entities)."""
         return self._morph

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -454,8 +454,8 @@ class RasterizerContext:
                     # For z-axis normal planes, render a single instance shared across all envs to avoid z-fighting,
                     # unless they do not overlap. Env-masked variants always take the per-env path.
                     env_shared = active_envs is None and not self.env_separate_rigid
-                    if not env_shared and active_envs is None and isinstance(entity.morph, gs.morphs.Plane):
-                        plane_normal, plane_size = entity.morph.normal, entity.morph.plane_size
+                    if not env_shared and active_envs is None and isinstance(entity.main_morph, gs.morphs.Plane):
+                        plane_normal, plane_size = entity.main_morph.normal, entity.main_morph.plane_size
                         if (
                             abs(plane_normal[0]) < gs.EPS
                             and abs(plane_normal[1]) < gs.EPS
@@ -578,8 +578,8 @@ class RasterizerContext:
                         geom_T = geoms_T[geom.idx][geom_envs_idx]
 
                     # Keep single-instance for z-axis normal planes (see on_rigid)
-                    if isinstance(entity.morph, gs.morphs.Plane):
-                        plane_normal, plane_size = entity.morph.normal, entity.morph.plane_size
+                    if isinstance(entity.main_morph, gs.morphs.Plane):
+                        plane_normal, plane_size = entity.main_morph.normal, entity.main_morph.plane_size
                         if (
                             abs(plane_normal[0]) < gs.EPS
                             and abs(plane_normal[1]) < gs.EPS

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -6999,6 +6999,40 @@ def test_heterogeneous_invalid_material_raises():
 
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
+def test_heterogeneous_morph_property_raises():
+    scene = gs.Scene(show_viewer=False)
+
+    single_morph = gs.morphs.Box(size=(0.1, 0.1, 0.1))
+    single_obj = scene.add_entity(morph=single_morph)
+
+    rigid_morphs_heterogeneous = (
+        gs.morphs.Box(size=(0.1, 0.1, 0.1)),
+        gs.morphs.Cylinder(radius=0.05, height=0.2),
+    )
+    rigid_obj = scene.add_entity(morph=rigid_morphs_heterogeneous)
+    kinematic_morphs_heterogeneous = (
+        gs.morphs.Box(size=(0.2, 0.2, 0.2)),
+        gs.morphs.Sphere(radius=0.1),
+    )
+    kinematic_obj = scene.add_entity(
+        morph=kinematic_morphs_heterogeneous,
+        material=gs.materials.Kinematic(),
+    )
+
+    assert single_obj.morph is single_morph
+    assert rigid_obj.main_morph is rigid_morphs_heterogeneous[0]
+    assert list(rigid_obj.morphs) == list(rigid_morphs_heterogeneous)
+    with pytest.raises(gs.GenesisException, match=r"Heterogeneous.*\.morphs") as exc_info:
+        _ = rigid_obj.morph
+    assert ".main_morph" in str(exc_info.value)
+
+    assert kinematic_obj.main_morph is kinematic_morphs_heterogeneous[0]
+    assert list(kinematic_obj.morphs) == list(kinematic_morphs_heterogeneous)
+    with pytest.raises(gs.GenesisException, match=r"Heterogeneous.*\.morphs"):
+        _ = kinematic_obj.morph
+
+
+@pytest.mark.required
 def test_heterogeneous_fewer_envs_than_variants():
     """Test that having fewer environments than variants works correctly.
 


### PR DESCRIPTION
## Description

This PR makes `.morph` fail closed for heterogeneous entities created from multiple morph variants. Heterogeneous entities already expose `.morphs` for all variants and `.main_morph` for the first variant, so `.morph` should not silently return only the first morph in an order-dependent way.

The PR also updates internal paths that need non-throwing access:

- Rasterizer Plane checks now use `.main_morph` when preserving the existing first-variant behavior.
- ImGui overlay scene-rebuild capture stores `tuple(entity.morphs)` for heterogeneous entities so variants are not dropped.
- Brief repr no longer probes `.morph` through `hasattr`, so `repr(scene.entities)` remains usable.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#2750

## Motivation and Context

Accessing `.morph` on a heterogeneous entity previously returned only the first morph. That made calls such as `.morph.size` ambiguous and order-dependent when variants had different morph types or dimensions. A maintainer clarified in the issue that heterogeneous entities should be accessed through `.morphs`, and that `.morph` should raise in this case.

This keeps the fail-closed public API while moving known internal renderer, overlay, and repr paths to explicit `.main_morph` / `.morphs` access.

Per-variant floor/reflection semantics are intentionally out of scope for this PR; this PR preserves the existing first-morph renderer behavior while avoiding accidental `.morph` property calls.

## How Has This Been / Can This Be Tested?

Tested locally with:

```bash
.venv/bin/python -m pytest -q \
  tests/test_rigid_physics.py::test_heterogeneous_morph_property_raises \
  tests/test_imgui_overlay.py::test_imgui_overlay_capture_pending_entities_preserves_heterogeneous_morphs \
  tests/test_render.py::test_rasterizer_context_heterogeneous_main_morph_no_throw

.venv/bin/python -m pytest tests/test_rigid_physics.py -q \
  -k 'heterogeneous and (invalid_material or morph_property or fewer_envs or mass_setters or aabb)'

.venv/bin/pre-commit run --files \
  genesis/engine/entities/rigid_entity/rigid_entity.py \
  genesis/repr_base.py \
  genesis/ext/pyrender/overlay/plugin.py \
  genesis/vis/rasterizer_context.py \
  tests/test_rigid_physics.py \
  tests/test_imgui_overlay.py \
  tests/test_render.py
```

The heterogeneous regression tests were run outside the sandbox because Quadrants writes compilation cache under `~/.cache/quadrants`. I did not run the full test suite locally.

## Screenshots (if appropriate):

N/A

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
