### PR TITLE
[BUG FIX] Add iteration cap to mpr_refine_portal to prevent GPU hang

### DIFF
--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -246,6 +246,7 @@ def mpr_refine_portal(
     quat_b: qd.types.vector(4, dtype=gs.qd_float),
 ):
     ret = 1
+    iterations = 0
     while True:
         direction = mpr_portal_dir(mpr_state, i_ga, i_gb, i_b)
 
@@ -270,11 +271,12 @@ def mpr_refine_portal(
 
         if not mpr_portal_can_encapsule_origin(mpr_info, v, direction) or mpr_portal_reach_tolerance(
             mpr_state, mpr_info, v, direction, i_ga, i_gb, i_b
-        ):
+        ) or iterations > mpr_info.CCD_ITERATIONS[None]:
             ret = -1
             break
 
         mpr_expand_portal(mpr_state, v, v1, v2, i_ga, i_gb, i_b)
+        iterations += 1
     return ret
 
 


### PR DESCRIPTION
## Description
Fixes #2815

`mpr_refine_portal()` in the MPR collision detection algorithm had an unbounded `while True` loop running on GPU. When numerical edge cases prevent convergence, the loop runs forever, causing a GPU kernel hang that can escalate to a system-level crash.

Every other iterative function in the collider already has iteration caps (GJK: 50, EPA: 50, `mpr_find_penetration`: 50, `mpr_discover_portal`: 15 trials) — `mpr_refine_portal` was the only one missing.

## Changes
- Added `iterations = 0` before `while True`
- Added `iterations > mpr_info.CCD_ITERATIONS[None]` (50) as an exit condition
- Added `iterations += 1` after `mpr_expand_portal`

When the loop exits via iteration cap, `ret = -1` is returned, matching other failure paths. The caller already handles `res < 0` as non-collision.

## Verification
- All SPH tests pass (11/11)
- All rigid physics tests pass (excluding pre-existing `test_convexify` failure unrelated to this change)