### PR TITLE
[MISC] Add solver state-change subscriber mechanism. Fix raycast sensor for heterogeneous entities.

### DIFF
--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -115,6 +115,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     faces_info=entry.solver.faces_info,
                     free_verts_state=entry.solver.free_verts_state,
                     fixed_verts_state=entry.solver.fixed_verts_state,
+                    links_info=entry.solver.links_info,
                     static_rigid_sim_config=entry.solver._static_rigid_sim_config,
                     aabb_state=entry.aabb,
                 )

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING
+import enum
+import functools
+import inspect
+from typing import TYPE_CHECKING, Callable
 
 import quadrants as qd
 import numpy as np
@@ -15,6 +18,71 @@ from genesis.repr_base import RBC
 if TYPE_CHECKING:
     from genesis.engine.scene import Scene
     from genesis.engine.simulator import Simulator
+
+
+class StateChange(enum.Enum):
+    """Category of solver state mutation broadcast to subscribers (see `Solver.subscribe`).
+
+    Deliberately solver-agnostic: it names what kind of state changed, never an index space (links, dofs, particles,
+    ...), which differs from one solver to the next. GEOMETRY covers anything that moves or deforms the world surface a
+    solver exposes (a rigid link teleport, a particle reset, ...); DYNAMICS covers mass / inertia / material / gains.
+    """
+
+    GEOMETRY = enum.auto()
+    DYNAMICS = enum.auto()
+
+
+def mutates(change: StateChange):
+    """Tag a solver state-mutating method so its subscribers are notified once it has run.
+
+    The wrapped method's `envs_idx` argument (None meaning all envs) is forwarded to each subscriber as-is. Untagged
+    methods, reads included, never notify, so a subscriber only ever wakes on a genuine mutation.
+    """
+
+    def decorator(method):
+        signature = inspect.signature(method)
+
+        @functools.wraps(method)
+        def wrapper(self, *args, **kwargs):
+            result = method(self, *args, **kwargs)
+            if self._subscribers:
+                envs_idx = signature.bind(self, *args, **kwargs).arguments.get("envs_idx")
+                for subscriber in self._subscribers:
+                    if change in subscriber.to:
+                        if subscriber.callback is None:
+                            subscriber._pending.add(change)
+                        else:
+                            subscriber.callback(change, envs_idx)
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+class Subscriber:
+    """A unique handle for the solver state changes whose category is in `to`.
+
+    A consumer constructs a Subscriber and registers it with a solver via Solver.subscribe. The mode is fixed at
+    construction by whether a callback is given:
+      - eager (callback given): each matching change immediately calls callback(change, envs_idx);
+      - lazy (no callback): matching changes accumulate into `pending` until the owner calls clear() - e.g. a sensor
+        that rebuilds a cache on its next update rather than on every set_pos.
+    """
+
+    def __init__(self, to: frozenset[StateChange], callback: Callable[[StateChange, object], None] | None = None):
+        self.to = to
+        self.callback = callback
+        self._pending: set[StateChange] = set()
+
+    @property
+    def pending(self) -> frozenset[StateChange]:
+        """Categories accumulated since the last clear() (always empty in eager mode)."""
+        return frozenset(self._pending)
+
+    def clear(self):
+        """Drop the accumulated changes, once they have been handled."""
+        self._pending.clear()
 
 
 class Solver(RBC):
@@ -39,8 +107,15 @@ class Solver(RBC):
         # force fields
         self._ffs = list()
 
+        # Registered Subscribers, notified after @mutates-tagged methods run; see subscribe().
+        self._subscribers: set[Subscriber] = set()
+
     def _add_force_field(self, force_field):
         self._ffs.append(force_field)
+
+    def subscribe(self, subscriber: Subscriber):
+        """Register a Subscriber to be notified after any @mutates-tagged method whose change is in its filter."""
+        self._subscribers.add(subscriber)
 
     def build(self):
         self._B = self._sim._B

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -17,7 +17,7 @@ from genesis.utils.misc import (
     assign_indexed_tensor,
 )
 
-from .base_solver import Solver
+from .base_solver import Solver, StateChange, mutates
 from .rigid.abd.misc import (
     kernel_init_dof_fields,
     kernel_init_link_fields,
@@ -700,6 +700,7 @@ class KinematicSolver(Solver):
 
         return tensor_, inputs_idx_, envs_idx_
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -758,6 +759,7 @@ class KinematicSolver(Solver):
             static_rigid_sim_config=self._static_rigid_sim_config,
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -817,6 +819,7 @@ class KinematicSolver(Solver):
             static_rigid_sim_config=self._static_rigid_sim_config,
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, skip_forward=False):
         if gs.use_zerocopy:
             data = qd_to_torch(self._rigid_global_info.qpos, transpose=True, copy=False)
@@ -951,6 +954,7 @@ class KinematicSolver(Solver):
             velocity_grad_, dofs_idx, envs_idx, self.dofs_state, self._static_rigid_sim_config
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_dofs_position(self, position, dofs_idx=None, envs_idx=None):
         position, dofs_idx, envs_idx = self._sanitize_io_variables(
             position, dofs_idx, self.n_dofs, "dofs_idx", envs_idx, skip_allocation=True

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -27,7 +27,7 @@ from genesis.utils.misc import (
 )
 from genesis.utils.sdf import SDF
 
-from ..base_solver import Solver
+from ..base_solver import Solver, StateChange, mutates
 from ..kinematic_solver import KinematicSolver
 from .collider import Collider
 from .constraint import ConstraintSolver, ConstraintSolverIsland
@@ -1724,6 +1724,7 @@ class RigidSolver(KinematicSolver):
     def set_links_pos(self, pos, links_idx=None, envs_idx=None):
         raise DeprecationError("This method has been removed. Please use 'set_base_links_pos' instead.")
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -1823,6 +1824,7 @@ class RigidSolver(KinematicSolver):
     def set_links_quat(self, quat, links_idx=None, envs_idx=None):
         raise DeprecationError("This method has been removed. Please use 'set_base_links_quat' instead.")
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -1991,6 +1993,7 @@ class RigidSolver(KinematicSolver):
             friction_ratio, geoms_idx, envs_idx, self.geoms_state, self._static_rigid_sim_config
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, skip_forward=False):
         if self.collider is not None:
             self.collider.reset(envs_idx)
@@ -2244,6 +2247,7 @@ class RigidSolver(KinematicSolver):
     def set_dofs_limit(self, lower, upper, dofs_idx=None, envs_idx=None):
         self._set_dofs_info([lower, upper], dofs_idx, "limit", envs_idx)
 
+    @mutates(StateChange.GEOMETRY)
     def set_dofs_position(self, position, dofs_idx=None, envs_idx=None):
         self.collider.reset(envs_idx)
         self.constraint_solver.reset(envs_idx)

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -232,23 +232,38 @@ def update_aabbs(
     fixed_verts_state: array_class.VertsState,
     verts_info: array_class.VertsInfo,
     faces_info: array_class.FacesInfo,
+    geoms_info: array_class.GeomsInfo,
+    links_info: array_class.LinksInfo,
+    static_rigid_sim_config: qd.template(),
     aabb_state: qd.template(),
 ):
+    """Update per-face collision AABBs from current vertex positions.
+
+    A face contributes to env i_b only if its geom lies in that env's active geom range (links_info.geom_start /
+    geom_end); otherwise its AABB is left inverted (unhittable) and skipped by ray queries. For a homogeneous solver
+    every geom is always in range, so this never excludes anything. For a heterogeneous solver, where all envs share
+    one vertex buffer but activate different per-env geom ranges, it makes each env cast against only its own variant
+    instead of the union of every variant.
+    """
     for i_b, i_f in qd.ndrange(free_verts_state.pos.shape[1], faces_info.verts_idx.shape[0]):
         aabb_state.aabbs[i_b, i_f].min.fill(qd.math.inf)
         aabb_state.aabbs[i_b, i_f].max.fill(-qd.math.inf)
 
-        for i in qd.static(range(3)):
-            i_v = faces_info.verts_idx[i_f][i]
-            i_fv = verts_info.verts_state_idx[i_v]
-            if verts_info.is_fixed[i_v]:
-                pos_v = fixed_verts_state.pos[i_fv]
-                aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
-            else:
-                pos_v = free_verts_state.pos[i_fv, i_b]
-                aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+        i_g = faces_info.geom_idx[i_f]
+        i_l = geoms_info.link_idx[i_g]
+        I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
+        if links_info.geom_start[I_l] <= i_g and i_g < links_info.geom_end[I_l]:
+            for i in qd.static(range(3)):
+                i_v = faces_info.verts_idx[i_f][i]
+                i_fv = verts_info.verts_state_idx[i_v]
+                if verts_info.is_fixed[i_v]:
+                    pos_v = fixed_verts_state.pos[i_fv]
+                    aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
+                    aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+                else:
+                    pos_v = free_verts_state.pos[i_fv, i_b]
+                    aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
+                    aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
 
 
 @qd.kernel
@@ -259,13 +274,23 @@ def kernel_update_verts_and_aabbs(
     faces_info: array_class.FacesInfo,
     free_verts_state: array_class.VertsState,
     fixed_verts_state: array_class.VertsState,
+    links_info: array_class.LinksInfo,
     static_rigid_sim_config: qd.template(),
     aabb_state: qd.template(),
 ):
     func_update_all_verts(
         geoms_state, geoms_info, verts_info, free_verts_state, fixed_verts_state, static_rigid_sim_config
     )
-    update_aabbs(free_verts_state, fixed_verts_state, verts_info, faces_info, aabb_state)
+    update_aabbs(
+        free_verts_state,
+        fixed_verts_state,
+        verts_info,
+        faces_info,
+        geoms_info,
+        links_info,
+        static_rigid_sim_config,
+        aabb_state,
+    )
 
 
 # =========================================== Visual Mesh Raycasting ===========================================

--- a/genesis/vis/viewer_plugins/raycast.py
+++ b/genesis/vis/viewer_plugins/raycast.py
@@ -71,6 +71,7 @@ class Raycaster:
             faces_info=self.solver.faces_info,
             free_verts_state=self.solver.free_verts_state,
             fixed_verts_state=self.solver.fixed_verts_state,
+            links_info=self.solver.links_info,
             static_rigid_sim_config=self.solver._static_rigid_sim_config,
             aabb_state=self.aabb,
         )

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1379,6 +1379,43 @@ def test_lidar_cache_offset_parallel_env(show_viewer, tol):
         assert (sensor_data.points.abs() > gs.EPS).any()
 
 
+@pytest.mark.required
+def test_raycaster_heterogeneous_object(show_viewer, tol):
+    scene = gs.Scene(show_viewer=show_viewer)
+    scene.add_entity(gs.morphs.Plane())
+    sensor_mount = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+            pos=(0.0, 0.0, 0.5),
+            fixed=True,
+            collision=False,
+        )
+    )
+    # Without per-env geom masking an env casts against the union of all variants (they share one vertex buffer). The
+    # variants overlap (same pose) so env 0's inactive variant is the nearer hit there - that is what makes a missing
+    # mask observable: env 0 would shadow its own box with env 1's closer sphere.
+    scene.add_entity(
+        morph=(
+            gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(1.0, 0.0, 0.5), fixed=True),
+            gs.morphs.Sphere(radius=0.2, pos=(1.0, 0.0, 0.5), fixed=True),
+        ),
+    )
+    lidar = scene.add_sensor(
+        gs.sensors.Lidar(
+            entity_idx=sensor_mount.idx,
+            pattern=gs.options.sensors.SphericalPattern(n_points=(1, 1), fov=(0.0, 0.0)),
+            max_range=5.0,
+            draw_debug=show_viewer,
+        )
+    )
+
+    scene.build(n_envs=2)
+    scene.step()
+
+    distances = lidar.read().distances[:, 0, 0]
+    assert_allclose(distances, (0.9, 0.8), tol=5e-3)
+
+
 # ------------------------------------------------------------------------------------------
 # -------------------------------------- Kinematic Tactile Sensors ---------------------------------------
 # ------------------------------------------------------------------------------------------

--- a/tests/test_solver_subscribers.py
+++ b/tests/test_solver_subscribers.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+import torch
+
+import genesis as gs
+from genesis.utils.misc import tensor_to_array
+
+
+@pytest.mark.required
+def test_solver_state_change_subscribers(show_viewer):
+    # Imported here rather than at module scope: pulling in the solver package at collection time would import its
+    # quadrants kernels before genesis is initialized (gs.qd_float undefined until then).
+    from genesis.engine.solvers.base_solver import StateChange, Subscriber
+
+    scene = gs.Scene(show_viewer=show_viewer)
+    scene.add_entity(gs.morphs.Plane())
+    cube = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.2, 0.2, 0.2),
+            pos=(0.0, 0.0, 0.5),
+        ),
+    )
+    scene.build(n_envs=2)
+
+    solver = scene.sim.rigid_solver
+
+    # Eager mode: a callback fires immediately on each matching change and nothing is retained.
+    eager_events = []
+    eager = Subscriber(
+        to=frozenset({StateChange.GEOMETRY}),
+        callback=lambda change, envs_idx: eager_events.append((change, envs_idx)),
+    )
+    solver.subscribe(eager)
+    # Lazy mode: matching changes accumulate on the Subscriber handle until cleared.
+    lazy = Subscriber(to=frozenset({StateChange.GEOMETRY}))
+    solver.subscribe(lazy)
+    # A DYNAMICS-only subscriber must stay silent on GEOMETRY changes (filter).
+    dynamics = Subscriber(to=frozenset({StateChange.DYNAMICS}))
+    solver.subscribe(dynamics)
+
+    cube.set_pos(torch.tensor([[0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], dtype=gs.tc_float, device=gs.device))
+    # Eager fired once with the right category; envs_idx forwarded verbatim (None == every env).
+    assert len(eager_events) == 1
+    assert eager_events[0][0] is StateChange.GEOMETRY
+    assert eager_events[0][1] is None
+    # Lazy accumulated the category; the DYNAMICS subscriber saw nothing; eager retains nothing.
+    assert lazy.pending == frozenset({StateChange.GEOMETRY})
+    assert dynamics.pending == frozenset()
+    assert eager.pending == frozenset()
+
+    # A targeted setter forwards the exact env subset to the eager callback.
+    cube.set_pos(torch.tensor([[0.0, 0.0, 3.0]], dtype=gs.tc_float, device=gs.device), envs_idx=[1])
+    assert len(eager_events) == 2
+    forwarded = eager_events[1][1]
+    assert forwarded is not None
+    assert int(np.atleast_1d(tensor_to_array(forwarded))[0]) == 1
+
+    # Lazy state is idempotent across repeated changes and resets on clear().
+    assert lazy.pending == frozenset({StateChange.GEOMETRY})
+    lazy.clear()
+    assert lazy.pending == frozenset()
+
+    # Reads never notify.
+    solver.get_links_pos()
+    solver.get_links_quat()
+    assert len(eager_events) == 2
+    assert lazy.pending == frozenset()
+
+    # Physics integration mutates state through kernels, not a tagged method, so it never notifies.
+    scene.step()
+    assert len(eager_events) == 2
+    assert lazy.pending == frozenset()


### PR DESCRIPTION
## Description

Two independent, self-contained changes, bundled so the raycaster-perf PR (#2867) can rebase on top and consume the mechanism instead of its per-step `torch.equal` pose diff.

### 1. Solver state-change subscriber mechanism (`[MISC]`)

A generic, solver-agnostic way for a solver to notify interested parties when its state is mutated by a setter, so caches (e.g. sensor BVHs) can be invalidated without polling.

- `StateChange` enum — categories only (`GEOMETRY` / `DYNAMICS`), never an index space (links/dofs/particles differ per solver).
- `Subscriber` — a unique handle a consumer constructs and registers via `solver.subscribe(subscriber)`; the solver keeps a `set` of them. Mode is fixed at construction:
  - eager (a callback is given): each matching change calls `callback(change, envs_idx)` immediately;
  - lazy (no callback): changes accumulate in `subscriber.pending` until the owner calls `clear()` — letting a sensor refresh on its next update rather than on every `set_pos`.
- `@mutates(StateChange.GEOMETRY)` tags the geometry-mutating setters (`set_base_links_pos/quat`, `set_qpos`, `set_dofs_position`) in the rigid and kinematic solvers. Reads and physics integration never notify, and there is zero overhead when a solver has no subscribers.

### 2. Heterogeneous-env collision raycasting fix (`[BUG FIX]`)

The raycaster collision BVH treated heterogeneous entities (`add_entity(morph=(variant_0, variant_1, ...))`) as the **union** of all variants in every env: all envs share one vertex buffer holding every variant, and `update_aabbs` built every face's AABB unconditionally. A ray then hit whichever variant was closer, identically in all envs.

`update_aabbs` now includes a face in env `i_b` only when its geom lies in that env's active range (`links_info.geom_start/geom_end`, indexed via the existing `batch_links_info` idiom). Inactive faces keep an inverted AABB and are skipped by ray queries — exactly like the visual `face_mask`. For a homogeneous solver every geom is always in range, so this is a no-op.

## Testing

`pytest tests/test_solver_subscribers.py tests/test_sensors.py -k "raycaster or lidar or subscriber"` (CPU backend):

- `test_solver_state_change_subscribers` — eager vs lazy modes, category filter, `envs_idx` forwarding, and that reads / physics steps never notify.
- `test_raycaster_heterogeneous_object` — box variant in env 0, sphere variant in env 1 at the same pose; asserts per-env distances `[0.9, 0.8]` (the union bug returned `[0.8, 0.8]`).
- Existing raycaster/lidar tests still pass (the masking is a verified no-op for homogeneous scenes).