### PR TITLE
[BUG FIX] Deduplicate textures across GLB submeshes sharing a material.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -382,6 +382,9 @@ def destroy():
         assert scene is not None
         scene.destroy()
 
+    # Release cached RGBA textures so large image arrays from destroyed scenes are not retained globally.
+    surfaces.clear_rgba_cache()
+
     # Destroy all externally registered modules
     for _init_fun, destroy_fun in _module_registry:
         destroy_fun()

--- a/genesis/ext/pyrender/mesh.py
+++ b/genesis/ext/pyrender/mesh.py
@@ -191,10 +191,11 @@ class Mesh(object):
             # Compute colors, texture coords, and material properties
             color_0, texcoord_0, primitive_material = Mesh._get_trimesh_props(m, smooth=smooth, material=material)
 
-            # Override if material is given.
+            # Override if material is given. Shallow-copy so per-primitive state (e.g. wireframe) stays isolated, while
+            # the heavy Texture objects stay shared with the source material. Primitives reusing one material then
+            # expose the same Texture instances, which the renderer deduplicates into a single host array and upload.
             if material is not None:
-                # primitive_material = copy.copy(material)
-                primitive_material = copy.deepcopy(material)  # TODO
+                primitive_material = copy.copy(material)
 
             if primitive_material is None:
                 # Replace material with default if needed

--- a/genesis/options/surfaces.py
+++ b/genesis/options/surfaces.py
@@ -1,3 +1,4 @@
+import functools
 import math
 from typing import Any, ClassVar, Literal
 from typing_extensions import Self
@@ -144,7 +145,7 @@ class Surface(Options):
         return False
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
-        return self._make_rgba(self.texture, None, batch)
+        return _make_rgba(self.texture, None, batch)
 
     def update_texture(
         self,
@@ -205,66 +206,73 @@ class Surface(Options):
                 opacity = tex
         return opacity
 
-    @staticmethod
-    def _make_rgba(
-        color_texture: Texture | None, opacity_texture: Texture | None, batch: bool
-    ) -> BatchTexture | Texture:
-        all_textures = []
-        for texture in (color_texture, opacity_texture):
-            textures = texture.textures if isinstance(texture, BatchTexture) else [texture]
-            all_textures.append(textures if batch else textures[:1])
-        color_textures, opacity_textures = all_textures
 
-        rgba_textures = []
-        num_colors = len(color_textures)
-        num_opacities = len(opacity_textures)
-        num_rgba = num_colors * num_opacities // math.gcd(num_colors, num_opacities)
+@functools.lru_cache(maxsize=128)
+def _make_rgba(color_texture: Texture | None, opacity_texture: Texture | None, batch: bool) -> "BatchTexture | Texture":
+    # Resolve a surface's color and opacity textures into a single RGBA texture. The result is memoized on the input
+    # texture instances: surfaces sharing the same textures (e.g. all textured submeshes of a GLB) then reuse a single
+    # merged array instead of allocating one full-resolution copy each. A texture update swaps in a new instance, which
+    # is a natural cache miss, so no explicit invalidation is needed.
+    all_textures = []
+    for texture in (color_texture, opacity_texture):
+        textures = texture.textures if isinstance(texture, BatchTexture) else [texture]
+        all_textures.append(textures if batch else textures[:1])
+    color_textures, opacity_textures = all_textures
 
-        for i in range(num_rgba):
-            color_texture = color_textures[i % num_colors]
-            opacity_texture = opacity_textures[i % num_opacities]
+    rgba_textures = []
+    num_colors = len(color_textures)
+    num_opacities = len(opacity_textures)
+    num_rgba = num_colors * num_opacities // math.gcd(num_colors, num_opacities)
 
-            if isinstance(color_texture, ColorTexture):
-                if isinstance(opacity_texture, ColorTexture):
-                    rgba_texture = ColorTexture(color=(*color_texture.color, *opacity_texture.color))
-                elif isinstance(opacity_texture, ImageTexture) and opacity_texture.image_array is not None:
-                    rgb_color = mu.color_f32_to_u8(color_texture.color)
-                    rgb_array = np.full((*opacity_texture.image_array.shape[:2], 3), rgb_color, dtype=np.uint8)
-                    rgba_array = np.dstack((rgb_array, opacity_texture.image_array))
-                    rgba_scale = (1.0, 1.0, 1.0, *opacity_texture.image_color)
-                    rgba_texture = ImageTexture(image_array=rgba_array, image_color=rgba_scale)
-                else:
-                    rgba_texture = ColorTexture(color=(*color_texture.color, 1.0))
+    for i in range(num_rgba):
+        color_texture = color_textures[i % num_colors]
+        opacity_texture = opacity_textures[i % num_opacities]
 
-            elif isinstance(color_texture, ImageTexture) and color_texture.image_array is not None:
-                if isinstance(opacity_texture, ColorTexture):
-                    a_color = mu.color_f32_to_u8(opacity_texture.color)
-                    a_array = np.full((*color_texture.image_array.shape[:2],), a_color, dtype=np.uint8)
-                    rgba_array = np.dstack((color_texture.image_array, a_array))
-                    rgba_scale = (*color_texture.image_color, 1.0)
-                elif (
-                    isinstance(opacity_texture, ImageTexture)
-                    and opacity_texture.image_array is not None
-                    and opacity_texture.image_array.shape[:2] == color_texture.image_array.shape[:2]
-                ):
-                    rgba_array = np.dstack((color_texture.image_array, opacity_texture.image_array))
-                    rgba_scale = (*color_texture.image_color, *opacity_texture.image_color)
-                else:
-                    if isinstance(opacity_texture, ImageTexture) and opacity_texture.image_array is not None:
-                        gs.logger.warning(
-                            "Color and opacity image shapes do not match. Fall back to fully opaque texture."
-                        )
-                    a_array = np.full(color_texture.image_array.shape[:2], 255, dtype=np.uint8)
-                    rgba_array = np.dstack((color_texture.image_array, a_array))
-                    rgba_scale = (*color_texture.image_color, 1.0)
+        if isinstance(color_texture, ColorTexture):
+            if isinstance(opacity_texture, ColorTexture):
+                rgba_texture = ColorTexture(color=(*color_texture.color, *opacity_texture.color))
+            elif isinstance(opacity_texture, ImageTexture) and opacity_texture.image_array is not None:
+                rgb_color = mu.color_f32_to_u8(color_texture.color)
+                rgb_array = np.full((*opacity_texture.image_array.shape[:2], 3), rgb_color, dtype=np.uint8)
+                rgba_array = np.dstack((rgb_array, opacity_texture.image_array))
+                rgba_scale = (1.0, 1.0, 1.0, *opacity_texture.image_color)
                 rgba_texture = ImageTexture(image_array=rgba_array, image_color=rgba_scale)
-
             else:
-                rgba_texture = ColorTexture(color=(1.0, 1.0, 1.0, 1.0))
+                rgba_texture = ColorTexture(color=(*color_texture.color, 1.0))
 
-            rgba_textures.append(rgba_texture)
+        elif isinstance(color_texture, ImageTexture) and color_texture.image_array is not None:
+            if isinstance(opacity_texture, ColorTexture):
+                a_color = mu.color_f32_to_u8(opacity_texture.color)
+                a_array = np.full((*color_texture.image_array.shape[:2],), a_color, dtype=np.uint8)
+                rgba_array = np.dstack((color_texture.image_array, a_array))
+                rgba_scale = (*color_texture.image_color, 1.0)
+            elif (
+                isinstance(opacity_texture, ImageTexture)
+                and opacity_texture.image_array is not None
+                and opacity_texture.image_array.shape[:2] == color_texture.image_array.shape[:2]
+            ):
+                rgba_array = np.dstack((color_texture.image_array, opacity_texture.image_array))
+                rgba_scale = (*color_texture.image_color, *opacity_texture.image_color)
+            else:
+                if isinstance(opacity_texture, ImageTexture) and opacity_texture.image_array is not None:
+                    gs.logger.warning("Color and opacity image shapes do not match. Fall back to fully opaque texture.")
+                a_array = np.full(color_texture.image_array.shape[:2], 255, dtype=np.uint8)
+                rgba_array = np.dstack((color_texture.image_array, a_array))
+                rgba_scale = (*color_texture.image_color, 1.0)
+            rgba_texture = ImageTexture(image_array=rgba_array, image_color=rgba_scale)
 
-        return BatchTexture(textures=rgba_textures) if batch else rgba_textures[0]
+        else:
+            rgba_texture = ColorTexture(color=(1.0, 1.0, 1.0, 1.0))
+
+        rgba_textures.append(rgba_texture)
+
+    return BatchTexture(textures=rgba_textures) if batch else rgba_textures[0]
+
+
+def clear_rgba_cache() -> None:
+    # Drop the memoized RGBA textures, releasing the strong references their large image arrays would otherwise keep
+    # alive. Called on genesis destroy so textures from gone scenes do not stay resident.
+    _make_rgba.cache_clear()
 
 
 ############################ Surface types ############################
@@ -356,7 +364,7 @@ class Glass(Surface):
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
         color = self.emissive_texture if self.emissive_texture is not None else self.specular_texture
-        return self._make_rgba(color, None, batch)
+        return _make_rgba(color, None, batch)
 
     def update_texture(
         self,
@@ -434,7 +442,7 @@ class Metal(Surface):
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
         color = self.emissive_texture if self.emissive_texture is not None else self.diffuse_texture
-        return self._make_rgba(color, self.opacity_texture, batch)
+        return _make_rgba(color, self.opacity_texture, batch)
 
     @model_validator(mode="after")
     def _post_init(self) -> Self:
@@ -525,7 +533,7 @@ class Plastic(Surface):
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
         color = self.emissive_texture if self.emissive_texture is not None else self.diffuse_texture
-        return self._make_rgba(color, self.opacity_texture, batch)
+        return _make_rgba(color, self.opacity_texture, batch)
 
     @model_validator(mode="after")
     def _post_init(self) -> Self:
@@ -622,7 +630,7 @@ class BSDF(Surface):
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
         color = self.emissive_texture if self.emissive_texture is not None else self.diffuse_texture
-        return self._make_rgba(color, self.opacity_texture, batch)
+        return _make_rgba(color, self.opacity_texture, batch)
 
     @model_validator(mode="after")
     def _post_init(self) -> Self:
@@ -690,7 +698,7 @@ class Emission(Surface):
         return self.emissive_texture is not None and self.emissive_texture.requires_uv
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
-        return self._make_rgba(self.emissive_texture, None, batch)
+        return _make_rgba(self.emissive_texture, None, batch)
 
     @model_validator(mode="after")
     def _post_init(self) -> Self:

--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -26,6 +26,12 @@ class Texture(Options):
     This class should *not* be instantiated directly.
     """
 
+    # Pydantic disables hashing for models with a field-based __eq__; its only opt-in (model_config frozen=True) also
+    # forbids the in-place edits done during setup (apply_cutoff, check_dim reassign image_array/color). Restore
+    # identity hashing instead: textures are shared by reference and stable once a surface is built, so their identity
+    # is a valid key for caches such as the get_rgba lru_cache.
+    __hash__ = object.__hash__
+
     def __init__(self, **data):
         super().__init__(**data)
 

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -417,6 +417,10 @@ class RasterizerContext:
             yield self.sim.kinematic_solver
 
     def on_rigid(self):
+        # Reuse a single pyrender material per genesis surface so that geoms sharing one surface (e.g. the many
+        # textured submeshes of a GLB, which are kept separate to preserve baked convex decompositions) expose the
+        # same Texture instances. The renderer then keeps a single host copy and GPU upload instead of one per geom.
+        vis_materials = {}
         for solver in self._rigid_solvers():
             # TODO: support dynamic switching in GUI later
             for entity in solver.entities:
@@ -453,19 +457,20 @@ class RasterizerContext:
                             geom_T = geom_T[:1]
                             env_shared = True
 
-                    self.add_rigid_node(
-                        geom,
-                        pyrender.Mesh.from_trimesh(
-                            mesh=mesh,
-                            poses=geom_T,
-                            smooth=geom.surface.smooth if "collision" not in entity.surface.vis_mode else False,
-                            double_sided=(
-                                geom.surface.double_sided if "collision" not in entity.surface.vis_mode else False
-                            ),
-                            is_floor=isinstance(entity._morph, gs.morphs.Plane),
-                            env_shared=env_shared,
+                    surface_key = id(geom.surface)
+                    mesh_node = pyrender.Mesh.from_trimesh(
+                        mesh=mesh,
+                        poses=geom_T,
+                        smooth=geom.surface.smooth if "collision" not in entity.surface.vis_mode else False,
+                        double_sided=(
+                            geom.surface.double_sided if "collision" not in entity.surface.vis_mode else False
                         ),
+                        is_floor=isinstance(entity._morph, gs.morphs.Plane),
+                        env_shared=env_shared,
+                        material=vis_materials.get(surface_key),
                     )
+                    vis_materials.setdefault(surface_key, mesh_node.primitives[0].material)
+                    self.add_rigid_node(geom, mesh_node)
                     if isinstance(entity._morph, gs.morphs.Plane):
                         self.set_reflection_mat(geom_T)
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import pytest
 import trimesh
+from PIL import Image
 
 import genesis as gs
 import genesis.utils.geom as gu
@@ -597,6 +598,54 @@ def test_glb_parse_material(glb_file):
                 material_name,
                 "emissive",
             )
+
+
+@pytest.mark.required
+def test_glb_shared_texture_not_duplicated(tmp_path):
+    n_submeshes = 16
+    texture_size = 64
+
+    yy, xx = np.mgrid[0:texture_size, 0:texture_size]
+    checker = (((xx // 8) % 2) ^ ((yy // 8) % 2)).astype(np.uint8) * 255
+    texture = Image.fromarray(np.stack([checker, checker, checker], axis=-1))
+    mesh = trimesh.Trimesh(
+        vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        faces=[[0, 1, 2]],
+        visual=trimesh.visual.TextureVisuals(
+            uv=[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            material=trimesh.visual.material.PBRMaterial(baseColorTexture=texture, doubleSided=True),
+        ),
+        process=False,
+    )
+
+    # Many nodes referencing a single shared geometry/material - the case that used to blow up host memory.
+    tm_scene = trimesh.Scene()
+    for i in range(n_submeshes):
+        transform = np.eye(4)
+        transform[:3, 3] = (2.0 * i, 0.0, 0.0)
+        tm_scene.add_geometry(mesh, node_name=f"instance_{i:02d}", geom_name="shared_mesh", transform=transform)
+    glb_path = tmp_path / "shared_texture.glb"
+    tm_scene.export(glb_path)
+
+    scene = gs.Scene(show_viewer=False)
+    entity = scene.add_entity(
+        gs.morphs.Mesh(
+            file=str(glb_path),
+            collision=False,
+            fixed=True,
+            file_meshes_are_zup=False,
+        ),
+    )
+
+    # Submeshes are kept separate (group_by_material defaults to False to preserve baked convex decompositions), but
+    # they share one Surface whose resolved RGBA texture is memoized, so a single image array backs all of them rather
+    # than one full-resolution copy per submesh.
+    vgeoms = entity.vgeoms
+    assert len(vgeoms) == n_submeshes
+    assert len({id(geom.surface) for geom in vgeoms}) == 1
+    # Hold every array alive before counting so that ids cannot be recycled by the garbage collector.
+    rgba_arrays = [geom.surface.get_rgba().image_array for geom in vgeoms]
+    assert len({id(array) for array in rgba_arrays}) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

With `group_by_material=False` (the default since #2493, kept to preserve baked convex decompositions), each glTF primitive becomes its own visual geom. Submeshes sharing one material still share a single `Surface`, but the texture was materialized *per submesh* in two places: the renderer built one pyrender `Texture` (host array + GPU upload) per geom, and `Surface.get_rgba` reallocated the merged RGBA array per geom. Host memory and build time then scaled linearly with the submesh count.

This shares the resolved texture across submeshes referencing the same surface:
- `_make_rgba` (backing `get_rgba`) is now a module-level `functools.lru_cache` keyed on its input textures. A texture update swaps in a new object, so it is a natural cache miss - no manual invalidation.
- `Texture` is made identity-hashable so it can key that cache (pydantic disables hashing for field-`__eq__` models, and `frozen=True` is unusable because `apply_cutoff`/`check_dim` mutate in place).
- The rasterizer caches one pyrender material per surface and passes it to `Mesh.from_trimesh`, which now shallow-copies the override material so shared `Texture` instances survive and the renderer dedups the upload.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#2890

## Motivation and Context

Key point for review: the `group_by_material=False` default is intentionally kept; this fixes the memory cost it introduced instead of reverting it. The dedup relies on submeshes sharing the same `Surface` instance, which `gltf.py` already guarantees (it caches `parse_glb_material` per material index).

Benchmark, issue repro `--count 800 --texture-size 2048`:

|        | peak RSS | build time |
|--------|---------:|-----------:|
| before |  26.2 GB |     ~24 s  |
| after  |   1.2 GB |      ~1 s  |

## How Has This Been Tested?

- New regression test `tests/test_mesh.py::test_glb_shared_texture_not_duplicated`: a GLB with 16 submeshes sharing one material now exposes a single backing image array (fails before the fix).
- `tests/test_mesh.py` (24 passed) and `tests/test_render.py` pass locally; the rendered output of a shared-texture GLB is unchanged.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.