### PR TITLE
[PERF] Split rigid collision BVH into static + dynamic subsets (RPL multi-depth)

### DIFF
--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -59,6 +59,14 @@ class _SolverBVH:
     # True when every env's link poses match, so the BVH is identical across envs and the cast reads one shared copy
     # (batch 0) with coalesced node loads instead of scattering over n_env identical trees. Recomputed each build.
     shared_across_envs: bool = False
+    # Compacted face subset this BVH covers: ``face_ids[k]`` is the global face index at BVH leaf slot ``k``. Static
+    # (fixed-link) and dynamic (movable-link) collision faces get separate subsets so the static tree is built once
+    # while only the small dynamic subset rebuilds. A 1-D int32 device tensor; ``None`` for visual BVH entries.
+    face_ids: torch.Tensor | None = None
+    # Global link indices whose faces are in this subset. The rebuild-skip pose check + shared-across-envs test read
+    # only these links (via get_links_pos(links_idx=link_ids)), so a static subset stays static and shared even while
+    # the robot's links move. ``None`` for visual BVH entries (which never skip).
+    link_ids: torch.Tensor | None = None
 
 
 @dataclass
@@ -104,6 +112,32 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
         self.ray_starts: torch.Tensor = torch.empty((0, 3), device=gs.device, dtype=gs.tc_float)
 
     @staticmethod
+    def _partition_collision_faces(solver: "RigidSolver") -> list[tuple[torch.Tensor, torch.Tensor, bool]]:
+        """Partition the solver's collision faces into static (fixed-link) and dynamic (movable-link) subsets.
+
+        Returns a list of ``(face_ids, link_ids, maybe_static)`` — one entry per non-empty subset, where
+        ``face_ids`` are global face indices and ``link_ids`` the global indices of the links owning them.
+        A pure-static or pure-dynamic solver yields a single entry (equivalent to one full-mesh BVH); a mixed
+        scene (robot on terrain) yields two, so the static terrain tree can be built once and shared while only
+        the robot subset rebuilds per step.
+        """
+        face_geom = qd_to_numpy(solver.faces_info.geom_idx).reshape(-1)  # (n_faces,) global geom per face
+        geom_link = qd_to_numpy(solver.geoms_info.link_idx).reshape(-1)  # (n_geoms,) global link per geom
+        link_fixed = np.array([bool(link.is_fixed) for link in solver.links], dtype=bool)  # (n_links,)
+        face_link = geom_link[face_geom]  # (n_faces,) global link per face
+        face_static = link_fixed[face_link]  # (n_faces,) is this face on a fixed link?
+
+        out: list[tuple[torch.Tensor, torch.Tensor, bool]] = []
+        for is_static in (True, False):
+            sel = np.nonzero(face_static == is_static)[0]
+            if sel.size == 0:
+                continue
+            face_ids = torch.as_tensor(sel, dtype=gs.tc_int, device=gs.device)
+            link_ids = torch.as_tensor(np.unique(face_link[sel]), dtype=gs.tc_int, device=gs.device)
+            out.append((face_ids, link_ids, bool(is_static)))
+        return out
+
+    @staticmethod
     def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
         """Build a per-vface mask (int8, shape (n_vfaces,)) selecting vfaces opted into visual raycasting.
         A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
@@ -130,12 +164,16 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
         common static-terrain case avoids the per-step rebuild entirely — the dominant cost on that path.
         """
         for entry in shared_metadata.solver_bvhs:
+            # The pose check reads only this subset's links (link_ids), so a static-terrain subset stays
+            # skippable even while the robot's links move in the same solver; a set_pos on a fixed terrain
+            # link still shows up here and forces a rebuild. link_ids is None only for visual entries, which
+            # never set maybe_static, so the short-circuit never reaches the get_links_pos call for them.
             if (
                 entry.maybe_static
                 and entry.built
                 and entry.cached_link_pos is not None
-                and torch.equal(entry.solver.get_links_pos(), entry.cached_link_pos)
-                and torch.equal(entry.solver.get_links_quat(), entry.cached_link_quat)
+                and torch.equal(entry.solver.get_links_pos(links_idx=entry.link_ids), entry.cached_link_pos)
+                and torch.equal(entry.solver.get_links_quat(links_idx=entry.link_ids), entry.cached_link_quat)
             ):
                 continue
             if entry.raycast_mask is None:
@@ -147,6 +185,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     free_verts_state=entry.solver.free_verts_state,
                     fixed_verts_state=entry.solver.fixed_verts_state,
                     static_rigid_sim_config=entry.solver._static_rigid_sim_config,
+                    face_ids=entry.face_ids,
                     aabb_state=entry.aabb,
                 )
                 entry.bvh.build()
@@ -170,8 +209,8 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
             # Snapshot the post-build link poses so the next call can detect a set_pos and rebuild only if needed, and
             # decide whether one shared BVH copy can serve all envs (see shared_across_envs).
             if entry.maybe_static:
-                pos = entry.solver.get_links_pos()
-                quat = entry.solver.get_links_quat()
+                pos = entry.solver.get_links_pos(links_idx=entry.link_ids)
+                quat = entry.solver.get_links_quat(links_idx=entry.link_ids)
                 entry.cached_link_pos = pos
                 entry.cached_link_quat = quat
                 # Identical link poses across envs <=> identical world geometry in every env, so the per-env trees are
@@ -202,17 +241,29 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     continue
                 n_envs = solver._B
                 if isinstance(solver, RigidSolver):
-                    n_faces = solver.faces_info.geom_idx.shape[0]
-                    aabb = AABB(n_batches=n_envs, n_aabbs=n_faces)
-                    bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                    # The collision BVH is a rebuild-skip candidate when no link has a DOF the physics can move: its
-                    # geometry then only changes through an explicit set_pos, which _update_bvh detects via the pose
-                    # cache. Keyed off link.is_fixed rather than "no free verts" because a fixed link whose verts are
-                    # batched (_batch_fixed_verts) counts toward n_free_verts yet never moves on its own.
-                    maybe_static = all(link.is_fixed for link in solver.links)
-                    self._shared_metadata.solver_bvhs.append(
-                        _SolverBVH(solver, bvh, aabb, None, maybe_static=maybe_static)
-                    )
+                    # Split the solver's collision faces into a static subset (faces whose owning link is
+                    # fixed — terrain, walls) and a dynamic subset (faces on links the physics can move —
+                    # the robot). Each gets its own compacted BVH so (a) the static subset's tree is built
+                    # once then skipped + shared across envs (the dominant per-step cost for one robot on a
+                    # big static terrain), and (b) the dynamic rebuild scales with the robot's face count,
+                    # not the whole scene. The cast kernels merge the two via is_merge, so the result is
+                    # identical to one combined BVH. This is the RPL "multi-depth" decomposition
+                    # (arXiv:2602.03002): cast dynamic robot + static terrain meshes separately, then merge.
+                    for face_ids, link_ids, maybe_static in self._partition_collision_faces(solver):
+                        n_sub = int(face_ids.shape[0])
+                        aabb = AABB(n_batches=n_envs, n_aabbs=n_sub)
+                        bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
+                        self._shared_metadata.solver_bvhs.append(
+                            _SolverBVH(
+                                solver,
+                                bvh,
+                                aabb,
+                                None,
+                                maybe_static=maybe_static,
+                                face_ids=face_ids,
+                                link_ids=link_ids,
+                            )
+                        )
                 n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
                 if n_vfaces > 0:
                     mask = self._compute_visual_raycast_mask(solver)
@@ -352,6 +403,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     solver.free_verts_state,
                     solver.verts_info,
                     solver.faces_info,
+                    entry.face_ids,
                     *args_common,
                 )
             else:

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
     from .sensor_manager import SensorManager
 
 
-class _SolverBVH(NamedTuple):
+@dataclass
+class _SolverBVH:
     """
     One BVH built against a solver's mesh.
 
@@ -42,6 +43,19 @@ class _SolverBVH(NamedTuple):
     bvh: LBVH
     aabb: AABB
     raycast_mask: np.ndarray | None
+
+    # True when no link in the solver has a DOF the physics can move, so its geometry only ever changes through an
+    # explicit user set_pos/set_quat. Full BVH rebuilds (the dominant per-step cost for static-terrain raycasting) are
+    # then skipped while the link poses are unchanged since the last build; a set_pos is detected via the pose cache
+    # below and triggers a rebuild. Collision-only: visual BVHs stay always-rebuilt because set_vverts can change their
+    # vverts without moving any link.
+    maybe_static: bool = False
+    # Whether build() has already run for this entry (reset() clears it to force one rebuild).
+    built: bool = False
+    # Snapshot of all link poses at the last build, used to detect a set_pos on an otherwise-static solver. Only
+    # populated for maybe_static entries.
+    cached_link_pos: torch.Tensor | None = None
+    cached_link_quat: torch.Tensor | None = None
 
 
 @dataclass
@@ -105,8 +119,22 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
 
     @classmethod
     def _update_bvh(cls, shared_metadata: RaycasterSharedMetadata):
-        """Rebuild every BVH from current geometry in the scene."""
+        """Rebuild every BVH from current geometry in the scene.
+
+        For a maybe_static entry (no link the physics can move) the rebuild is skipped while the link poses are
+        byte-identical to the snapshot from the last build, since the tree would come out unchanged. A user set_pos on
+        such a (fixed) link shows up as a pose difference and forces a rebuild, so correctness is preserved while the
+        common static-terrain case avoids the per-step rebuild entirely — the dominant cost on that path.
+        """
         for entry in shared_metadata.solver_bvhs:
+            if (
+                entry.maybe_static
+                and entry.built
+                and entry.cached_link_pos is not None
+                and torch.equal(entry.solver.get_links_pos(), entry.cached_link_pos)
+                and torch.equal(entry.solver.get_links_quat(), entry.cached_link_quat)
+            ):
+                continue
             if entry.raycast_mask is None:
                 kernel_update_verts_and_aabbs(
                     geoms_info=entry.solver.geoms_info,
@@ -135,6 +163,11 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     aabb_state=entry.aabb,
                 )
                 entry.bvh.build()
+            entry.built = True
+            # Snapshot the post-build link poses so the next call can detect a set_pos and rebuild only if needed.
+            if entry.maybe_static:
+                entry.cached_link_pos = entry.solver.get_links_pos()
+                entry.cached_link_quat = entry.solver.get_links_quat()
 
     def build(self):
         super().build()
@@ -157,7 +190,14 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     n_faces = solver.faces_info.geom_idx.shape[0]
                     aabb = AABB(n_batches=n_envs, n_aabbs=n_faces)
                     bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                    self._shared_metadata.solver_bvhs.append(_SolverBVH(solver, bvh, aabb, None))
+                    # The collision BVH is a rebuild-skip candidate when no link has a DOF the physics can move: its
+                    # geometry then only changes through an explicit set_pos, which _update_bvh detects via the pose
+                    # cache. Keyed off link.is_fixed rather than "no free verts" because a fixed link whose verts are
+                    # batched (_batch_fixed_verts) counts toward n_free_verts yet never moves on its own.
+                    maybe_static = all(link.is_fixed for link in solver.links)
+                    self._shared_metadata.solver_bvhs.append(
+                        _SolverBVH(solver, bvh, aabb, None, maybe_static=maybe_static)
+                    )
                 n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
                 if n_vfaces > 0:
                     mask = self._compute_visual_raycast_mask(solver)
@@ -224,6 +264,10 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
     @classmethod
     def reset(cls, shared_metadata: RaycasterSharedMetadata, current_ground_truth_data_T: torch.Tensor, envs_idx):
         super().reset(shared_metadata, current_ground_truth_data_T, envs_idx)
+        # A reset may change otherwise-static geometry (e.g. re-randomized terrain), so force every entry to rebuild
+        # once here; static entries then resume being skipped on subsequent steps.
+        for entry in shared_metadata.solver_bvhs:
+            entry.built = False
         cls._update_bvh(shared_metadata)
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -56,6 +56,9 @@ class _SolverBVH:
     # populated for maybe_static entries.
     cached_link_pos: torch.Tensor | None = None
     cached_link_quat: torch.Tensor | None = None
+    # True when every env's link poses match, so the BVH is identical across envs and the cast reads one shared copy
+    # (batch 0) with coalesced node loads instead of scattering over n_env identical trees. Recomputed each build.
+    shared_across_envs: bool = False
 
 
 @dataclass
@@ -164,10 +167,22 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                 )
                 entry.bvh.build()
             entry.built = True
-            # Snapshot the post-build link poses so the next call can detect a set_pos and rebuild only if needed.
+            # Snapshot the post-build link poses so the next call can detect a set_pos and rebuild only if needed, and
+            # decide whether one shared BVH copy can serve all envs (see shared_across_envs).
             if entry.maybe_static:
-                entry.cached_link_pos = entry.solver.get_links_pos()
-                entry.cached_link_quat = entry.solver.get_links_quat()
+                pos = entry.solver.get_links_pos()
+                quat = entry.solver.get_links_quat()
+                entry.cached_link_pos = pos
+                entry.cached_link_quat = quat
+                # Identical link poses across envs <=> identical world geometry in every env, so the per-env trees are
+                # bit-identical and the cast can read a single copy (batch 0) with coalesced loads. get_links_pos
+                # returns (n_envs, n_links, 3) for a batched solver; a single-env solver gains nothing from sharing.
+                entry.shared_across_envs = bool(
+                    pos.ndim == 3
+                    and pos.shape[0] > 1
+                    and torch.equal(pos, pos[:1].expand_as(pos))
+                    and torch.equal(quat, quat[:1].expand_as(quat))
+                )
 
     def build(self):
         super().build()
@@ -329,6 +344,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                 raw_data_T,
                 gs.EPS,
                 i > 0,
+                entry.shared_across_envs,
             )
             if entry.raycast_mask is None:
                 kernel_cast_rays(

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -535,11 +535,15 @@ def kernel_cast_rays(
     output_hits: qd.types.ndarray(ndim=2),  # [total_cache_size, n_env]
     eps: float,
     is_merge: qd.template(),
+    shared_bvh: qd.template(),
 ):
     """Cast rays against a collision-mesh BVH, accelerated by a BVH. See write_ray_hit for `is_merge` semantics.
 
     The result `output_hits` is a 2D array of shape (total_cache_size, n_env) where in the first dimension each
     sensor's data is stored as [sensor_points (n_points * 3), sensor_ranges (n_points)].
+
+    `shared_bvh` is a compile-time flag set when the geometry is identical across envs, so a single BVH copy (batch 0)
+    serves every env and the per-env node loads coalesce instead of scattering over n_env identical trees.
     """
     n_points = ray_starts.shape[0]
     for i_p, i_b in qd.ndrange(n_points, output_hits.shape[-1]):
@@ -556,11 +560,17 @@ def kernel_cast_rays(
         ray_dir_local = qd.math.vec3(ray_directions[i_p, 0], ray_directions[i_p, 1], ray_directions[i_p, 2])
         ray_direction_world = gu.qd_normalize(gu.qd_transform_by_quat(ray_dir_local, link_quat), eps)
 
+        i_b_bvh = i_b
+        if shared_bvh:
+            # All envs share one BVH copy (identical geometry); reading batch 0 coalesces the node loads across the
+            # warp's envs instead of scattering them over n_envs identical trees.
+            i_b_bvh = 0
+
         hit_face, hit_distance, _hit_normal = bvh_ray_cast(
             ray_start=ray_start_world,
             ray_dir=ray_direction_world,
             max_range=max_ranges[i_s],
-            i_b=i_b,
+            i_b=i_b_bvh,
             bvh_nodes=bvh_nodes,
             bvh_morton_codes=bvh_morton_codes,
             faces_info=faces_info,
@@ -614,8 +624,9 @@ def kernel_cast_rays_visual(
     output_hits: qd.types.ndarray(ndim=2),
     eps: float,
     is_merge: qd.template(),
+    shared_bvh: qd.template(),
 ):
-    """Visual-mesh variant of kernel_cast_rays."""
+    """Visual-mesh variant of kernel_cast_rays. See kernel_cast_rays for `shared_bvh`."""
     n_points = ray_starts.shape[0]
     for i_p, i_b in qd.ndrange(n_points, output_hits.shape[-1]):
         i_s = points_to_sensor_idx[i_p]
@@ -631,11 +642,15 @@ def kernel_cast_rays_visual(
         ray_dir_local = qd.math.vec3(ray_directions[i_p, 0], ray_directions[i_p, 1], ray_directions[i_p, 2])
         ray_direction_world = gu.qd_normalize(gu.qd_transform_by_quat(ray_dir_local, link_quat), eps)
 
+        i_b_bvh = i_b
+        if shared_bvh:
+            i_b_bvh = 0
+
         hit_face, hit_distance, _hit_normal = bvh_ray_cast_visual(
             ray_start=ray_start_world,
             ray_dir=ray_direction_world,
             max_range=max_ranges[i_s],
-            i_b=i_b,
+            i_b=i_b_bvh,
             bvh_nodes=bvh_nodes,
             bvh_morton_codes=bvh_morton_codes,
             vverts_info=vverts_info,

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -56,10 +56,17 @@ def bvh_ray_cast(
     verts_info: array_class.VertsInfo,
     fixed_verts_state: array_class.VertsState,
     free_verts_state: array_class.VertsState,
+    face_ids: qd.types.ndarray(ndim=1),
     eps: float,
 ):
     """
     Cast a ray through a BVH and find the closest intersection.
+
+    `face_ids` maps a BVH leaf slot (0..n_leaves-1) to the global face index it
+    was built from. The BVH may be built over a compacted face subset (static
+    terrain faces vs dynamic robot faces — see RaycasterSensor.build), so the
+    leaf index the morton codes carry is subset-local; this array remaps it back
+    to the solver-global face. For a single full-mesh BVH it is the identity map.
 
     Returns
     -------
@@ -70,7 +77,9 @@ def bvh_ray_cast(
     hit_normal : qd.math.vec3
         normal vector at hit point (zero vector if no hit)
     """
-    n_triangles = faces_info.verts_idx.shape[0]
+    # Leaf count = this BVH's AABB count, NOT the solver's global face count: the
+    # BVH may cover a compacted face subset. morton_codes is (n_batch, n_leaves).
+    n_triangles = bvh_morton_codes.shape[1]
 
     hit_face = -1
     closest_distance = gs.qd_float(max_range)
@@ -94,7 +103,8 @@ def bvh_ray_cast(
             if node.left == -1:  # Leaf node
                 # Get original triangle/face index
                 sorted_leaf_idx = node_idx - (n_triangles - 1)
-                i_f = qd.cast(bvh_morton_codes[i_b, sorted_leaf_idx][1], gs.qd_int)
+                # morton code carries the subset-local leaf slot; remap to global face.
+                i_f = qd.cast(face_ids[qd.cast(bvh_morton_codes[i_b, sorted_leaf_idx][1], gs.qd_int)], gs.qd_int)
 
                 # Get triangle vertices
                 tri_vertices = get_triangle_vertices(
@@ -232,23 +242,29 @@ def update_aabbs(
     fixed_verts_state: array_class.VertsState,
     verts_info: array_class.VertsInfo,
     faces_info: array_class.FacesInfo,
+    face_ids: qd.types.ndarray(ndim=1),
     aabb_state: qd.template(),
 ):
-    for i_b, i_f in qd.ndrange(free_verts_state.pos.shape[1], faces_info.verts_idx.shape[0]):
-        aabb_state.aabbs[i_b, i_f].min.fill(qd.math.inf)
-        aabb_state.aabbs[i_b, i_f].max.fill(-qd.math.inf)
+    # AABB slot k holds the bounding box of the global face face_ids[k]. The BVH
+    # is built over this compacted subset, so the rebuild cost scales with the
+    # subset size (e.g. only the moving robot's faces) rather than every face in
+    # the solver. For a full-mesh BVH face_ids is the identity map.
+    for i_b, k in qd.ndrange(free_verts_state.pos.shape[1], face_ids.shape[0]):
+        i_f = face_ids[k]
+        aabb_state.aabbs[i_b, k].min.fill(qd.math.inf)
+        aabb_state.aabbs[i_b, k].max.fill(-qd.math.inf)
 
         for i in qd.static(range(3)):
             i_v = faces_info.verts_idx[i_f][i]
             i_fv = verts_info.verts_state_idx[i_v]
             if verts_info.is_fixed[i_v]:
                 pos_v = fixed_verts_state.pos[i_fv]
-                aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+                aabb_state.aabbs[i_b, k].min = qd.min(aabb_state.aabbs[i_b, k].min, pos_v)
+                aabb_state.aabbs[i_b, k].max = qd.max(aabb_state.aabbs[i_b, k].max, pos_v)
             else:
                 pos_v = free_verts_state.pos[i_fv, i_b]
-                aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+                aabb_state.aabbs[i_b, k].min = qd.min(aabb_state.aabbs[i_b, k].min, pos_v)
+                aabb_state.aabbs[i_b, k].max = qd.max(aabb_state.aabbs[i_b, k].max, pos_v)
 
 
 @qd.kernel
@@ -260,12 +276,13 @@ def kernel_update_verts_and_aabbs(
     free_verts_state: array_class.VertsState,
     fixed_verts_state: array_class.VertsState,
     static_rigid_sim_config: qd.template(),
+    face_ids: qd.types.ndarray(ndim=1),
     aabb_state: qd.template(),
 ):
     func_update_all_verts(
         geoms_state, geoms_info, verts_info, free_verts_state, fixed_verts_state, static_rigid_sim_config
     )
-    update_aabbs(free_verts_state, fixed_verts_state, verts_info, faces_info, aabb_state)
+    update_aabbs(free_verts_state, fixed_verts_state, verts_info, faces_info, face_ids, aabb_state)
 
 
 # =========================================== Visual Mesh Raycasting ===========================================
@@ -519,6 +536,7 @@ def kernel_cast_rays(
     free_verts_state: array_class.VertsState,
     verts_info: array_class.VertsInfo,
     faces_info: array_class.FacesInfo,
+    face_ids: qd.types.ndarray(ndim=1),  # maps BVH leaf slot -> global face index (identity for a full-mesh BVH)
     bvh_nodes: qd.template(),
     bvh_morton_codes: qd.template(),  # maps sorted leaves to original triangle indices
     links_pos: qd.types.ndarray(ndim=3),  # [n_env, n_sensors, 3]
@@ -590,6 +608,7 @@ def kernel_cast_rays(
             verts_info=verts_info,
             fixed_verts_state=fixed_verts_state,
             free_verts_state=free_verts_state,
+            face_ids=face_ids,
             eps=eps,
         )
 

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -542,11 +542,25 @@ def kernel_cast_rays(
     The result `output_hits` is a 2D array of shape (total_cache_size, n_env) where in the first dimension each
     sensor's data is stored as [sensor_points (n_points * 3), sensor_ranges (n_points)].
 
-    `shared_bvh` is a compile-time flag set when the geometry is identical across envs, so a single BVH copy (batch 0)
-    serves every env and the per-env node loads coalesce instead of scattering over n_env identical trees.
+    `shared_bvh` is a compile-time flag set when the geometry is identical across envs. It selects both which BVH copy
+    is read and how threads are mapped to (ray, env) pairs (see the loop comment), so the homogeneous and heterogeneous
+    cases each get their optimal GPU access pattern from the same kernel.
     """
     n_points = ray_starts.shape[0]
-    for i_p, i_b in qd.ndrange(n_points, output_hits.shape[-1]):
+    n_envs = output_hits.shape[-1]
+    # One flat parallel loop whose thread -> (ray, env) decomposition is chosen at compile time from shared_bvh:
+    #  - shared (homogeneous geometry): env is the fastest-varying index, so a warp's threads span consecutive envs and
+    #    all read the same batch-0 node -> a coalesced broadcast.
+    #  - not shared (heterogeneous): the ray is the fastest-varying index, so a warp stays within one env's distinct
+    #    tree and rides ray coherence instead of diverging across n_env different trees.
+    for i_flat in range(n_points * n_envs):
+        # env is the fastest index by default; the compile-time override below flips ray to fastest when not shared.
+        i_p = i_flat // n_envs
+        i_b = i_flat % n_envs
+        if not shared_bvh:
+            i_b = i_flat // n_points
+            i_p = i_flat % n_points
+
         i_s = points_to_sensor_idx[i_p]
 
         link_pos = qd.math.vec3(links_pos[i_b, i_s, 0], links_pos[i_b, i_s, 1], links_pos[i_b, i_s, 2])
@@ -560,10 +574,9 @@ def kernel_cast_rays(
         ray_dir_local = qd.math.vec3(ray_directions[i_p, 0], ray_directions[i_p, 1], ray_directions[i_p, 2])
         ray_direction_world = gu.qd_normalize(gu.qd_transform_by_quat(ray_dir_local, link_quat), eps)
 
+        # Reading batch 0 (valid only when shared_bvh) is what makes the coalesced broadcast above possible.
         i_b_bvh = i_b
         if shared_bvh:
-            # All envs share one BVH copy (identical geometry); reading batch 0 coalesces the node loads across the
-            # warp's envs instead of scattering them over n_envs identical trees.
             i_b_bvh = 0
 
         hit_face, hit_distance, _hit_normal = bvh_ray_cast(
@@ -626,9 +639,16 @@ def kernel_cast_rays_visual(
     is_merge: qd.template(),
     shared_bvh: qd.template(),
 ):
-    """Visual-mesh variant of kernel_cast_rays. See kernel_cast_rays for `shared_bvh`."""
+    """Visual-mesh variant of kernel_cast_rays. See kernel_cast_rays for `shared_bvh` and the thread mapping."""
     n_points = ray_starts.shape[0]
-    for i_p, i_b in qd.ndrange(n_points, output_hits.shape[-1]):
+    n_envs = output_hits.shape[-1]
+    for i_flat in range(n_points * n_envs):
+        i_p = i_flat // n_envs
+        i_b = i_flat % n_envs
+        if not shared_bvh:
+            i_b = i_flat // n_points
+            i_p = i_flat % n_points
+
         i_s = points_to_sensor_idx[i_p]
 
         link_pos = qd.math.vec3(links_pos[i_b, i_s, 0], links_pos[i_b, i_s, 1], links_pos[i_b, i_s, 2])

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1128,6 +1128,69 @@ def test_raycaster_hits(show_viewer, n_envs):
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
+def test_raycaster_static_dynamic_bvh_split(show_viewer, n_envs):
+    """The rigid-solver collision mesh is split into a static (fixed-link) BVH and a dynamic (movable-link)
+    BVH, cast separately and merged. Asserts: (a) the split structure (one static + one dynamic collision
+    entry, static one shared across envs); (b) the merge is correct as the dynamic body moves into / out of
+    a ray's path; (c) the static entry is genuinely skipped (its cached pose is untouched by a dynamic move).
+    """
+    HEIGHT = 1.0
+    BOX = 0.2  # movable box edge
+
+    scene = gs.Scene(
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())  # static (fixed)
+    # A single downward ray from a fixed mount at height HEIGHT over the origin. collision=False so the
+    # mount carries no collision faces and the ray doesn't immediately hit its own mount geometry.
+    mount = scene.add_entity(gs.morphs.Box(size=(0.05, 0.05, 0.05), pos=(0.0, 0.0, HEIGHT), fixed=True, collision=False))
+    box = scene.add_entity(gs.morphs.Box(size=(BOX, BOX, BOX), pos=(5.0, 5.0, 0.5 * BOX)))  # dynamic (movable)
+    sensor = scene.add_sensor(
+        gs.sensors.Raycaster(
+            pattern=gs.sensors.raycaster.GridPattern(resolution=1.0, size=(0.0, 0.0), direction=(0.0, 0.0, -1.0)),
+            entity_idx=mount.idx,
+            return_world_frame=False,
+        )
+    )
+
+    scene.build(n_envs=n_envs)
+    batch_shape = (n_envs,) if n_envs > 0 else ()
+
+    # (a) Split structure: exactly two collision BVH entries (raycast_mask is None), one static + one dynamic;
+    # the static one is shared across envs when batched (identical fixed geometry in every env).
+    collision_bvhs = [e for e in sensor._shared_metadata.solver_bvhs if e.raycast_mask is None]
+    assert len(collision_bvhs) == 2, f"expected static+dynamic split, got {len(collision_bvhs)} collision BVHs"
+    static_entries = [e for e in collision_bvhs if e.maybe_static]
+    dynamic_entries = [e for e in collision_bvhs if not e.maybe_static]
+    assert len(static_entries) == 1 and len(dynamic_entries) == 1
+    if n_envs > 0:
+        assert static_entries[0].shared_across_envs, "static terrain BVH should be shared across envs"
+        assert not dynamic_entries[0].shared_across_envs, "dynamic (movable) BVH must stay per-env"
+
+    # (b1) Box parked far away → the ray falls through to the static ground at distance HEIGHT.
+    scene.sim._sensor_manager.step()
+    assert_allclose(sensor.read().distances.reshape(batch_shape), HEIGHT, tol=gs.EPS)
+
+    # Snapshot the static entry's cached pose to prove it is not rebuilt by a dynamic move below.
+    static_pose_before = static_entries[0].cached_link_pos.clone()
+
+    # (b2) Move the box directly under the ray → the merge must now report the closer hit (box top).
+    box.set_pos(np.tile((0.0, 0.0, 0.5 * BOX), (*batch_shape, 1)))
+    scene.sim._sensor_manager.step()
+    assert_allclose(sensor.read().distances.reshape(batch_shape), HEIGHT - BOX, tol=gs.EPS)
+
+    # (c) The static (terrain) BVH was skipped across the dynamic move: its cached link pose is untouched.
+    assert torch.equal(static_entries[0].cached_link_pos, static_pose_before), "static BVH was rebuilt unexpectedly"
+
+    # (b3) Move the box back out → ray returns to the static ground distance (dynamic BVH tracked the motion).
+    box.set_pos(np.tile((5.0, 5.0, 0.5 * BOX), (*batch_shape, 1)))
+    scene.sim._sensor_manager.step()
+    assert_allclose(sensor.read().distances.reshape(batch_shape), HEIGHT, tol=gs.EPS)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
 @pytest.mark.parametrize("kin_raycastable", [True, False])
 def test_raycaster_against_visual(tmp_path, show_viewer, n_envs, kin_raycastable):
     # Two depth cameras, one per entity:

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1144,7 +1144,9 @@ def test_raycaster_static_dynamic_bvh_split(show_viewer, n_envs):
     scene.add_entity(gs.morphs.Plane())  # static (fixed)
     # A single downward ray from a fixed mount at height HEIGHT over the origin. collision=False so the
     # mount carries no collision faces and the ray doesn't immediately hit its own mount geometry.
-    mount = scene.add_entity(gs.morphs.Box(size=(0.05, 0.05, 0.05), pos=(0.0, 0.0, HEIGHT), fixed=True, collision=False))
+    mount = scene.add_entity(
+        gs.morphs.Box(size=(0.05, 0.05, 0.05), pos=(0.0, 0.0, HEIGHT), fixed=True, collision=False)
+    )
     box = scene.add_entity(gs.morphs.Box(size=(BOX, BOX, BOX), pos=(5.0, 5.0, 0.5 * BOX)))  # dynamic (movable)
     sensor = scene.add_sensor(
         gs.sensors.Raycaster(


### PR DESCRIPTION
> **Draft / needs work — do not merge yet.** Split out of #2867 so it stops blocking the three validated, CI-green perf commits there. This PR stacks on #2867 (its first three commits are #2867); review/merge after that lands.

## Description

Adds the RPL "multi-depth" decomposition: split the rigid solver's collision faces into a **static** subset (faces on fixed links — terrain/walls) and a **dynamic** subset (faces on movable links — the robot), build a separate BVH for each, and merge the casts. The static tree is built once and shared across envs; only the small dynamic subset rebuilds per step. (Full design in the commit message of `095dbe2`.)

The new test `test_raycaster_static_dynamic_bvh_split` passes in isolation on GPU, CPU, and the `field` backend.

## ⚠️ Known blocker (why this is a draft)

The commit was added to #2867 and **regressed CI on every platform**. Investigation on an RTX 3080 (10 GB):

1. **`precommit-checks`** — the new test wasn't ruff-formatted. **Fixed** here (commit `2a450...`).
2. **Unit tests — `CUDA_ERROR_OUT_OF_MEMORY`.** Under parallel test execution (`pytest -n auto --dev`), the suite OOMs. Root cause: the split allocates a **second per-env BVH** — the static-terrain subset is still allocated at `n_batches=n_envs` (like the existing shared BVH), so a mixed scene now holds two full per-env node arrays instead of one. At large `n_env` × terrain-face counts this roughly doubles the already-large BVH memory.
   - Each test **passes in isolation** (GPU / CPU / `field`, run with `-n0`); it's the **aggregate footprint** under parallel workers that tips over, not a logic bug.

### Suggested fix direction
This is the `n_batches=1` memory optimization that #2867's shared-BVH path already wanted: a BVH flagged `shared_across_envs` only ever reads batch 0, so it should be **allocated and built at `n_batches=1`** rather than `n_envs`. That both removes the regression and reclaims the duplicate-node memory #2867 left on the table. It touches `AABB`/`LBVH` allocation and the update kernels (they currently iterate `free_verts_state.pos.shape[1] == n_env`), so it's a non-trivial change — hence parking this rather than rushing it into #2867.

## How Has This Been / Can This Be Tested?

- `pytest tests/test_sensors.py -k "raycaster or lidar or static_dynamic" --backend gpu` — passes (release build).
- The same with `--dev -n0` (serial) — passes on GPU, CPU, and `field`.
- The same with `--dev` under parallel workers — OOMs on a 10 GB GPU (the blocker above).

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. ← **blocked on the memory regression above**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
