### PR TITLE
[MISC] Speed raycaster-related sensors using cross-sensor shared context.

### DIFF
--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -95,21 +95,56 @@ class SimpleSensorMetadata(SharedSensorMetadata):
     has_any_resolution: bool = False
 
 
+class SharedSensorContext:
+    """
+    Resource shared across *different* sensor types, owned by ``SensorManager``.
+
+    Distinct from ``SharedSensorMetadata``: metadata aggregates the per-sensor state of all sensors of a *single*
+    type so one kernel can run over them (a batching optimization that grows with the number of sensors); a context
+    is a *single* resource (e.g. one collision BVH for the simulator) read by *several* sensor types, O(1) in the
+    number of sensors (a sharing optimization). A sensor type declares the context it consumes as the second
+    ``Sensor[Options, Context, Metadata, Data]`` parameter (``None`` when it has none); every type declaring the same
+    context class resolves to the one instance the manager owns.
+
+    A context is purely an optimization (runtime speed or memory): a sensor must produce identical results whether
+    or not the context is shared, so it is always safe to rebuild or duplicate it. Cross-sensor consistency remains
+    the responsibility of ``SensorManager``, never of the context.
+
+    The whole lifecycle is driven by ``SensorManager``: ``build`` once after the scene geometry exists, ``update``
+    once per step before the per-type update loop reads it, ``reset`` on ``scene.reset()``, ``destroy`` on teardown.
+    """
+
+    def build(self, sim):
+        """Build the shared resource from the scene; called once after every sensor is built."""
+
+    def update(self):
+        """Refresh the shared resource for the current step; called once before sensors read it."""
+
+    def reset(self, envs_idx):
+        """Reset the shared resource for the given environments."""
+
+    def destroy(self):
+        """Release any resources held by the context."""
+
+
 SharedSensorMetadataT = TypeVar("SharedSensorMetadataT", bound=SharedSensorMetadata)
 OptionsT = TypeVar("OptionsT", bound="SensorOptions")
 DataT = TypeVarWithDefault("DataT", default=tuple, covariant=True)
+# Second ``Sensor[...]`` parameter: the cross-type shared context. No default - declare ``None`` explicitly when the
+# sensor type has no shared context (``SensorManager`` then passes ``None`` to the per-step hooks for that type).
+SharedSensorContextT = TypeVar("SharedSensorContextT")
 
 
-class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
+class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT, DataT]):
     """
     Base class for all types of sensors.
 
-    To create a sensor, prefer using `scene.add_sensor(sensor_options)` instead of instantiating this class directly.
+    To create a sensor, prefer using `scene.add_sensor(options)` instead of instantiating this class directly.
 
     Each concrete sensor class declares its associated options, metadata, and data types via Generic type parameters::
 
-        class MySensor(Sensor[MyOptions, MyMetadata, MyData]):
-            ...  # DataT defaults to tuple; specify explicitly for NamedTuple returns
+        class MySensor(Sensor[MyOptions, MyContext, MyMetadata, MyData]):
+            ...  # 2nd param is the shared context (use ``None`` if none); DataT defaults to tuple
 
     Note
     -----
@@ -122,6 +157,9 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
     _options_cls: ClassVar[type]
     _metadata_cls: ClassVar[type]
     _return_data_class: ClassVar[type] = tuple
+    # Cross-type shared context class declared as the second ``Sensor[...]`` parameter; ``NoneType`` (declared as
+    # ``None``) means this sensor type consumes no shared context.
+    _shared_context_cls: ClassVar[type] = type(None)
     # Whether instances of this class participate in the ring-based per-step pipeline (delay sampling, transform
     # recurrence, history snapshots). Drives allocation of the GT + measured timeline rings in `SensorManager.build`.
     # Subclasses whose `_update_shared_cache` bypasses the rings (e.g. cameras handling rendering lazily) explicitly set
@@ -137,9 +175,11 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
                 if len(args) >= 1 and not isinstance(args[0], TypeVar):
                     cls._options_cls = args[0]
                 if len(args) >= 2 and not isinstance(args[1], TypeVar):
-                    cls._metadata_cls = args[1]
+                    cls._shared_context_cls = args[1]
                 if len(args) >= 3 and not isinstance(args[2], TypeVar):
-                    cls._return_data_class = args[2]
+                    cls._metadata_cls = args[2]
+                if len(args) >= 4 and not isinstance(args[3], TypeVar):
+                    cls._return_data_class = args[3]
                 break
         # Strict contract: overriding `_post_process` requires overriding `_get_intermediate_format` and/or
         # `_get_intermediate_dtype`. The intermediate buffer must be a distinct buffer regardless of whether its
@@ -158,32 +198,43 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
         # specify the metadata type parameter.
         if "_options_cls" in cls.__dict__:
             if "_metadata_cls" not in cls.__dict__:
-                raise TypeError(f"{cls.__name__} must specify Sensor[OptionsT, MetadataT, DataT=tuple].")
+                raise TypeError(f"{cls.__name__} must specify Sensor[OptionsT, ContextT, MetadataT, DataT=tuple].")
             from .sensor_manager import SensorManager
 
             SensorManager.SENSOR_TYPES_MAP[cls._options_cls] = cls
 
-    def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
-        self._options: "SensorOptions" = sensor_options
-        self._idx: int = sensor_idx
-        self._manager: "SensorManager" = sensor_manager
-        self._shared_metadata: SharedSensorMetadataT = sensor_manager._sensors_metadata[type(self)]
+    def __init__(
+        self,
+        options: "SensorOptions",
+        idx: int,
+        shared_context: SharedSensorContextT,
+        shared_metadata: SharedSensorMetadataT,
+        manager: "SensorManager",
+    ):
+        self._options: "SensorOptions" = options
+        self._idx: int = idx
+        # The per-type metadata and cross-type context a sensor needs are passed in explicitly so sensors never
+        # introspect the manager's registries. The manager itself comes last as it is only a backdoor for debug / fast
+        # prototyping (and so it can be dropped from the signature later).
+        self._manager: "SensorManager" = manager
+        # The cross-type shared context instance, or ``None`` when this sensor type declares no context. Reachable from
+        # instance methods (build / debug); the per-step classmethod hooks receive it as the ``shared_context`` argument.
+        self._shared_context: SharedSensorContextT = shared_context
+        self._shared_metadata: SharedSensorMetadataT = shared_metadata
         self._is_built = False
 
         # Classes that opt out of the ring pipeline (e.g. cameras handling rendering lazily on read) cannot honor delay
         # / jitter / history because those features depend on the per-class return-space ring. Reject the inputs at
         # construction so the user picks a different sensor or drops the option rather than silently getting no-ops.
         if not self.uses_ring_pipeline:
-            if sensor_options.delay > 0.0:
-                gs.raise_exception(f"{type(self).__name__} does not support `delay`; got delay={sensor_options.delay}.")
-            if sensor_options.jitter > 0.0:
-                gs.raise_exception(
-                    f"{type(self).__name__} does not support `jitter`; got jitter={sensor_options.jitter}."
-                )
-            if sensor_options.history_length > 0:
+            if options.delay > 0.0:
+                gs.raise_exception(f"{type(self).__name__} does not support `delay`; got delay={options.delay}.")
+            if options.jitter > 0.0:
+                gs.raise_exception(f"{type(self).__name__} does not support `jitter`; got jitter={options.jitter}.")
+            if options.history_length > 0:
                 gs.raise_exception(
                     f"{type(self).__name__} does not support `history_length`; got "
-                    f"history_length={sensor_options.history_length}."
+                    f"history_length={options.history_length}."
                 )
 
         self._dt = self._manager._sim.dt
@@ -296,6 +347,7 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorMetadataT, DataT]):
     @classmethod
     def _update_shared_cache(
         cls,
+        shared_context: SharedSensorContextT,
         shared_metadata: SharedSensorMetadataT,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -601,7 +653,7 @@ class KinematicSensorMixin(_LinkAttachedSensorMixin, Generic[KinematicSensorMeta
             )
 
 
-class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
+class SimpleSensor(Sensor[OptionsT, SharedSensorContextT, SharedSensorMetadataT, DataT]):
     """
     Base class for sensors that use the standard per-step pipeline.
 
@@ -726,6 +778,7 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
     @classmethod
     def _update_shared_cache(
         cls,
+        shared_context: SharedSensorContextT,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -739,7 +792,7 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
         if measured_data_timeline is None:
             # No measured pipeline for this dtype (only non-SimpleSensor classes); shouldn't happen for SimpleSensor
             # instances but keep the path correct: raw GT -> intermediate cache.
-            cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
+            cls._update_raw_data(shared_context, shared_metadata, current_ground_truth_data_T)
             intermediate_cache.copy_(current_ground_truth_data_T.T)
         else:
             gt_slot_0 = ground_truth_data_timeline.at(0, copy=False)
@@ -750,7 +803,11 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
             # in place on the measured ring slot only - GT keeps the raw simulated phenomenon, measured carries the
             # noised value.
             cls._update_current_timestep_data(
-                shared_metadata, current_ground_truth_data_T, ground_truth_data_timeline, measured_data_timeline
+                shared_context,
+                shared_metadata,
+                current_ground_truth_data_T,
+                ground_truth_data_timeline,
+                measured_data_timeline,
             )
 
             # GT branch transform. `is_measured=False` lets sensor-element-specific effects (RC filter, mechanical
@@ -777,6 +834,7 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
     @classmethod
     def _update_current_timestep_data(
         cls,
+        shared_context: SharedSensorContextT,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -792,7 +850,7 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
         ``current_ground_truth_data_T`` and to the GT ring slot, and write the noised value directly to the measured
         ring slot.
         """
-        cls._update_raw_data(shared_metadata, current_ground_truth_data_T)
+        cls._update_raw_data(shared_context, shared_metadata, current_ground_truth_data_T)
         if ground_truth_data_timeline is not None:
             ground_truth_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
         measured_slot_0 = measured_data_timeline.at(0, copy=False)
@@ -819,7 +877,9 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorMetadataT, DataT]):
         """
 
     @classmethod
-    def _update_raw_data(cls, shared_metadata: SharedSensorMetadata, raw_data_T: torch.Tensor):
+    def _update_raw_data(
+        cls, shared_context: SharedSensorContextT, shared_metadata: SharedSensorMetadata, raw_data_T: torch.Tensor
+    ):
         """Sensor-specific kernel computing raw data into ``raw_data_T`` (shape ``(cols, B)``)."""
         raise NotImplementedError(f"{cls.__name__} has not implemented `_update_raw_data()`.")
 

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 # ========================== Data Class ==========================
 
 
-class CameraData(NamedTuple):
+class CameraReturnType(NamedTuple):
     """Camera sensor return data."""
 
     rgb: torch.Tensor
@@ -214,7 +214,7 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
 # ========================== Base Camera Sensor ==========================
 
 
-class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetadata, CameraData]):
+class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensorMetadata, CameraReturnType]):
     """
     Base class for camera sensors that render RGB images into an internal image_cache.
 
@@ -227,9 +227,16 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
 
     uses_ring_pipeline: ClassVar[bool] = False
 
-    def __init__(self, options: "SensorOptions", idx: int, manager: "SensorManager"):
+    def __init__(
+        self,
+        options: "SensorOptions",
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
         # `uses_ring_pipeline = False` triggers the generic delay / jitter / history rejection in `Sensor.__init__`.
-        super().__init__(options, idx, manager)
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._stale: bool = True
 
     # ========================== Cache Integration (shared) ==========================
@@ -245,6 +252,7 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
     @classmethod
     def _update_shared_cache(
         cls,
+        shared_context: None,
         shared_metadata: SharedSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -339,7 +347,7 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
         return np.asarray(envs_idx)
 
     @gs.assert_built
-    def read(self, envs_idx=None) -> CameraData:
+    def read(self, envs_idx=None) -> CameraReturnType:
         """Render if needed, then read the cached image from the backend-specific cache."""
         self._ensure_rendered_for_current_state()
         cached_image = self._get_image_cache_entry()
@@ -347,9 +355,9 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, SharedSensorMetada
 
 
 # ========================== Camera Sensor Helpers ==========================
-def _camera_read_from_image_cache(sensor, cached_image, envs_idx, *, to_numpy: bool) -> CameraData:
+def _camera_read_from_image_cache(sensor, cached_image, envs_idx, *, to_numpy: bool) -> CameraReturnType:
     """
-    Shared helper to convert a cached RGB image array into CameraData with correct env handling.
+    Shared helper to convert a cached RGB image array into CameraReturnType with correct env handling.
 
     Parameters
     ----------
@@ -377,7 +385,7 @@ def _camera_read_from_image_cache(sensor, cached_image, envs_idx, *, to_numpy: b
 
 
 class RasterizerCameraSensor(
-    BaseCameraSensor, Sensor[RasterizerCameraOptions, RasterizerCameraSharedMetadata, CameraData]
+    BaseCameraSensor, Sensor[RasterizerCameraOptions, None, RasterizerCameraSharedMetadata, CameraReturnType]
 ):
     """
     Rasterizer camera sensor using OpenGL-based rendering.
@@ -386,8 +394,15 @@ class RasterizerCameraSensor(
     visualizer.
     """
 
-    def __init__(self, options: RasterizerCameraOptions, idx: int, manager: "SensorManager"):
-        super().__init__(options, idx, manager)
+    def __init__(
+        self,
+        options: RasterizerCameraOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._options: RasterizerCameraOptions
         self._camera_node = None
         self._camera_target = None
@@ -571,14 +586,21 @@ class RasterizerCameraSensor(
 
 # ========================== Raytracer Camera Sensor ==========================
 class RaytracerCameraSensor(
-    BaseCameraSensor, Sensor[RaytracerCameraOptions, RaytracerCameraSharedMetadata, CameraData]
+    BaseCameraSensor, Sensor[RaytracerCameraOptions, None, RaytracerCameraSharedMetadata, CameraReturnType]
 ):
     """
     Raytracer camera sensor using LuisaRender path tracing.
     """
 
-    def __init__(self, options: RaytracerCameraOptions, idx: int, manager: "SensorManager"):
-        super().__init__(options, idx, manager)
+    def __init__(
+        self,
+        options: RaytracerCameraOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._options: RaytracerCameraOptions
         self._camera_obj = None
 
@@ -721,7 +743,7 @@ class RaytracerCameraSensor(
 
 
 class BatchRendererCameraSensor(
-    BaseCameraSensor, Sensor[BatchRendererCameraOptions, BatchRendererCameraSharedMetadata, CameraData]
+    BaseCameraSensor, Sensor[BatchRendererCameraOptions, None, BatchRendererCameraSharedMetadata, CameraReturnType]
 ):
     """
     Batch renderer camera sensor using Madrona GPU batch rendering.
@@ -729,8 +751,15 @@ class BatchRendererCameraSensor(
     Note: All batch renderer cameras must have the same resolution.
     """
 
-    def __init__(self, options: BatchRendererCameraOptions, idx: int, manager: "SensorManager"):
-        super().__init__(options, idx, manager)
+    def __init__(
+        self,
+        options: BatchRendererCameraOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._options: BatchRendererCameraOptions
         self._camera_obj = None
 

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -76,13 +76,20 @@ class ContactSensorMetadata(SimpleSensorMetadata):
     thresholds: torch.Tensor = make_tensor_field((0,))
 
 
-class ContactSensor(SimpleSensor[ContactSensorOptions, ContactSensorMetadata]):
+class ContactSensor(SimpleSensor[ContactSensorOptions, None, ContactSensorMetadata]):
     """
     Sensor that returns bool based on whether associated RigidLink is in contact.
     """
 
-    def __init__(self, sensor_options: ContactSensorOptions, sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: ContactSensorOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
         self._link: "RigidLink | None" = None
         self.debug_object: "Mesh | None" = None
@@ -132,7 +139,7 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, ContactSensorMetadata]):
         return gs.tc_float
 
     @classmethod
-    def _update_raw_data(cls, shared_metadata: ContactSensorMetadata, raw_data_T: torch.Tensor):
+    def _update_raw_data(cls, shared_context: None, shared_metadata: ContactSensorMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
         all_contacts = shared_metadata.solver.collider.get_contacts(as_tensor=True, to_torch=True)
         link_a, link_b = all_contacts["link_a"], all_contacts["link_b"]
@@ -199,14 +206,22 @@ class ContactForceSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata)
 
 
 class ContactForceSensor(
-    RigidSensorMixin[ContactForceSensorMetadata], SimpleSensor[ContactForceSensorOptions, ContactForceSensorMetadata]
+    RigidSensorMixin[ContactForceSensorMetadata],
+    SimpleSensor[ContactForceSensorOptions, None, ContactForceSensorMetadata],
 ):
     """
     Sensor that returns the total contact force being applied to the associated RigidLink in its local frame.
     """
 
-    def __init__(self, options: ContactForceSensorOptions, sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: ContactForceSensorOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
         self.debug_object: "Mesh" | None = None
 
@@ -237,7 +252,9 @@ class ContactForceSensor(
         return cls._get_cache_dtype()
 
     @classmethod
-    def _update_raw_data(cls, shared_metadata: ContactForceSensorMetadata, raw_data_T: torch.Tensor):
+    def _update_raw_data(
+        cls, shared_context: None, shared_metadata: ContactForceSensorMetadata, raw_data_T: torch.Tensor
+    ):
         assert shared_metadata.solver is not None
 
         # Note that forcing GPU sync to operate on `slice(0, max(n_contacts))` is usually faster overall.

--- a/genesis/engine/sensors/depth_camera.py
+++ b/genesis/engine/sensors/depth_camera.py
@@ -3,10 +3,14 @@ import torch
 from genesis.options.sensors import DepthCamera as DepthCameraOptions
 
 from .base_sensor import Sensor
-from .raycaster import RaycasterData, RaycasterSensor, RaycasterSharedMetadata
+from .raycaster import RaycastContext, RaycasterReturnType, RaycasterSensor, RaycasterSharedMetadata
 
 
-class DepthCameraSensor(RaycasterSensor, Sensor[DepthCameraOptions, RaycasterSharedMetadata, RaycasterData]):
+# DepthCamera declares no fourth (context) parameter, so it inherits RaycasterSensor's ``_shared_context_cls``
+# (RaycastContext) and shares the one BVH set with any Raycaster in the scene.
+class DepthCameraSensor(
+    RaycasterSensor, Sensor[DepthCameraOptions, RaycastContext, RaycasterSharedMetadata, RaycasterReturnType]
+):
     def build(self):
         super().build()
 

--- a/genesis/engine/sensors/imu.py
+++ b/genesis/engine/sensors/imu.py
@@ -64,21 +64,28 @@ class IMUSharedMetadata(RigidSensorMetadataMixin, SimpleSensorMetadata):
     mag_indices: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
 
 
-class IMUData(NamedTuple):
+class IMUReturnType(NamedTuple):
     lin_acc: torch.Tensor
     ang_vel: torch.Tensor
     mag: torch.Tensor  # added magnetometer to complete 9-axis IMU
 
 
-class IMUSensor(RigidSensorMixin[IMUSharedMetadata], SimpleSensor[IMUOptions, IMUSharedMetadata, IMUData]):
-    def __init__(self, options: IMUOptions, shared_metadata: IMUSharedMetadata, manager: "SensorManager"):
+class IMUSensor(RigidSensorMixin[IMUSharedMetadata], SimpleSensor[IMUOptions, None, IMUSharedMetadata, IMUReturnType]):
+    def __init__(
+        self,
+        options: IMUOptions,
+        idx: int,
+        shared_context,
+        shared_metadata: IMUSharedMetadata,
+        manager: "SensorManager",
+    ):
         # FIXME: Resolution should be made private in mixin, so that it cannot be set by the user directly.
         options.resolution = options.acc_resolution + options.gyro_resolution + options.mag_resolution
         options.bias = options.acc_bias + options.gyro_bias + options.mag_bias
         options.random_walk = options.acc_random_walk + options.gyro_random_walk + options.mag_random_walk
         options.noise = options.acc_noise + options.gyro_noise + options.mag_noise
 
-        super().__init__(options, shared_metadata, manager)
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
         self.debug_objects: list["Mesh"] = []
         self.quat_offset: torch.Tensor
@@ -144,7 +151,7 @@ class IMUSensor(RigidSensorMixin[IMUSharedMetadata], SimpleSensor[IMUOptions, IM
         return gs.tc_float
 
     @classmethod
-    def _update_raw_data(cls, shared_metadata: IMUSharedMetadata, raw_data_T: torch.Tensor):
+    def _update_raw_data(cls, shared_context: None, shared_metadata: IMUSharedMetadata, raw_data_T: torch.Tensor):
         assert shared_metadata.solver is not None
         # Extract acceleration and gravity in world frame.
         gravity = shared_metadata.solver.get_gravity()

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -354,8 +354,15 @@ def _kernel_contact_depth_probe(
 
 
 class KinematicTactileSensorMixin(ProbeSensorMixin[ProbesWithNormalSensorSharedMetadataT]):
-    def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: "SensorOptions",
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._debug_objects: list = []
 
     def build(self):
@@ -391,7 +398,7 @@ class ContactDepthProbeMetadata(ProbeSensorMetadataMixin, RigidSensorMetadataMix
 class ContactDepthProbeSensor(
     KinematicTactileSensorMixin[ContactDepthProbeMetadata],
     RigidSensorMixin[ContactDepthProbeMetadata],
-    SimpleSensor[ContactDepthProbeOptions, ContactDepthProbeMetadata, tuple],
+    SimpleSensor[ContactDepthProbeOptions, None, ContactDepthProbeMetadata, tuple],
 ):
     """Returns contact depth in meters per probe."""
 
@@ -405,6 +412,7 @@ class ContactDepthProbeSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
+        shared_context: None,
         shared_metadata: ContactDepthProbeMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -450,7 +458,7 @@ class ContactProbeMetadata(ContactDepthProbeMetadata):
     threshold_row: torch.Tensor = make_tensor_field((0,))
 
 
-class ContactProbeSensor(ContactDepthProbeSensor, SimpleSensor[ContactProbeOptions, ContactProbeMetadata, tuple]):
+class ContactProbeSensor(ContactDepthProbeSensor, SimpleSensor[ContactProbeOptions, None, ContactProbeMetadata, tuple]):
     """Returns boolean contact per probe (depth > threshold). Shares the depth-probe kernel."""
 
     def build(self):
@@ -494,7 +502,7 @@ class ContactProbeSensor(ContactDepthProbeSensor, SimpleSensor[ContactProbeOptio
         self._draw_debug_probes(context, lambda data: data)
 
 
-class KinematicTaxelData(NamedTuple):
+class KinematicTaxelReturnType(NamedTuple):
     """
     Parameters
     ----------
@@ -520,12 +528,19 @@ class KinematicTaxelSensor(
     KinematicTactileSensorMixin[KinematicTaxelMetadata],
     ProbesWithNormalSensorMixin[KinematicTaxelMetadata],
     RigidSensorMixin[KinematicTaxelMetadata],
-    SimpleSensor[KinematicTaxelOptions, KinematicTaxelMetadata, KinematicTaxelData],
+    SimpleSensor[KinematicTaxelOptions, None, KinematicTaxelMetadata, KinematicTaxelReturnType],
 ):
     """Kinematic taxels: spring-damper force and torque per probe from contact geometry and relative motion."""
 
-    def __init__(self, sensor_options: KinematicTaxelOptions, sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: KinematicTaxelOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
     def build(self):
         super().build()
@@ -556,6 +571,7 @@ class KinematicTaxelSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
+        shared_context: None,
         shared_metadata: KinematicTaxelMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -611,8 +611,15 @@ PointCloudTactileSensorMetadataMixinT = TypeVar(
 
 
 class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetadataMixinT]):
-    def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: "SensorOptions",
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._debug_objects: list = []
         self._probe_start_idx = -1
         self._debug_pc_chunks: list[tuple[int, torch.Tensor, torch.Tensor]] | None = None
@@ -723,7 +730,7 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
         return tensor_to_array(values[:, envs_idx].T)
 
 
-class ProximityTaxelData(NamedTuple):
+class ProximityTaxelReturnType(NamedTuple):
     """Per-taxel estimates in link-local frame."""
 
     force: torch.Tensor
@@ -742,7 +749,7 @@ class ProximityTaxelSensor(
     PointCloudTactileSensorMixin[ProximityTaxelMetadata],
     ProbesWithNormalSensorMixin[ProximityTaxelMetadata],
     RigidSensorMixin[ProximityTaxelMetadata],
-    SimpleSensor[ProximityTaxelOptions, ProximityTaxelMetadata, ProximityTaxelData],
+    SimpleSensor[ProximityTaxelOptions, None, ProximityTaxelMetadata, ProximityTaxelReturnType],
 ):
     """Spherical point-cloud taxels: per-taxel force and torque in link-local frame vs tracked meshes."""
 
@@ -783,6 +790,7 @@ class ProximityTaxelSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
+        shared_context: None,
         shared_metadata: ProximityTaxelMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -1535,18 +1543,25 @@ class ElastomerTaxelSensor(
     PointCloudTactileSensorMixin[ElastomerTaxelSensorMetadata],
     ProbesWithNormalSensorMixin[ElastomerTaxelSensorMetadata],
     RigidSensorMixin[ElastomerTaxelSensorMetadata],
-    SimpleSensor[ElastomerTaxelSensorOptions, ElastomerTaxelSensorMetadata],
+    SimpleSensor[ElastomerTaxelSensorOptions, None, ElastomerTaxelSensorMetadata],
 ):
-    def __init__(self, sensor_options: ElastomerTaxelSensorOptions, sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: ElastomerTaxelSensorOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
         self._is_grid = self._probe_local_pos.ndim > 2
         self._shape = self._probe_local_pos.shape[:-1]
 
         (probe_pos, probe_normals, use_grid_fft, grid_normal, grid_tangent_u, grid_tangent_v, grid_spacing) = (
             _normalize_elastomer_probe_layout(
-                np.asarray(sensor_options.probe_local_pos, dtype=gs.np_float),
-                np.asarray(sensor_options.probe_local_normal, dtype=gs.np_float),
+                np.asarray(options.probe_local_pos, dtype=gs.np_float),
+                np.asarray(options.probe_local_normal, dtype=gs.np_float),
                 self._is_grid,
             )
         )
@@ -1745,6 +1760,7 @@ class ElastomerTaxelSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
+        shared_context: None,
         shared_metadata: ElastomerTaxelSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",

--- a/genesis/engine/sensors/probe.py
+++ b/genesis/engine/sensors/probe.py
@@ -50,11 +50,18 @@ ProbeSensorSharedMetadataT = TypeVar("ProbeSensorSharedMetadataT", bound=ProbeSe
 class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
     """Shared logic for registering this sensor's probes in ``ProbeSensorMetadataMixin`` fields."""
 
-    def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
+    def __init__(
+        self,
+        options: "SensorOptions",
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
         # `_get_return_format` runs inside `super().__init__`, so `_probe_local_pos` / `_n_probes` must already be set.
-        self._probe_local_pos = torch.tensor(sensor_options.probe_local_pos, dtype=gs.tc_float, device=gs.device)
+        self._probe_local_pos = torch.tensor(options.probe_local_pos, dtype=gs.tc_float, device=gs.device)
         self._n_probes = int(np.prod(self._probe_local_pos.shape[:-1]))
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
     def build(self) -> None:
         super().build()
@@ -144,8 +151,15 @@ ProbesWithNormalSensorSharedMetadataT = TypeVar(
 class ProbesWithNormalSensorMixin(ProbeSensorMixin[ProbesWithNormalSensorSharedMetadataT]):
     """Probe sensor whose probes carry a per-probe outward normal in link-local frame."""
 
-    def __init__(self, sensor_options: "SensorOptions", sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: "SensorOptions",
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._probe_local_normal = torch.tensor(self._options.probe_local_normal, dtype=gs.tc_float, device=gs.device)
         if self._probe_local_normal.ndim == 1:
             self._probe_local_normal = self._probe_local_normal.expand(self._n_probes, 3).contiguous()

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -21,7 +21,13 @@ from genesis.utils.raycast_qd import (
 )
 from genesis.vis.rasterizer_context import RasterizerContext
 
-from .base_sensor import KinematicSensorMetadataMixin, KinematicSensorMixin, Sensor, SimpleSensorMetadata, SimpleSensor
+from .base_sensor import (
+    KinematicSensorMetadataMixin,
+    KinematicSensorMixin,
+    SharedSensorContext,
+    SimpleSensorMetadata,
+    SimpleSensor,
+)
 
 if TYPE_CHECKING:
     from genesis.engine.solvers.kinematic_solver import KinematicSolver
@@ -48,7 +54,7 @@ class BVHContext:
     # when flagged.
     maybe_static: bool = False
     # Lazy GEOMETRY subscriber for a static entry, registered on its solver; None for a movable entry (which rebuilds
-    # every step regardless). _update_bvh polls it: a pending set_pos/set_quat/set_vverts flags the entry for rebuild.
+    # every step regardless). RaycastContext.update polls it: a pending set_pos/set_quat/set_vverts flags for rebuild.
     rebuild_subscriber: Subscriber | None = None
     # Set whenever this entry must rebuild before the next cast: at init, on reset, and when its rebuild_subscriber
     # reveals a set_pos/set_quat/set_vverts since the last build. Ignored by non-static entries, which rebuild every
@@ -59,47 +65,18 @@ class BVHContext:
     shared_across_envs: bool = False
 
 
-@dataclass
-class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata):
-    # All BVHs (one per active solver per mesh type) cast against each frame. The first is written into the output cache
-    # with is_merge=False (initializes hits or no_hit_value), the rest merge in closer hits. Per-sensor link poses are
-    # gathered via KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
-    solver_bvhs: list[BVHContext] = field(default_factory=list)
+class RaycastContext(SharedSensorContext):
+    """
+    Per-simulator collision/visual raycast BVHs, shared across sensor types that cast rays.
 
-    # Per-step scratch tensors for sensor link poses, lazily allocated on the first cast (B and n_sensors known).
-    links_pos: torch.Tensor | None = None
-    links_quat: torch.Tensor | None = None
+    Holds one ``BVHContext`` per (active solver, mesh type): a collision BVH over a rigid solver's faces and a visual
+    BVH over the vfaces opted into ``material.use_visual_raycasting``. ``SensorManager`` builds it once after the scene
+    geometry exists and refreshes it once per step, so a ``Raycaster`` and a ``DepthCamera`` (or future raycast
+    consumers) share one set of trees instead of rebuilding identical ones per sensor type.
+    """
 
-    sensors_ray_start_idx: list[int] = field(default_factory=list)
-    total_n_rays: int = 0
-
-    min_ranges: torch.Tensor = make_tensor_field((0,))
-    max_ranges: torch.Tensor = make_tensor_field((0,))
-    no_hit_values: torch.Tensor = make_tensor_field((0,))
-    return_world_frame: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_bool)
-
-    patterns: list[RaycastPattern] = field(default_factory=list)
-    ray_dirs: torch.Tensor = make_tensor_field((0, 3))
-    ray_starts: torch.Tensor = make_tensor_field((0, 3))
-    ray_starts_world: torch.Tensor = make_tensor_field((0, 3))
-    ray_dirs_world: torch.Tensor = make_tensor_field((0, 3))
-
-    points_to_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    sensor_cache_offsets: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    sensor_point_offsets: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    sensor_point_counts: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-
-
-class RaycasterData(NamedTuple):
-    points: torch.Tensor
-    distances: torch.Tensor
-
-
-class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, RaycasterSharedMetadata, RaycasterData]):
-    def __init__(self, options: RaycasterOptions, sensor_idx: int, manager: "SensorManager"):
-        super().__init__(options, sensor_idx, manager)
-        self.debug_objects: list["Mesh"] = []
-        self.ray_starts: torch.Tensor = torch.empty((0, 3), device=gs.device, dtype=gs.tc_float)
+    def __init__(self):
+        self.bvh_contexts: list[BVHContext] = []
 
     @staticmethod
     def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
@@ -118,16 +95,52 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
         vface_vgeom_idx = qd_to_numpy(solver.vfaces_info.vgeom_idx)
         return vgeom_enabled[vface_vgeom_idx].astype(np.int8)
 
-    @classmethod
-    def _update_bvh(cls, shared_metadata: RaycasterSharedMetadata):
+    def build(self, sim):
+        """
+        Build the per-(solver, mesh-type) BVHs once. Rigid solvers get a collision BVH covering all collision faces;
+        any solver with entities opting in via ``material.use_visual_raycasting`` gets a visual BVH masked to those
+        entities' vfaces. Collision and visual entries coexist transparently because the cast kernels merge in place.
+        """
+        for solver in (sim.rigid_solver, sim.kinematic_solver):
+            if not solver.is_active:
+                continue
+            n_envs = solver._B
+            # A solver's geometry is static when no link can be moved by the physics (all links fixed); it then changes
+            # only through an explicit set_pos/set_quat/set_vverts, all GEOMETRY mutations the subscription catches.
+            # Applies to both the collision and the visual BVH.
+            maybe_static = all(link.is_fixed for link in solver.links)
+            if isinstance(solver, RigidSolver):
+                n_faces = solver.faces_info.geom_idx.shape[0]
+                aabb = AABB(n_batches=n_envs, n_aabbs=n_faces)
+                bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
+                self.bvh_contexts.append(BVHContext(solver, bvh, aabb, None, maybe_static))
+            n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
+            if n_vfaces > 0:
+                mask = self._compute_visual_raycast_mask(solver)
+                if mask.any():
+                    aabb = AABB(n_batches=n_envs, n_aabbs=n_vfaces)
+                    bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
+                    self.bvh_contexts.append(BVHContext(solver, bvh, aabb, mask, maybe_static))
+
+        # Lazily watch each static BVH (collision or visual) for GEOMETRY changes. ``update`` polls its
+        # rebuild_subscriber so an explicit set_pos / set_quat / set_vverts on the otherwise-immovable geometry forces
+        # the (normally skipped) rebuild before the next cast.
+        for entry in self.bvh_contexts:
+            if entry.maybe_static:
+                entry.rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
+                entry.solver.subscribe(entry.rebuild_subscriber)
+
+        self.update()
+
+    def update(self):
         """Rebuild every BVH whose geometry may have changed since the last cast.
 
         A static entry (maybe_static: no link the physics can move) is skipped while it is not flagged for rebuild,
         since its tree would come out unchanged. Its rebuild_subscriber flags it after an explicit
-        set_pos/set_quat/set_vverts, and reset() flags every entry, so a re-randomized terrain or teleported obstacle
+        set_pos/set_quat/set_vverts, and ``reset`` flags every entry, so a re-randomized terrain or teleported obstacle
         still rebuilds. Movable entries are never static, so they rebuild on every call.
         """
-        for entry in shared_metadata.solver_bvhs:
+        for entry in self.bvh_contexts:
             # A pending GEOMETRY change means a set_pos/set_quat/set_vverts hit this otherwise-static geometry since the
             # last build; flag it for rebuild and clear the subscriber so the next idle update skips again.
             if entry.rebuild_subscriber is not None and entry.rebuild_subscriber.pending:
@@ -179,55 +192,85 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
             else:
                 entry.shared_across_envs = False
 
+    def reset(self, envs_idx):
+        # A reset may change otherwise-static geometry (re-randomized terrain, teleported obstacles), so force every
+        # entry to rebuild once; static entries resume skipping on subsequent steps. The BVHs are geometry-global, not
+        # per-env, so ``envs_idx`` is unused.
+        for entry in self.bvh_contexts:
+            entry.needs_rebuild = True
+        self.update()
+
+    def destroy(self):
+        self.bvh_contexts.clear()
+
+
+@dataclass
+class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata):
+    # The BVHs cast against each frame live on the shared ``RaycastContext`` (one per active solver per mesh type),
+    # so a Raycaster and a DepthCamera share one set of trees. The first cast entry initializes the output cache
+    # (is_merge=False), the rest merge in closer hits. Per-sensor link poses are gathered via
+    # KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
+
+    # Per-step scratch tensors for sensor link poses, lazily allocated on the first cast (B and n_sensors known).
+    links_pos: torch.Tensor | None = None
+    links_quat: torch.Tensor | None = None
+
+    sensors_ray_start_idx: list[int] = field(default_factory=list)
+    total_n_rays: int = 0
+
+    min_ranges: torch.Tensor = make_tensor_field((0,))
+    max_ranges: torch.Tensor = make_tensor_field((0,))
+    no_hit_values: torch.Tensor = make_tensor_field((0,))
+    return_world_frame: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_bool)
+
+    patterns: list[RaycastPattern] = field(default_factory=list)
+    ray_dirs: torch.Tensor = make_tensor_field((0, 3))
+    ray_starts: torch.Tensor = make_tensor_field((0, 3))
+    ray_starts_world: torch.Tensor = make_tensor_field((0, 3))
+    ray_dirs_world: torch.Tensor = make_tensor_field((0, 3))
+
+    points_to_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    sensor_cache_offsets: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    sensor_point_offsets: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    sensor_point_counts: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+
+class RaycasterReturnType(NamedTuple):
+    points: torch.Tensor
+    distances: torch.Tensor
+
+
+class RaycasterSensor(
+    KinematicSensorMixin,
+    SimpleSensor[RaycasterOptions, RaycastContext, RaycasterSharedMetadata, RaycasterReturnType],
+):
+    def __init__(
+        self,
+        options: RaycasterOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
+        self.debug_objects: list["Mesh"] = []
+        self.ray_starts: torch.Tensor = torch.empty((0, 3), device=gs.device, dtype=gs.tc_float)
+
     def build(self):
         super().build()
 
-        # First raycast sensor: build the per-(solver, mesh-type) BVHs once. Rigid solvers get a collision BVH covering
-        # all collision faces; any solver with entities opting in via material.use_visual_raycasting gets a visual BVH
-        # masked to those entities' vfaces. Collision and visual entries coexist transparently because the cast kernels
-        # merge in place via is_merge.
-        if not self._shared_metadata.solver_bvhs:
+        # The BVHs are built and owned by the shared ``RaycastContext`` (already built by SensorManager before any
+        # sensor). The first sensor of this class pushes the initial cache offset; every sensor validates there is
+        # geometry to cast against.
+        if self._idx == 0:
             self._shared_metadata.sensor_cache_offsets = concat_with_tensor(
                 self._shared_metadata.sensor_cache_offsets, 0
             )
-
-            sim = self._manager._sim
-            for solver in (sim.rigid_solver, sim.kinematic_solver):
-                if not solver.is_active:
-                    continue
-                n_envs = solver._B
-                # A solver's geometry is static when no link can be moved by the physics (all links fixed); it then
-                # changes only through an explicit set_pos/set_quat/set_vverts, all GEOMETRY mutations the subscription
-                # catches. Applies to both the collision and the visual BVH.
-                maybe_static = all(link.is_fixed for link in solver.links)
-                if isinstance(solver, RigidSolver):
-                    n_faces = solver.faces_info.geom_idx.shape[0]
-                    aabb = AABB(n_batches=n_envs, n_aabbs=n_faces)
-                    bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                    self._shared_metadata.solver_bvhs.append(BVHContext(solver, bvh, aabb, None, maybe_static))
-                n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
-                if n_vfaces > 0:
-                    mask = self._compute_visual_raycast_mask(solver)
-                    if mask.any():
-                        aabb = AABB(n_batches=n_envs, n_aabbs=n_vfaces)
-                        bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                        self._shared_metadata.solver_bvhs.append(BVHContext(solver, bvh, aabb, mask, maybe_static))
-
-            if not self._shared_metadata.solver_bvhs:
-                gs.raise_exception(
-                    "Raycaster sensor has no geometry to raycast against: rigid_solver is inactive and no entity "
-                    "has material.use_visual_raycasting=True."
-                )
-
-            # Lazily watch each static BVH (collision or visual) for GEOMETRY changes. _update_bvh polls its
-            # rebuild_subscriber so an explicit set_pos / set_quat / set_vverts on the otherwise-immovable geometry
-            # forces the (normally skipped) rebuild before the next cast.
-            for entry in self._shared_metadata.solver_bvhs:
-                if entry.maybe_static:
-                    entry.rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
-                    entry.solver.subscribe(entry.rebuild_subscriber)
-
-            self._update_bvh(self._shared_metadata)
+        if not self._shared_context.bvh_contexts:
+            gs.raise_exception(
+                "Raycaster sensor has no geometry to raycast against: rigid_solver is inactive and no entity "
+                "has material.use_visual_raycasting=True."
+            )
 
         self._shared_metadata.patterns.append(self._options.pattern)
 
@@ -270,20 +313,11 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
 
         # Multi-BVH merge passes use raw distance comparison to pick the closer hit; this only works if no_hit_value >=
         # max_range. The negated form also rejects NaN (every IEEE 754 comparison with NaN is False).
-        if len(self._shared_metadata.solver_bvhs) > 1 and not (self._options.no_hit_value >= self._options.max_range):
+        if len(self._shared_context.bvh_contexts) > 1 and not (self._options.no_hit_value >= self._options.max_range):
             gs.raise_exception(
                 f"no_hit_value ({self._options.no_hit_value}) must be >= max_range ({self._options.max_range}) "
                 f"when multiple BVHs are active (the merge step compares raw distances)."
             )
-
-    @classmethod
-    def reset(cls, shared_metadata: RaycasterSharedMetadata, current_ground_truth_data_T: torch.Tensor, envs_idx):
-        super().reset(shared_metadata, current_ground_truth_data_T, envs_idx)
-        # A reset may change otherwise-static geometry (re-randomized terrain, teleported obstacles), so force every
-        # entry to rebuild once; static entries resume skipping on subsequent steps.
-        for entry in shared_metadata.solver_bvhs:
-            entry.needs_rebuild = True
-        cls._update_bvh(shared_metadata)
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
         shape = self._options.pattern.return_shape
@@ -294,14 +328,17 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
         return gs.tc_float
 
     @classmethod
-    def _update_raw_data(cls, shared_metadata: RaycasterSharedMetadata, raw_data_T: torch.Tensor):
-        cls._update_bvh(shared_metadata)
+    def _update_raw_data(
+        cls, shared_context: RaycastContext, shared_metadata: RaycasterSharedMetadata, raw_data_T: torch.Tensor
+    ):
+        # The BVHs were already refreshed once this step by SensorManager (``RaycastContext.update``); read them here.
+        bvh_contexts = shared_context.bvh_contexts
 
         # Allocate the link-pose scratch buffers on first cast (B and n_sensors are known here). Identity quat is baked
         # into the initial allocation so static sensors (entity_idx<0) leave their rows at identity, letting the cast
         # kernel apply pos_offset / euler_offset in world frame.
         if shared_metadata.links_pos is None:
-            B = shared_metadata.solver_bvhs[0].solver._B
+            B = bvh_contexts[0].solver._B
             shared_metadata.links_pos = torch.zeros(
                 B, shared_metadata.n_sensors, 3, device=gs.device, dtype=gs.tc_float
             )
@@ -325,7 +362,7 @@ class RaycasterSensor(KinematicSensorMixin, SimpleSensor[RaycasterOptions, Rayca
 
         # First entry initializes the cache (is_merge=False, writes a hit or no_hit_value into every slot). Each
         # subsequent entry merges in place (is_merge=True, writes only where it found a closer hit).
-        for i, entry in enumerate(shared_metadata.solver_bvhs):
+        for i, entry in enumerate(bvh_contexts):
             solver = entry.solver
             args_common = (
                 entry.bvh.nodes,

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -10,7 +10,7 @@ from genesis.options.sensors import types as _sensor_types_namespace
 from genesis.options.sensors.options import SensorOptions
 from genesis.utils.ring_buffer import TensorRingBuffer
 
-from .base_sensor import Sensor, SharedSensorMetadata
+from .base_sensor import Sensor, SharedSensorContext, SharedSensorMetadata
 
 if TYPE_CHECKING:
     from genesis.vis.rasterizer_context import RasterizerContext
@@ -24,6 +24,9 @@ class SensorManager:
         self._sim = sim
         self._sensors_by_type: dict[type["Sensor"], list["Sensor"]] = {}
         self._sensors_metadata: dict[type["Sensor"], SharedSensorMetadata | None] = {}
+        # Cross-type shared contexts, keyed by context class so every sensor type declaring the same context resolves
+        # to one instance. Built/updated/reset/destroyed by this manager; see ``SharedSensorContext``.
+        self._shared_contexts: dict[type, SharedSensorContext] = {}
         # Per-dtype intermediate caches: pre-`_post_process` storage in intermediate space. The transposed GT cache is
         # `(cols, B)` for C-contiguous per-class row slices required by kernel writes.
         self._ground_truth_intermediate_cache: dict[type[torch.dtype], torch.Tensor] = {}
@@ -60,7 +63,18 @@ class SensorManager:
         self._sensors_by_type.setdefault(sensor_cls, [])
         if sensor_cls not in self._sensors_metadata:
             self._sensors_metadata[sensor_cls] = sensor_cls._metadata_cls()
-        sensor = sensor_cls(sensor_options, len(self._sensors_by_type[sensor_cls]), self)
+        # Lazily create the cross-type shared context (one instance per context class, shared by every sensor type
+        # declaring it). ``NoneType`` marks "no context"; the sensor then receives ``None``.
+        context_cls = sensor_cls._shared_context_cls
+        if context_cls is not type(None) and context_cls not in self._shared_contexts:
+            self._shared_contexts[context_cls] = context_cls()
+        sensor = sensor_cls(
+            sensor_options,
+            len(self._sensors_by_type[sensor_cls]),
+            self._shared_contexts.get(context_cls),
+            self._sensors_metadata[sensor_cls],
+            self,
+        )
         self._sensors_by_type[sensor_cls].append(sensor)
         return sensor
 
@@ -243,12 +257,20 @@ class SensorManager:
             if cls_max_history > 0:
                 self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
 
+        # Build shared contexts before any sensor, so a sensor's ``build()`` reads a ready context (e.g. the raycaster
+        # validating it has geometry to cast against).
+        for context in self._shared_contexts.values():
+            context.build(self._sim)
+
         for sensor_cls, sensors in self._sensors_by_type.items():
             for sensor in sensors:
                 sensor.build()
                 sensor._is_built = True
 
     def destroy(self):
+        for context in self._shared_contexts.values():
+            context.destroy()
+        self._shared_contexts.clear()
         for sensors_metadata in self._sensors_metadata.values():
             if sensors_metadata is not None:
                 sensors_metadata.destroy()
@@ -280,6 +302,11 @@ class SensorManager:
         for ring in self._measured_return_timeline_ring.values():
             ring.buffer[:, envs_idx] = 0
 
+        # Reset shared contexts before the per-type sensor reset (a reset may change otherwise-static geometry, so the
+        # context must rebuild before any sensor reads it again).
+        for context in self._shared_contexts.values():
+            context.reset(envs_idx)
+
         for sensor_cls, sensors in self._sensors_by_type.items():
             dtype = sensor_cls._get_intermediate_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
@@ -296,6 +323,11 @@ class SensorManager:
         for ring in self._measured_timeline_ring.values():
             ring.rotate()
 
+        # Refresh each shared context once per step, before the per-type loop reads it, so multiple consuming sensor
+        # types (e.g. Raycaster + DepthCamera) rebuild the shared resource at most once rather than once each.
+        for context in self._shared_contexts.values():
+            context.update()
+
         for sensor_cls, sensors in self._sensors_by_type.items():
             dtype = sensor_cls._get_intermediate_dtype()
             cache_slice = self._cache_slices_by_type[sensor_cls]
@@ -311,7 +343,12 @@ class SensorManager:
             )
             metadata = self._sensors_metadata[sensor_cls]
             sensor_cls._update_shared_cache(
-                metadata, ground_truth_slice, ground_truth_data_timeline, measured_data_timeline, intermediate
+                self._shared_contexts.get(sensor_cls._shared_context_cls),
+                metadata,
+                ground_truth_slice,
+                ground_truth_data_timeline,
+                measured_data_timeline,
+                intermediate,
             )
 
             gt_return_ring = self._ground_truth_return_timeline_ring.get(sensor_cls)

--- a/genesis/engine/sensors/surface_distance_probe.py
+++ b/genesis/engine/sensors/surface_distance_probe.py
@@ -209,12 +209,19 @@ class SurfaceDistanceProbeMetadata(
 class SurfaceDistanceProbeSensor(
     ProbeSensorMixin[SurfaceDistanceProbeMetadata],
     RigidSensorMixin[SurfaceDistanceProbeMetadata],
-    SimpleSensor[SurfaceDistanceProbeOptions, SurfaceDistanceProbeMetadata, tuple],
+    SimpleSensor[SurfaceDistanceProbeOptions, None, SurfaceDistanceProbeMetadata, tuple],
 ):
     """Surface distance probe: distance and nearest point from probe positions to tracked mesh surfaces."""
 
-    def __init__(self, sensor_options: SurfaceDistanceProbeOptions, sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: SurfaceDistanceProbeOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
         self._debug_objects: list = []
         self._nearest_points_slice: slice | None = None
 
@@ -266,6 +273,7 @@ class SurfaceDistanceProbeSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
+        shared_context: None,
         shared_metadata: SurfaceDistanceProbeMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -508,10 +508,17 @@ class TemperatureGridSensorMetadata(RigidSensorMetadataMixin, SimpleSensorMetada
 
 class TemperatureGridSensor(
     RigidSensorMixin[TemperatureGridSensorMetadata],
-    SimpleSensor[TemperatureGridOptions, TemperatureGridSensorMetadata, TemperatureGridSensorMetadata],
+    SimpleSensor[TemperatureGridOptions, None, TemperatureGridSensorMetadata, TemperatureGridSensorMetadata],
 ):
-    def __init__(self, sensor_options: TemperatureGridOptions, sensor_idx: int, sensor_manager: "SensorManager"):
-        super().__init__(sensor_options, sensor_idx, sensor_manager)
+    def __init__(
+        self,
+        options: TemperatureGridOptions,
+        idx: int,
+        shared_context,
+        shared_metadata,
+        manager: "SensorManager",
+    ):
+        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
         self._link: "RigidLink | None" = None
         self._debug_objects: list = []
@@ -689,7 +696,9 @@ class TemperatureGridSensor(
             shared_metadata.link_temps[envs_idx, :] = base_T_per_link.unsqueeze(0).expand(n_envs, -1)
 
     @classmethod
-    def _update_raw_data(cls, shared_metadata: TemperatureGridSensorMetadata, raw_data_T: torch.Tensor):
+    def _update_raw_data(
+        cls, shared_context: None, shared_metadata: TemperatureGridSensorMetadata, raw_data_T: torch.Tensor
+    ):
         solver = shared_metadata.solver
         dt = solver._sim.dt
         props = shared_metadata.link_material_properties

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -69,7 +69,7 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
             pass
 
 
-        class FakeSensor(Sensor[FakeSensorOptions, FakeSensorMetadata]):
+        class FakeSensor(Sensor[FakeSensorOptions, None, FakeSensorMetadata]):
             def _get_return_format(self):
                 return (1,)
 
@@ -79,7 +79,7 @@ def test_lazy_sensor_discovery(show_viewer, tmp_path):
 
             @classmethod
             def _update_shared_cache(
-                cls, metadata, gt_cache, ground_truth_data_timeline, measured_data_timeline, intermediate_cache,
+                cls, context, metadata, gt_cache, ground_truth_data_timeline, measured_data_timeline, intermediate_cache,
             ):
                 pass
 
@@ -182,7 +182,7 @@ def test_pipeline_contract(tol):
         transform_alpha: tuple[float, ...] = (0.0,)
         hardware_imp: tuple[float, ...] = (0.0,)
 
-    class FakePipelineSensor(SimpleSensor[FakeOptions, FakeMetadata]):
+    class FakePipelineSensor(SimpleSensor[FakeOptions, None, FakeMetadata]):
         def _get_return_format(self):
             return (len(self._options.physics_imp),)
 
@@ -211,7 +211,7 @@ def test_pipeline_contract(tol):
             shared_metadata.step_counter = 0
 
         @classmethod
-        def _update_raw_data(cls, metadata, raw_data_T):
+        def _update_raw_data(cls, context, metadata, raw_data_T):
             # Same scalar raw value across all components and envs; per-component divergence is introduced by the
             # downstream hook vectors. 1-indexed step.
             metadata.step_counter += 1
@@ -261,7 +261,7 @@ def test_pipeline_contract(tol):
     class FakeSimpleOptions(SimpleSensorOptions["FakeSimpleSensor"]):
         pass
 
-    class FakeSimpleSensor(SimpleSensor[FakeSimpleOptions, FakeSimpleMetadata]):
+    class FakeSimpleSensor(SimpleSensor[FakeSimpleOptions, None, FakeSimpleMetadata]):
         def _get_return_format(self):
             return (1,)
 
@@ -275,7 +275,7 @@ def test_pipeline_contract(tol):
             shared_metadata.step_counter = 0
 
         @classmethod
-        def _update_raw_data(cls, metadata, raw_data_T):
+        def _update_raw_data(cls, context, metadata, raw_data_T):
             metadata.step_counter += 1
             raw_data_T.fill_(float(metadata.step_counter))
 
@@ -375,7 +375,7 @@ def test_pipeline_contract_uint8_delay(tol):
     class FakeQuantizedOptions(SimpleSensorOptions["FakeQuantizedSensor"]):
         pass
 
-    class FakeQuantizedSensor(SimpleSensor[FakeQuantizedOptions, FakeQuantizedMetadata]):
+    class FakeQuantizedSensor(SimpleSensor[FakeQuantizedOptions, None, FakeQuantizedMetadata]):
         def _get_return_format(self):
             return (1,)
 
@@ -393,7 +393,7 @@ def test_pipeline_contract_uint8_delay(tol):
             shared_metadata.step_counter = 0
 
         @classmethod
-        def _update_raw_data(cls, metadata, raw_data_T):
+        def _update_raw_data(cls, context, metadata, raw_data_T):
             metadata.step_counter += 1
             raw_data_T.fill_(float(metadata.step_counter))
 
@@ -951,6 +951,51 @@ def test_contact_sensor_filter_link_idx(show_viewer):
 
 
 @pytest.mark.required
+def test_shared_context(show_viewer):
+    # Raycaster and DepthCamera are distinct sensor types that both cast against the scene geometry; they must share
+    # one RaycastContext (a single BVH set) instead of each building its own. A sensor type declaring no context (IMU)
+    # must resolve to None.
+    from genesis.engine.sensors.raycaster import RaycastContext
+
+    scene = gs.Scene(show_viewer=show_viewer)
+    scene.add_entity(gs.morphs.Plane())
+    box = scene.add_entity(gs.morphs.Box(size=(0.4, 0.4, 0.4), pos=(0.0, 0.0, 1.0)))
+
+    raycaster = scene.add_sensor(
+        gs.sensors.Raycaster(
+            pattern=gs.sensors.raycaster.GridPattern(resolution=0.2, size=(0.4, 0.4), direction=(0.0, 0.0, -1.0)),
+            pos_offset=(0.0, 0.0, 2.0),
+        )
+    )
+    depth_camera = scene.add_sensor(
+        gs.sensors.DepthCamera(
+            pattern=gs.sensors.raycaster.DepthCameraPattern(res=(4, 4)),
+            pos_offset=(0.0, 0.0, 2.0),
+        )
+    )
+    imu = scene.add_sensor(gs.sensors.IMU(entity_idx=box.idx))
+    scene.build()
+
+    contexts = list(raycaster._manager._shared_contexts.values())
+    # Exactly one shared context instance, of type RaycastContext.
+    assert len(contexts) == 1
+    assert isinstance(contexts[0], RaycastContext)
+    # Both raycast-casting sensor types resolve to that single instance, so they cast against the very same BVH list
+    # (one collision BVH, not one built per sensor type).
+    assert raycaster._shared_context is contexts[0]
+    assert depth_camera._shared_context is contexts[0]
+    assert raycaster._shared_context.bvh_contexts is depth_camera._shared_context.bvh_contexts
+    assert len(raycaster._shared_context.bvh_contexts) == 1
+    # A sensor type that declares no context resolves to None.
+    assert imu._shared_context is None
+
+    # Functional smoke: both casters return finite hit distances after a step.
+    scene.step()
+    assert torch.isfinite(raycaster.read().distances).all()
+    assert torch.isfinite(depth_camera.read_image()).all()
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_raycaster_hits(show_viewer, n_envs):
     """Test if the Raycaster sensor with GridPattern rays pointing to ground returns the correct distance."""
@@ -1230,7 +1275,7 @@ def test_raycaster_against_visual(tmp_path, show_viewer, n_envs, kin_raycastable
 
     # Every entity is fixed, so each visual BVH is static (maybe_static) and rebuilt only when a GEOMETRY change is
     # pending; nothing is pending after the baseline step, so an idle step would rebuild none of them.
-    visual_entries = [entry for entry in cam_kin._shared_metadata.solver_bvhs if entry.raycast_mask is not None]
+    visual_entries = [entry for entry in cam_kin._shared_context.bvh_contexts if entry.raycast_mask is not None]
     assert visual_entries and all(entry.maybe_static for entry in visual_entries)
     assert all(not entry.rebuild_subscriber.pending for entry in visual_entries)
 
@@ -1337,7 +1382,7 @@ def test_lidar_bvh_parallel_env(show_viewer, tol):
 
     # All links are fixed, so the collision BVH is static: rebuilt only when a set_pos invalidates it, never on an
     # ordinary step. The per-env obstacle geometry differs here, so it cannot be shared across envs.
-    collision_bvh = next(entry for entry in lidar._shared_metadata.solver_bvhs if entry.raycast_mask is None)
+    collision_bvh = next(entry for entry in lidar._shared_context.bvh_contexts if entry.raycast_mask is None)
     assert collision_bvh.maybe_static
     assert not collision_bvh.shared_across_envs
 
@@ -1450,7 +1495,7 @@ def test_raycaster_heterogeneous_object(show_viewer, tol):
     assert_allclose(distances, (0.9, 0.8), tol=5e-3)
 
     # The per-env trees differ (each masks the other variant), so the cast must not share one tree across envs.
-    collision_bvh = next(entry for entry in lidar._shared_metadata.solver_bvhs if entry.raycast_mask is None)
+    collision_bvh = next(entry for entry in lidar._shared_context.bvh_contexts if entry.raycast_mask is None)
     assert collision_bvh.maybe_static
     assert not collision_bvh.shared_across_envs
 


### PR DESCRIPTION
## Description

Adds `SharedSensorContext`: a resource shared across *different* sensor types, as opposed to `SharedSensorMetadata` which aggregates all sensors of one type. It is declared as the 4th `Sensor[Options, Metadata, Data, Context]` generic; `SensorManager` owns one instance per context class and drives its lifecycle (`build` once, `update` once per step, `reset`, `destroy`), passing it to the per-step hooks as a leading `shared_context` argument. A context is optimization-only -- results must not depend on it.

First consumer: `RaycastContext` owns the raycast BVHs, so `Raycaster` and `DepthCamera` now share one BVH set instead of each building its own.

Also renames the `*Data` NamedTuple sensor return types to `*ReturnType` (to avoid confusion with the new context).

## Motivation and Context

`Raycaster` and `DepthCamera` are distinct classes, so each built its own BVH; nothing could be shared across sensor types. Also unblocks tactile sensors reusing the raycast BVH in their upcoming raycast mode.

## How Has This Been / Can This Be Tested?

Added `test_shared_context`. Full `tests/test_sensors.py` (41 tests) passes on CPU.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.