### PR TITLE
[BUG FIX] Fix raycast sensor for heterogeneous entities.

### DIFF
--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -115,6 +115,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
                     faces_info=entry.solver.faces_info,
                     free_verts_state=entry.solver.free_verts_state,
                     fixed_verts_state=entry.solver.fixed_verts_state,
+                    links_info=entry.solver.links_info,
                     static_rigid_sim_config=entry.solver._static_rigid_sim_config,
                     aabb_state=entry.aabb,
                 )

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -232,23 +232,38 @@ def update_aabbs(
     fixed_verts_state: array_class.VertsState,
     verts_info: array_class.VertsInfo,
     faces_info: array_class.FacesInfo,
+    geoms_info: array_class.GeomsInfo,
+    links_info: array_class.LinksInfo,
+    static_rigid_sim_config: qd.template(),
     aabb_state: qd.template(),
 ):
+    """Update per-face collision AABBs from current vertex positions.
+
+    A face contributes to env i_b only if its geom lies in that env's active geom range (links_info.geom_start /
+    geom_end); otherwise its AABB is left inverted (unhittable) and skipped by ray queries. For a homogeneous solver
+    every geom is always in range, so this never excludes anything. For a heterogeneous solver, where all envs share
+    one vertex buffer but activate different per-env geom ranges, it makes each env cast against only its own variant
+    instead of the union of every variant.
+    """
     for i_b, i_f in qd.ndrange(free_verts_state.pos.shape[1], faces_info.verts_idx.shape[0]):
         aabb_state.aabbs[i_b, i_f].min.fill(qd.math.inf)
         aabb_state.aabbs[i_b, i_f].max.fill(-qd.math.inf)
 
-        for i in qd.static(range(3)):
-            i_v = faces_info.verts_idx[i_f][i]
-            i_fv = verts_info.verts_state_idx[i_v]
-            if verts_info.is_fixed[i_v]:
-                pos_v = fixed_verts_state.pos[i_fv]
-                aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
-            else:
-                pos_v = free_verts_state.pos[i_fv, i_b]
-                aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+        i_g = faces_info.geom_idx[i_f]
+        i_l = geoms_info.link_idx[i_g]
+        I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
+        if links_info.geom_start[I_l] <= i_g and i_g < links_info.geom_end[I_l]:
+            for i in qd.static(range(3)):
+                i_v = faces_info.verts_idx[i_f][i]
+                i_fv = verts_info.verts_state_idx[i_v]
+                if verts_info.is_fixed[i_v]:
+                    pos_v = fixed_verts_state.pos[i_fv]
+                    aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
+                    aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+                else:
+                    pos_v = free_verts_state.pos[i_fv, i_b]
+                    aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
+                    aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
 
 
 @qd.kernel
@@ -259,13 +274,23 @@ def kernel_update_verts_and_aabbs(
     faces_info: array_class.FacesInfo,
     free_verts_state: array_class.VertsState,
     fixed_verts_state: array_class.VertsState,
+    links_info: array_class.LinksInfo,
     static_rigid_sim_config: qd.template(),
     aabb_state: qd.template(),
 ):
     func_update_all_verts(
         geoms_state, geoms_info, verts_info, free_verts_state, fixed_verts_state, static_rigid_sim_config
     )
-    update_aabbs(free_verts_state, fixed_verts_state, verts_info, faces_info, aabb_state)
+    update_aabbs(
+        free_verts_state,
+        fixed_verts_state,
+        verts_info,
+        faces_info,
+        geoms_info,
+        links_info,
+        static_rigid_sim_config,
+        aabb_state,
+    )
 
 
 # =========================================== Visual Mesh Raycasting ===========================================

--- a/genesis/vis/viewer_plugins/raycast.py
+++ b/genesis/vis/viewer_plugins/raycast.py
@@ -71,6 +71,7 @@ class Raycaster:
             faces_info=self.solver.faces_info,
             free_verts_state=self.solver.free_verts_state,
             fixed_verts_state=self.solver.fixed_verts_state,
+            links_info=self.solver.links_info,
             static_rigid_sim_config=self.solver._static_rigid_sim_config,
             aabb_state=self.aabb,
         )

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1379,6 +1379,43 @@ def test_lidar_cache_offset_parallel_env(show_viewer, tol):
         assert (sensor_data.points.abs() > gs.EPS).any()
 
 
+@pytest.mark.required
+def test_raycaster_heterogeneous_object(show_viewer, tol):
+    scene = gs.Scene(show_viewer=show_viewer)
+    scene.add_entity(gs.morphs.Plane())
+    sensor_mount = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+            pos=(0.0, 0.0, 0.5),
+            fixed=True,
+            collision=False,
+        )
+    )
+    # Without per-env geom masking an env casts against the union of all variants (they share one vertex buffer). The
+    # variants overlap (same pose) so env 0's inactive variant is the nearer hit there - that is what makes a missing
+    # mask observable: env 0 would shadow its own box with env 1's closer sphere.
+    scene.add_entity(
+        morph=(
+            gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(1.0, 0.0, 0.5), fixed=True),
+            gs.morphs.Sphere(radius=0.2, pos=(1.0, 0.0, 0.5), fixed=True),
+        ),
+    )
+    lidar = scene.add_sensor(
+        gs.sensors.Lidar(
+            entity_idx=sensor_mount.idx,
+            pattern=gs.options.sensors.SphericalPattern(n_points=(1, 1), fov=(0.0, 0.0)),
+            max_range=5.0,
+            draw_debug=show_viewer,
+        )
+    )
+
+    scene.build(n_envs=2)
+    scene.step()
+
+    distances = lidar.read().distances[:, 0, 0]
+    assert_allclose(distances, (0.9, 0.8), tol=5e-3)
+
+
 # ------------------------------------------------------------------------------------------
 # -------------------------------------- Kinematic Tactile Sensors ---------------------------------------
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The raycaster collision BVH built every face's AABB unconditionally, so a heterogeneous entity (one variant per env, all sharing one vertex buffer) was cast as the union of every variant in each env. `update_aabbs` now skips a face whose geom is outside the env's active range (`links_info.geom_start/geom_end`), leaving its AABB unhittable. 

## Motivation and Context

Each env must raycast against only its own variant, not the union of all variants.

## How Has This Been / Can This Be Tested?

`pytest tests/test_sensors.py -k "raycaster or lidar"` (CPU backend). New `test_raycaster_heterogeneous_object` asserts per-env distances `[0.9, 0.8]`; the union bug returned `[0.8, 0.8]`.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.