### PR TITLE
[BUG FIX] Fix collision non-convex vs any for watertight geometries.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -127,19 +127,22 @@ class RigidGeom(RBC):
         self.vert_n_neighbors = np.array(tuple(map(len, all_vert_neighbors_list)), dtype=gs.np_int)
         self.vert_neighbor_start = np.array((0, *np.cumsum(self.vert_n_neighbors)[:-1]), dtype=gs.np_int)
 
-        # NOTE: sdf size is from the center of the lower voxel cell to the center of the upper voxel cell
-        # add padding. Adjust the cell size to keep resolution within bounds.
+        # NOTE: sdf size is from the center of the lower voxel cell to the center of the upper voxel cell. Add
+        # padding. The cell size is anisotropic - each axis is sized independently to its own extent - so a thin
+        # slab gets fine resolution perpendicular to its surface without bloating the cell count along the long axes
+        # (which a uniform `grid_size.max() / sdf_max_res` cell size would force, leaving primitive-vs-mesh contacts
+        # noisy when the primitive's smallest dimension is below the cell size).
         padding_ratio = 0.2
         lower = self._init_verts.min(axis=0)
         upper = self._init_verts.max(axis=0)
         grid_size = (upper - lower).max() * padding_ratio + (upper - lower)
-        self._sdf_cell_size = gs.EPS + np.clip(
-            self._material.sdf_cell_size,
-            grid_size.max() / (self._material.sdf_max_res - 1),
-            grid_size.min() / max(self._material.sdf_min_res - 1, 2),
-        )
+        per_axis_lower = grid_size / (self._material.sdf_max_res - 1)
+        per_axis_upper = grid_size / max(self._material.sdf_min_res - 1, 2)
+        self._sdf_cell_size = gs.EPS + np.clip(self._material.sdf_cell_size, per_axis_lower, per_axis_upper)
         self._sdf_res = np.ceil(grid_size / self._sdf_cell_size).astype(gs.np_int) + 1
-        self._sdf_grad_delta = 0.0 if self.type == gs.GEOM_TYPE.TERRAIN else self._sdf_cell_size * 1e-2
+        self._sdf_grad_delta = (
+            np.zeros(3, dtype=gs.np_float) if self.type == gs.GEOM_TYPE.TERRAIN else self._sdf_cell_size * 1e-2
+        )
         self._is_preprocessed = False
 
     def _build(self):
@@ -244,16 +247,19 @@ class RigidGeom(RBC):
 
     def _compute_sd_grad(self, query_points, delta=5e-4):
         ######## sdf gradient via finite differencing ########
-        sd_val_xpos = self._compute_sd(query_points + np.array((delta, 0.0, 0.0), dtype=gs.np_float))
-        sd_val_xneg = self._compute_sd(query_points - np.array((delta, 0.0, 0.0), dtype=gs.np_float))
-        sd_val_ypos = self._compute_sd(query_points + np.array((0.0, delta, 0.0), dtype=gs.np_float))
-        sd_val_yneg = self._compute_sd(query_points - np.array((0.0, delta, 0.0), dtype=gs.np_float))
-        sd_val_zpos = self._compute_sd(query_points + np.array((0.0, 0.0, delta), dtype=gs.np_float))
-        sd_val_zneg = self._compute_sd(query_points - np.array((0.0, 0.0, delta), dtype=gs.np_float))
+        # `delta` can be a scalar or a per-axis array (anisotropic SDF cells).
+        delta_arr = np.broadcast_to(np.asarray(delta, dtype=gs.np_float), (3,))
+        dx, dy, dz = float(delta_arr[0]), float(delta_arr[1]), float(delta_arr[2])
+        sd_val_xpos = self._compute_sd(query_points + np.array((dx, 0.0, 0.0), dtype=gs.np_float))
+        sd_val_xneg = self._compute_sd(query_points - np.array((dx, 0.0, 0.0), dtype=gs.np_float))
+        sd_val_ypos = self._compute_sd(query_points + np.array((0.0, dy, 0.0), dtype=gs.np_float))
+        sd_val_yneg = self._compute_sd(query_points - np.array((0.0, dy, 0.0), dtype=gs.np_float))
+        sd_val_zpos = self._compute_sd(query_points + np.array((0.0, 0.0, dz), dtype=gs.np_float))
+        sd_val_zneg = self._compute_sd(query_points - np.array((0.0, 0.0, dz), dtype=gs.np_float))
 
-        sd_grad_x = (sd_val_xpos - sd_val_xneg) / (2 * delta)
-        sd_grad_y = (sd_val_ypos - sd_val_yneg) / (2 * delta)
-        sd_grad_z = (sd_val_zpos - sd_val_zneg) / (2 * delta)
+        sd_grad_x = (sd_val_xpos - sd_val_xneg) / (2 * dx)
+        sd_grad_y = (sd_val_ypos - sd_val_yneg) / (2 * dy)
+        sd_grad_z = (sd_val_zpos - sd_val_zneg) / (2 * dz)
         sd_grad = np.stack([sd_grad_x, sd_grad_y, sd_grad_z], -1)
         return sd_grad
 

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -108,13 +108,24 @@ def func_contact_vertex_sdf(
                 penetration = new_penetration
 
     if is_col:
-        # Compute contact normal only once, and only in case of contact, then shift contact_pos to the midpoint
-        # between A's surface (the iterated vertex) and B's surface.
+        # Sample B's SDF gradient at A's geometric center when A is a convex geom (primitive or convexified mesh). For
+        # any convex shape the centroid of its vertices is by construction inside its hull, so the sampling point sits
+        # deep inside A's surface and several SDF cells away from B's zero-isosurface in this post-penetration
+        # configuration; the tri-linear interpolation of B's gradient there is dominated by the smooth interior and not
+        # by the cell-aligned noise that contaminates the gradient evaluated at the deepest iterated vertex. Without
+        # this override the contact normal acquires a tangential component that flips frame to frame as the deepest
+        # vertex migrates between neighbouring tessellated points, driving spheres at rest into a ~m/s vertical jitter
+        # and a slow lateral drift. We use `geoms_info.center` - already populated and used by MPR for the same
+        # purpose - rather than A's frame origin so the property generalises beyond primitives whose modeller happened
+        # to centre the pivot.
+        center_a = gu.qd_transform_by_trans_quat(geoms_info.center[i_ga], ga_pos, ga_quat)
+        normal_sample = center_a if geoms_info.is_convex[i_ga] else contact_pos
         normal = sdf.sdf_func_normal_world_local(
-            geoms_info, rigid_global_info, collider_static_config, sdf_info, contact_pos, i_gb, gb_pos, gb_quat
+            geoms_info, rigid_global_info, collider_static_config, sdf_info, normal_sample, i_gb, gb_pos, gb_quat
         )
 
-        # The contact point must be offsetted by half the penetration depth
+        # Shift contact_pos from the deepest vertex (interior side) by half the penetration along the outward normal
+        # so it lands at the midpoint between A's surface and B's surface.
         contact_pos = contact_pos + 0.5 * penetration * normal
 
     return is_col, normal, penetration, contact_pos
@@ -144,7 +155,10 @@ def func_contact_edge_sdf(
     normal = qd.Vector.zero(gs.qd_float, 3)
     contact_pos = qd.Vector.zero(gs.qd_float, 3)
 
-    ga_sdf_cell_size = sdf_info.geoms_info.sdf_cell_size[i_ga]
+    # Use the smallest per-axis cell size as the edge-length threshold so we still subdivide edges that are short
+    # relative to the finest grid resolution available.
+    ga_sdf_cell_size_vec = sdf_info.geoms_info.sdf_cell_size[i_ga]
+    ga_sdf_cell_size = qd.min(qd.min(ga_sdf_cell_size_vec[0], ga_sdf_cell_size_vec[1]), ga_sdf_cell_size_vec[2])
 
     for i_e in range(geoms_info.edge_start[i_ga], geoms_info.edge_end[i_ga]):
         cur_length = edges_info.length[i_e]
@@ -309,7 +323,10 @@ def func_contact_convex_convex_sdf(
                 # check if closest point is between the two points
                 if sdf_grad_0_b.dot(vec_01) < 0 and sdf_grad_1_b.dot(vec_01) > 0:
                     cur_length = (p_1 - p_0).norm()
-                    ga_sdf_cell_size = sdf_info.geoms_info.sdf_cell_size[i_ga]
+                    ga_sdf_cell_size_vec = sdf_info.geoms_info.sdf_cell_size[i_ga]
+                    ga_sdf_cell_size = qd.min(
+                        qd.min(ga_sdf_cell_size_vec[0], ga_sdf_cell_size_vec[1]), ga_sdf_cell_size_vec[2]
+                    )
                     while cur_length > ga_sdf_cell_size:
                         p_mid = 0.5 * (p_0 + p_1)
                         side = sdf.sdf_func_grad_world(
@@ -2535,10 +2552,18 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                     not (geoms_info.is_convex[i_ga] and geoms_info.is_convex[i_gb])
                     and geoms_info.type[i_gb] != gs.GEOM_TYPE.TERRAIN
                 ):
+                    # Canonical ordering: ascending type so smooth primitives sit on the A side. The smooth-contact
+                    # refinement helper assumes this; without the swap, refinement on the mesh-as-A pair side would
+                    # feed sphere data through the type_b branch with -normal, silently inverting the position
+                    # correction. Mirrors the swap done at the head of the convex-vs-convex narrowphase.
+                    if geoms_info.type[i_ga] > geoms_info.type[i_gb]:
+                        i_ga, i_gb = i_gb, i_ga
+
                     is_col = False
                     tolerance = func_compute_tolerance(
                         i_ga, i_gb, i_b, collider_info.mc_tolerance[None], geoms_info, geoms_init_AABB
                     )
+
                     for i in range(2):
                         if i == 1:
                             i_ga, i_gb = i_gb, i_ga
@@ -2595,9 +2620,10 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                     collider_info,
                                     errno,
                                 )
+                                is_col = True
 
                         if qd.static(static_rigid_sim_config.enable_multi_contact):
-                            if not is_col and is_col_i:
+                            if is_col_i:
                                 ga_pos_original, ga_quat_original = (
                                     geoms_state.pos[i_ga, i_b],
                                     geoms_state.quat[i_ga, i_b],
@@ -2636,7 +2662,7 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                         gb_pos_original, gb_quat_original, contact_pos_i, gu.qd_inv_quat(qrot)
                                     )
 
-                                    is_col, normal, penetration, contact_pos = func_contact_vertex_sdf(
+                                    is_col_mc, normal, penetration, contact_pos = func_contact_vertex_sdf(
                                         i_ga,
                                         i_gb,
                                         i_b,
@@ -2652,7 +2678,7 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                         sdf_info,
                                     )
 
-                                    if is_col:
+                                    if is_col_mc:
                                         contact_pos = func_apply_smooth_refinement(
                                             i_ga,
                                             i_gb,

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1316,7 +1316,7 @@ def get_sdf_geom_info(n_geoms):
         T_mesh_to_sdf=V_MAT(n=4, m=4, dtype=gs.qd_float, shape=(n_geoms,)),
         sdf_res=V_VEC(3, dtype=gs.qd_int, shape=(n_geoms,)),
         sdf_max=V(dtype=gs.qd_float, shape=(n_geoms,)),
-        sdf_cell_size=V(dtype=gs.qd_float, shape=(n_geoms,)),
+        sdf_cell_size=V_VEC(3, dtype=gs.qd_float, shape=(n_geoms,)),
         sdf_cell_start=V(dtype=gs.qd_int, shape=(n_geoms,)),
     )
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -122,7 +122,10 @@ def get_asset_path(file):
 
 
 def get_gsd_path(verts, faces, sdf_cell_size, sdf_min_res, sdf_max_res):
-    hashkey = get_hashkey(verts, faces, sdf_cell_size, sdf_min_res, sdf_max_res)
+    # Schema tag bumped when the on-disk SDF layout changes (e.g. scalar -> per-axis cell size).
+    # Forces a cache miss on stale entries written by older code without manually clearing the cache.
+    schema = "v2-anisotropic-cells"
+    hashkey = get_hashkey(verts, faces, sdf_cell_size, sdf_min_res, sdf_max_res, schema)
     return os.path.join(get_gsd_cache_dir(), f"{hashkey}.gsd")
 
 

--- a/genesis/utils/sdf.py
+++ b/genesis/utils/sdf.py
@@ -25,7 +25,10 @@ class SDF:
                 geoms_sdf_val=np.concatenate([geom.sdf_val_flattened for geom in geoms], dtype=gs.np_float),
                 geoms_sdf_grad=np.concatenate([geom.sdf_grad_flattened for geom in geoms], dtype=gs.np_float),
                 geoms_sdf_max=np.array([geom.sdf_max for geom in geoms], dtype=gs.np_float),
-                geoms_sdf_cell_size=np.array([geom.sdf_cell_size for geom in geoms], dtype=gs.np_float),
+                geoms_sdf_cell_size=np.array(
+                    [np.broadcast_to(np.asarray(geom.sdf_cell_size, dtype=gs.np_float), (3,)) for geom in geoms],
+                    dtype=gs.np_float,
+                ),
                 geoms_sdf_closest_vert=np.concatenate(
                     [geom.sdf_closest_vert_flattened for geom in geoms], dtype=gs.np_int
                 ),
@@ -66,7 +69,8 @@ def sdf_kernel_init_geom_fields(
 
         sdf_info.geoms_info.sdf_cell_start[i] = geoms_sdf_cell_start[i]
         sdf_info.geoms_info.sdf_max[i] = geoms_sdf_max[i]
-        sdf_info.geoms_info.sdf_cell_size[i] = geoms_sdf_cell_size[i]
+        for j in qd.static(range(3)):
+            sdf_info.geoms_info.sdf_cell_size[i][j] = geoms_sdf_cell_size[i, j]
 
     for i in range(n_cells):
         sdf_info.geoms_sdf_val[i] = geoms_sdf_val[i]
@@ -156,11 +160,17 @@ def sdf_func_is_outside_sdf_grid(sdf_info: array_class.SDFInfo, pos_sdf, geom_id
 @qd.func
 def sdf_func_proxy_sdf(sdf_info: array_class.SDFInfo, pos_sdf, geom_idx):
     """
-    Use distance to center as a proxy sdf, strictly greater than any point inside the cube to ensure value comparison is valid. Only considers region outside of cube.
+    Use distance to center as a proxy sdf, strictly greater than any point inside the cube to ensure value comparison
+    is valid.
+
+    Only considers region outside of cube. For anisotropic SDF grids the per-axis cell sizes are applied before taking
+    the norm so the result remains a world distance.
     """
     center = (sdf_info.geoms_info.sdf_res[geom_idx] - 1) / 2.0
-    sd = (pos_sdf - center).norm() / sdf_info.geoms_info.sdf_cell_size[geom_idx]
-    return sd + sdf_info.geoms_info.sdf_max[geom_idx]
+    delta = pos_sdf - center
+    cs = sdf_info.geoms_info.sdf_cell_size[geom_idx]
+    scaled = qd.Vector([delta[0] * cs[0], delta[1] * cs[1], delta[2] * cs[2]], dt=gs.qd_float)
+    return scaled.norm() + sdf_info.geoms_info.sdf_max[geom_idx]
 
 
 @qd.func
@@ -230,6 +240,7 @@ def sdf_func_grad(
 ):
     """
     sdf grad at sdf frame coordinate.
+
     Note that the stored sdf magnitude is already w.r.t world/mesh frame.
     """
     grad_sdf = qd.Vector.zero(gs.qd_float, 3)
@@ -245,11 +256,19 @@ def sdf_func_proxy_grad(
     rigid_global_info: array_class.RigidGlobalInfo, sdf_info: array_class.SDFInfo, pos_sdf, geom_idx
 ):
     """
-    Use direction to sdf center to approximate gradient direction.
-    Only considers region outside of cube.
+    Use direction from sdf center, scaled per-axis by the anisotropic cell size, to approximate the gradient
+    direction outside the cube.
+
+    The matching :func:`sdf_func_proxy_sdf` distance is `||(pos_sdf - center) * cs||` in world units, whose gradient
+    direction (after the chain rule for the diagonal SDF<->mesh transform) is the per-axis-scaled delta. Using the raw
+    `pos_sdf - center` would skew outside-grid normals toward fine-resolution axes on anisotropic grids and yield
+    directionally wrong contact normals for points falling back on this proxy.
     """
     center = (sdf_info.geoms_info.sdf_res[geom_idx] - 1) / 2.0
-    proxy_sdf_grad = gu.qd_normalize(pos_sdf - center, rigid_global_info.EPS[None])
+    delta = pos_sdf - center
+    cs = sdf_info.geoms_info.sdf_cell_size[geom_idx]
+    scaled = qd.Vector([delta[0] * cs[0], delta[1] * cs[1], delta[2] * cs[2]], dt=gs.qd_float)
+    proxy_sdf_grad = gu.qd_normalize(scaled, rigid_global_info.EPS[None])
     return proxy_sdf_grad
 
 


### PR DESCRIPTION
* Add support of non-isotropic SDF cell for efficiency
* Fix broken multi-contact non-convex vs any

Related to https://github.com/Genesis-Embodied-AI/genesis-world/issues/925. Robust non-convex non-watertight mesh repair is still missing to fully close this issue.