### PR TITLE
[MISC] Add solver state-change subscriber mechanism.

### DIFF
--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING
+import enum
+import functools
+import inspect
+from typing import TYPE_CHECKING, Any, Callable
 
 import quadrants as qd
 import numpy as np
@@ -15,6 +18,86 @@ from genesis.repr_base import RBC
 if TYPE_CHECKING:
     from genesis.engine.scene import Scene
     from genesis.engine.simulator import Simulator
+
+
+class StateChange(enum.Enum):
+    """Category of solver scene-state mutation broadcast to subscribers (see `Solver.subscribe`).
+
+    Solver-agnostic: it names what kind of state changed, never an index space (links, dofs, particles, ...), which
+    differs from one solver to the next. GEOMETRY is the kinematic configuration that places or deforms the world
+    surface (link poses, qpos, vertices); DYNAMICS is the velocity state. Model parameters (mass, inertia, friction,
+    gains, limits) are not scene state and are never broadcast.
+    """
+
+    GEOMETRY = enum.auto()
+    DYNAMICS = enum.auto()
+
+
+def mutates(*changes: StateChange) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Tag a solver state-mutating method with the StateChange categories it produces (one method may produce several,
+    e.g. set_state changes both GEOMETRY and DYNAMICS).
+
+    Notification is deferred to the outermost tagged call: a setter that internally calls other tagged setters fires a
+    single notification per StateChange that occurred, when the outermost call returns, rather than one per nested
+    call. The outermost call's `envs_idx` (None meaning all envs) is forwarded. Untagged methods, reads included, never
+    notify, so a subscriber only ever wakes on a genuine mutation.
+    """
+    triggered = frozenset(changes)
+
+    def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
+        signature = inspect.signature(method)
+
+        @functools.wraps(method)
+        def wrapper(self: "Solver", *args: Any, **kwargs: Any) -> Any:
+            if not self._subscribers:
+                return method(self, *args, **kwargs)
+            if self._is_mutating:
+                # Nested tagged call: record the changes, let the outermost call do the single notification.
+                self._mutation_changes |= triggered
+                return method(self, *args, **kwargs)
+            self._is_mutating = True
+            self._mutation_changes = set(triggered)
+            try:
+                result = method(self, *args, **kwargs)
+            finally:
+                self._is_mutating = False
+            envs_idx = signature.bind(self, *args, **kwargs).arguments.get("envs_idx")
+            for subscriber in self._subscribers:
+                for changed in self._mutation_changes & subscriber.to:
+                    if subscriber.callback is None:
+                        subscriber._pending.add(changed)
+                    else:
+                        subscriber.callback(changed, envs_idx)
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+class Subscriber:
+    """A unique handle for the solver state changes whose category is in `to`.
+
+    A consumer constructs a Subscriber and registers it with a solver via Solver.subscribe. The mode is fixed at
+    construction by whether a callback is given:
+      - eager (callback given): each matching change immediately calls callback(change, envs_idx);
+      - lazy (no callback): matching changes accumulate into `pending` until the owner calls clear() - e.g. a sensor
+        that rebuilds a cache on its next update rather than on every set_pos.
+    """
+
+    def __init__(self, to: frozenset[StateChange], callback: Callable[[StateChange, object], None] | None = None):
+        self.to = to
+        self.callback = callback
+        self._pending: set[StateChange] = set()
+
+    @property
+    def pending(self) -> frozenset[StateChange]:
+        """Categories accumulated since the last clear() (always empty in eager mode)."""
+        return frozenset(self._pending)
+
+    def clear(self):
+        """Drop the accumulated changes, once they have been handled."""
+        self._pending.clear()
 
 
 class Solver(RBC):
@@ -39,8 +122,19 @@ class Solver(RBC):
         # force fields
         self._ffs = list()
 
+        # Registered Subscribers, notified after @mutates-tagged methods run; see subscribe(). The re-entrancy guard
+        # below defers notification to the outermost tagged call, accumulating every change that occurred in between,
+        # so a setter calling other tagged setters notifies once rather than per nested call.
+        self._subscribers: set[Subscriber] = set()
+        self._is_mutating = False
+        self._mutation_changes: set[StateChange] = set()
+
     def _add_force_field(self, force_field):
         self._ffs.append(force_field)
+
+    def subscribe(self, subscriber: Subscriber):
+        """Register a Subscriber to be notified after any @mutates-tagged method whose change is in its filter."""
+        self._subscribers.add(subscriber)
 
     def build(self):
         self._B = self._sim._B

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -17,7 +17,7 @@ from genesis.utils.misc import (
     assign_indexed_tensor,
 )
 
-from .base_solver import Solver
+from .base_solver import Solver, StateChange, mutates
 from .rigid.abd.misc import (
     kernel_init_dof_fields,
     kernel_init_link_fields,
@@ -597,6 +597,7 @@ class KinematicSolver(Solver):
             state = None
         return state
 
+    @mutates(StateChange.GEOMETRY, StateChange.DYNAMICS)
     def set_state(self, f, state, envs_idx=None, *, partial: bool = False) -> None:
         if not self.is_active:
             return
@@ -700,6 +701,7 @@ class KinematicSolver(Solver):
 
         return tensor_, inputs_idx_, envs_idx_
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -758,6 +760,7 @@ class KinematicSolver(Solver):
             static_rigid_sim_config=self._static_rigid_sim_config,
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -817,6 +820,7 @@ class KinematicSolver(Solver):
             static_rigid_sim_config=self._static_rigid_sim_config,
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, skip_forward=False):
         if gs.use_zerocopy:
             data = qd_to_torch(self._rigid_global_info.qpos, transpose=True, copy=False)
@@ -873,6 +877,7 @@ class KinematicSolver(Solver):
             self._is_forward_pos_updated = False
             self._is_forward_vel_updated = False
 
+    @mutates(StateChange.DYNAMICS)
     def set_dofs_velocity(self, velocity, dofs_idx=None, envs_idx=None, *, skip_forward=False):
         if gs.use_zerocopy:
             vel = qd_to_torch(self.dofs_state.vel, transpose=True, copy=False)
@@ -951,6 +956,7 @@ class KinematicSolver(Solver):
             velocity_grad_, dofs_idx, envs_idx, self.dofs_state, self._static_rigid_sim_config
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_dofs_position(self, position, dofs_idx=None, envs_idx=None):
         position, dofs_idx, envs_idx = self._sanitize_io_variables(
             position, dofs_idx, self.n_dofs, "dofs_idx", envs_idx, skip_allocation=True
@@ -1087,6 +1093,7 @@ class KinematicSolver(Solver):
             self._static_rigid_sim_config,
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_vverts(self, custom_vvert_start, custom_vvert_end, vgeoms_idx, vverts, envs_idx=None):
         """Write the slice [custom_vvert_start:custom_vvert_end] of vverts_state.pos.
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -27,7 +27,7 @@ from genesis.utils.misc import (
 )
 from genesis.utils.sdf import SDF
 
-from ..base_solver import Solver
+from ..base_solver import Solver, StateChange, mutates
 from ..kinematic_solver import KinematicSolver
 from .collider import Collider
 from .constraint import ConstraintSolver, ConstraintSolverIsland
@@ -1547,6 +1547,7 @@ class RigidSolver(KinematicSolver):
             state = None
         return state
 
+    @mutates(StateChange.GEOMETRY, StateChange.DYNAMICS)
     def set_state(self, f, state, envs_idx=None, *, partial: bool = False) -> None:
         if not self.is_active:
             return
@@ -1724,6 +1725,7 @@ class RigidSolver(KinematicSolver):
     def set_links_pos(self, pos, links_idx=None, envs_idx=None):
         raise DeprecationError("This method has been removed. Please use 'set_base_links_pos' instead.")
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -1823,6 +1825,7 @@ class RigidSolver(KinematicSolver):
     def set_links_quat(self, quat, links_idx=None, envs_idx=None):
         raise DeprecationError("This method has been removed. Please use 'set_base_links_quat' instead.")
 
+    @mutates(StateChange.GEOMETRY)
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -1991,6 +1994,7 @@ class RigidSolver(KinematicSolver):
             friction_ratio, geoms_idx, envs_idx, self.geoms_state, self._static_rigid_sim_config
         )
 
+    @mutates(StateChange.GEOMETRY)
     def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, skip_forward=False):
         if self.collider is not None:
             self.collider.reset(envs_idx)
@@ -2244,6 +2248,7 @@ class RigidSolver(KinematicSolver):
     def set_dofs_limit(self, lower, upper, dofs_idx=None, envs_idx=None):
         self._set_dofs_info([lower, upper], dofs_idx, "limit", envs_idx)
 
+    @mutates(StateChange.GEOMETRY)
     def set_dofs_position(self, position, dofs_idx=None, envs_idx=None):
         self.collider.reset(envs_idx)
         self.constraint_solver.reset(envs_idx)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,6 +11,7 @@ import genesis as gs
 import genesis.utils.point_cloud as pc
 from genesis.options.surfaces import Surface
 from genesis.options.textures import ColorTexture
+from genesis.utils.misc import tensor_to_array
 
 from .utils import assert_allclose, assert_equal
 
@@ -316,3 +317,83 @@ def test_destroy_after_failed_camera_build(monkeypatch, raise_before_build):
     assert shared_metadata.context is None
     assert shared_metadata.sensors is None
     assert shared_metadata.image_cache is None
+
+
+@pytest.mark.required
+def test_solver_state_change_subscribers(show_viewer):
+    # Imported lazily: the solver package pulls in quadrants kernels that need gs.qd_float, set only by gs.init.
+    from genesis.engine.solvers.base_solver import StateChange, Subscriber
+
+    scene = gs.Scene(show_viewer=show_viewer)
+    scene.add_entity(gs.morphs.Plane())
+    cube = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.2, 0.2, 0.2),
+            pos=(0.0, 0.0, 0.5),
+        ),
+    )
+    scene.build(n_envs=2)
+
+    solver = scene.sim.rigid_solver
+
+    # Eager mode: a callback fires immediately on each matching change and nothing is retained.
+    eager_events = []
+    eager = Subscriber(
+        to=frozenset({StateChange.GEOMETRY}),
+        callback=lambda change, envs_idx: eager_events.append((change, envs_idx)),
+    )
+    solver.subscribe(eager)
+    # Lazy mode: matching changes accumulate on the Subscriber handle until cleared.
+    lazy = Subscriber(to=frozenset({StateChange.GEOMETRY}))
+    solver.subscribe(lazy)
+    # A DYNAMICS-only subscriber must stay silent on GEOMETRY changes (filter).
+    dynamics = Subscriber(to=frozenset({StateChange.DYNAMICS}))
+    solver.subscribe(dynamics)
+
+    # zero_velocity=False isolates the pure GEOMETRY change (a default set_pos also zeroes velocity; see below).
+    cube.set_pos([[0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], zero_velocity=False)
+    # Eager fired once with the right category; envs_idx forwarded verbatim (None == every env).
+    assert len(eager_events) == 1
+    assert eager_events[0][0] is StateChange.GEOMETRY
+    assert eager_events[0][1] is None
+    # Lazy accumulated the category; the DYNAMICS subscriber saw nothing; eager retains nothing.
+    assert lazy.pending == frozenset({StateChange.GEOMETRY})
+    assert dynamics.pending == frozenset()
+    assert eager.pending == frozenset()
+
+    # A targeted setter forwards the exact env subset to the eager callback.
+    cube.set_pos([[0.0, 0.0, 3.0]], envs_idx=[1], zero_velocity=False)
+    assert len(eager_events) == 2
+    forwarded = eager_events[1][1]
+    assert forwarded is not None
+    assert int(np.atleast_1d(tensor_to_array(forwarded))[0]) == 1
+
+    # Lazy state is idempotent across repeated changes and resets on clear().
+    assert lazy.pending == frozenset({StateChange.GEOMETRY})
+    lazy.clear()
+    assert lazy.pending == frozenset()
+
+    # A velocity setter is a DYNAMICS change only: it wakes the DYNAMICS subscriber, not the GEOMETRY ones (setting a
+    # velocity does not move the surface).
+    cube.set_dofs_velocity([0.0] * cube.n_dofs)
+    assert dynamics.pending == frozenset({StateChange.DYNAMICS})
+    assert lazy.pending == frozenset()
+    assert len(eager_events) == 2
+
+    # Reads never notify.
+    solver.get_links_pos()
+    solver.get_links_quat()
+    assert len(eager_events) == 2
+    assert lazy.pending == frozenset()
+
+    # Physics integration mutates state through kernels, not a tagged method, so it never notifies.
+    scene.step()
+    assert len(eager_events) == 2
+    assert lazy.pending == frozenset()
+
+    # A default set_pos both moves the link and zeroes its velocity, so a subscriber listening for either category
+    # receives both - the accumulated union of every change the call produced.
+    both = Subscriber(to=frozenset({StateChange.GEOMETRY, StateChange.DYNAMICS}))
+    solver.subscribe(both)
+    cube.set_pos([[0.0, 0.0, 4.0], [0.0, 0.0, 5.0]])
+    assert both.pending == frozenset({StateChange.GEOMETRY, StateChange.DYNAMICS})


### PR DESCRIPTION
## Description

Generic solver state-change notification. Solvers tag state-mutating setters with `@mutates(StateChange.GEOMETRY|DYNAMICS)`; a consumer registers a `Subscriber` handle via `solver.subscribe(...)`. A Subscriber either fires a callback eagerly or accumulates changes in `pending` for lazy polling. Zero overhead when a solver has no subscribers.

## Related Issue

No tracking issue.

## Motivation and Context

Lets caches (e.g. sensor BVHs) be invalidated on a setter without per-step polling. Foundation for #2867 to skip static raycast-BVH rebuilds instead of diffing poses every step.

## How Has This Been / Can This Be Tested?

`pytest tests/test_solver_subscribers.py` (CPU backend): eager/lazy modes, category filter, `envs_idx` forwarding, and that reads and physics steps never notify.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.