### PR TITLE
[BUG FIX] Fix static-contact drift on smooth-vs-polytope contacts.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/box_contact.py
+++ b/genesis/engine/solvers/rigid/collider/box_contact.py
@@ -3,6 +3,7 @@ Box collision contact detection functions.
 
 This module contains specialized contact detection algorithms for box geometries:
 - Plane-box contact detection
+- Sphere-box contact detection
 - Box-box contact detection (MuJoCo algorithm)
 """
 
@@ -19,6 +20,97 @@ from .contact import (
     rotaxis,
     rotmatx,
 )
+
+
+@qd.func
+def func_sphere_box_contact(
+    i_ga,
+    i_gb,
+    ga_pos,
+    ga_quat,
+    gb_pos,
+    gb_quat,
+    geoms_info: array_class.GeomsInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+):
+    """
+    Analytical sphere-box collision detection.
+
+    Reduces to finding the closest point on the box (in the box's local frame) to the sphere center,
+    then comparing the distance to the sphere radius. Produces an exact normal aligned with one of the
+    box's face axes, avoiding the small tilt that MPR/GJK introduces for shallow contacts.
+
+    Parameters
+    ----------
+    ga_pos, ga_quat : Position and orientation of geom A (may be perturbed for multi-contact).
+    gb_pos, gb_quat : Position and orientation of geom B (may be perturbed for multi-contact).
+    """
+    EPS = rigid_global_info.EPS[None]
+
+    # Caller guarantees sphere is i_ga and box is i_gb (geoms are sorted by ascending type).
+    sphere_center = ga_pos
+    box_center = gb_pos
+    box_quat = gb_quat
+    sphere_radius = geoms_info.data[i_ga][0]
+    box_half_size = qd.Vector(
+        [
+            0.5 * geoms_info.data[i_gb][0],
+            0.5 * geoms_info.data[i_gb][1],
+            0.5 * geoms_info.data[i_gb][2],
+        ],
+        dt=gs.qd_float,
+    )
+
+    # Express the sphere center in the box's local frame
+    p_local = gu.qd_inv_transform_by_trans_quat(sphere_center, box_center, box_quat)
+
+    # Closest point on the box to the sphere center, in the box's local frame
+    closest_local = qd.Vector(
+        [
+            qd.math.clamp(p_local[0], -box_half_size[0], box_half_size[0]),
+            qd.math.clamp(p_local[1], -box_half_size[1], box_half_size[1]),
+            qd.math.clamp(p_local[2], -box_half_size[2], box_half_size[2]),
+        ],
+        dt=gs.qd_float,
+    )
+    diff_local = p_local - closest_local
+    dist_sq = diff_local.dot(diff_local)
+
+    is_col = False
+    normal_unit = qd.Vector([1.0, 0.0, 0.0], dt=gs.qd_float)
+    contact_pos = qd.Vector.zero(gs.qd_float, 3)
+    penetration = gs.qd_float(0.0)
+
+    if dist_sq < sphere_radius * sphere_radius:
+        is_col = True
+        normal_local = qd.Vector([1.0, 0.0, 0.0], dt=gs.qd_float)
+        if dist_sq > EPS:
+            # Sphere center outside the box, normal points from box surface to sphere center
+            dist = qd.sqrt(dist_sq)
+            normal_local = diff_local / dist
+            penetration = sphere_radius - dist
+        else:
+            # Sphere center inside the box. The gap to the nearest face along each axis is half_size[i] - |p_local[i]|;
+            # the smallest of those three gaps picks the contact axis, with the normal sign determined by which side
+            # the sphere center is on.
+            gaps = box_half_size - qd.abs(p_local)
+            sign_x = gs.qd_float(1.0) if p_local[0] >= 0.0 else gs.qd_float(-1.0)
+            sign_y = gs.qd_float(1.0) if p_local[1] >= 0.0 else gs.qd_float(-1.0)
+            sign_z = gs.qd_float(1.0) if p_local[2] >= 0.0 else gs.qd_float(-1.0)
+            normal_local = qd.Vector([sign_x, 0.0, 0.0], dt=gs.qd_float)
+            min_gap = gaps[0]
+            if gaps[1] < min_gap:
+                min_gap = gaps[1]
+                normal_local = qd.Vector([0.0, sign_y, 0.0], dt=gs.qd_float)
+            if gaps[2] < min_gap:
+                min_gap = gaps[2]
+                normal_local = qd.Vector([0.0, 0.0, sign_z], dt=gs.qd_float)
+            penetration = sphere_radius + min_gap
+
+        normal_unit = gu.qd_transform_by_quat(normal_local, box_quat)
+        contact_pos = sphere_center - (sphere_radius - 0.5 * penetration) * normal_unit
+
+    return is_col, normal_unit, contact_pos, penetration
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/collider/capsule_contact.py
+++ b/genesis/engine/solvers/rigid/collider/capsule_contact.py
@@ -124,21 +124,11 @@ def func_sphere_capsule_contact(
     """
     EPS = rigid_global_info.EPS[None]
 
-    # Ensure sphere is always i_ga and capsule is i_gb
-    normal_dir = 1
+    # Caller guarantees sphere is i_ga and capsule is i_gb (geoms are sorted by ascending type).
     sphere_center = ga_pos
     capsule_center = gb_pos
-    capsule_q = gb_quat
-    if geoms_info.type[i_gb] == gs.GEOM_TYPE.SPHERE:
-        i_ga, i_gb = i_gb, i_ga
-        sphere_center = gb_pos
-        capsule_center = ga_pos
-        capsule_q = ga_quat
-        normal_dir = -1
-
+    capsule_quat = gb_quat
     sphere_radius = geoms_info.data[i_ga][0]
-
-    capsule_quat = capsule_q
     capsule_radius = geoms_info.data[i_gb][0]
     capsule_halflength = 0.5 * geoms_info.data[i_gb][1]
 
@@ -193,4 +183,4 @@ def func_sphere_capsule_contact(
         # Contact position at midpoint between surfaces
         contact_pos = sphere_center - (sphere_radius - 0.5 * penetration) * normal_unit
 
-    return is_col, normal_unit * normal_dir, contact_pos, penetration
+    return is_col, normal_unit, contact_pos, penetration

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -13,6 +13,105 @@ import genesis.utils.geom as gu
 
 
 @qd.func
+def func_refine_smooth_contact_pos(
+    geom_type,
+    geom_data,
+    geom_pos: qd.types.vector(3),
+    geom_quat: qd.types.vector(4),
+    normal: qd.types.vector(3),
+    penetration,
+    ccd_contact_pos: qd.types.vector(3),
+):
+    """
+    Reconstruct the contact position analytically from the smooth side of the contact.
+
+    MPR/GJK leave a position-dependent bias in the reported contact position that, on static contacts against
+    rotationally-symmetric geometry, becomes torque on the smooth body and drives a persistent tangential drift (the
+    lever arm becomes non-zero on what should be a face-aligned contact). For smooth primitives we have a closed-form
+    surface point given the CCD-reported normal, so we can replace the biased contact position with the exact midpoint
+    between that surface point and the inferred polytope-side surface. The result has the lever arm parallel to the
+    contact normal, so the constraint force creates no spurious torque.
+
+    Conventions: normal points from geom B to geom A (geom A is the one being refined). The refined contact position
+    is the midpoint between A's surface (in the -normal direction from A's center) and the implicit B surface (offset
+    by penetration along normal). Idempotent on the analytical paths (sphere-box, sphere-capsule, capsule-capsule)
+    since those use the same closed-form expression.
+    """
+    refined = ccd_contact_pos
+    if geom_type == gs.GEOM_TYPE.SPHERE:
+        radius = geom_data[0]
+        refined = geom_pos - (radius - 0.5 * penetration) * normal
+    elif geom_type == gs.GEOM_TYPE.ELLIPSOID:
+        # Surface point on ellipsoid in direction -normal, in local frame, is at p = -(a^2 n_x, b^2 n_y, c^2 n_z) /
+        # sqrt(a^2 n_x^2 + b^2 n_y^2 + c^2 n_z^2). This comes from the Lagrangian "closest point in direction d" with
+        # f(p) = (px/a)^2 + ... - 1 = 0.
+        a = geom_data[0]
+        b = geom_data[1]
+        c = geom_data[2]
+        n_local = gu.qd_inv_transform_by_quat(normal, geom_quat)
+        denom = qd.sqrt(
+            a * a * n_local[0] * n_local[0] + b * b * n_local[1] * n_local[1] + c * c * n_local[2] * n_local[2]
+        )
+        p_local = qd.Vector(
+            [-a * a * n_local[0] / denom, -b * b * n_local[1] / denom, -c * c * n_local[2] / denom], dt=gs.qd_float
+        )
+        surface_pt = gu.qd_transform_by_trans_quat(p_local, geom_pos, geom_quat)
+        refined = surface_pt + 0.5 * penetration * normal
+    elif geom_type == gs.GEOM_TYPE.CAPSULE:
+        # Capsule axis is along local +z. Project ccd_contact_pos onto the axis (clamped to the segment), then offset by
+        # radius along -normal. The clamp lets cap contacts degenerate to the sphere case automatically. Barrel contacts
+        # inherit the axial coordinate from ccd_contact_pos, which is only as good as the CCD's axial estimate.
+        radius = geom_data[0]
+        half_length = 0.5 * geom_data[1]
+        axis_dir = gu.qd_transform_by_quat_fast(qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float), geom_quat)
+        t_axial = (ccd_contact_pos - geom_pos).dot(axis_dir)
+        t_clamped = qd.math.clamp(t_axial, -half_length, half_length)
+        axis_point = geom_pos + t_clamped * axis_dir
+        refined = axis_point - (radius - 0.5 * penetration) * normal
+    return refined
+
+
+@qd.func
+def func_apply_smooth_refinement(
+    i_ga,
+    i_gb,
+    normal: qd.types.vector(3),
+    penetration,
+    contact_pos: qd.types.vector(3),
+    ga_pos: qd.types.vector(3),
+    ga_quat: qd.types.vector(4),
+    gb_pos: qd.types.vector(3),
+    gb_quat: qd.types.vector(4),
+    geoms_info: array_class.GeomsInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    """
+    Reconstruct the contact position analytically from the smooth side when one of the geoms is a smooth primitive.
+
+    Idempotent on analytical contact paths; on MPR/GJK paths it removes the position-dependent bias that drives
+    spurious torque and drift on static smooth-vs-polytope contacts. Must be invoked right after collision detection
+    and before any post-processing (deduplication, perturbation reversal, etc.), so downstream stages see contact
+    positions in the same canonical frame the constraint solver will store. The pose inputs must match the pose CCD
+    or the analytical formula actually saw - the perturbed pose under multi-contact, not the unperturbed state.
+    """
+    if qd.static(not static_rigid_sim_config.enable_mujoco_compatibility):
+        # Geom pairs are sorted by ascending type, so smooth primitives (SPHERE/ELLIPSOID/CAPSULE) always sit on the
+        # A side when paired with a polytope (BOX/MESH/TERRAIN/PLANE). Smooth-vs-smooth pairs go through analytical
+        # fast paths and never reach this helper, so at most one side ever needs refinement.
+        type_a = geoms_info.type[i_ga]
+        type_b = geoms_info.type[i_gb]
+        if type_a == gs.GEOM_TYPE.SPHERE or type_a == gs.GEOM_TYPE.ELLIPSOID or type_a == gs.GEOM_TYPE.CAPSULE:
+            contact_pos = func_refine_smooth_contact_pos(
+                type_a, geoms_info.data[i_ga], ga_pos, ga_quat, normal, penetration, contact_pos
+            )
+        elif type_b == gs.GEOM_TYPE.SPHERE or type_b == gs.GEOM_TYPE.ELLIPSOID or type_b == gs.GEOM_TYPE.CAPSULE:
+            contact_pos = func_refine_smooth_contact_pos(
+                type_b, geoms_info.data[i_gb], gb_pos, gb_quat, -normal, penetration, contact_pos
+            )
+    return contact_pos
+
+
+@qd.func
 def rotaxis(vecin, i0, i1, i2, f0, f1, f2):
     vecres = qd.Vector([0.0, 0.0, 0.0], dt=gs.qd_float)
     vecres[0] = vecin[i0] * f0
@@ -239,7 +338,7 @@ def func_set_contact(
 ):
     """
     Set the contact data for the contact [i_c]. This is used for the backward pass, which parallelizes over the entire
-    contact data.
+    contact data, and for the split narrowphase multi-contact writes.
     """
     friction_a = geoms_info.friction[i_ga] * geoms_state.friction_ratio[i_ga, i_b]
     friction_b = geoms_info.friction[i_gb] * geoms_state.friction_ratio[i_gb, i_b]

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -776,6 +776,7 @@ def func_convex_convex_contact(
                                 )
 
                     ### GJK, MJ_GJK
+                    # TODO: Add support of smooth refinement to differentiable contact.
                     if qd.static(collider_static_config.ccd_algorithm != CCD_ALGORITHM_CODE.MJ_MPR):
                         if prefer_gjk:
                             if qd.static(static_rigid_sim_config.requires_grad):
@@ -844,25 +845,11 @@ def func_convex_convex_contact(
                                             collider_state,
                                             collider_info,
                                         )
-                                        # FIXME: Is it the correct way to apply refinement for auto-diff?
-                                        contact_pos = func_apply_smooth_refinement(
-                                            i_ga,
-                                            i_gb,
-                                            gjk_state.normal[i_b, i_c],
-                                            gjk_state.diff_penetration[i_b, i_c],
-                                            gjk_state.contact_pos[i_b, i_c],
-                                            ga_pos_current,
-                                            ga_quat_current,
-                                            gb_pos_current,
-                                            gb_quat_current,
-                                            geoms_info,
-                                            static_rigid_sim_config,
-                                        )
                                         func_add_contact(
                                             i_ga,
                                             i_gb,
                                             gjk_state.normal[i_b, i_c],
-                                            contact_pos,
+                                            gjk_state.contact_pos[i_b, i_c],
                                             gjk_state.diff_penetration[i_b, i_c],
                                             i_b,
                                             i_pair,
@@ -882,8 +869,6 @@ def func_convex_convex_contact(
                                             if i_c < qd.static(collider_static_config.n_contacts_per_pair):
                                                 contact_pos = gjk_state.contact_pos[i_b, i_c]
                                                 normal = gjk_state.normal[i_b, i_c]
-                                                if qd.static(static_rigid_sim_config.requires_grad):
-                                                    penetration = gjk_state.diff_penetration[i_b, i_c]
                                                 contact_pos = func_apply_smooth_refinement(
                                                     i_ga,
                                                     i_gb,
@@ -2273,20 +2258,6 @@ def func_narrow_phase_diff_convex_vs_convex(
                 )
                 collider_state.diff_contact_input.ref_penetration[i_b, i_c] = penetration
 
-                contact_pos = func_apply_smooth_refinement(
-                    i_ga,
-                    i_gb,
-                    contact_normal,
-                    penetration,
-                    contact_pos,
-                    geoms_state.pos[i_ga, i_b],
-                    geoms_state.quat[i_ga, i_b],
-                    geoms_state.pos[i_gb, i_b],
-                    geoms_state.quat[i_gb, i_b],
-                    geoms_info,
-                    static_rigid_sim_config,
-                )
-
                 func_set_contact(
                     i_ga,
                     i_gb,
@@ -2314,20 +2285,6 @@ def func_narrow_phase_diff_convex_vs_convex(
                 ref_penetration = collider_state.diff_contact_input.ref_penetration[i_b, ref_id]
                 contact_pos, contact_normal, penetration, weight = diff_gjk.func_differentiable_contact(
                     geoms_state, diff_contact_input, gjk_info, i_ga, i_gb, i_b, i_c, ref_penetration
-                )
-
-                contact_pos = func_apply_smooth_refinement(
-                    i_ga,
-                    i_gb,
-                    contact_normal,
-                    penetration,
-                    contact_pos,
-                    geoms_state.pos[i_ga, i_b],
-                    geoms_state.quat[i_ga, i_b],
-                    geoms_state.pos[i_gb, i_b],
-                    geoms_state.quat[i_gb, i_b],
-                    geoms_info,
-                    static_rigid_sim_config,
                 )
 
                 func_set_contact(

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -1015,7 +1015,7 @@ def func_convex_convex_contact(
 
                     # Make sure that the penetration is still positive before adding contact point.
                     # Note that adding some negative tolerance improves physical stability by encouraging persistent
-                    # contact points and thefore more continuous contact forces, without changing the mean-field
+                    # contact points and therefore more continuous contact forces, without changing the mean-field
                     # dynamics since zero-penetration contact points should not induce any force.
                     penetration = normal.dot(contact_point_b - contact_point_a)
 

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -5,7 +5,6 @@ This module contains SDF-based contact detection, convex-convex contact,
 terrain detection, box-box contact, and multi-contact search algorithms.
 """
 
-import sys
 from enum import IntEnum
 
 import quadrants as qd
@@ -467,20 +466,20 @@ def func_contact_mpr_terrain(
                                     gb_quat_terrain_frame,
                                 )
                                 if is_col:
-                                    # Snap normal to the prism's top face normal. Cell boundaries in a heightfield are
-                                    # discretization artefacts of an underlying smooth surface, not physical edges, so
-                                    # MPR's polytope-edge radial normal at those boundaries is a position-dependent bias
-                                    # rather than a real surface feature. The top face spans 3 consecutive top vertices
-                                    # (prism[3..5]) and its normal is exact at the heightfield's sampling precision.
-                                    e1 = collider_state.prism[4, i_b] - collider_state.prism[3, i_b]
-                                    e2 = collider_state.prism[5, i_b] - collider_state.prism[3, i_b]
-                                    top_face_normal = e1.cross(e2).normalized()
-                                    if top_face_normal[2] < 0.0:
-                                        top_face_normal = -top_face_normal
-                                    # Only snap when MPR reported an upward-facing contact; preserve MPR for side-face
-                                    # contacts (rare but valid for spheres wedged inside heightfield discontinuities).
-                                    if normal[2] > 0.0:
-                                        normal = top_face_normal
+                                    if qd.static(not static_rigid_sim_config.enable_mujoco_compatibility):
+                                        # Snap normal to the prism's top face normal when MPR's reported normal is already
+                                        # close to it. Cell boundaries on a SMOOTH heightfield are discretization artefacts,
+                                        # not physical edges, and MPR's polytope-edge radial normal there picks up a small
+                                        # position-dependent bias relative to the exact face normal. Only snap when the bias
+                                        # is small (dot > 0.95) so that contacts on real cliff edges - where MPR's normal is
+                                        # genuinely far from any single cell's top face normal - keep MPR's result.
+                                        e1 = collider_state.prism[4, i_b] - collider_state.prism[3, i_b]
+                                        e2 = collider_state.prism[5, i_b] - collider_state.prism[3, i_b]
+                                        top_face_normal = e1.cross(e2).normalized()
+                                        if top_face_normal[2] < 0.0:
+                                            top_face_normal = -top_face_normal
+                                        if top_face_normal.dot(normal) > 0.95:
+                                            normal = top_face_normal
 
                                     normal = gu.qd_transform_by_quat(normal, gb_quat)
                                     contact_pos = gu.qd_transform_by_quat(contact_pos, gb_quat)
@@ -1339,6 +1338,20 @@ def _func_multicontact_mpr(
                         needs_gjk_upgrade = True
 
             if is_col and not needs_gjk_upgrade:
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    normal,
+                    penetration,
+                    contact_pos,
+                    ga_pos_current,
+                    ga_quat_current,
+                    gb_pos_current,
+                    gb_quat_current,
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
+
                 if qd.static(
                     collider_static_config.ccd_algorithm not in (CCD_ALGORITHM_CODE.MJ_MPR, CCD_ALGORITHM_CODE.MJ_GJK)
                 ):
@@ -1364,20 +1377,6 @@ def _func_multicontact_mpr(
                     penetration = normal.dot(contact_point_b - contact_point_a)
                     if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MJ_GJK):
                         penetration = penetration_0
-
-                contact_pos = func_apply_smooth_refinement(
-                    i_ga,
-                    i_gb,
-                    normal,
-                    penetration,
-                    contact_pos,
-                    geoms_state.pos[i_ga, i_b],
-                    geoms_state.quat[i_ga, i_b],
-                    geoms_state.pos[i_gb, i_b],
-                    geoms_state.quat[i_gb, i_b],
-                    geoms_info,
-                    static_rigid_sim_config,
-                )
 
                 repeated = False
                 for i_c in range(n_con):
@@ -1564,12 +1563,27 @@ def _func_multicontact_gjk_full(
                     if gjk_state.multi_contact_flag[i_scratch]:
                         for i_c in range(n_contacts_gjk):
                             if i_c < qd.static(collider_static_config.n_contacts_per_pair):
-                                local_contact_pos[n_con, 0] = gjk_state.contact_pos[i_scratch, i_c][0]
-                                local_contact_pos[n_con, 1] = gjk_state.contact_pos[i_scratch, i_c][1]
-                                local_contact_pos[n_con, 2] = gjk_state.contact_pos[i_scratch, i_c][2]
-                                local_normal[n_con, 0] = gjk_state.normal[i_scratch, i_c][0]
-                                local_normal[n_con, 1] = gjk_state.normal[i_scratch, i_c][1]
-                                local_normal[n_con, 2] = gjk_state.normal[i_scratch, i_c][2]
+                                gjk_contact_pos = gjk_state.contact_pos[i_scratch, i_c]
+                                gjk_normal = gjk_state.normal[i_scratch, i_c]
+                                gjk_contact_pos = func_apply_smooth_refinement(
+                                    i_ga,
+                                    i_gb,
+                                    gjk_normal,
+                                    penetration,
+                                    gjk_contact_pos,
+                                    ga_pos_current,
+                                    ga_quat_current,
+                                    gb_pos_current,
+                                    gb_quat_current,
+                                    geoms_info,
+                                    static_rigid_sim_config,
+                                )
+                                local_contact_pos[n_con, 0] = gjk_contact_pos[0]
+                                local_contact_pos[n_con, 1] = gjk_contact_pos[1]
+                                local_contact_pos[n_con, 2] = gjk_contact_pos[2]
+                                local_normal[n_con, 0] = gjk_normal[0]
+                                local_normal[n_con, 1] = gjk_normal[1]
+                                local_normal[n_con, 2] = gjk_normal[2]
                                 local_penetration[n_con, 0] = penetration
                                 n_con = n_con + 1
                         gjk_multi_done = True
@@ -1577,6 +1591,19 @@ def _func_multicontact_gjk_full(
             if i_detection == 0 and not gjk_multi_done:
                 is_col_0, normal_0, penetration_0, contact_pos_0 = is_col, normal, penetration, contact_pos
                 if is_col_0:
+                    contact_pos_0 = func_apply_smooth_refinement(
+                        i_ga,
+                        i_gb,
+                        normal_0,
+                        penetration_0,
+                        contact_pos_0,
+                        ga_pos_current,
+                        ga_quat_current,
+                        gb_pos_current,
+                        gb_quat_current,
+                        geoms_info,
+                        static_rigid_sim_config,
+                    )
                     local_contact_pos[0, 0] = contact_pos_0[0]
                     local_contact_pos[0, 1] = contact_pos_0[1]
                     local_contact_pos[0, 2] = contact_pos_0[2]
@@ -1607,6 +1634,20 @@ def _func_multicontact_gjk_full(
                 else:
                     collider_state.contact_cache.normal[i_pair, i_b] = qd.Vector.zero(gs.qd_float, 3)
             elif not gjk_multi_done and multi_contact and is_col:
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    normal,
+                    penetration,
+                    contact_pos,
+                    ga_pos_current,
+                    ga_quat_current,
+                    gb_pos_current,
+                    gb_quat_current,
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
+
                 if qd.static(
                     collider_static_config.ccd_algorithm not in (CCD_ALGORITHM_CODE.MJ_MPR, CCD_ALGORITHM_CODE.MJ_GJK)
                 ):
@@ -1630,20 +1671,6 @@ def _func_multicontact_gjk_full(
                     penetration = normal.dot(contact_point_b - contact_point_a)
                     if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MJ_GJK):
                         penetration = penetration_0
-
-                contact_pos = func_apply_smooth_refinement(
-                    i_ga,
-                    i_gb,
-                    normal,
-                    penetration,
-                    contact_pos,
-                    geoms_state.pos[i_ga, i_b],
-                    geoms_state.quat[i_ga, i_b],
-                    geoms_state.pos[i_gb, i_b],
-                    geoms_state.quat[i_gb, i_b],
-                    geoms_info,
-                    static_rigid_sim_config,
-                )
 
                 repeated = False
                 for i_c in range(n_con):
@@ -2078,6 +2105,23 @@ def _func_narrowphase_contact0(
             if is_col:
                 if qd.static(collider_static_config.ccd_algorithm in (CCD_ALGORITHM_CODE.MPR, CCD_ALGORITHM_CODE.GJK)):
                     collider_state.contact_cache.normal[i_pair, i_b] = normal
+                # Refine the contact position before enqueueing or storing it. The downstream multicontact functions
+                # store this as the initial contact (index 0 of local_contact_pos) without re-refining, so refinement
+                # must happen here to stay consistent with the monolithic path's consolidated refinement at the start
+                # of each i_detection iteration.
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    normal,
+                    penetration,
+                    contact_pos,
+                    geoms_state.pos[i_ga, i_b],
+                    geoms_state.quat[i_ga, i_b],
+                    geoms_state.pos[i_gb, i_b],
+                    geoms_state.quat[i_gb, i_b],
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
                 if prefer_gjk:
                     # GJK algorithm: always enqueue to GJK queue — multicontact
                     # runs full GJK detection regardless of multi_contact.
@@ -2108,19 +2152,6 @@ def _func_narrowphase_contact0(
                         prefer_gjk=False,
                     )
                 else:
-                    contact_pos = func_apply_smooth_refinement(
-                        i_ga,
-                        i_gb,
-                        normal,
-                        penetration,
-                        contact_pos,
-                        geoms_state.pos[i_ga, i_b],
-                        geoms_state.quat[i_ga, i_b],
-                        geoms_state.pos[i_gb, i_b],
-                        geoms_state.quat[i_gb, i_b],
-                        geoms_info,
-                        static_rigid_sim_config,
-                    )
                     func_add_contact(
                         i_ga,
                         i_gb,

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -19,10 +19,12 @@ from . import capsule_contact, diff_gjk, gjk, mpr
 from .box_contact import (
     func_box_box_contact,
     func_plane_box_contact,
+    func_sphere_box_contact,
 )
 from .contact import (
     func_add_contact,
     func_add_diff_contact_input,
+    func_apply_smooth_refinement,
     func_compute_mj_tolerance,
     func_compute_tolerance,
     func_contact_orthogonals,
@@ -107,7 +109,8 @@ def func_contact_vertex_sdf(
                 penetration = new_penetration
 
     if is_col:
-        # Compute contact normal only once, and only in case of contact
+        # Compute contact normal only once, and only in case of contact, then shift contact_pos to the midpoint
+        # between A's surface (the iterated vertex) and B's surface.
         normal = sdf.sdf_func_normal_world_local(
             geoms_info, rigid_global_info, collider_static_config, sdf_info, contact_pos, i_gb, gb_pos, gb_quat
         )
@@ -274,7 +277,7 @@ def func_contact_convex_convex_sdf(
             geoms_state, geoms_info, rigid_global_info, collider_static_config, sdf_info, pos_a, i_gb, i_b
         )
         penetration = -sd_v_closest
-        contact_pos = pos_a + 0.5 * penetration * normal
+        contact_pos = pos_a
     elif enable_edge_detection_fallback:  # check edge surrounding it
         for i_neighbor_ in range(
             collider_info.vert_neighbor_start[i_va],
@@ -328,7 +331,6 @@ def func_contact_convex_convex_sdf(
                         cur_length = 0.5 * cur_length
 
                     p = 0.5 * (p_0 + p_1)
-
                     new_penetration = -sdf.sdf_func_world(geoms_state, geoms_info, sdf_info, p, i_gb, i_b)
 
                     if new_penetration > 0.0:
@@ -339,6 +341,9 @@ def func_contact_convex_convex_sdf(
                         contact_pos = p
                         penetration = new_penetration
                         break
+
+    # The contact point must be offsetted by half the penetration depth, for consistency with MPR
+    contact_pos = contact_pos + 0.5 * penetration * normal
 
     return is_col, normal, penetration, contact_pos, i_va
 
@@ -462,9 +467,38 @@ def func_contact_mpr_terrain(
                                     gb_quat_terrain_frame,
                                 )
                                 if is_col:
+                                    # Snap normal to the prism's top face normal. Cell boundaries in a heightfield are
+                                    # discretization artefacts of an underlying smooth surface, not physical edges, so
+                                    # MPR's polytope-edge radial normal at those boundaries is a position-dependent bias
+                                    # rather than a real surface feature. The top face spans 3 consecutive top vertices
+                                    # (prism[3..5]) and its normal is exact at the heightfield's sampling precision.
+                                    e1 = collider_state.prism[4, i_b] - collider_state.prism[3, i_b]
+                                    e2 = collider_state.prism[5, i_b] - collider_state.prism[3, i_b]
+                                    top_face_normal = e1.cross(e2).normalized()
+                                    if top_face_normal[2] < 0.0:
+                                        top_face_normal = -top_face_normal
+                                    # Only snap when MPR reported an upward-facing contact; preserve MPR for side-face
+                                    # contacts (rare but valid for spheres wedged inside heightfield discontinuities).
+                                    if normal[2] > 0.0:
+                                        normal = top_face_normal
+
                                     normal = gu.qd_transform_by_quat(normal, gb_quat)
                                     contact_pos = gu.qd_transform_by_quat(contact_pos, gb_quat)
                                     contact_pos = contact_pos + gb_pos
+
+                                    contact_pos = func_apply_smooth_refinement(
+                                        i_ga,
+                                        i_gb,
+                                        normal,
+                                        penetration,
+                                        contact_pos,
+                                        geoms_state.pos[i_ga, i_b],
+                                        geoms_state.quat[i_ga, i_b],
+                                        geoms_state.pos[i_gb, i_b],
+                                        geoms_state.quat[i_gb, i_b],
+                                        geoms_info,
+                                        static_rigid_sim_config,
+                                    )
 
                                     valid = True
                                     i_c = collider_state.n_contacts[i_b]
@@ -645,10 +679,19 @@ def func_convex_convex_contact(
                         geoms_info,
                         rigid_global_info,
                     )
-                elif (
-                    geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.CAPSULE
-                ) or (geoms_info.type[i_ga] == gs.GEOM_TYPE.CAPSULE and geoms_info.type[i_gb] == gs.GEOM_TYPE.SPHERE):
+                elif geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.CAPSULE:
                     is_col, normal, contact_pos, penetration = capsule_contact.func_sphere_capsule_contact(
+                        i_ga,
+                        i_gb,
+                        ga_pos_current,
+                        ga_quat_current,
+                        gb_pos_current,
+                        gb_quat_current,
+                        geoms_info,
+                        rigid_global_info,
+                    )
+                elif geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.BOX:
+                    is_col, normal, contact_pos, penetration = func_sphere_box_contact(
                         i_ga,
                         i_gb,
                         ga_pos_current,
@@ -802,11 +845,25 @@ def func_convex_convex_contact(
                                             collider_state,
                                             collider_info,
                                         )
+                                        # FIXME: Is it the correct way to apply refinement for auto-diff?
+                                        contact_pos = func_apply_smooth_refinement(
+                                            i_ga,
+                                            i_gb,
+                                            gjk_state.normal[i_b, i_c],
+                                            gjk_state.diff_penetration[i_b, i_c],
+                                            gjk_state.contact_pos[i_b, i_c],
+                                            ga_pos_current,
+                                            ga_quat_current,
+                                            gb_pos_current,
+                                            gb_quat_current,
+                                            geoms_info,
+                                            static_rigid_sim_config,
+                                        )
                                         func_add_contact(
                                             i_ga,
                                             i_gb,
                                             gjk_state.normal[i_b, i_c],
-                                            gjk_state.contact_pos[i_b, i_c],
+                                            contact_pos,
                                             gjk_state.diff_penetration[i_b, i_c],
                                             i_b,
                                             i_pair,
@@ -828,6 +885,19 @@ def func_convex_convex_contact(
                                                 normal = gjk_state.normal[i_b, i_c]
                                                 if qd.static(static_rigid_sim_config.requires_grad):
                                                     penetration = gjk_state.diff_penetration[i_b, i_c]
+                                                contact_pos = func_apply_smooth_refinement(
+                                                    i_ga,
+                                                    i_gb,
+                                                    normal,
+                                                    penetration,
+                                                    contact_pos,
+                                                    ga_pos_current,
+                                                    ga_quat_current,
+                                                    gb_pos_current,
+                                                    gb_quat_current,
+                                                    geoms_info,
+                                                    static_rigid_sim_config,
+                                                )
                                                 func_add_contact(
                                                     i_ga,
                                                     i_gb,
@@ -847,6 +917,21 @@ def func_convex_convex_contact(
                                     else:
                                         contact_pos = gjk_state.contact_pos[i_b, 0]
                                         normal = gjk_state.normal[i_b, 0]
+
+            if is_col:
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    normal,
+                    penetration,
+                    contact_pos,
+                    ga_pos_current,
+                    ga_quat_current,
+                    gb_pos_current,
+                    gb_quat_current,
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
 
             if i_detection == 0:
                 is_col_0, normal_0, penetration_0, contact_pos_0 = is_col, normal, penetration, contact_pos
@@ -1020,10 +1105,19 @@ def _func_multicontact_run_detection(
             geoms_info,
             rigid_global_info,
         )
-    elif (geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.CAPSULE) or (
-        geoms_info.type[i_ga] == gs.GEOM_TYPE.CAPSULE and geoms_info.type[i_gb] == gs.GEOM_TYPE.SPHERE
-    ):
+    elif geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.CAPSULE:
         is_col, normal, contact_pos, penetration = capsule_contact.func_sphere_capsule_contact(
+            i_ga,
+            i_gb,
+            ga_pos,
+            ga_quat,
+            gb_pos,
+            gb_quat,
+            geoms_info,
+            rigid_global_info,
+        )
+    elif geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.BOX:
+        is_col, normal, contact_pos, penetration = func_sphere_box_contact(
             i_ga,
             i_gb,
             ga_pos,
@@ -1270,6 +1364,20 @@ def _func_multicontact_mpr(
                     penetration = normal.dot(contact_point_b - contact_point_a)
                     if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MJ_GJK):
                         penetration = penetration_0
+
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    normal,
+                    penetration,
+                    contact_pos,
+                    geoms_state.pos[i_ga, i_b],
+                    geoms_state.quat[i_ga, i_b],
+                    geoms_state.pos[i_gb, i_b],
+                    geoms_state.quat[i_gb, i_b],
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
 
                 repeated = False
                 for i_c in range(n_con):
@@ -1522,6 +1630,20 @@ def _func_multicontact_gjk_full(
                     penetration = normal.dot(contact_point_b - contact_point_a)
                     if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MJ_GJK):
                         penetration = penetration_0
+
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    normal,
+                    penetration,
+                    contact_pos,
+                    geoms_state.pos[i_ga, i_b],
+                    geoms_state.quat[i_ga, i_b],
+                    geoms_state.pos[i_gb, i_b],
+                    geoms_state.quat[i_gb, i_b],
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
 
                 repeated = False
                 for i_c in range(n_con):
@@ -1840,10 +1962,19 @@ def _func_narrowphase_contact0(
                     geoms_info,
                     rigid_global_info,
                 )
-            elif (geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.CAPSULE) or (
-                geoms_info.type[i_ga] == gs.GEOM_TYPE.CAPSULE and geoms_info.type[i_gb] == gs.GEOM_TYPE.SPHERE
-            ):
+            elif geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.CAPSULE:
                 is_col, normal, contact_pos, penetration = capsule_contact.func_sphere_capsule_contact(
+                    i_ga,
+                    i_gb,
+                    ga_pos,
+                    ga_quat,
+                    gb_pos,
+                    gb_quat,
+                    geoms_info,
+                    rigid_global_info,
+                )
+            elif geoms_info.type[i_ga] == gs.GEOM_TYPE.SPHERE and geoms_info.type[i_gb] == gs.GEOM_TYPE.BOX:
+                is_col, normal, contact_pos, penetration = func_sphere_box_contact(
                     i_ga,
                     i_gb,
                     ga_pos,
@@ -1977,6 +2108,19 @@ def _func_narrowphase_contact0(
                         prefer_gjk=False,
                     )
                 else:
+                    contact_pos = func_apply_smooth_refinement(
+                        i_ga,
+                        i_gb,
+                        normal,
+                        penetration,
+                        contact_pos,
+                        geoms_state.pos[i_ga, i_b],
+                        geoms_state.quat[i_ga, i_b],
+                        geoms_state.pos[i_gb, i_b],
+                        geoms_state.quat[i_gb, i_b],
+                        geoms_info,
+                        static_rigid_sim_config,
+                    )
                     func_add_contact(
                         i_ga,
                         i_gb,
@@ -2098,6 +2242,20 @@ def func_narrow_phase_diff_convex_vs_convex(
                 )
                 collider_state.diff_contact_input.ref_penetration[i_b, i_c] = penetration
 
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    contact_normal,
+                    penetration,
+                    contact_pos,
+                    geoms_state.pos[i_ga, i_b],
+                    geoms_state.quat[i_ga, i_b],
+                    geoms_state.pos[i_gb, i_b],
+                    geoms_state.quat[i_gb, i_b],
+                    geoms_info,
+                    static_rigid_sim_config,
+                )
+
                 func_set_contact(
                     i_ga,
                     i_gb,
@@ -2125,6 +2283,20 @@ def func_narrow_phase_diff_convex_vs_convex(
                 ref_penetration = collider_state.diff_contact_input.ref_penetration[i_b, ref_id]
                 contact_pos, contact_normal, penetration, weight = diff_gjk.func_differentiable_contact(
                     geoms_state, diff_contact_input, gjk_info, i_ga, i_gb, i_b, i_c, ref_penetration
+                )
+
+                contact_pos = func_apply_smooth_refinement(
+                    i_ga,
+                    i_gb,
+                    contact_normal,
+                    penetration,
+                    contact_pos,
+                    geoms_state.pos[i_ga, i_b],
+                    geoms_state.quat[i_ga, i_b],
+                    geoms_state.pos[i_gb, i_b],
+                    geoms_state.quat[i_gb, i_b],
+                    geoms_info,
+                    static_rigid_sim_config,
                 )
 
                 func_set_contact(
@@ -2320,6 +2492,19 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                 sdf_info,
                             )
                             if is_col_i:
+                                contact_pos_i = func_apply_smooth_refinement(
+                                    i_ga,
+                                    i_gb,
+                                    normal_i,
+                                    penetration_i,
+                                    contact_pos_i,
+                                    geoms_state.pos[i_ga, i_b],
+                                    geoms_state.quat[i_ga, i_b],
+                                    geoms_state.pos[i_gb, i_b],
+                                    geoms_state.quat[i_gb, i_b],
+                                    geoms_info,
+                                    static_rigid_sim_config,
+                                )
                                 func_add_contact(
                                     i_ga,
                                     i_gb,
@@ -2392,6 +2577,20 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                     )
 
                                     if is_col:
+                                        contact_pos = func_apply_smooth_refinement(
+                                            i_ga,
+                                            i_gb,
+                                            normal,
+                                            penetration,
+                                            contact_pos,
+                                            ga_pos_perturbed,
+                                            ga_quat_perturbed,
+                                            gb_pos_perturbed,
+                                            gb_quat_perturbed,
+                                            geoms_info,
+                                            static_rigid_sim_config,
+                                        )
+
                                         if qd.static(not static_rigid_sim_config.enable_mujoco_compatibility):
                                             # 1. Project the contact point on both geometries
                                             # 2. Revert the effect of small rotation
@@ -2475,6 +2674,19 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                 sdf_info,
                             )
                             if is_col:
+                                contact_pos = func_apply_smooth_refinement(
+                                    i_ga,
+                                    i_gb,
+                                    normal,
+                                    penetration,
+                                    contact_pos,
+                                    geoms_state.pos[i_ga, i_b],
+                                    geoms_state.quat[i_ga, i_b],
+                                    geoms_state.pos[i_gb, i_b],
+                                    geoms_state.quat[i_gb, i_b],
+                                    geoms_info,
+                                    static_rigid_sim_config,
+                                )
                                 func_add_contact(
                                     i_ga,
                                     i_gb,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -365,14 +365,19 @@ def hinge_slide():
     return mjcf
 
 
-@pytest.fixture(scope="session")
-def ellipsoid():
+def _ellipsoid_mjcf(semi_axes, body_name="obj", joint_name="root"):
+    a, b, c = semi_axes
     mjcf = ET.Element("mujoco", model="ellipsoid")
     worldbody = ET.SubElement(mjcf, "worldbody")
-    body = ET.SubElement(worldbody, "body", name="obj", pos="0 0 0.0")
-    ET.SubElement(body, "joint", name="root", type="free")
-    ET.SubElement(body, "geom", type="ellipsoid", size="0.05 0.05 0.02")
+    body = ET.SubElement(worldbody, "body", name=body_name, pos="0 0 0.0")
+    ET.SubElement(body, "joint", name=joint_name, type="free")
+    ET.SubElement(body, "geom", type="ellipsoid", size=f"{a} {b} {c}")
     return mjcf
+
+
+@pytest.fixture(scope="session")
+def ellipsoid():
+    return _ellipsoid_mjcf((0.05, 0.05, 0.02))
 
 
 @pytest.fixture(scope="session")
@@ -1067,6 +1072,279 @@ def test_box_box_dynamics(gs_sim):
 
         qpos = gs_robot.get_dofs_position()
         assert_allclose(qpos[8], 0.6, atol=2e-3)
+
+
+def _capsule_mjcf_path(tmp_path, radius, length, name="capsule"):
+    mjcf = ET.Element("mujoco", model=name)
+    body = ET.SubElement(ET.SubElement(mjcf, "worldbody"), "body")
+    ET.SubElement(body, "geom", type="capsule", size=f"{radius} {0.5 * length}")
+    ET.SubElement(body, "joint", type="free")
+    path = tmp_path / f"{name}.xml"
+    ET.ElementTree(mjcf).write(path)
+    return str(path)
+
+
+def _ellipsoid_mjcf_path(tmp_path, semi_axes):
+    path = tmp_path / "ellipsoid.xml"
+    ET.ElementTree(_ellipsoid_mjcf(semi_axes)).write(path)
+    return str(path)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("gjk_collision", [False, True])
+@pytest.mark.parametrize(
+    "smooth_kind, pair_kind",
+    [
+        ("sphere", "prim-prim"),
+        ("sphere", "prim-mesh"),
+        ("sphere", "mesh-mesh"),
+        ("capsule", "prim-prim"),
+        ("capsule", "prim-mesh"),
+        ("ellipsoid", "prim-prim"),
+        ("ellipsoid", "prim-mesh"),
+    ],
+)
+def test_smooth_box_no_drift(gjk_collision, smooth_kind, pair_kind, show_viewer, tmp_path):
+    HEIGHT = 0.02
+    # The smooth-primitive characteristic length must be small enough to amplify the bias and make drift evident.
+    SMOOTH_RADIUS = 0.0025
+    # Two capsule lengths exist as separate entities: the zero-length capsule (sphere-like, used by "vertical-axis"
+    # envs because a full-length capsule standing on its cap is a tippy-pencil configuration that is numerically
+    # unstable regardless of the bias fix) and the full-length capsule (used by "horizontal-axis" envs, barrel contact).
+    # MuJoCo rejects an exact zero length so we use a tiny positive value.
+    CAPSULE_LENGTH_VERTICAL = 1e-6
+    CAPSULE_LENGTH_HORIZONTAL = 0.005
+    ELLIPSOID_SEMI_AXES = (0.0035, 0.0030, SMOOTH_RADIUS)
+    BOX_HALF_EXTENT = 0.1
+    N_ENVS = 16
+    SPHERE_TESSELLATION_SUBDIVISIONS = 3
+
+    smooth_is_mesh = smooth_kind == "sphere" and pair_kind == "mesh-mesh"
+    box_is_mesh = pair_kind != "prim-prim"
+
+    # The box and the gravity vector are rotated by the same tilt, which is physically equivalent to the untilted setup.
+    tilt_axis = np.array([1.0, 1.0, 0.0]) / math.sqrt(2.0)
+    tilt_quat = gu.rotvec_to_quat(math.radians(50.0) * tilt_axis)
+    R = gu.quat_to_R(tilt_quat)
+
+    # Per-env initial z offset and entity-local orientation, depending on which smooth primitive is being tested. For
+    # capsule we randomly sample one of two stable resting modes per env: axis vertical (rests on a hemispherical cap,
+    # collapsed to zero length to avoid the pencil-on-tip instability) and axis horizontal (barrel contact, stable).
+    quat_identity = np.array([1.0, 0.0, 0.0, 0.0], dtype=gs.np_float)
+    if smooth_kind == "sphere":
+        z_offsets = np.full(N_ENVS, SMOOTH_RADIUS)
+        smooth_quat_local = np.tile(quat_identity, (N_ENVS, 1))
+    elif smooth_kind == "ellipsoid":
+        # Smallest semi-axis along body z so the ellipsoid rests on its narrowest cross-section.
+        z_offsets = np.full(N_ENVS, ELLIPSOID_SEMI_AXES[2])
+        smooth_quat_local = np.tile(quat_identity, (N_ENVS, 1))
+    elif smooth_kind == "capsule":
+        axis_mode = np.random.randint(0, 2, size=N_ENVS)
+        z_offsets = np.full(N_ENVS, SMOOTH_RADIUS)
+        quat_horizontal = gu.rotvec_to_quat(np.array([0.0, 0.5 * np.pi, 0.0], dtype=gs.np_float))
+        smooth_quat_local = np.where(axis_mode[:, None] == 0, quat_identity, quat_horizontal)
+    else:
+        raise ValueError(f"Unknown smooth_kind: {smooth_kind}")
+
+    sphere_offsets = np.random.uniform(
+        low=-(BOX_HALF_EXTENT - 2.0 * SMOOTH_RADIUS),
+        high=BOX_HALF_EXTENT - 2.0 * SMOOTH_RADIUS,
+        size=(N_ENVS, 2),
+    )
+    # Add small vertical offset (-1e-5) to ensure contact at init; otherwise the primitive will sink before bouncing up.
+    smooth_pos_local = np.column_stack([sphere_offsets, HEIGHT + z_offsets - 1e-5])
+    smooth_pos_world = smooth_pos_local @ R.T
+    # Compose tilt with the per-env entity-local quat (world_R = tilt_R @ local_R).
+    smooth_quat_world = gu.transform_quat_by_quat(smooth_quat_local, np.tile(tilt_quat, (N_ENVS, 1)))
+
+    box_pos_world = R @ np.array([0.0, 0.0, 0.5 * HEIGHT])
+    gravity_world = R @ np.array([0.0, 0.0, -9.81])
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=0.004,
+            gravity=gravity_world,
+        ),
+        rigid_options=gs.options.RigidOptions(
+            use_gjk_collision=gjk_collision,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.25, 0.25, 0.2),
+            camera_lookat=(0.0, 0.0, 0.5 * HEIGHT),
+            camera_fov=30.0,
+        ),
+        show_viewer=show_viewer,
+    )
+    if box_is_mesh:
+        box_mesh = trimesh.creation.box(extents=(2.0 * BOX_HALF_EXTENT, 2.0 * BOX_HALF_EXTENT, HEIGHT))
+        scene.add_entity(
+            morph=gs.morphs.MeshSet(
+                files=(box_mesh,),
+                pos=box_pos_world,
+                quat=tilt_quat,
+                fixed=True,
+            ),
+            surface=gs.surfaces.Default(
+                smooth=False,
+            ),
+        )
+    else:
+        scene.add_entity(
+            morph=gs.morphs.Box(
+                pos=box_pos_world,
+                quat=tilt_quat,
+                size=(2.0 * BOX_HALF_EXTENT, 2.0 * BOX_HALF_EXTENT, HEIGHT),
+                fixed=True,
+            ),
+        )
+
+    if smooth_kind == "sphere":
+        if smooth_is_mesh:
+            sphere_mesh = trimesh.creation.icosphere(
+                radius=SMOOTH_RADIUS, subdivisions=SPHERE_TESSELLATION_SUBDIVISIONS
+            )
+            # Rotate the icosphere so that one face plane is perpendicular to the body -z axis. With the sphere oriented
+            # to match the box tilt, this puts that face squarely against the box's top, eliminating the discretization
+            # xy shift the sphere would otherwise pick up while rocking onto its nearest supporting feature. We align
+            # the face's OUTWARD NORMAL with -z; aligning the centroid direction instead leaves the face plane slightly
+            # tilted because for subdivided icosphere faces the centroid is not exactly along the face normal.
+            bottom_dir = sphere_mesh.face_normals[int(np.argmin(sphere_mesh.face_normals[:, 2]))]
+            cross_axis = np.cross(bottom_dir, np.array([0.0, 0.0, -1.0]))
+            sin_t = float(np.linalg.norm(cross_axis))
+            if sin_t > 1e-12:
+                cross_axis = cross_axis / sin_t
+                angle = np.arctan2(sin_t, float(np.dot(bottom_dir, np.array([0.0, 0.0, -1.0]))))
+                sphere_mesh.apply_transform(trimesh.transformations.rotation_matrix(angle, cross_axis))
+            smooth_entities = [
+                scene.add_entity(
+                    morph=gs.morphs.MeshSet(
+                        files=(sphere_mesh,),
+                        pos=smooth_pos_world[0],
+                        quat=tilt_quat,
+                        decimate=False,
+                    ),
+                    vis_mode="collision",
+                ),
+            ]
+            entity_idx_per_env = np.zeros(N_ENVS, dtype=int)
+        else:
+            smooth_entities = [
+                scene.add_entity(
+                    morph=gs.morphs.Sphere(
+                        radius=SMOOTH_RADIUS,
+                        pos=smooth_pos_world[0],
+                    ),
+                ),
+            ]
+            entity_idx_per_env = np.zeros(N_ENVS, dtype=int)
+    elif smooth_kind == "capsule":
+        # Heterogeneous capsule entities: zero-length (vertical-axis envs, sphere-like geometry, stable) and full-length
+        # (horizontal-axis envs, barrel contact). Each env activates one and parks the other far from the box.
+        smooth_entities = [
+            scene.add_entity(
+                morph=gs.morphs.MJCF(
+                    file=_capsule_mjcf_path(tmp_path, SMOOTH_RADIUS, CAPSULE_LENGTH_VERTICAL, name="capsule_v"),
+                ),
+            ),
+            scene.add_entity(
+                morph=gs.morphs.MJCF(
+                    file=_capsule_mjcf_path(tmp_path, SMOOTH_RADIUS, CAPSULE_LENGTH_HORIZONTAL, name="capsule_h"),
+                ),
+            ),
+        ]
+        entity_idx_per_env = axis_mode
+    elif smooth_kind == "ellipsoid":
+        smooth_entities = [
+            scene.add_entity(
+                morph=gs.morphs.MJCF(
+                    file=_ellipsoid_mjcf_path(tmp_path, ELLIPSOID_SEMI_AXES),
+                ),
+            ),
+        ]
+        entity_idx_per_env = np.zeros(N_ENVS, dtype=int)
+    scene.build(n_envs=N_ENVS)
+
+    # Set the per-env pose on the active entity, park the others far from the box. With only one entity (sphere /
+    # ellipsoid) it just becomes a regular set_pos / set_quat.
+    parked = np.tile(np.array([10.0, 10.0, 0.0], dtype=gs.np_float), (N_ENVS, 1))
+    for idx, entity in enumerate(smooth_entities):
+        active = (entity_idx_per_env == idx)[:, None]
+        entity.set_pos(np.where(active, smooth_pos_world, parked))
+        entity.set_quat(smooth_quat_world)
+    if show_viewer:
+        scene.visualizer.update()
+
+    for _ in range(300):
+        scene.step()
+
+    # Gather positions from the per-env active entity.
+    pos_per_entity = np.stack([tensor_to_array(entity.get_pos()) for entity in smooth_entities], axis=0)
+    pos_world_after = pos_per_entity[entity_idx_per_env, np.arange(N_ENVS)]
+    pos_local = pos_world_after @ R
+    # The tolerance must be large enough to accomate small numerical error for mesh-mesh.
+    assert_allclose(pos_local[..., :2], sphere_offsets, atol=1e-3)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("surface_kind", ["primitive_box", "primitive_plane", "vertex_box", "flat_terrain"])
+def test_sphere_static_contact_dedup(surface_kind, show_viewer):
+    # Sphere at rest on a flat surface has a single physical contact point. Every multi-contact perturbation
+    # path (analytical sphere-box, MPR convex-convex, MPR terrain over prisms) generates several candidate
+    # samples around that point and is supposed to dedup them before storage. Regression check: after the
+    # sphere has settled, only one contact must remain.
+    SPHERE_RADIUS = 0.05
+    GROUND_SIZE = 1.0
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(dt=0.005),
+        show_viewer=show_viewer,
+    )
+    if surface_kind == "primitive_box":
+        scene.add_entity(
+            morph=gs.morphs.Box(
+                pos=(0.0, 0.0, -0.05),
+                size=(GROUND_SIZE, GROUND_SIZE, 0.1),
+                fixed=True,
+            ),
+        )
+    elif surface_kind == "primitive_plane":
+        scene.add_entity(
+            morph=gs.morphs.Plane(
+                pos=(0.0, 0.0, 0.0),
+            ),
+        )
+    elif surface_kind == "vertex_box":
+        box_mesh = trimesh.creation.box(extents=(GROUND_SIZE, GROUND_SIZE, 0.1))
+        scene.add_entity(
+            morph=gs.morphs.MeshSet(
+                files=(box_mesh,),
+                pos=(0.0, 0.0, -0.05),
+                fixed=True,
+            ),
+        )
+    elif surface_kind == "flat_terrain":
+        flat_hf = np.zeros((16, 16), dtype=np.float32)
+        scene.add_entity(
+            morph=gs.morphs.Terrain(
+                horizontal_scale=0.1,
+                vertical_scale=1.0,
+                height_field=flat_hf,
+                pos=(-0.8, -0.8, 0.0),
+            ),
+        )
+    scene.add_entity(
+        morph=gs.morphs.Sphere(
+            radius=SPHERE_RADIUS,
+            pos=(0.0, 0.0, SPHERE_RADIUS + 1e-4),
+        ),
+    )
+    scene.build()
+
+    for _ in range(10):
+        scene.step()
+
+    n_contacts = int(scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()[0])
+    assert n_contacts == 1, f"Expected 1 contact after dedup, got {n_contacts}"
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1091,72 +1091,39 @@ def _ellipsoid_mjcf_path(tmp_path, semi_axes):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("gjk_collision", [False, True])
 @pytest.mark.parametrize(
     "smooth_kind, pair_kind",
     [
         ("sphere", "prim-prim"),
         ("sphere", "prim-mesh"),
+        ("sphere", "prim-terrain"),
         ("sphere", "mesh-mesh"),
         ("capsule", "prim-prim"),
         ("capsule", "prim-mesh"),
+        ("cylinder", "prim-prim"),
+        ("cylinder", "prim-mesh"),
         ("ellipsoid", "prim-prim"),
         ("ellipsoid", "prim-mesh"),
     ],
 )
+@pytest.mark.parametrize("gjk_collision", [False, True])
 def test_smooth_box_no_drift(gjk_collision, smooth_kind, pair_kind, show_viewer, tmp_path):
+    WORLD_TILT_ANGLE = 50.0
     HEIGHT = 0.02
-    # The smooth-primitive characteristic length must be small enough to amplify the bias and make drift evident.
+    # The smooth-primitive characteristic length must be small enough to amplify the bias and make drift evident
     SMOOTH_RADIUS = 0.0025
-    # Two capsule lengths exist as separate entities: the zero-length capsule (sphere-like, used by "vertical-axis"
-    # envs because a full-length capsule standing on its cap is a tippy-pencil configuration that is numerically
-    # unstable regardless of the bias fix) and the full-length capsule (used by "horizontal-axis" envs, barrel contact).
-    # MuJoCo rejects an exact zero length so we use a tiny positive value.
-    CAPSULE_LENGTH_VERTICAL = 1e-6
-    CAPSULE_LENGTH_HORIZONTAL = 0.005
+    CYLINDER_HEIGHT = 0.005
+    # Smallest semi-axis along body z so the ellipsoid rests on its narrowest cross-section
     ELLIPSOID_SEMI_AXES = (0.0035, 0.0030, SMOOTH_RADIUS)
     BOX_HALF_EXTENT = 0.1
     N_ENVS = 16
     SPHERE_TESSELLATION_SUBDIVISIONS = 3
 
-    smooth_is_mesh = smooth_kind == "sphere" and pair_kind == "mesh-mesh"
-    box_is_mesh = pair_kind != "prim-prim"
-
     # The box and the gravity vector are rotated by the same tilt, which is physically equivalent to the untilted setup.
     tilt_axis = np.array([1.0, 1.0, 0.0]) / math.sqrt(2.0)
-    tilt_quat = gu.rotvec_to_quat(math.radians(50.0) * tilt_axis)
+    tilt_quat = gu.rotvec_to_quat(math.radians(WORLD_TILT_ANGLE) * tilt_axis)
     R = gu.quat_to_R(tilt_quat)
-
-    # Per-env initial z offset and entity-local orientation, depending on which smooth primitive is being tested. For
-    # capsule we randomly sample one of two stable resting modes per env: axis vertical (rests on a hemispherical cap,
-    # collapsed to zero length to avoid the pencil-on-tip instability) and axis horizontal (barrel contact, stable).
-    quat_identity = np.array([1.0, 0.0, 0.0, 0.0], dtype=gs.np_float)
-    if smooth_kind == "sphere":
-        z_offsets = np.full(N_ENVS, SMOOTH_RADIUS)
-        smooth_quat_local = np.tile(quat_identity, (N_ENVS, 1))
-    elif smooth_kind == "ellipsoid":
-        # Smallest semi-axis along body z so the ellipsoid rests on its narrowest cross-section.
-        z_offsets = np.full(N_ENVS, ELLIPSOID_SEMI_AXES[2])
-        smooth_quat_local = np.tile(quat_identity, (N_ENVS, 1))
-    elif smooth_kind == "capsule":
-        axis_mode = np.random.randint(0, 2, size=N_ENVS)
-        z_offsets = np.full(N_ENVS, SMOOTH_RADIUS)
-        quat_horizontal = gu.rotvec_to_quat(np.array([0.0, 0.5 * np.pi, 0.0], dtype=gs.np_float))
-        smooth_quat_local = np.where(axis_mode[:, None] == 0, quat_identity, quat_horizontal)
-    else:
-        raise ValueError(f"Unknown smooth_kind: {smooth_kind}")
-
-    sphere_offsets = np.random.uniform(
-        low=-(BOX_HALF_EXTENT - 2.0 * SMOOTH_RADIUS),
-        high=BOX_HALF_EXTENT - 2.0 * SMOOTH_RADIUS,
-        size=(N_ENVS, 2),
-    )
-    # Add small vertical offset (-1e-5) to ensure contact at init; otherwise the primitive will sink before bouncing up.
-    smooth_pos_local = np.column_stack([sphere_offsets, HEIGHT + z_offsets - 1e-5])
-    smooth_pos_world = smooth_pos_local @ R.T
-    # Compose tilt with the per-env entity-local quat (world_R = tilt_R @ local_R).
-    smooth_quat_world = gu.transform_quat_by_quat(smooth_quat_local, np.tile(tilt_quat, (N_ENVS, 1)))
-
+    terrain_pos_world = R @ np.array([-BOX_HALF_EXTENT, -BOX_HALF_EXTENT, HEIGHT])
     box_pos_world = R @ np.array([0.0, 0.0, 0.5 * HEIGHT])
     gravity_world = R @ np.array([0.0, 0.0, -9.81])
 
@@ -1175,7 +1142,7 @@ def test_smooth_box_no_drift(gjk_collision, smooth_kind, pair_kind, show_viewer,
         ),
         show_viewer=show_viewer,
     )
-    if box_is_mesh:
+    if pair_kind == "prim-mesh":
         box_mesh = trimesh.creation.box(extents=(2.0 * BOX_HALF_EXTENT, 2.0 * BOX_HALF_EXTENT, HEIGHT))
         scene.add_entity(
             morph=gs.morphs.MeshSet(
@@ -1186,6 +1153,17 @@ def test_smooth_box_no_drift(gjk_collision, smooth_kind, pair_kind, show_viewer,
             ),
             surface=gs.surfaces.Default(
                 smooth=False,
+            ),
+        )
+    elif pair_kind == "prim-terrain":
+        flat_hf = np.zeros((2, 2), dtype=np.float32)
+        scene.add_entity(
+            morph=gs.morphs.Terrain(
+                horizontal_scale=2.0 * BOX_HALF_EXTENT,
+                vertical_scale=2.0 * BOX_HALF_EXTENT,
+                height_field=flat_hf,
+                pos=terrain_pos_world,
+                quat=tilt_quat,
             ),
         )
     else:
@@ -1199,7 +1177,7 @@ def test_smooth_box_no_drift(gjk_collision, smooth_kind, pair_kind, show_viewer,
         )
 
     if smooth_kind == "sphere":
-        if smooth_is_mesh:
+        if smooth_kind == "sphere" and pair_kind == "mesh-mesh":
             sphere_mesh = trimesh.creation.icosphere(
                 radius=SMOOTH_RADIUS, subdivisions=SPHERE_TESSELLATION_SUBDIVISIONS
             )
@@ -1215,88 +1193,109 @@ def test_smooth_box_no_drift(gjk_collision, smooth_kind, pair_kind, show_viewer,
                 cross_axis = cross_axis / sin_t
                 angle = np.arctan2(sin_t, float(np.dot(bottom_dir, np.array([0.0, 0.0, -1.0]))))
                 sphere_mesh.apply_transform(trimesh.transformations.rotation_matrix(angle, cross_axis))
-            smooth_entities = [
-                scene.add_entity(
-                    morph=gs.morphs.MeshSet(
-                        files=(sphere_mesh,),
-                        pos=smooth_pos_world[0],
-                        quat=tilt_quat,
-                        decimate=False,
-                    ),
-                    vis_mode="collision",
+            entity = scene.add_entity(
+                morph=gs.morphs.MeshSet(
+                    files=(sphere_mesh,),
+                    decimate=False,
                 ),
-            ]
-            entity_idx_per_env = np.zeros(N_ENVS, dtype=int)
+                vis_mode="collision",
+                # visualize_contact=True,
+            )
         else:
-            smooth_entities = [
-                scene.add_entity(
-                    morph=gs.morphs.Sphere(
-                        radius=SMOOTH_RADIUS,
-                        pos=smooth_pos_world[0],
-                    ),
+            entity = scene.add_entity(
+                morph=gs.morphs.Sphere(
+                    radius=SMOOTH_RADIUS,
                 ),
-            ]
-            entity_idx_per_env = np.zeros(N_ENVS, dtype=int)
+            )
+    elif smooth_kind == "cylinder":
+        entity = scene.add_entity(
+            morph=gs.morphs.Cylinder(
+                radius=SMOOTH_RADIUS,
+                height=CYLINDER_HEIGHT,
+            ),
+        )
     elif smooth_kind == "capsule":
-        # Heterogeneous capsule entities: zero-length (vertical-axis envs, sphere-like geometry, stable) and full-length
-        # (horizontal-axis envs, barrel contact). Each env activates one and parks the other far from the box.
-        smooth_entities = [
-            scene.add_entity(
-                morph=gs.morphs.MJCF(
-                    file=_capsule_mjcf_path(tmp_path, SMOOTH_RADIUS, CAPSULE_LENGTH_VERTICAL, name="capsule_v"),
+        # Two capsule lengths exist as separate entities: the zero-length capsule (sphere-like, used by "vertical-axis"
+        # envs because a full-length capsule standing on its cap is a tippy-pencil configuration that is numerically
+        # unstable regardless of the bias fix) and the full-length capsule (used by "horizontal-axis" envs, barrel
+        # contact). MuJoCo rejects an exact zero length so we use a tiny positive value.
+        entity = scene.add_entity(
+            morph=(
+                gs.morphs.MJCF(
+                    file=_capsule_mjcf_path(tmp_path, SMOOTH_RADIUS, gs.EPS, name="capsule_v"),
                 ),
-            ),
-            scene.add_entity(
-                morph=gs.morphs.MJCF(
-                    file=_capsule_mjcf_path(tmp_path, SMOOTH_RADIUS, CAPSULE_LENGTH_HORIZONTAL, name="capsule_h"),
+                gs.morphs.MJCF(
+                    file=_capsule_mjcf_path(tmp_path, SMOOTH_RADIUS, CYLINDER_HEIGHT, name="capsule_h"),
                 ),
+            )
+        )
+    else:  # if smooth_kind == "ellipsoid":
+        entity = scene.add_entity(
+            morph=gs.morphs.MJCF(
+                file=_ellipsoid_mjcf_path(tmp_path, ELLIPSOID_SEMI_AXES),
             ),
-        ]
-        entity_idx_per_env = axis_mode
-    elif smooth_kind == "ellipsoid":
-        smooth_entities = [
-            scene.add_entity(
-                morph=gs.morphs.MJCF(
-                    file=_ellipsoid_mjcf_path(tmp_path, ELLIPSOID_SEMI_AXES),
-                ),
-            ),
-        ]
-        entity_idx_per_env = np.zeros(N_ENVS, dtype=int)
+        )
     scene.build(n_envs=N_ENVS)
 
-    # Set the per-env pose on the active entity, park the others far from the box. With only one entity (sphere /
-    # ellipsoid) it just becomes a regular set_pos / set_quat.
-    parked = np.tile(np.array([10.0, 10.0, 0.0], dtype=gs.np_float), (N_ENVS, 1))
-    for idx, entity in enumerate(smooth_entities):
-        active = (entity_idx_per_env == idx)[:, None]
-        entity.set_pos(np.where(active, smooth_pos_world, parked))
-        entity.set_quat(smooth_quat_world)
+    # Randomly sample position in local frame.
+    # Add small vertical offset to ensure contact at init; otherwise the primitive will sink before bouncing up.
+    sphere_offsets = np.random.uniform(
+        low=-(BOX_HALF_EXTENT - 2.0 * SMOOTH_RADIUS),
+        high=BOX_HALF_EXTENT - 2.0 * SMOOTH_RADIUS,
+        size=(N_ENVS, 2),
+    )
+    smooth_pos_local = np.concatenate([sphere_offsets, np.full((N_ENVS, 1), HEIGHT + SMOOTH_RADIUS - 1e-4)], axis=-1)
+
+    # Randomly sample orientation in local frame.
+    # Special handling for capsule to ensure stable barrel contact if needed.
+    smooth_quat_local = np.random.uniform(low=-1.0, high=1.0, size=(N_ENVS, 4))
+    if smooth_kind in "cylinder":
+        singular_mask = np.ones((N_ENVS,), dtype=np.bool_)
+        angle_pitch = 0.5 * np.pi
+    elif smooth_kind in "ellipsoid":
+        singular_mask = np.ones((N_ENVS,), dtype=np.bool_)
+        angle_pitch = 0.0
+    elif smooth_kind == "capsule":
+        singular_mask = np.arange(N_ENVS) >= N_ENVS // 2
+        angle_pitch = 0.5 * np.pi
+    else:
+        singular_mask = np.zeros((N_ENVS,), dtype=np.bool_)
+        angle_pitch = 0.0
+    n_singulars = np.sum(singular_mask)
+    angle_yaw = np.random.uniform(low=-np.pi, high=np.pi, size=(n_singulars, 1))
+    smooth_quat_local[singular_mask] = gu.xyz_to_quat(
+        np.concatenate([np.zeros((n_singulars, 1)), np.full((n_singulars, 1), angle_pitch), angle_yaw], axis=-1),
+        rpy=True,
+    )
+
+    # Convert pose from local to world frame
+    smooth_pos_world = smooth_pos_local @ R.T
+    smooth_quat_world = gu.transform_quat_by_quat(smooth_quat_local, np.tile(tilt_quat, (N_ENVS, 1)))
+
+    entity.set_pos(smooth_pos_world)
+    entity.set_quat(smooth_quat_world)
     if show_viewer:
         scene.visualizer.update()
 
     for _ in range(300):
         scene.step()
 
-    # Gather positions from the per-env active entity.
-    pos_per_entity = np.stack([tensor_to_array(entity.get_pos()) for entity in smooth_entities], axis=0)
-    pos_world_after = pos_per_entity[entity_idx_per_env, np.arange(N_ENVS)]
-    pos_local = pos_world_after @ R
+    pos_local = tensor_to_array(entity.get_pos()) @ R
     # The tolerance must be large enough to accomate small numerical error for mesh-mesh.
     assert_allclose(pos_local[..., :2], sphere_offsets, atol=1e-3)
 
 
 @pytest.mark.required
+@pytest.mark.xfail(reason="De-duplication of repeated contact points is currently too naive for this test to pass...")
 @pytest.mark.parametrize("surface_kind", ["primitive_box", "primitive_plane", "vertex_box", "flat_terrain"])
-def test_sphere_static_contact_dedup(surface_kind, show_viewer):
-    # Sphere at rest on a flat surface has a single physical contact point. Every multi-contact perturbation
-    # path (analytical sphere-box, MPR convex-convex, MPR terrain over prisms) generates several candidate
-    # samples around that point and is supposed to dedup them before storage. Regression check: after the
-    # sphere has settled, only one contact must remain.
+def test_contact_dedup(surface_kind, show_viewer):
     SPHERE_RADIUS = 0.05
     GROUND_SIZE = 1.0
 
     scene = gs.Scene(
-        sim_options=gs.options.SimOptions(dt=0.005),
+        sim_options=gs.options.SimOptions(
+            dt=0.005,
+        ),
         show_viewer=show_viewer,
     )
     if surface_kind == "primitive_box":
@@ -1332,19 +1331,23 @@ def test_sphere_static_contact_dedup(surface_kind, show_viewer):
                 pos=(-0.8, -0.8, 0.0),
             ),
         )
-    scene.add_entity(
-        morph=gs.morphs.Sphere(
-            radius=SPHERE_RADIUS,
-            pos=(0.0, 0.0, SPHERE_RADIUS + 1e-4),
+    sphere = scene.add_entity(
+        morph=gs.morphs.MeshSet(
+            files=(trimesh.creation.icosphere(radius=SPHERE_RADIUS, subdivisions=3),),
+            pos=(0.0, 0.0, SPHERE_RADIUS - 1e-4),
+            decimate=False,
         ),
+        vis_mode="collision",
+        visualize_contact=True,
     )
     scene.build()
 
-    for _ in range(10):
+    for i in range(80):
         scene.step()
-
-    n_contacts = int(scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()[0])
-    assert n_contacts == 1, f"Expected 1 contact after dedup, got {n_contacts}"
+        if i == 20:
+            sphere.set_dofs_velocity(0.2, dofs_idx_local=sphere.dof_start)
+        n_contacts = scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()
+        assert np.all(n_contacts == 1), f"Expected 1 contact after dedup, got {n_contacts}"
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/test_rigid_physics_analytical_vs_gjk.py
+++ b/tests/test_rigid_physics_analytical_vs_gjk.py
@@ -271,6 +271,9 @@ def create_modified_narrowphase_file(tmp_path: Path):
     # Disable sphere-capsule analytical path in all kernels
     lines = find_and_disable_all_conditions(lines, "capsule_contact.func_sphere_capsule_contact")
 
+    # Disable sphere-box analytical path in all kernels
+    lines = find_and_disable_all_conditions(lines, "func_sphere_box_contact")
+
     # Insert errno marker in contact0's GJK path (before gjk.func_gjk call, uses i_b)
     lines = insert_errno_before_call(lines, "gjk.func_gjk(", ERRNO_CALLED_GJK_K1, "MODIFIED: GJK detection in contact0")
 
@@ -633,6 +636,40 @@ def create_sphere_mjcf(name, pos, radius):
     return mjcf
 
 
+def create_box_mjcf(name, pos, euler, size):
+    """Helper function to create an MJCF file with a single box (full-size, axis-aligned in local frame)."""
+    mjcf = ET.Element("mujoco", model=name)
+    ET.SubElement(mjcf, "compiler", angle="degree")
+    ET.SubElement(mjcf, "option", timestep="0.01")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    body = ET.SubElement(
+        worldbody,
+        "body",
+        name=name,
+        pos=f"{pos[0]} {pos[1]} {pos[2]}",
+        euler=f"{euler[0]} {euler[1]} {euler[2]}",
+    )
+    half = (0.5 * size[0], 0.5 * size[1], 0.5 * size[2])
+    ET.SubElement(body, "geom", type="box", size=f"{half[0]} {half[1]} {half[2]}")
+    ET.SubElement(body, "joint", name=f"{name}_joint", type="free")
+    return mjcf
+
+
+def scene_add_box(tmp_path: Path, scene: gs.Scene, size) -> "RigidEntity":
+    box_mjcf = create_box_mjcf("box", (0, 0, 0), (0, 0, 0), size)
+    box_path = tmp_path / "box.xml"
+    ET.ElementTree(box_mjcf).write(box_path)
+    entity_box = scene.add_entity(
+        gs.morphs.MJCF(
+            file=box_path,
+            align=False,
+        ),
+        vis_mode="collision",
+        visualize_contact=True,
+    )
+    return cast("RigidEntity", entity_box)
+
+
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_sphere_capsule_vs_gjk(backend, monkeypatch, tmp_path: Path, show_viewer: bool) -> None:
@@ -762,6 +799,148 @@ def test_sphere_capsule_vs_gjk(backend, monkeypatch, tmp_path: Path, show_viewer
                 f"Backend: {backend}\n"
                 f"Sphere radius: {sphere_radius}\n"
                 f"Capsule radius: {capsule_radius}, Half-length: {capsule_half_length}\n"
+            ) from e
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
+def test_sphere_box_vs_gjk(backend, monkeypatch, tmp_path: Path, show_viewer: bool) -> None:
+    sphere_radius = 0.1
+    box_size = (0.4, 0.4, 0.2)
+    half = (0.5 * box_size[0], 0.5 * box_size[1], 0.5 * box_size[2])
+
+    test_cases = [
+        # (sphere_pos, box_pos, box_euler, should_collide, description, exp_pen, exp_normal)
+        # Sphere directly above top face by 0.05 -> dist 0.05, pen = 0.05, normal +z
+        ((0, 0, half[2] + sphere_radius - 0.05), (0, 0, 0), (0, 0, 0), True, "top_face_center", 0.05, (0, 0, 1)),
+        # Sphere off-center above top face, just touching -> shallow contact, normal must be +z
+        # This is the issue #2793 regression scenario
+        (
+            (0.05, 0.05, half[2] + sphere_radius - 1e-4),
+            (0, 0, 0),
+            (0, 0, 0),
+            True,
+            "shallow_top_offcenter",
+            1e-4,
+            (0, 0, 1),
+        ),
+        # Sphere just outside the +x +y +z corner (AABB overlaps but no actual contact)
+        # Corner = (half[0], half[1], half[2]); offset along (1,1,1)*sphere_radius*0.7 from corner
+        (
+            (half[0] + 0.7 * sphere_radius, half[1] + 0.7 * sphere_radius, half[2] + 0.7 * sphere_radius),
+            (0, 0, 0),
+            (0, 0, 0),
+            False,
+            "near_corner_no_contact",
+            None,
+            None,
+        ),
+        # Sphere off the +x face -> normal +x, pen = 0.04
+        ((half[0] + sphere_radius - 0.04, 0, 0), (0, 0, 0), (0, 0, 0), True, "x_face", 0.04, (1, 0, 0)),
+        # Sphere off the -y face -> normal -y, pen = 0.03
+        ((0, -(half[1] + sphere_radius - 0.03), 0), (0, 0, 0), (0, 0, 0), True, "ny_face", 0.03, (0, -1, 0)),
+        # Sphere near a +x +z edge: closest point is the edge, normal along the diagonal
+        # closest = (half[0], 0, half[2]) -> diff = (0.06, 0, 0.08), dist = 0.1, pen = 0
+        # offset diff to (0.06*0.5, 0, 0.08*0.5) so the sphere has pen
+        ((half[0] + 0.03, 0, half[2] + 0.04), (0, 0, 0), (0, 0, 0), True, "edge_x_z", 0.05, (3, 0, 4)),
+        # Box rotated 45 deg around z -- still axis-aligned in own frame; sphere above
+        ((0, 0, half[2] + sphere_radius - 0.05), (0, 0, 0), (0, 0, 45), True, "top_rotated_z", 0.05, (0, 0, 1)),
+        # Box rotated 90 deg around y -> original local +x face is now world +z
+        # Sphere above world origin -> contact with face that was +x in local frame
+        (
+            (0, 0, half[0] + sphere_radius - 0.05),
+            (0, 0, 0),
+            (0, 90, 0),
+            True,
+            "top_rotated_y90",
+            0.05,
+            (0, 0, 1),
+        ),
+    ]
+
+    def build_scene(scene: gs.Scene, tmp_path: Path, entities: list) -> None:
+        entities.append(scene_add_sphere(tmp_path, scene, radius=sphere_radius))
+        entities.append(scene_add_box(tmp_path, scene, size=box_size))
+        scene.build()
+
+    scene_creator = AnalyticalVsGJKSceneCreator(
+        monkeypatch=monkeypatch,
+        build_scene=build_scene,
+        tmp_path=tmp_path,
+        show_viewer=show_viewer,
+    )
+    scene_analytical, scene_gjk = scene_creator.setup_scenes()
+    assert scene_analytical.rigid_solver.collider is not None
+    assert scene_gjk.rigid_solver.collider is not None
+
+    analytical_results = {}
+    for sphere_pos, box_pos, box_euler, should_collide, description, exp_pen, exp_normal in test_cases:
+        try:
+            scene_creator.update_pos_quat_analytical(entity_idx=0, pos=sphere_pos, euler=[0, 0, 0])
+            scene_creator.update_pos_quat_analytical(entity_idx=1, pos=box_pos, euler=box_euler)
+            scene_creator.step_analytical()
+
+            contacts = scene_analytical.rigid_solver.collider.get_contacts(as_tensor=False, to_torch=False)
+            has_collision = len(contacts["geom_a"]) > 0
+            assert has_collision == should_collide, "Analytical collision mismatch"
+            _check_expected_values(
+                contacts, description, exp_pen, exp_normal, "analytical", ANALYTICAL_PEN_TOL, ANALYTICAL_NORMAL_TOL
+            )
+            analytical_results[description] = copy.deepcopy(contacts)
+        except AssertionError as e:
+            raise AssertionError(
+                f"\nFAILED TEST SCENARIO (analytical phase): {description}\n"
+                f"Sphere: pos={sphere_pos}\n"
+                f"Box: pos={box_pos}, euler={box_euler}\n"
+                f"Expected collision: {should_collide}\n"
+                f"Backend: {backend}\n"
+                f"Sphere radius: {sphere_radius}\n"
+                f"Box size: {box_size}\n"
+            ) from e
+
+    scene_creator.apply_gjk_patch()
+
+    for sphere_pos, box_pos, box_euler, should_collide, description, exp_pen, exp_normal in test_cases:
+        try:
+            scene_creator.update_pos_quat_gjk(entity_idx=0, pos=sphere_pos, euler=[0, 0, 0])
+            scene_creator.update_pos_quat_gjk(entity_idx=1, pos=box_pos, euler=box_euler)
+            scene_creator.step_gjk(should_collide)
+
+            contacts_gjk = scene_gjk.rigid_solver.collider.get_contacts(as_tensor=False, to_torch=False)
+            contacts_analytical = analytical_results[description]
+
+            has_collision_analytical = len(contacts_analytical["geom_a"]) > 0
+            has_collision_gjk = len(contacts_gjk["geom_a"]) > 0
+
+            assert has_collision_analytical == has_collision_gjk, "Collision detection mismatch!"
+            assert has_collision_gjk == should_collide
+
+            _check_expected_values(contacts_gjk, description, exp_pen, exp_normal, "GJK", GJK_PEN_TOL, GJK_NORMAL_TOL)
+
+            if has_collision_analytical and has_collision_gjk:
+                pen_analytical = contacts_analytical["penetration"][0]
+                pen_gjk = contacts_gjk["penetration"][0]
+
+                normal_analytical = np.array(contacts_analytical["normal"][0])
+                normal_gjk = np.array(contacts_gjk["normal"][0])
+
+                pos_analytical = np.array(contacts_analytical["position"][0])
+                pos_gjk = np.array(contacts_gjk["position"][0])
+                assert_allclose(pen_analytical, pen_gjk, atol=POS_TOL, rtol=0.1, err_msg="Penetration mismatch!")
+
+                normal_agreement = abs(np.dot(normal_analytical, normal_gjk))
+                assert normal_agreement > 0.95, "Normal mismatch!"
+
+                assert_allclose(pos_analytical, pos_gjk, tol=POS_TOL)
+        except AssertionError as e:
+            raise AssertionError(
+                f"\nFAILED TEST SCENARIO (GJK phase): {description}\n"
+                f"Sphere: pos={sphere_pos}\n"
+                f"Box: pos={box_pos}, euler={box_euler}\n"
+                f"Expected collision: {should_collide}\n"
+                f"Backend: {backend}\n"
+                f"Sphere radius: {sphere_radius}\n"
+                f"Box size: {box_size}\n"
             ) from e
 
 


### PR DESCRIPTION
## Description

Small smooth primitives (sphere, capsule, ellipsoid) resting on a fixed box drift tangentially over time instead of staying put. The drift is driven by a position-dependent bias in the contact position returned by MPR/GJK on shallow contacts: the lever arm between the contact and the smooth body's centre acquires a small spurious component, the constraint force creates a torque, and the resulting rolling becomes translation.

This PR adds a post-CCD analytical reconstruction of the contact position on the smooth side of any contact. Given the CCD-returned normal and penetration, the smooth-side surface point is computed in closed form and the contact position is set to the midpoint between that surface point and the implicit polytope-side surface.

It is idempotent on the existing analytical paths (sphere-box, sphere-capsule, capsule-capsule) and skipped under mujoco compatibility mode.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#2793

## Motivation and Context

The reporter described a small sphere (radius 2.5 mm) placed off-centre on a fixed box rolling away over a few hundred steps. The root cause is the same iterative-CCD position bias regardless of whether MPR or GJK is in use, and it shows up on any smooth-vs-polytope contact.

## How Has This Been / Can This Be Tested?

New parametrized regression test `test_smooth_box_no_drift` in `tests/test_rigid_physics.py` covers sphere / capsule / ellipsoid (primitive and mesh box, MPR and GJK) with a 50-degree tilted box, batched over 16 envs.

## Checklist:

- [x] I read the CONTRIBUTING document.
- [x] I followed the Submitting Code Changes section of CONTRIBUTING document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.