### PR TITLE
[BUG FIX] Reorder elastomer taxel FFT dilate after qd accumulate kernel.

### DIFF
--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -1771,18 +1771,6 @@ class ElastomerTaxelSensor(
             solver.collider._sdf._sdf_info,
             shared_metadata.probe_depth_buf,
         )
-        _elastomer_taxel_grid_fft_dilate(
-            shared_metadata.fft_grid_meta,
-            shared_metadata.fft_grid_kernels_stacked,
-            shared_metadata.probe_depth_buf,
-            shared_metadata.fft_depth_buffer,
-            shared_metadata.dilate_scale,
-            shared_metadata.grid_normal,
-            shared_metadata.grid_tangent_u,
-            shared_metadata.grid_tangent_v,
-            shared_metadata.grid_dilate_out_buffer,
-            current_ground_truth_data_T,
-        )
         _kernel_elastomer_dilate_accumulate(
             shared_metadata.use_grid_fft,
             shared_metadata.probe_positions,
@@ -1794,6 +1782,20 @@ class ElastomerTaxelSensor(
             shared_metadata.lambda_d,
             shared_metadata.dilate_scale,
             shared_metadata.probe_depth_buf,
+            current_ground_truth_data_T,
+        )
+        # FFT runs after the qd dilate kernel: on Metal, write-only kernel outputs zero unwritten slots on copy-back,
+        # which would erase the grid range the FFT just wrote.
+        _elastomer_taxel_grid_fft_dilate(
+            shared_metadata.fft_grid_meta,
+            shared_metadata.fft_grid_kernels_stacked,
+            shared_metadata.probe_depth_buf,
+            shared_metadata.fft_depth_buffer,
+            shared_metadata.dilate_scale,
+            shared_metadata.grid_normal,
+            shared_metadata.grid_tangent_u,
+            shared_metadata.grid_tangent_v,
+            shared_metadata.grid_dilate_out_buffer,
             current_ground_truth_data_T,
         )
         if shared_metadata.any_shear:


### PR DESCRIPTION
## Description

Swap the order of the two dilate-phase calls in `ElastomerTaxelSensor._update_current_timestep_data`: run the qd `_kernel_elastomer_dilate_accumulate` first, then the torch FFT path `_elastomer_taxel_grid_fft_dilate`.

## Related Issue

Follow-up to #2800 (CI failure on the Apple Metal job).

## Motivation and Context

In #2800, grid-detected `ElastomerTaxel` sensors are dilated via an FFT torch path while non-grid sensors stay on a qd kernel. Both write disjoint ranges of the same `current_ground_truth_data_T` tensor, and the kernel uses `if use_grid_fft[i_s]: continue` so that grid sensors' cache slots are not touched.

That ordering works on CUDA and CPU because the qd kernel writes the torch tensor in place: positions no thread touches are simply left alone, and the FFT range survives the kernel call.

It does not work on Apple Metal. `_kernel_elastomer_dilate_accumulate` writes `output[i] = acc[k]` with no read of `output` anywhere, so quadrants treats the output as write-only: a staged buffer is allocated for the kernel, threads write into it, and the staged buffer is then copied back over the torch tensor. Slots no thread wrote (the grid-sensor range) come back as zeros, clobbering the FFT result that was written just before.

This shows up as `test_elastomer_sensor_grid_box_sphere` failing on Metal with the grid sensor returning all-zeros while the flat sensor returns the expected small non-zero values:

```
[BEFORE-ACC] output[0:192] sum: 0.0592   # FFT-written grid range
[AFTER-ACC ] output[0:192] sum: 0.0      # zeroed by kernel write-back
[AFTER-ACC ] output[192:384] sum: 0.0592 # non-grid range written correctly
```

The shear kernel right after does not have the same problem because it is a read-modify-write (`output[i] = output[i] + acc[k]`), which forces quadrants to bind `output` as read-write and preserves skipped slots. Verified by printing the FFT range sum before and after the shear call: unchanged on both Metal and CUDA.

Reordering so the FFT runs after the qd kernel makes the FFT the last writer to the grid range on every backend, with no other behavior change.

## How Has This Been / Can This Be Tested?

Reproduced the original failure on Apple Metal (M4 Max, torch 2.10) with:

```
pytest -xsv -n 0 --backend gpu "tests/test_sensors.py::test_elastomer_sensor_grid_box_sphere[0]"
```

With the reorder, the following pass locally on Metal:

- `tests/test_sensors.py::test_elastomer_sensor_grid_box_sphere[0,2]`
- `tests/test_sensors.py::test_elastomer_sensor_sphere_ground_dilate_shear[0,2]`

CUDA/CPU behavior is unchanged because both paths still target the same disjoint ranges.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.