### PR TITLE
[MISC] Add activation mechanism to sensor shared context.

### DIFF
--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar, Generic, NamedTuple, TypeVar, get_args, get_origin
@@ -95,36 +96,56 @@ class SimpleSensorMetadata(SharedSensorMetadata):
     has_any_resolution: bool = False
 
 
-class SharedSensorContext:
+class SharedSensorContext(ABC):
     """
-    Resource shared across *different* sensor types, owned by ``SensorManager``.
+    Abstract base for a resource shared across *different* sensor types, owned by ``SensorManager``. A sensor type
+    declares the context it consumes as the second ``Sensor[Options, Context, Metadata, Data]`` parameter (``None``
+    when it has none); every type declaring the same context class resolves to the one instance the manager owns.
 
-    Distinct from ``SharedSensorMetadata``: metadata aggregates the per-sensor state of all sensors of a *single*
-    type so one kernel can run over them (a batching optimization that grows with the number of sensors); a context
-    is a *single* resource (e.g. one collision BVH for the simulator) read by *several* sensor types, O(1) in the
-    number of sensors (a sharing optimization). A sensor type declares the context it consumes as the second
-    ``Sensor[Options, Context, Metadata, Data]`` parameter (``None`` when it has none); every type declaring the same
-    context class resolves to the one instance the manager owns.
+    Distinct from ``SharedSensorMetadata``: metadata aggregates the per-sensor state of all sensors of a *single* type
+    so one kernel can run over them (a batching optimization that grows with the number of sensors); a context is a
+    *single* resource read by *several* sensor types, O(1) in the number of sensors (a sharing optimization). A context
+    is purely an optimization: a sensor must produce identical results whether or not it is shared, so consistency stays
+    ``SensorManager``'s responsibility, never the context's.
 
-    A context is purely an optimization (runtime speed or memory): a sensor must produce identical results whether
-    or not the context is shared, so it is always safe to rebuild or duplicate it. Cross-sensor consistency remains
-    the responsibility of ``SensorManager``, never of the context.
+    The manager constructs the context with the sim at sensor-creation time, since the context must already exist to be
+    handed to consuming sensors, but it stays an empty shell until a consumer activates it.
 
-    The whole lifecycle is driven by ``SensorManager``: ``build`` once after the scene geometry exists, ``update``
-    once per step before the per-type update loop reads it, ``reset`` on ``scene.reset()``, ``destroy`` on teardown.
+    - ``activate`` - a consuming sensor calls this from its own ``build`` (must be idempotent). The first call
+      constructs the resource on the spot; the scene geometry is available by then. Inactive contexts stay empty shells
+      and pay nothing. There is no separate manager-driven build: activation does the construction.
+    - ``update`` - the manager calls this once per step before the per-type update loop; a no-op when inactive.
+    - ``reset`` / ``destroy`` - manager-driven on ``scene.reset()`` and teardown.
+
+    Querying an inactive context (e.g. reading its resource) must raise: only consumers that activated it may read it.
+    Subclasses must implement every lifecycle method; ``update`` / ``reset`` / ``destroy`` guard themselves on
+    ``is_active``.
     """
 
-    def build(self, sim):
-        """Build the shared resource from the scene; called once after every sensor is built."""
+    def __init__(self, sim):
+        self._sim = sim
+        self._active = False
 
-    def update(self):
-        """Refresh the shared resource for the current step; called once before sensors read it."""
+    @property
+    def is_active(self) -> bool:
+        return self._active
 
-    def reset(self, envs_idx):
-        """Reset the shared resource for the given environments."""
+    @abstractmethod
+    def activate(self) -> None:
+        """Declare the context active (a consumer needs it) and construct the resource; must be idempotent. Called from
+        a consuming sensor's ``build``, when the scene geometry is available."""
 
-    def destroy(self):
-        """Release any resources held by the context."""
+    @abstractmethod
+    def update(self) -> None:
+        """Refresh the resource for the current step; manager-driven once per step. Must no-op when inactive."""
+
+    @abstractmethod
+    def reset(self, envs_idx) -> None:
+        """Reset the resource; manager-driven on ``scene.reset()``. Must no-op when inactive."""
+
+    @abstractmethod
+    def destroy(self) -> None:
+        """Release any resources held by the context; manager-driven on teardown."""
 
 
 SharedSensorMetadataT = TypeVar("SharedSensorMetadataT", bound=SharedSensorMetadata)

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -70,13 +70,19 @@ class RaycastContext(SharedSensorContext):
     Per-simulator collision/visual raycast BVHs, shared across sensor types that cast rays.
 
     Holds one ``BVHContext`` per (active solver, mesh type): a collision BVH over a rigid solver's faces and a visual
-    BVH over the vfaces opted into ``material.use_visual_raycasting``. ``SensorManager`` builds it once after the scene
-    geometry exists and refreshes it once per step, so a ``Raycaster`` and a ``DepthCamera`` (or future raycast
-    consumers) share one set of trees instead of rebuilding identical ones per sensor type.
+    BVH over the vfaces opted into ``material.use_visual_raycasting``.
     """
 
-    def __init__(self):
-        self.bvh_contexts: list[BVHContext] = []
+    def __init__(self, sim):
+        super().__init__(sim)
+        self._bvh_contexts: list[BVHContext] = []
+
+    @property
+    def bvh_contexts(self) -> list[BVHContext]:
+        """The per-(solver, mesh-type) BVHs. Raises if inactive: only a consumer that activated it may read them."""
+        if not self._active:
+            raise gs.GenesisException("RaycastContext queried before activation; no sensor declared a raycast need.")
+        return self._bvh_contexts
 
     @staticmethod
     def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
@@ -95,13 +101,16 @@ class RaycastContext(SharedSensorContext):
         vface_vgeom_idx = qd_to_numpy(solver.vfaces_info.vgeom_idx)
         return vgeom_enabled[vface_vgeom_idx].astype(np.int8)
 
-    def build(self, sim):
+    def activate(self):
         """
-        Build the per-(solver, mesh-type) BVHs once. Rigid solvers get a collision BVH covering all collision faces;
-        any solver with entities opting in via ``material.use_visual_raycasting`` gets a visual BVH masked to those
-        entities' vfaces. Collision and visual entries coexist transparently because the cast kernels merge in place.
+        Build the per-(solver, mesh-type) BVHs on first activation; idempotent. Rigid solvers get a collision BVH
+        covering all collision faces; any solver with entities opting in via ``material.use_visual_raycasting`` gets a
+        visual BVH masked to those vfaces. Collision and visual entries coexist (the cast kernels merge in place).
         """
-        for solver in (sim.rigid_solver, sim.kinematic_solver):
+        if self._active:
+            return
+        self._active = True
+        for solver in (self._sim.rigid_solver, self._sim.kinematic_solver):
             if not solver.is_active:
                 continue
             n_envs = solver._B
@@ -113,19 +122,19 @@ class RaycastContext(SharedSensorContext):
                 n_faces = solver.faces_info.geom_idx.shape[0]
                 aabb = AABB(n_batches=n_envs, n_aabbs=n_faces)
                 bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                self.bvh_contexts.append(BVHContext(solver, bvh, aabb, None, maybe_static))
+                self._bvh_contexts.append(BVHContext(solver, bvh, aabb, None, maybe_static))
             n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
             if n_vfaces > 0:
                 mask = self._compute_visual_raycast_mask(solver)
                 if mask.any():
                     aabb = AABB(n_batches=n_envs, n_aabbs=n_vfaces)
                     bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                    self.bvh_contexts.append(BVHContext(solver, bvh, aabb, mask, maybe_static))
+                    self._bvh_contexts.append(BVHContext(solver, bvh, aabb, mask, maybe_static))
 
         # Lazily watch each static BVH (collision or visual) for GEOMETRY changes. ``update`` polls its
         # rebuild_subscriber so an explicit set_pos / set_quat / set_vverts on the otherwise-immovable geometry forces
         # the (normally skipped) rebuild before the next cast.
-        for entry in self.bvh_contexts:
+        for entry in self._bvh_contexts:
             if entry.maybe_static:
                 entry.rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
                 entry.solver.subscribe(entry.rebuild_subscriber)
@@ -140,7 +149,9 @@ class RaycastContext(SharedSensorContext):
         set_pos/set_quat/set_vverts, and ``reset`` flags every entry, so a re-randomized terrain or teleported obstacle
         still rebuilds. Movable entries are never static, so they rebuild on every call.
         """
-        for entry in self.bvh_contexts:
+        if not self._active:
+            return
+        for entry in self._bvh_contexts:
             # A pending GEOMETRY change means a set_pos/set_quat/set_vverts hit this otherwise-static geometry since the
             # last build; flag it for rebuild and clear the subscriber so the next idle update skips again.
             if entry.rebuild_subscriber is not None and entry.rebuild_subscriber.pending:
@@ -195,13 +206,13 @@ class RaycastContext(SharedSensorContext):
     def reset(self, envs_idx):
         # A reset may change otherwise-static geometry (re-randomized terrain, teleported obstacles), so force every
         # entry to rebuild once; static entries resume skipping on subsequent steps. The BVHs are geometry-global, not
-        # per-env, so ``envs_idx`` is unused.
-        for entry in self.bvh_contexts:
+        # per-env, so ``envs_idx`` is unused. No-op when inactive (``_bvh_contexts`` is empty).
+        for entry in self._bvh_contexts:
             entry.needs_rebuild = True
         self.update()
 
     def destroy(self):
-        self.bvh_contexts.clear()
+        self._bvh_contexts.clear()
 
 
 @dataclass
@@ -259,9 +270,10 @@ class RaycasterSensor(
     def build(self):
         super().build()
 
-        # The BVHs are built and owned by the shared ``RaycastContext`` (already built by SensorManager before any
-        # sensor). The first sensor of this class pushes the initial cache offset; every sensor validates there is
-        # geometry to cast against.
+        # A raycaster always casts, so activate the shared ``RaycastContext`` now: the first consumer's activation
+        # builds the BVHs. Every raycaster then validates there is geometry to cast against.
+        self._shared_context.activate()
+        # The first raycaster seeds the leading boundary (0) of the per-sensor offsets into the shared cache tensor.
         if self._idx == 0:
             self._shared_metadata.sensor_cache_offsets = concat_with_tensor(
                 self._shared_metadata.sensor_cache_offsets, 0

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -63,11 +63,11 @@ class SensorManager:
         self._sensors_by_type.setdefault(sensor_cls, [])
         if sensor_cls not in self._sensors_metadata:
             self._sensors_metadata[sensor_cls] = sensor_cls._metadata_cls()
-        # Lazily create the cross-type shared context (one instance per context class, shared by every sensor type
-        # declaring it). ``NoneType`` marks "no context"; the sensor then receives ``None``.
+        # Create the shared context before the sensor, so the instance exists to hand to it. ``NoneType`` marks
+        # "no context"; the sensor then receives ``None``.
         context_cls = sensor_cls._shared_context_cls
         if context_cls is not type(None) and context_cls not in self._shared_contexts:
-            self._shared_contexts[context_cls] = context_cls()
+            self._shared_contexts[context_cls] = context_cls(self._sim)
         sensor = sensor_cls(
             sensor_options,
             len(self._sensors_by_type[sensor_cls]),
@@ -256,11 +256,6 @@ class SensorManager:
                 ].T
             if cls_max_history > 0:
                 self._hist_idx_by_class[sensor_cls] = torch.arange(cls_max_history, device=gs.device, dtype=torch.int32)
-
-        # Build shared contexts before any sensor, so a sensor's ``build()`` reads a ready context (e.g. the raycaster
-        # validating it has geometry to cast against).
-        for context in self._shared_contexts.values():
-            context.build(self._sim)
 
         for sensor_cls, sensors in self._sensors_by_type.items():
             for sensor in sensors:


### PR DESCRIPTION
## Description

Refactor `SharedSensorContext` into an abstract base following the rigid-solver add-on pattern (`activate` / `is_active`), replacing the previous manager-driven eager build introduced in #2882.

- `SharedSensorContext` is now abstract: subclasses implement `activate` / `update` / `reset` / `destroy`. The manager constructs the context with the sim at sensor-creation time (it must exist to be handed to consuming sensors), but it stays an empty shell until a consumer activates it.
- `activate` is called by a consuming sensor from its own `build`, is idempotent, and does the construction on the spot (scene geometry is available by then). There is no separate manager build pass. `update` / `reset` no-op while inactive, and querying an inactive context raises.
- `RaycastContext` implements the new contract; `bvh_contexts` is now a guarded property. `RaycasterSensor` / `DepthCameraSensor` activate it from `build` (they always cast), so behavior is unchanged, while a future consumer that needs no rays never builds the BVHs.

## Motivation and Context

Prepares the cross-sensor shared-context machinery for consumers that only need a context conditionally at runtime (e.g. tactile sensors that build the collision BVH only in `"raycast"` contact-depth mode) without paying for it otherwise, and aligns the lifecycle with the rigid-solver add-on pattern (collider / GJK).

## How Has This Been / Can This Be Tested?

`pytest tests/test_sensors.py` (raycaster, depth-camera, and shared-context cases) passes on the CPU backend.

## Checklist:
- [x] I tagged the title correctly (MISC).
- [x] I updated the documentation accordingly (separate genesis-doc PR).
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
