### PR TITLE
[BUG FIX] Support passing sliced env mask to RigidSolver.set_base_links_(pos|quat).

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1772,8 +1772,11 @@ class RigidSolver(KinematicSolver):
             else:
                 data = qd_to_torch(self._rigid_global_info.qpos, transpose=True, copy=False)
                 target = data[:, link.q_start : link.q_start + 3]
-            pos = broadcast_tensor(pos, gs.tc_float, target.shape)
-            torch.where(envs_idx[:, None], pos, target, out=target)
+            if pos.ndim == 2 and len(pos) not in (1, len(target)):
+                target.masked_scatter_(envs_idx[:, None], pos.view_as(pos))
+            else:
+                pos = broadcast_tensor(pos, gs.tc_float, target.shape)
+                torch.where(envs_idx[:, None], pos, target, out=target)
             if gs.backend == gs.metal:
                 torch.mps.synchronize()
         else:
@@ -1872,8 +1875,11 @@ class RigidSolver(KinematicSolver):
             else:
                 data = qd_to_torch(self._rigid_global_info.qpos, transpose=True, copy=False)
                 target = data[:, link.q_start + 3 : link.q_start + 7]
-            quat = broadcast_tensor(quat, gs.tc_float, target.shape)
-            torch.where(envs_idx[:, None], quat, target, out=target)
+            if quat.ndim == 2 and len(quat) not in (1, len(target)):
+                target.masked_scatter_(envs_idx[:, None], quat.view_as(quat))
+            else:
+                quat = broadcast_tensor(quat, gs.tc_float, target.shape)
+                torch.where(envs_idx[:, None], quat, target, out=target)
             if gs.backend == gs.metal:
                 torch.mps.synchronize()
         else:


### PR DESCRIPTION
## Summary

The zero-copy **bool-mask** fast path in `set_base_links_pos` / `set_base_links_quat` only has the `torch.where(mask, new, current)` branch, which operates over the **full** `(n_envs, K)` buffer and rejects a pre-indexed `(n_selected, K)` subset inside `broadcast_tensor`:

```
GenesisException: Invalid input shape: (9, 3). Dimension 0 consistent with required size 4096.
```

So the accepted shape of `pos`/`quat` silently depends on the **dtype of `envs_idx`**:

- int / slice `envs_idx` → slow path → wants the `(n_selected, K)` **subset**
- bool-mask `envs_idx` → fast path → wants the **full** `(n_envs, K)` tensor only

This is also inconsistent with `set_qpos`, whose bool-mask fast path already detects the subset case and uses `masked_scatter_`:

```python
if qpos.ndim == 2 and len(qpos) != len(qs_data):
    qs_data.masked_scatter_(envs_idx[:, None], qpos.view_as(qpos))
else:
    qpos = broadcast_tensor(qpos, gs.tc_float, qs_data.shape)
    torch.where(envs_idx[:, None], qpos, qs_data, out=qs_data)
```

Setting state for a subset of environments under a bool mask is the common pattern for staggered RL resets, so the asymmetry surfaces as a crash on the first partial reset.

## Fix

Mirror `set_qpos` in both base-link setters: when the input is a 2-D per-selected-env subset, scatter it into the masked rows of the full buffer; otherwise keep the existing broadcast + `torch.where`.

The guard is `len(pos) not in (1, len(target))` (rather than `set_qpos`'s `len != len`) so a single-row `(1, K)` input still broadcasts via `torch.where` instead of `masked_scatter_` (which can't broadcast one row across multiple masked envs). Full `(n_envs, K)` tensors are unchanged, and no device→host sync is introduced — the zero-copy path stays sync-free.

## Validation

CPU backend (`use_zerocopy=True`), 4-env scene, mask `[True, False, True, False]`:

- `set_pos` with a `(2, 3)` subset + bool mask → sets only the masked envs, leaves the others untouched (previously crashed)
- `set_quat` with a `(2, 4)` subset + bool mask (`relative=False`) → works (previously crashed)
- full `(4, 3)` + bool mask → unchanged
- single-row `(1, 3)` broadcast + bool mask → unchanged