### PR TITLE
[BUG FIX] Support passing sliced env mask to RigidSolver.set_base_links_(pos|quat).

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1757,14 +1757,9 @@ class RigidSolver(KinematicSolver):
         if links_idx is None:
             links_idx = self._base_links_idx
 
-        # Zero-copy fast path: single base link, bool mask, non-relative
-        if (
-            gs.use_zerocopy
-            and not relative
-            and isinstance(links_idx, int)
-            and isinstance(envs_idx, torch.Tensor)
-            and envs_idx.dtype == torch.bool
-        ):
+        # Zero-copy fast path: single base link, non-relative. Write the position buffer in place instead of
+        # launching a kernel. The kernel path below handles relative or multi-link updates.
+        if gs.use_zerocopy and not relative and isinstance(links_idx, int):
             link = self.links[links_idx]
             if link.is_fixed:
                 data = qd_to_torch(self.links_state.pos, transpose=True, copy=False)
@@ -1772,8 +1767,32 @@ class RigidSolver(KinematicSolver):
             else:
                 data = qd_to_torch(self._rigid_global_info.qpos, transpose=True, copy=False)
                 target = data[:, link.q_start : link.q_start + 3]
-            pos = broadcast_tensor(pos, gs.tc_float, target.shape)
-            torch.where(envs_idx[:, None], pos, target, out=target)
+            if isinstance(envs_idx, torch.Tensor) and envs_idx.dtype == torch.bool:
+                if pos.ndim == 2 and len(pos) not in (1, len(target)):
+                    # A fresh source view is needed because masked_scatter_ may reshape it in-place. Metal
+                    # mis-scatters a stride-0 broadcast mask, so it must be materialized to a dense mask there.
+                    envs_mask = envs_idx[:, None]
+                    if gs.backend == gs.metal:
+                        envs_mask = envs_mask.expand_as(target).contiguous()
+                    target.masked_scatter_(envs_mask, pos.view_as(pos))
+                else:
+                    pos = broadcast_tensor(pos, gs.tc_float, target.shape)
+                    torch.where(envs_idx[:, None], pos, target, out=target)
+            else:
+                # Fixed links with at least one geom and non-batched vertices cannot take env-specific positions
+                if link.is_fixed and link.geoms and not link.entity._batch_fixed_verts:
+                    pos = torch.as_tensor(pos, dtype=gs.tc_float, device=gs.device)
+                    same_pos = pos.ndim < 2 or len(pos) == 1 or (torch.diff(pos, dim=0).abs() < gs.EPS).all()
+                    set_all_envs = envs_idx is None or torch.equal(
+                        torch.sort(self._scene._sanitize_envs_idx(envs_idx)).values, self._scene._envs_idx
+                    )
+                    if not (set_all_envs and same_pos):
+                        gs.raise_exception(
+                            "Specifying env-specific pos for fixed links with at least one geometry requires "
+                            "setting morph option 'batch_fixed_verts=True'."
+                        )
+                mask = (0,) if self.n_envs == 0 else indices_to_mask(envs_idx)
+                assign_indexed_tensor(target, mask, pos)
             if gs.backend == gs.metal:
                 torch.mps.synchronize()
         else:
@@ -1857,14 +1876,9 @@ class RigidSolver(KinematicSolver):
         if links_idx is None:
             links_idx = self._base_links_idx
 
-        # Zero-copy fast path: single base link, bool mask, non-relative
-        if (
-            gs.use_zerocopy
-            and not relative
-            and isinstance(links_idx, int)
-            and isinstance(envs_idx, torch.Tensor)
-            and envs_idx.dtype == torch.bool
-        ):
+        # Zero-copy fast path: single base link, non-relative. Write the quaternion buffer in place instead of
+        # launching a kernel. The kernel path below handles relative or multi-link updates.
+        if gs.use_zerocopy and not relative and isinstance(links_idx, int):
             link = self.links[links_idx]
             if link.is_fixed:
                 data = qd_to_torch(self.links_state.quat, transpose=True, copy=False)
@@ -1872,8 +1886,31 @@ class RigidSolver(KinematicSolver):
             else:
                 data = qd_to_torch(self._rigid_global_info.qpos, transpose=True, copy=False)
                 target = data[:, link.q_start + 3 : link.q_start + 7]
-            quat = broadcast_tensor(quat, gs.tc_float, target.shape)
-            torch.where(envs_idx[:, None], quat, target, out=target)
+            if isinstance(envs_idx, torch.Tensor) and envs_idx.dtype == torch.bool:
+                if quat.ndim == 2 and len(quat) not in (1, len(target)):
+                    # A fresh source view is needed because masked_scatter_ may reshape it in-place. Metal
+                    # mis-scatters a stride-0 broadcast mask, so it must be materialized to a dense mask there.
+                    envs_mask = envs_idx[:, None]
+                    if gs.backend == gs.metal:
+                        envs_mask = envs_mask.expand_as(target).contiguous()
+                    target.masked_scatter_(envs_mask, quat.view_as(quat))
+                else:
+                    quat = broadcast_tensor(quat, gs.tc_float, target.shape)
+                    torch.where(envs_idx[:, None], quat, target, out=target)
+            else:
+                # Fixed links with at least one geom and non-batched vertices cannot take env-specific orientations
+                if link.is_fixed and link.geoms and not link.entity._batch_fixed_verts:
+                    quat = torch.as_tensor(quat, dtype=gs.tc_float, device=gs.device)
+                    same_quat = quat.ndim < 2 or len(quat) == 1 or (torch.diff(quat, dim=0).abs() < gs.EPS).all()
+                    set_all_envs = envs_idx is None or torch.equal(
+                        torch.sort(self._scene._sanitize_envs_idx(envs_idx)).values, self._scene._envs_idx
+                    )
+                    if not (set_all_envs and same_quat):
+                        gs.raise_exception(
+                            "Impossible to set env-specific quat for fixed links with at least one geometry."
+                        )
+                mask = (0,) if self.n_envs == 0 else indices_to_mask(envs_idx)
+                assign_indexed_tensor(target, mask, quat)
             if gs.backend == gs.metal:
                 torch.mps.synchronize()
         else:
@@ -2038,9 +2075,13 @@ class RigidSolver(KinematicSolver):
                 and envs_idx.dtype == torch.bool
             ):
                 qs_data = data[(slice(None), *qs_mask)]
-                if qpos.ndim == 2 and len(qpos) != len(qs_data):
-                    # Note that it is necessary to create a new temporary view because it will be reshaped in-place
-                    qs_data.masked_scatter_(envs_idx[:, None], qpos.view_as(qpos))
+                if qpos.ndim == 2 and len(qpos) not in (1, len(qs_data)):
+                    # A fresh source view is needed because masked_scatter_ may reshape it in-place. Metal mis-scatters
+                    # a stride-0 broadcast mask, so it must be materialized to a dense full-shape mask there.
+                    envs_mask = envs_idx[:, None]
+                    if gs.backend == gs.metal:
+                        envs_mask = envs_mask.expand_as(qs_data).contiguous()
+                    qs_data.masked_scatter_(envs_mask, qpos.view_as(qpos))
                 else:
                     qpos = broadcast_tensor(qpos, gs.tc_float, qs_data.shape)
                     torch.where(envs_idx[:, None], qpos, qs_data, out=qs_data)

--- a/tests/test_rigid_benchmarks.py
+++ b/tests/test_rigid_benchmarks.py
@@ -372,6 +372,10 @@ def make_franka(
     dofs_stiffness = franka.get_dofs_stiffness()
     dofs_damping = franka.get_dofs_damping()
 
+    # Per-selected-env base pose subset exercising the bool-mask zero-copy 'masked_scatter_' path
+    base_pos0 = franka.get_pos(reset_envs_mask)
+    base_quat0 = franka.get_quat(reset_envs_mask)
+
     def step():
         scene.step()
         if accessors:
@@ -392,6 +396,8 @@ def make_franka(
             franka.set_dofs_damping(dofs_damping)
             franka.set_dofs_velocity(vel0, envs_idx=reset_envs_mask, skip_forward=True)
             franka.set_qpos(qpos0, envs_idx=reset_envs_mask, zero_velocity=False, skip_forward=True)
+            franka.set_pos(base_pos0, envs_idx=reset_envs_mask, skip_forward=True)
+            franka.set_quat(base_quat0, envs_idx=reset_envs_mask, relative=False, skip_forward=True)
 
     return scene, step, SceneMeta(compile_time=compile_time)
 


### PR DESCRIPTION
## Summary

Reworks `set_base_links_pos` / `set_base_links_quat` (originally based on @Kashu7100's #2893):

- **Partial-env subset under a bool mask.** Accept a per-selected-env `(n_selected, K)` subset under a bool mask; previously only the full `(n_envs, K)` buffer was accepted and a subset crashed in `broadcast_tensor`.
- **Metal silent-corruption fix.** `masked_scatter_` with a broadcast `(N, 1)` mask scatters to the wrong rows on MPS (CPU/CUDA are correct). The mask is materialized to a dense full-shape mask on the `metal` backend only.
- **Zero-copy fast path for all `envs_idx`.** The single-link, non-relative case now writes the buffer in place for every `envs_idx` form (bool mask / `None` / int / slice), skipping both the kernel launch and `_sanitize_io_variables`. `set_pos`/`set_quat` drop from ~120 us to ~11 us, matching `set_qpos`. The fixed-link-with-geometry guard is preserved.
- **`set_qpos` consistency.** Guard aligned (`!=` -> `not in (1, ...)`), fixing a latent single-row `(1, K)` crash, plus the same Metal fix.
- **Benchmark.** `franka_accessors` now exercises the bool-mask subset path.

## Validation

- CPU and Metal: `test_set_root_pose` (fixed/free links, `batch_fixed_verts` both, `relative` both), `test_reset`, and a 25-test pose/reset/kinematic sweep.
- A standalone pure-torch probe confirms the broadcast mask is correct on CPU/CUDA and wrong only on Metal.

The last commit stabilizes flaky `test_stickman` / `test_mesh_repair` (settle-loop + collision tolerances), needed for green CI.
