### PR TITLE
[MISC] Speedup rigid solver for large dofs count (> ~128).

### DIFF
--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -492,7 +492,87 @@ def func_factor_mass(
         n_entities = entities_info.n_links.shape[0]
         _B = dofs_state.ctrl_mode.shape[1]
 
-        if qd.static(
+        if qd.static(static_rigid_sim_config.enable_tiled_cholesky_mass_matrix_large):
+            # Uncapped cooperative per-entity LDL^T (max_n_dofs_per_entity > max_n_threads). Factors the entity
+            # mass submatrix in-place in global memory (mass_mat_L), cooperatively over a block of BLOCK_DIM
+            # threads. Each elimination step snapshots the pivot row into a small shared vector (O(n_dofs), not
+            # O(n_dofs^2)) BEFORE updating the trailing submatrix, so the parallel row updates only ever READ
+            # the pivot row (from shared) -- race-free regardless of thread scheduling. Numerically identical to
+            # the scalar branch below; only the parallelization (and lack of an O(n_dofs^2) shared array) differs.
+            BLOCK_DIM = qd.static(32)
+            MAX_DOFS_PER_ENTITY = qd.static(static_rigid_sim_config.tiled_n_dofs_per_entity_large)
+
+            qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
+            for i in range(n_entities * _B * BLOCK_DIM):
+                tid = i % BLOCK_DIM
+                i_e = (i // BLOCK_DIM) % n_entities
+                i_b = i // (BLOCK_DIM * n_entities)
+                if i_b >= _B:
+                    continue
+
+                if rigid_global_info.mass_mat_mask[i_e, i_b]:
+                    entity_dof_start = entities_info.dof_start[i_e]
+                    entity_dof_end = entities_info.dof_end[i_e]
+                    n_dofs = entities_info.n_dofs[i_e]
+
+                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_ENTITY,), gs.qd_float)
+
+                    # Copy the lower triangle of M into mass_mat_L (+ implicit damping on the diagonal), cooperatively.
+                    i_d_ = tid
+                    while i_d_ < n_dofs:
+                        i_d = entity_dof_start + i_d_
+                        for j_d in range(entity_dof_start, i_d + 1):
+                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
+                        if qd.static(implicit_damping):
+                            I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
+                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
+                            )
+                            if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                                if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                    rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
+                                        rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                        - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                    )
+                        i_d_ = i_d_ + BLOCK_DIM
+                    qd.simt.block.sync()
+
+                    # In-place LDL^T, eliminating dofs from last to first (matches the scalar branch).
+                    for j in range(n_dofs):
+                        i_d_ = n_dofs - j - 1
+                        i_d = entity_dof_end - j - 1
+                        D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                        if tid == 0:
+                            rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
+
+                        # Phase A: snapshot the (Schur-updated) pivot-row entries below the diagonal into shared.
+                        j_d_ = tid
+                        while j_d_ < i_d_:
+                            pivot_row[j_d_] = rigid_global_info.mass_mat_L[i_d, entity_dof_start + j_d_, i_b]
+                            j_d_ = j_d_ + BLOCK_DIM
+                        qd.simt.block.sync()
+
+                        # Phase B: each lane eliminates one column j_d, updating its own row j_d of the trailing
+                        # submatrix from the read-only snapshot. Distinct rows per lane => no write conflicts, and
+                        # the pivot row is only read (from shared) => no read/write race on row i_d.
+                        j_d_ = tid
+                        while j_d_ < i_d_:
+                            a = pivot_row[j_d_] * D_inv
+                            j_d = entity_dof_start + j_d_
+                            for k_d_ in range(j_d_ + 1):
+                                rigid_global_info.mass_mat_L[j_d, entity_dof_start + k_d_, i_b] = (
+                                    rigid_global_info.mass_mat_L[j_d, entity_dof_start + k_d_, i_b]
+                                    - a * pivot_row[k_d_]
+                                )
+                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
+                            j_d_ = j_d_ + BLOCK_DIM
+                        qd.simt.block.sync()
+
+                        # Diagonal coeffs of L are ignored downstream (see scalar branch) but set to 1.0 to match.
+                        if tid == 0:
+                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
+        elif qd.static(
             not static_rigid_sim_config.enable_tiled_cholesky_mass_matrix or static_rigid_sim_config.backend == gs.cpu
         ):
             qd.loop_config(name="factor_mass", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL)

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -492,14 +492,17 @@ def func_factor_mass(
         n_entities = entities_info.n_links.shape[0]
         _B = dofs_state.ctrl_mode.shape[1]
 
-        if qd.static(static_rigid_sim_config.enable_tiled_cholesky_mass_matrix_large):
-            # Uncapped cooperative per-entity LDL^T (max_n_dofs_per_entity > max_n_threads): factors the entity mass
-            # submatrix in-place in global memory (mass_mat_L) over a block of BLOCK_DIM threads. Each elimination step
-            # snapshots the pivot row into a small shared vector (O(n_dofs), not O(n_dofs^2)) before updating the
+        if qd.static(
+            static_rigid_sim_config.enable_tiled_cholesky_mass_matrix
+            and not static_rigid_sim_config.mass_matrix_fits_shared
+        ):
+            # Uncapped cooperative per-entity LDL^T (entity submatrix does not fit shared memory): factors the entity
+            # mass submatrix in-place in global memory (mass_mat_L) over a block of BLOCK_DIM threads. Each elimination
+            # step snapshots the pivot row into a small shared vector (O(n_dofs), not O(n_dofs^2)) before updating the
             # trailing submatrix, so the parallel per-row updates only READ the pivot row (from shared) -- race-free
             # regardless of scheduling. Numerically identical to the scalar branch below; only parallelization differs.
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_ENTITY = qd.static(static_rigid_sim_config.tiled_n_dofs_per_entity_large)
+            MAX_DOFS_PER_ENTITY = qd.static(static_rigid_sim_config.tiled_n_dofs_per_entity)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
             for i in range(n_entities * _B * BLOCK_DIM):

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -493,12 +493,11 @@ def func_factor_mass(
         _B = dofs_state.ctrl_mode.shape[1]
 
         if qd.static(static_rigid_sim_config.enable_tiled_cholesky_mass_matrix_large):
-            # Uncapped cooperative per-entity LDL^T (max_n_dofs_per_entity > max_n_threads). Factors the entity
-            # mass submatrix in-place in global memory (mass_mat_L), cooperatively over a block of BLOCK_DIM
-            # threads. Each elimination step snapshots the pivot row into a small shared vector (O(n_dofs), not
-            # O(n_dofs^2)) BEFORE updating the trailing submatrix, so the parallel row updates only ever READ
-            # the pivot row (from shared) -- race-free regardless of thread scheduling. Numerically identical to
-            # the scalar branch below; only the parallelization (and lack of an O(n_dofs^2) shared array) differs.
+            # Uncapped cooperative per-entity LDL^T (max_n_dofs_per_entity > max_n_threads): factors the entity mass
+            # submatrix in-place in global memory (mass_mat_L) over a block of BLOCK_DIM threads. Each elimination step
+            # snapshots the pivot row into a small shared vector (O(n_dofs), not O(n_dofs^2)) before updating the
+            # trailing submatrix, so the parallel per-row updates only READ the pivot row (from shared) -- race-free
+            # regardless of scheduling. Numerically identical to the scalar branch below; only parallelization differs.
             BLOCK_DIM = qd.static(32)
             MAX_DOFS_PER_ENTITY = qd.static(static_rigid_sim_config.tiled_n_dofs_per_entity_large)
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -2193,6 +2193,15 @@ def func_hessian_and_cholesky_factor_direct(
             # ``func_update_gradient_tiled`` below); skipping the standalone factor here avoids doing the work twice.
             if qd.static(not static_rigid_sim_config.enable_fused_factor_solve_init):
                 func_cholesky_factor_direct_tiled(constraint_state, rigid_global_info, static_rigid_sim_config)
+        elif qd.static(static_rigid_sim_config.enable_tiled_cholesky_hessian_large):
+            # n_dofs > max_n_threads: the shared-memory tiled solve/fused kernels don't fit, but the
+            # standalone register-streaming tiled factor has no DOF limit. Use it instead of the scalar
+            # one-thread-per-env Cholesky (O(n_dofs**3) serial). The triangular solve stays on the scalar
+            # batch path (func_update_gradient_batch) since enable_tiled_cholesky_hessian is False here, and
+            # the per-iteration incremental rank-1 update remains scalar -- both read L from nt_H, which the
+            # tiled factor writes back. This removes the dominant serial factorization cost for high-DOF
+            # scenes (multi-humanoid, dexterous hands) while leaving low-DOF dispatch unchanged.
+            func_cholesky_factor_direct_tiled(constraint_state, rigid_global_info, static_rigid_sim_config)
         else:
             qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL, block_dim=32)
             for i_b in range(_B):

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -2189,19 +2189,14 @@ def func_hessian_and_cholesky_factor_direct(
         func_hessian_direct_tiled(constraint_state, rigid_global_info)
 
         if qd.static(static_rigid_sim_config.enable_tiled_cholesky_hessian):
-            # When the fused warm-start dispatch is on, the factor is folded into the fused kernel (called from
-            # ``func_update_gradient_tiled`` below); skipping the standalone factor here avoids doing the work twice.
+            # The register-streaming tiled factor has no shared-memory DOF cap, so it replaces the scalar one-thread-
+            # per-env Cholesky (O(n_dofs^3) serial) for any n_dofs >= 16. Above the shared cap (hessian_fits_shared is
+            # False) the triangular solve falls back to the scalar batch path and the per-iteration incremental rank-1
+            # update stays scalar, both reading L back from nt_H. When the fused warm-start dispatch is on, the factor
+            # is folded into the fused kernel (called from func_update_gradient_tiled below), so the standalone factor
+            # is skipped to avoid doing it twice.
             if qd.static(not static_rigid_sim_config.enable_fused_factor_solve_init):
                 func_cholesky_factor_direct_tiled(constraint_state, rigid_global_info, static_rigid_sim_config)
-        elif qd.static(static_rigid_sim_config.enable_tiled_cholesky_hessian_large):
-            # n_dofs > max_n_threads: the shared-memory tiled solve/fused kernels don't fit, but the
-            # standalone register-streaming tiled factor has no DOF limit. Use it instead of the scalar
-            # one-thread-per-env Cholesky (O(n_dofs**3) serial). The triangular solve stays on the scalar
-            # batch path (func_update_gradient_batch) since enable_tiled_cholesky_hessian is False here, and
-            # the per-iteration incremental rank-1 update remains scalar -- both read L from nt_H, which the
-            # tiled factor writes back. This removes the dominant serial factorization cost for high-DOF
-            # scenes (multi-humanoid, dexterous hands) while leaving low-DOF dispatch unchanged.
-            func_cholesky_factor_direct_tiled(constraint_state, rigid_global_info, static_rigid_sim_config)
         else:
             qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL, block_dim=32)
             for i_b in range(_B):
@@ -3614,13 +3609,14 @@ def func_update_gradient(
     Note that the tiled cholesky factorization and solving is not systematically enabled because it is not always
     superior in terms of performance and does not support arbitrary matrix sizes. More specifically, tiling gets more
     beneficial as n_dofs increases, but n_dofs>=96 is not supported for now. It is the responsibility of the calling
-    code to configure the static global flag `enable_tiled_cholesky_hessian` accordingly. Failing to do so will cause
-    the requested shared memory allocation to exceed 48kB and raise an exception.
+    code to configure the static global flag `hessian_fits_shared` accordingly. Failing to do so will cause the
+    requested shared memory allocation to exceed 48kB and raise an exception.
     """
     _B = constraint_state.jac.shape[2]
 
     if qd.static(
-        not static_rigid_sim_config.enable_tiled_cholesky_hessian or static_rigid_sim_config.backend == gs.cpu
+        not (static_rigid_sim_config.enable_tiled_cholesky_hessian and static_rigid_sim_config.hessian_fits_shared)
+        or static_rigid_sim_config.backend == gs.cpu
     ):
         # CPU
         qd.loop_config(

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -1021,6 +1021,7 @@ def _kernel_solve_graph(
         if qd.static(
             static_rigid_sim_config.solver_type == gs.constraint_solver.Newton
             and static_rigid_sim_config.enable_tiled_cholesky_hessian
+            and static_rigid_sim_config.hessian_fits_shared
         ):
             # Fused path: H patching + fused Cholesky+Solve (L in shmem, H preserved in nt_H)
             _func_build_changed_and_decide_hessian_mode(constraint_state, static_rigid_sim_config)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -470,6 +470,13 @@ class RigidSolver(KinematicSolver):
 
                 enable_tiled_cholesky_mass_matrix = 8 <= max_n_dofs_per_entity <= max_n_threads and self.n_envs <= 16384
                 enable_tiled_cholesky_hessian = 16 <= self.n_dofs <= max_n_threads and self.n_envs <= 16384
+                # Above the shared-memory cap, the standalone register-streaming tiled factor
+                # (func_cholesky_factor_direct_tiled) has no DOF limit and replaces the scalar
+                # one-thread-per-env Cholesky fallback. Not used for sparse_solve (its incremental
+                # update assumes a different jac layout) -- that path keeps the scalar direct rebuild.
+                enable_tiled_cholesky_hessian_large = (
+                    self.n_dofs > max_n_threads and self.n_envs <= 16384 and not self._options.sparse_solve
+                )
 
                 # n_dofs-based dispatch between Tile16x16 and Tile32x32 Cholesky kernels (Hessian only).
                 # Derived from a padded-volume + sub-warp utilization model:
@@ -496,6 +503,7 @@ class RigidSolver(KinematicSolver):
                 static_rigid_sim_config.update(
                     enable_tiled_cholesky_mass_matrix=enable_tiled_cholesky_mass_matrix,
                     enable_tiled_cholesky_hessian=enable_tiled_cholesky_hessian,
+                    enable_tiled_cholesky_hessian_large=enable_tiled_cholesky_hessian_large,
                     cholesky_tile_size=cholesky_tile_size,
                     enable_fused_factor_solve_init=enable_fused_factor_solve_init,
                     tiled_n_dofs_per_entity=tiled_n_dofs_per_entity,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -22,6 +22,8 @@ from genesis.utils.misc import (
     broadcast_tensor,
     sanitize_indexed_tensor,
     assign_indexed_tensor,
+    get_gpu_core_count,
+    fits_in_gpu_shared_memory,
 )
 from genesis.utils.sdf import SDF
 
@@ -379,29 +381,6 @@ class RigidSolver(KinematicSolver):
             return gs.broadphase_traversal.SAP
         return gs.broadphase_traversal.ALL_VS_ALL
 
-    def _should_use_parallel_init(self):
-        """Use parallel init (ndrange over constraints+envs) when envs alone don't saturate the GPU.
-
-        Uses hardware-derived GPU core count to determine saturation threshold, following the same
-        multi-backend pattern as collider.py (line 219).
-        """
-        if gs.backend == gs.cpu or self.sim.options.requires_grad:
-            return False
-        import torch
-
-        if torch.cuda.is_available():
-            gpu_props = torch.cuda.get_device_properties(torch.cuda.current_device())
-            # NVIDIA: 128 CUDA cores per SM. AMD/ROCm: 64 stream processors per CU.
-            cores_per_unit = 64 if torch.version.hip else 128
-            gpu_cores = gpu_props.multi_processor_count * cores_per_unit
-        elif gs.backend == gs.metal:
-            # Upper-bound estimate for Apple Silicon: 40 GPU cores * 128 ALUs
-            gpu_cores = 5120
-        else:
-            # Fallback for other GPU backends (e.g. Vulkan)
-            gpu_cores = 16384
-        return self.n_envs <= gpu_cores
-
     def _should_transpose_constraint_layout(self) -> bool:
         """Decide whether to allocate the layout-flippable constraint-state with layout=(1, 0).
 
@@ -448,7 +427,10 @@ class RigidSolver(KinematicSolver):
             integrator=self._integrator,
             solver_type=self._options.constraint_solver,
             broadphase_traversal=self._resolve_broadphase_traversal(),
-            parallel_init=self._should_use_parallel_init(),
+            # Parallelize init over (constraints, envs) when envs alone don't saturate the GPU.
+            parallel_init=(
+                gs.backend != gs.cpu and not self.sim.options.requires_grad and self.n_envs <= get_gpu_core_count()
+            ),
             constraint_layout_transposed=self._should_transpose_constraint_layout(),
         )
 
@@ -457,28 +439,15 @@ class RigidSolver(KinematicSolver):
             static_rigid_sim_config["prefer_decomposed_solver"] = 0
 
         if self.is_active:
-            # TODO: These alternative tiled algorithms are designed to reduce the impact of latency. However, naive
-            # implementation scales slightly better asymptotically than shared memory-based implementation because the
-            # scheduler of modern GPUs is able to hides latency by swapping warps if the workload is sufficient. The
-            # crossover threshold is both hardware and kernel-dependent. As a result, the optimal implementation should
-            # be selected based on dynamic timer-based profiling instead of hard-coded heuristic.
+            # The tiled and cooperative Cholesky kernels trade per-env serial work for cross-lane parallelism, so they
+            # only help while envs alone do not already saturate the GPU. Above that env count one-thread-per-env keeps
+            # every core busy and the scalar path wins; below it the parallel kernels hide latency by swapping warps.
+            # The crossover is also hardware- and kernel-dependent, so the env threshold (GPU core count) is a heuristic
+            # and a dynamic timer-based selection would be more accurate still.
             max_n_dofs_per_entity = max(entity.n_dofs for entity in self.entities) if self.entities else 0
             if gs.backend != gs.cpu:
-                max_shared_bytes = qd.lang.impl.get_max_shared_memory_bytes(is_lowerbound_ok=True)
-                max_n_warps = int(math.sqrt(max_shared_bytes / (4 if gs.qd_float == qd.f32 else 8))) // 32
-                max_n_threads = max_n_warps * 32
-
-                enable_tiled_cholesky_mass_matrix = 8 <= max_n_dofs_per_entity <= max_n_threads and self.n_envs <= 16384
-                # No tiled mass factor exists above the per-entity shared-memory cap, so use the uncapped cooperative
-                # LDL^T (factors in-place in global memory with only an O(n_dofs) shared pivot-row snapshot). No n_envs
-                # guard: the alternative is the O(n_dofs^3) serial scalar factor, so this helps at any env count.
-                enable_tiled_cholesky_mass_matrix_large = max_n_dofs_per_entity > max_n_threads
-                tiled_n_dofs_per_entity_large = max(math.ceil(max_n_dofs_per_entity / 32), 1) * 32
-                enable_tiled_cholesky_hessian = 16 <= self.n_dofs <= max_n_threads and self.n_envs <= 16384
-                # Above the cap, route the Hessian factor to the uncapped register-streaming tiled kernel rather than
-                # the scalar O(n_dofs^3) per-env factor (the triangular solve stays scalar). Excluded for sparse_solve,
-                # whose per-iteration path rebuilds via the scalar direct factor. No n_envs guard, as for the mass case.
-                enable_tiled_cholesky_hessian_large = self.n_dofs > max_n_threads and not self._options.sparse_solve
+                max_tiled_envs = get_gpu_core_count()
+                envs_undersaturate = self.n_envs <= max_tiled_envs
 
                 # n_dofs-based dispatch between Tile16x16 and Tile32x32 Cholesky kernels (Hessian only).
                 # Derived from a padded-volume + sub-warp utilization model:
@@ -488,29 +457,44 @@ class RigidSolver(KinematicSolver):
                 #   n_dofs in [49..]     -> T=32 (lane utilization wins, T=16 needs many sequential tiles)
                 # Confirmed by dex_hand (n_dofs=62, T=32 +2.6 %) and g1_fall (n_dofs=35, T=16 +2.9 %).
                 cholesky_tile_size = 16 if (self.n_dofs <= 16 or 32 < self.n_dofs <= 48) else 32
-                tiled_n_dofs = min(
-                    max(math.ceil(self.n_dofs / cholesky_tile_size), 1) * cholesky_tile_size,
-                    max_n_warps * 32,
-                )
-                tiled_n_dofs_per_entity = min(max(math.ceil(max_n_dofs_per_entity / 32), 1), max_n_warps) * 32
+                tiled_n_dofs = max(math.ceil(self.n_dofs / cholesky_tile_size), 1) * cholesky_tile_size
+                tiled_n_dofs_per_entity = max(math.ceil(max_n_dofs_per_entity / 32), 1) * 32
 
-                # Route the per-step warm-start factor+solve through the fused kernel whenever the tiled cholesky path
-                # is available. The monolith body's incremental rank-1 update needs L in nt_H, so the fused kernel
-                # also writes L back via the ``write_L_to_nt_H`` argument; see ``func_update_gradient_tiled``.
-                # Disabled for ``sparse_solve`` because the sparse path runs the per-env factor inside
-                # ``func_hessian_and_cholesky_factor_direct_batch`` (leaving nt_H = L); routing the warm-start through
-                # the fused kernel would then re-factor L as if it were H.
-                enable_fused_factor_solve_init = enable_tiled_cholesky_hessian and not self._options.sparse_solve
+                # enable_tiled_cholesky_hessian selects the register-streaming tiled factor (no shared-memory cap):
+                # worth tiling from n_dofs >= 16, and below the shared cap only when envs undersaturate (above it the
+                # scalar O(n_dofs^3) per-env factor is always worse). hessian_fits_shared additionally gates the
+                # shared-memory tiled triangular solve and fused factor+solve, which stage the full L tile in shared.
+                hessian_fits_shared = fits_in_gpu_shared_memory(tiled_n_dofs, tiled_n_dofs + 1)
+                enable_tiled_cholesky_hessian = self.n_dofs >= 16 and (not hessian_fits_shared or envs_undersaturate)
+
+                # The cooperative in-place LDL^T has no cap; the shared-memory tile is faster but capped. Same env logic
+                # as the Hessian: tile from n_dofs_per_entity >= 8, drop the env guard above the cap where the scalar
+                # O(n_dofs^3) per-(entity, env) factor is always worse.
+                mass_matrix_fits_shared = fits_in_gpu_shared_memory(
+                    tiled_n_dofs_per_entity, tiled_n_dofs_per_entity + 1
+                )
+                enable_tiled_cholesky_mass_matrix = max_n_dofs_per_entity >= 8 and (
+                    not mass_matrix_fits_shared or envs_undersaturate
+                )
+
+                # Route the per-step warm-start factor+solve through the fused kernel whenever the shared tiled solve is
+                # available (factor tiled and L fits shared). The monolith body's incremental rank-1 update needs L in
+                # nt_H, so the fused kernel also writes L back via the ``write_L_to_nt_H`` argument; see
+                # ``func_update_gradient_tiled``. Disabled for ``sparse_solve`` because the sparse path runs the per-env
+                # factor inside ``func_hessian_and_cholesky_factor_direct_batch`` (leaving nt_H = L); routing the
+                # warm-start through the fused kernel would then re-factor L as if it were H.
+                enable_fused_factor_solve_init = (
+                    enable_tiled_cholesky_hessian and hessian_fits_shared and not self._options.sparse_solve
+                )
 
                 static_rigid_sim_config.update(
                     enable_tiled_cholesky_mass_matrix=enable_tiled_cholesky_mass_matrix,
-                    enable_tiled_cholesky_mass_matrix_large=enable_tiled_cholesky_mass_matrix_large,
+                    mass_matrix_fits_shared=mass_matrix_fits_shared,
                     enable_tiled_cholesky_hessian=enable_tiled_cholesky_hessian,
-                    enable_tiled_cholesky_hessian_large=enable_tiled_cholesky_hessian_large,
+                    hessian_fits_shared=hessian_fits_shared,
                     cholesky_tile_size=cholesky_tile_size,
                     enable_fused_factor_solve_init=enable_fused_factor_solve_init,
                     tiled_n_dofs_per_entity=tiled_n_dofs_per_entity,
-                    tiled_n_dofs_per_entity_large=tiled_n_dofs_per_entity_large,
                     tiled_n_dofs=tiled_n_dofs,
                 )
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -469,6 +469,11 @@ class RigidSolver(KinematicSolver):
                 max_n_threads = max_n_warps * 32
 
                 enable_tiled_cholesky_mass_matrix = 8 <= max_n_dofs_per_entity <= max_n_threads and self.n_envs <= 16384
+                # Above the per-entity shared-memory cap, factor the entity mass submatrix with the uncapped
+                # cooperative LDL^T (in-place in global memory, only an O(n_dofs) pivot-row snapshot in shared
+                # memory) instead of the scalar one-thread-per-(entity,env) fallback.
+                enable_tiled_cholesky_mass_matrix_large = max_n_dofs_per_entity > max_n_threads and self.n_envs <= 16384
+                tiled_n_dofs_per_entity_large = max(math.ceil(max_n_dofs_per_entity / 32), 1) * 32
                 enable_tiled_cholesky_hessian = 16 <= self.n_dofs <= max_n_threads and self.n_envs <= 16384
                 # Above the shared-memory cap, the standalone register-streaming tiled factor
                 # (func_cholesky_factor_direct_tiled) has no DOF limit and replaces the scalar
@@ -502,11 +507,13 @@ class RigidSolver(KinematicSolver):
 
                 static_rigid_sim_config.update(
                     enable_tiled_cholesky_mass_matrix=enable_tiled_cholesky_mass_matrix,
+                    enable_tiled_cholesky_mass_matrix_large=enable_tiled_cholesky_mass_matrix_large,
                     enable_tiled_cholesky_hessian=enable_tiled_cholesky_hessian,
                     enable_tiled_cholesky_hessian_large=enable_tiled_cholesky_hessian_large,
                     cholesky_tile_size=cholesky_tile_size,
                     enable_fused_factor_solve_init=enable_fused_factor_solve_init,
                     tiled_n_dofs_per_entity=tiled_n_dofs_per_entity,
+                    tiled_n_dofs_per_entity_large=tiled_n_dofs_per_entity_large,
                     tiled_n_dofs=tiled_n_dofs,
                 )
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -469,19 +469,16 @@ class RigidSolver(KinematicSolver):
                 max_n_threads = max_n_warps * 32
 
                 enable_tiled_cholesky_mass_matrix = 8 <= max_n_dofs_per_entity <= max_n_threads and self.n_envs <= 16384
-                # Above the per-entity shared-memory cap, factor the entity mass submatrix with the uncapped
-                # cooperative LDL^T (in-place in global memory, only an O(n_dofs) pivot-row snapshot in shared
-                # memory) instead of the scalar one-thread-per-(entity,env) fallback.
-                enable_tiled_cholesky_mass_matrix_large = max_n_dofs_per_entity > max_n_threads and self.n_envs <= 16384
+                # No tiled mass factor exists above the per-entity shared-memory cap, so use the uncapped cooperative
+                # LDL^T (factors in-place in global memory with only an O(n_dofs) shared pivot-row snapshot). No n_envs
+                # guard: the alternative is the O(n_dofs^3) serial scalar factor, so this helps at any env count.
+                enable_tiled_cholesky_mass_matrix_large = max_n_dofs_per_entity > max_n_threads
                 tiled_n_dofs_per_entity_large = max(math.ceil(max_n_dofs_per_entity / 32), 1) * 32
                 enable_tiled_cholesky_hessian = 16 <= self.n_dofs <= max_n_threads and self.n_envs <= 16384
-                # Above the shared-memory cap, the standalone register-streaming tiled factor
-                # (func_cholesky_factor_direct_tiled) has no DOF limit and replaces the scalar
-                # one-thread-per-env Cholesky fallback. Not used for sparse_solve (its incremental
-                # update assumes a different jac layout) -- that path keeps the scalar direct rebuild.
-                enable_tiled_cholesky_hessian_large = (
-                    self.n_dofs > max_n_threads and self.n_envs <= 16384 and not self._options.sparse_solve
-                )
+                # Above the cap, route the Hessian factor to the uncapped register-streaming tiled kernel rather than
+                # the scalar O(n_dofs^3) per-env factor (the triangular solve stays scalar). Excluded for sparse_solve,
+                # whose per-iteration path rebuilds via the scalar direct factor. No n_envs guard, as for the mass case.
+                enable_tiled_cholesky_hessian_large = self.n_dofs > max_n_threads and not self._options.sparse_solve
 
                 # n_dofs-based dispatch between Tile16x16 and Tile32x32 Cholesky kernels (Hessian only).
                 # Derived from a padded-volume + sub-warp utilization model:

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -2127,6 +2127,12 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     parallel_init: bool = False  # parallelize init over (constraints, envs) when GPU is not saturated by envs alone
     broadphase_traversal: int = 0
     enable_tiled_cholesky_mass_matrix: bool = False
+    # The per-entity tiled mass-matrix factor keeps the whole entity mass submatrix in shared memory, so
+    # ``enable_tiled_cholesky_mass_matrix`` is capped at ``max_n_dofs_per_entity <= max_n_threads``. Above that
+    # cap this flag selects a cooperative LDL^T that factors the entity submatrix in-place in global memory,
+    # snapshotting only the current pivot row into a small shared vector (O(n_dofs) shared, not O(n_dofs^2)),
+    # so it has no DOF cap. Replaces the scalar one-thread-per-(entity,env) fallback for high-DOF entities.
+    enable_tiled_cholesky_mass_matrix_large: bool = False
     enable_tiled_cholesky_hessian: bool = False
     # The shared-memory tiled paths (fused factor+solve and the tiled triangular solve) keep the whole
     # Cholesky factor L resident in shared memory, so ``enable_tiled_cholesky_hessian`` is capped at
@@ -2149,6 +2155,9 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # subgroup-cooperative refinement in the linesearch and contiguous per-thread access.
     constraint_layout_transposed: bool = False
     tiled_n_dofs_per_entity: int = -1
+    # Shared-vector length (>= max_n_dofs_per_entity, multiple of 32) for the pivot-row snapshot used by the
+    # uncapped cooperative mass factor selected by ``enable_tiled_cholesky_mass_matrix_large``.
+    tiled_n_dofs_per_entity_large: int = -1
     tiled_n_dofs: int = -1
     max_n_links_per_entity: int = -1
     max_n_joints_per_link: int = -1

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -2128,6 +2128,13 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     broadphase_traversal: int = 0
     enable_tiled_cholesky_mass_matrix: bool = False
     enable_tiled_cholesky_hessian: bool = False
+    # The shared-memory tiled paths (fused factor+solve and the tiled triangular solve) keep the whole
+    # Cholesky factor L resident in shared memory, so ``enable_tiled_cholesky_hessian`` is capped at
+    # ``n_dofs <= max_n_threads`` (~96-128). The *standalone* factor ``func_cholesky_factor_direct_tiled``
+    # streams TxT tiles through registers and has no shared-memory residency requirement, hence no DOF
+    # limit. This flag enables that register-streaming factor for ``n_dofs > max_n_threads``, replacing the
+    # scalar one-thread-per-env fallback; the triangular solve then stays on the scalar batch path.
+    enable_tiled_cholesky_hessian_large: bool = False
     # Register-tile width for the Hessian Cholesky kernels: 16 (Tile16x16) or 32 (Tile32x32). Selected at build time
     # based on n_dofs: 32 wins for large problems (e.g. dex_hand, n_dofs=62); 16 wins when n_dofs is small or lands in a
     # padding-unfavorable band (e.g. g1_fall, n_dofs=35).

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -2127,9 +2127,9 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     parallel_init: bool = False  # parallelize init over (constraints, envs) when GPU is not saturated by envs alone
     broadphase_traversal: int = 0
     enable_tiled_cholesky_mass_matrix: bool = False
-    enable_tiled_cholesky_mass_matrix_large: bool = False
+    mass_matrix_fits_shared: bool = False
     enable_tiled_cholesky_hessian: bool = False
-    enable_tiled_cholesky_hessian_large: bool = False
+    hessian_fits_shared: bool = False
     # Register-tile width for the Hessian Cholesky kernels: 16 (Tile16x16) or 32 (Tile32x32). Selected at build time
     # based on n_dofs: 32 wins for large problems (e.g. dex_hand, n_dofs=62); 16 wins when n_dofs is small or lands in a
     # padding-unfavorable band (e.g. g1_fall, n_dofs=35).
@@ -2144,7 +2144,6 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # subgroup-cooperative refinement in the linesearch and contiguous per-thread access.
     constraint_layout_transposed: bool = False
     tiled_n_dofs_per_entity: int = -1
-    tiled_n_dofs_per_entity_large: int = -1
     tiled_n_dofs: int = -1
     max_n_links_per_entity: int = -1
     max_n_joints_per_link: int = -1

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -2127,19 +2127,8 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     parallel_init: bool = False  # parallelize init over (constraints, envs) when GPU is not saturated by envs alone
     broadphase_traversal: int = 0
     enable_tiled_cholesky_mass_matrix: bool = False
-    # The per-entity tiled mass-matrix factor keeps the whole entity mass submatrix in shared memory, so
-    # ``enable_tiled_cholesky_mass_matrix`` is capped at ``max_n_dofs_per_entity <= max_n_threads``. Above that
-    # cap this flag selects a cooperative LDL^T that factors the entity submatrix in-place in global memory,
-    # snapshotting only the current pivot row into a small shared vector (O(n_dofs) shared, not O(n_dofs^2)),
-    # so it has no DOF cap. Replaces the scalar one-thread-per-(entity,env) fallback for high-DOF entities.
     enable_tiled_cholesky_mass_matrix_large: bool = False
     enable_tiled_cholesky_hessian: bool = False
-    # The shared-memory tiled paths (fused factor+solve and the tiled triangular solve) keep the whole
-    # Cholesky factor L resident in shared memory, so ``enable_tiled_cholesky_hessian`` is capped at
-    # ``n_dofs <= max_n_threads`` (~96-128). The *standalone* factor ``func_cholesky_factor_direct_tiled``
-    # streams TxT tiles through registers and has no shared-memory residency requirement, hence no DOF
-    # limit. This flag enables that register-streaming factor for ``n_dofs > max_n_threads``, replacing the
-    # scalar one-thread-per-env fallback; the triangular solve then stays on the scalar batch path.
     enable_tiled_cholesky_hessian_large: bool = False
     # Register-tile width for the Hessian Cholesky kernels: 16 (Tile16x16) or 32 (Tile32x32). Selected at build time
     # based on n_dofs: 32 wins for large problems (e.g. dex_hand, n_dofs=62); 16 wins when n_dofs is small or lands in a
@@ -2155,8 +2144,6 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # subgroup-cooperative refinement in the linesearch and contiguous per-thread access.
     constraint_layout_transposed: bool = False
     tiled_n_dofs_per_entity: int = -1
-    # Shared-vector length (>= max_n_dofs_per_entity, multiple of 32) for the pivot-row snapshot used by the
-    # uncapped cooperative mass factor selected by ``enable_tiled_cholesky_mass_matrix_large``.
     tiled_n_dofs_per_entity_large: int = -1
     tiled_n_dofs: int = -1
     max_n_links_per_entity: int = -1

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -206,6 +206,32 @@ def get_device(backend: gs.constants.backend, device_idx: Optional[int] = None):
     return device, device_name, total_mem, backend
 
 
+def get_gpu_core_count() -> int:
+    """Return the number of GPU compute cores for the active device.
+
+    This is the env count above which one-thread-per-env already saturates the GPU, so cooperative or tiled kernels
+    stop being worthwhile. NVIDIA reports 128 CUDA cores per SM and AMD/ROCm 64 stream processors per CU; for backends
+    where the driver cannot be queried (Metal, or a GPU without a torch.cuda device) an upper-bound estimate is used.
+    """
+    if torch.cuda.is_available():
+        gpu_props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        cores_per_unit = 64 if torch.version.hip else 128
+        return gpu_props.multi_processor_count * cores_per_unit
+    if gs.backend == gs.metal:
+        # Upper-bound estimate for Apple Silicon: 40 GPU cores * 128 ALUs.
+        return 5120
+    # Fallback for other GPU backends (e.g. Vulkan), using AMD MI350X (256 CUs * 64 cores) as a baseline.
+    return 16384
+
+
+def fits_in_gpu_shared_memory(*dims: int) -> bool:
+    """Whether a dense ``gs.qd_float`` array of shape ``dims`` fits in one block's GPU shared memory."""
+    if gs.backend == gs.cpu:
+        gs.raise_exception("CPU backend not supported by this method.")
+    itemsize = 4 if gs.qd_float == qd.f32 else 8
+    return math.prod(dims) * itemsize <= qd.lang.impl.get_max_shared_memory_bytes(is_lowerbound_ok=True)
+
+
 def get_src_dir():
     return os.path.dirname(gs.__file__)
 

--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -550,6 +550,82 @@ def make_g1_fall(n_envs, solver=None, gjk=None, **scene_kwargs):
     )
 
 
+def make_double_smplx(n_envs, solver=None, gjk=None, **scene_kwargs):
+    """Two SMPL-X humanoids (159 DOFs each) dropped onto a plane with random per-DOF torques.
+
+    A high-DOF, multi-humanoid stress test for the rigid constraint solver: each entity has 159 DOFs
+    (> the per-entity tiled-Cholesky shared-memory cap), and the two-entity environment has 318 DOFs
+    (> the constraint-Hessian cap), so this exercises both the mass-matrix and Hessian factorizations on
+    high-DOF problems. Mirrors :func:`make_g1_fall`; adapted from @hughperkins' ``hp/double-smpl-benchmark``.
+    Self-collision is disabled (the SMPL-X hands carry many finger geoms) to keep the cost dominated by the
+    solver rather than self-collision broad-phase. The MJCF is fetched from the ``Kashu7100/eden_assets``
+    HuggingFace dataset (the SMPL-X humanoid tracked by the Eden project, https://github.com/Kashu7100/Eden).
+    """
+    step_dt = 0.005
+
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            dt=step_dt,
+            iterations=10,
+            tolerance=1e-5,
+            ls_iterations=20,
+            enable_self_collision=False,
+            **(dict(constraint_solver=solver) if solver is not None else {}),
+            **(dict(use_gjk_collision=gjk) if gjk is not None else {}),
+        ),
+        **{"show_viewer": False, "show_FPS": False, **scene_kwargs},
+    )
+
+    scene.add_entity(gs.morphs.Plane())
+    asset_path = get_hf_dataset(pattern="humanoids/smplx_humanoid/*", repo_name="eden_assets")
+    smplx_xml = f"{asset_path}/humanoids/smplx_humanoid/smplx_humanoid.xml"
+
+    init_z = 1.2  # drop height for the pelvis above the plane
+    y_offsets = (-0.5, 0.5)
+    robots = []
+    for y in y_offsets:
+        robot = scene.add_entity(
+            gs.morphs.MJCF(
+                **get_file_morph_options(
+                    file=smplx_xml,
+                    pos=(0.0, y, init_z),
+                )
+            ),
+            vis_mode="collision",
+        )
+        robots.append(robot)
+    time_start = time.time()
+    scene.build(n_envs=n_envs)
+    compile_time = time.time() - time_start
+
+    for robot, y in zip(robots, y_offsets):
+        init_qpos = torch.zeros((robot.n_qs,), dtype=gs.tc_float, device=gs.device)
+        init_qpos[1] = y  # y position
+        init_qpos[2] = init_z  # z position
+        init_qpos[3] = 1.0  # quaternion w component
+        robot.set_qpos(init_qpos)
+
+    random_forces = [torch.zeros((n_envs, robot.n_dofs), dtype=gs.tc_float, device=gs.device) for robot in robots]
+    max_force = 50.0
+
+    def step():
+        for robot, forces in zip(robots, random_forces):
+            forces.uniform_(-max_force, max_force)
+            robot.control_dofs_force(forces)
+        scene.step()
+
+    return (
+        scene,
+        step,
+        SceneMeta(
+            compile_time=compile_time,
+            step_dt=step_dt,
+            duration_warmup=20.0,
+            duration_record=5.0,
+        ),
+    )
+
+
 def make_shadow_hand_cubes(n_envs, solver=None, gjk=None, sparse_solve=False, **scene_kwargs):
     _STEP_DT = 1.0 / 30
     TABLE_Z = 0.762
@@ -971,6 +1047,12 @@ def g1_fall(solver, n_envs, gjk):
 
 
 @pytest.fixture
+def double_smplx(solver, n_envs, gjk):
+    _, step_fn, meta = make_double_smplx(n_envs, solver=solver, gjk=gjk)
+    return run_benchmark(step_fn, n_envs=n_envs, meta=meta)
+
+
+@pytest.fixture
 def shadow_hand_cubes(solver, n_envs, gjk):
     _, step_fn, meta = make_shadow_hand_cubes(n_envs, solver=solver, gjk=gjk)
     return run_benchmark(step_fn, n_envs=n_envs, meta=meta)
@@ -1025,6 +1107,7 @@ def dex_hand(solver, n_envs, gjk):
         ("box_pyramid_6", None, True, 4096, gs.gpu),
         ("box_pyramid_6", None, False, 4096, gs.gpu),
         ("g1_fall", gs.constraint_solver.Newton, None, 4096, gs.gpu),
+        ("double_smplx", gs.constraint_solver.Newton, None, 4096, gs.gpu),
         ("shadow_hand_cubes", None, None, 0, gs.cpu),
         ("shadow_hand_cubes_sparse", None, None, 0, gs.cpu),
         ("dex_hand", None, None, 4096, gs.gpu),

--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -551,25 +551,20 @@ def make_g1_fall(n_envs, solver=None, gjk=None, **scene_kwargs):
 
 
 def make_double_smplx(n_envs, solver=None, gjk=None, **scene_kwargs):
-    """Two SMPL-X humanoids (159 DOFs each) dropped onto a plane with random per-DOF torques.
-
-    A high-DOF, multi-humanoid stress test for the rigid constraint solver: each entity has 159 DOFs
-    (> the per-entity tiled-Cholesky shared-memory cap), and the two-entity environment has 318 DOFs
-    (> the constraint-Hessian cap), so this exercises both the mass-matrix and Hessian factorizations on
-    high-DOF problems. Mirrors :func:`make_g1_fall`; adapted from @hughperkins' ``hp/double-smpl-benchmark``.
-    Self-collision is disabled (the SMPL-X hands carry many finger geoms) to keep the cost dominated by the
-    solver rather than self-collision broad-phase. The MJCF is fetched from the ``Kashu7100/eden_assets``
-    HuggingFace dataset (the SMPL-X humanoid tracked by the Eden project, https://github.com/Kashu7100/Eden).
-    """
-    step_dt = 0.005
+    # Two 159-DOF SMPL-X humanoids dropped on a plane with random per-DOF torques: the 318-DOF environment exceeds the
+    # constraint-Hessian shared-memory cap and each entity exceeds the per-entity mass-matrix cap, so both
+    # factorizations exercise their uncapped paths.
+    STEP_DT = 0.005
+    INIT_POSS = ((0.0, -0.5, 1.4), (0.0, 0.5, 1.4))  # pelvis dropped 1.4 m above the plane, offset in y
+    INIT_EULER = (90.0, 0.0, 0.0)  # SMPL-X canonical frame is Y-up; rotate to stand upright in Genesis (Z-up)
+    MAX_FORCE = 500.0
 
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
-            dt=step_dt,
-            iterations=10,
-            tolerance=1e-5,
-            ls_iterations=20,
-            enable_self_collision=False,
+            dt=STEP_DT,
+            # Cap the reserved contacts so the self-colliding 318-DOF Jacobian (n_constraints * n_dofs * n_envs) stays
+            # within int32 at n_envs=4096.
+            max_collision_pairs=40,
             **(dict(constraint_solver=solver) if solver is not None else {}),
             **(dict(use_gjk_collision=gjk) if gjk is not None else {}),
         ),
@@ -577,40 +572,30 @@ def make_double_smplx(n_envs, solver=None, gjk=None, **scene_kwargs):
     )
 
     scene.add_entity(gs.morphs.Plane())
-    asset_path = get_hf_dataset(pattern="humanoids/smplx_humanoid/*", repo_name="eden_assets")
-    smplx_xml = f"{asset_path}/humanoids/smplx_humanoid/smplx_humanoid.xml"
-
-    init_z = 1.2  # drop height for the pelvis above the plane
-    y_offsets = (-0.5, 0.5)
-    robots = []
-    for y in y_offsets:
-        robot = scene.add_entity(
+    asset_path = get_hf_dataset(pattern="smplx_humanoid/*")
+    smplx_xml = f"{asset_path}/smplx_humanoid/smplx_humanoid.xml"
+    robots = [
+        scene.add_entity(
             gs.morphs.MJCF(
                 **get_file_morph_options(
                     file=smplx_xml,
-                    pos=(0.0, y, init_z),
+                    pos=pos,
+                    euler=INIT_EULER,
                 )
             ),
             vis_mode="collision",
         )
-        robots.append(robot)
+        for pos in INIT_POSS
+    ]
     time_start = time.time()
     scene.build(n_envs=n_envs)
     compile_time = time.time() - time_start
 
-    for robot, y in zip(robots, y_offsets):
-        init_qpos = torch.zeros((robot.n_qs,), dtype=gs.tc_float, device=gs.device)
-        init_qpos[1] = y  # y position
-        init_qpos[2] = init_z  # z position
-        init_qpos[3] = 1.0  # quaternion w component
-        robot.set_qpos(init_qpos)
-
     random_forces = [torch.zeros((n_envs, robot.n_dofs), dtype=gs.tc_float, device=gs.device) for robot in robots]
-    max_force = 50.0
 
     def step():
         for robot, forces in zip(robots, random_forces):
-            forces.uniform_(-max_force, max_force)
+            forces.uniform_(-MAX_FORCE, MAX_FORCE)
             robot.control_dofs_force(forces)
         scene.step()
 
@@ -619,7 +604,7 @@ def make_double_smplx(n_envs, solver=None, gjk=None, **scene_kwargs):
         step,
         SceneMeta(
             compile_time=compile_time,
-            step_dt=step_dt,
+            step_dt=STEP_DT,
             duration_warmup=20.0,
             duration_record=5.0,
         ),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,9 +37,8 @@ from genesis.utils.misc import tensor_to_array
 REPOSITY_URL = "Genesis-Embodied-AI/Genesis"
 DEFAULT_BRANCH_NAME = "main"
 
-HUGGINGFACE_ASSETS_REVISION = "8ae68c5236abf310367345dfb6dd6e6e8affe3c6"
+HUGGINGFACE_ASSETS_REVISION = "13b6270d302730ca7ca77f7d40b2b2dc897978fb"
 HUGGINGFACE_SNAPSHOT_REVISION = "fe84ed8bdef4866078b9e18456be025008bfafe9"
-HUGGINGFACE_EDEN_ASSETS_REVISION = "6326d763de4e5e7f78a0a18bf3e03efa37da8192"
 
 MESH_EXTENSIONS = (".mtl", *MESH_FORMATS, *GLTF_FORMATS, *USD_FORMATS)
 IMAGE_EXTENSIONS = (".png", ".jpg")
@@ -191,16 +190,9 @@ def get_hf_dataset(
     assert num_retry >= 1
 
     if repo_name == "assets":
-        repo_id = "Genesis-Intelligence/assets"
         revision = HUGGINGFACE_ASSETS_REVISION
     elif repo_name == "snapshots":
-        repo_id = "Genesis-Intelligence/snapshots"
         revision = HUGGINGFACE_SNAPSHOT_REVISION
-    elif repo_name == "eden_assets":
-        # Eden's robot assets (https://huggingface.co/datasets/Kashu7100/eden_assets), used by benchmarks
-        # that load high-DOF robots tracked by the Eden project (e.g. the SMPL-X humanoid).
-        repo_id = "Kashu7100/eden_assets"
-        revision = HUGGINGFACE_EDEN_ASSETS_REVISION
     else:
         raise ValueError(f"Unsupported repository '{repo_name}'")
 
@@ -209,7 +201,7 @@ def get_hf_dataset(
             # Try downloading the assets
             asset_path = snapshot_download(
                 repo_type="dataset",
-                repo_id=repo_id,
+                repo_id=f"Genesis-Intelligence/{repo_name}",
                 revision=revision,
                 allow_patterns=pattern,
                 max_workers=1,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,6 +39,7 @@ DEFAULT_BRANCH_NAME = "main"
 
 HUGGINGFACE_ASSETS_REVISION = "8ae68c5236abf310367345dfb6dd6e6e8affe3c6"
 HUGGINGFACE_SNAPSHOT_REVISION = "fe84ed8bdef4866078b9e18456be025008bfafe9"
+HUGGINGFACE_EDEN_ASSETS_REVISION = "6326d763de4e5e7f78a0a18bf3e03efa37da8192"
 
 MESH_EXTENSIONS = (".mtl", *MESH_FORMATS, *GLTF_FORMATS, *USD_FORMATS)
 IMAGE_EXTENSIONS = (".png", ".jpg")
@@ -190,9 +191,16 @@ def get_hf_dataset(
     assert num_retry >= 1
 
     if repo_name == "assets":
+        repo_id = "Genesis-Intelligence/assets"
         revision = HUGGINGFACE_ASSETS_REVISION
     elif repo_name == "snapshots":
+        repo_id = "Genesis-Intelligence/snapshots"
         revision = HUGGINGFACE_SNAPSHOT_REVISION
+    elif repo_name == "eden_assets":
+        # Eden's robot assets (https://huggingface.co/datasets/Kashu7100/eden_assets), used by benchmarks
+        # that load high-DOF robots tracked by the Eden project (e.g. the SMPL-X humanoid).
+        repo_id = "Kashu7100/eden_assets"
+        revision = HUGGINGFACE_EDEN_ASSETS_REVISION
     else:
         raise ValueError(f"Unsupported repository '{repo_name}'")
 
@@ -201,7 +209,7 @@ def get_hf_dataset(
             # Try downloading the assets
             asset_path = snapshot_download(
                 repo_type="dataset",
-                repo_id=f"Genesis-Intelligence/{repo_name}",
+                repo_id=repo_id,
                 revision=revision,
                 allow_patterns=pattern,
                 max_workers=1,


### PR DESCRIPTION
## Problem

The GPU rigid constraint solver is dramatically slow for environments with many DOFs (multi-humanoid, dexterous hands, SMPL-X). On an RTX 3090, two SMPL-X humanoids (318 DOFs) run at ~2.1 s per `scene.step()`, and step time is roughly **flat in `n_envs`** (occupancy-bound) and **independent of solver `iterations`** — i.e. the cost is once-per-step dense factorizations, not the iterative solve.

Two factorizations are gated by the GPU shared-memory size and silently fall back to **serial one-GPU-thread-per-env** dense factorization (`O(n_dofs³)`) above the cap:

1. **Constraint Hessian** `H = M + JᵀDJ` — gated by `enable_tiled_cholesky_hessian = 16 <= n_dofs <= max_n_threads` (`max_n_threads` ~96–128, bounded by holding the full `L` in shared memory).
2. **Mass matrix** `M` (per entity) — gated by `enable_tiled_cholesky_mass_matrix = max_n_dofs_per_entity <= max_n_threads`; factored every substep for the unconstrained acceleration.

A single SMPL-X humanoid is 159 DOFs/entity, so **both** hit the serial path. A Franka micro-benchmark (stack *k* Frankas) shows the Hessian cliff exactly at the cap: 126 DOFs → 77 ms, 135 DOFs → 252 ms.

## Fixes

**1. Hessian (commit 1) — re-route, no new kernel.** The standalone `func_cholesky_factor_direct_tiled` is a left-looking blocked Cholesky that streams `T×T` tiles through registers (*"no shared memory… no inherent DOF limit"*) — only the *fused* factor+solve and the *tiled triangular solve* need the full `L` resident. Add `enable_tiled_cholesky_hessian_large` (`n_dofs > max_n_threads`) and route the above-cap factor to the existing register-streaming kernel; the triangular solve stays on the scalar `O(n_dofs²)` batch path and per-iteration incremental rank-1 updates remain scalar.

**2. Mass matrix (commit 2) — new cooperative LDLᵀ.** The mass matrix has no register-streaming factor, and its tiled path stages the whole entity submatrix in shared memory. Add `enable_tiled_cholesky_mass_matrix_large` and a cooperative LDLᵀ that factors the entity submatrix **in-place in global memory** over a block of threads. To be both uncapped and race-free, each elimination step snapshots the pivot row into a small shared **vector** (`O(n_dofs)`, not `O(n_dofs²)`) before updating the trailing submatrix, so the parallel per-row updates only ever *read* the pivot row — no read/write aliasing on the eliminated row regardless of scheduling. Otherwise identical to the scalar branch.

Both keep the existing shared-memory fast paths for `n_dofs ≤ cap` (no low-DOF regression) and leave CPU / `sparse_solve` / `n_dofs < 16` on their current paths.

## Results (RTX 3090, Newton, iterations=10/20, num_envs=256)

Hessian fix — Franka micro-benchmark (small entities, so only the Hessian crosses the cap):

| env DOFs | before | after | speedup |
|--:|--:|--:|--:|
| 126 (below cap, control) | 36.6 ms | 37.1 ms | 1.0× |
| 135 | 118.6 ms | 31.8 ms | **3.7×** |
| 180 | 273.4 ms | 51.4 ms | **5.3×** |
| 270 | 731.2 ms | 114.8 ms | **6.4×** |

Both fixes — SMPL-X humanoids (159 DOFs/entity, so the mass matrix is also above the cap):

| scene | before | after | speedup |
|--|--:|--:|--:|
| 1 humanoid (159 DOFs) | 1162 ms | **96 ms** | **12.1×** |
| 2 humanoids (318 DOFs) | 2136 ms | **208 ms** | **10.3×** |

(The mass-matrix fix unlocks the bulk of the humanoid gain: with only the Hessian fix the dual-humanoid was ~1115 ms; the per-entity mass factor was the dominant remaining serial cost.)

## Correctness

Both factorizations match their scalar counterparts to floating-point precision and produce stable dynamics:
- Hessian: Franka link-position checksum after 160 substeps 35613.3506 (scalar) vs 35613.3532 (tiled).
- Mass: SMPL-X checksums 72459.9002 vs 72459.8918 (1 humanoid), 161006.689 vs 161006.681 (2 humanoids), all finite.
- Below-cap and small-entity controls (Franka) are unchanged.

## Notes / follow-ups

- The Hessian *triangular solve* and *fused* kernel remain shared-memory-capped; above the cap the solve uses the scalar `O(n_dofs²)` batch path. A tile-streaming triangular solve would uncap it fully (the `O(n_dofs³)` factor was the dominant cost, so this is minor).
- Validated by applying the change to an installed build and running the benchmarks above; I have not run the full upstream CI/test suite locally. Happy to add unit tests (factor a known SPD/mass system above the cap, compare to the scalar factor) and split into two PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
