### PR TITLE
[DOC] get_mass_mat: document the LTDL (M = Lᵀ D L) decomposition convention

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2618,6 +2618,19 @@ class RigidSolver(KinematicSolver):
         return tensor[0] if self.n_envs == 0 and self._options.batch_dofs_info else tensor
 
     def get_mass_mat(self, dofs_idx=None, envs_idx=None, decompose=False):
+        """Return the joint-space mass matrix M (shape ``(n_envs, n_dofs, n_dofs)``, or ``(n_dofs, n_dofs)`` when
+        ``n_envs == 0``).
+
+        If ``decompose=True``, return ``(L, D_inv)`` of the per-entity factorization instead of M. Note the
+        convention is **LTDL** (reverse-pivot), i.e. ``L`` is **unit lower-triangular** and reconstructs M as::
+
+            M = L.mT @ diag(1.0 / D_inv) @ L          # NOT L @ diag(1/D_inv) @ L.mT
+
+        This is the form the internal mass solve consumes (eliminating DOFs last-to-first), and it differs from
+        the textbook ``M = L D L^T`` LDL^T: here it is ``M = L^T D L``. ``D_inv`` holds the reciprocals of the
+        diagonal D. ``L`` is block-diagonal across entities (one independent factor per articulated body); only
+        the strict-lower triangle of each block is meaningful (the unit diagonal and the upper triangle are not).
+        """
         tensor = qd_to_torch(self.mass_mat_L if decompose else self.mass_mat, envs_idx, transpose=True, copy=True)
         if dofs_idx is not None:
             tensor = tensor[indices_to_mask(None, dofs_idx, dofs_idx)]


### PR DESCRIPTION
## Summary

`RigidSolver.get_mass_mat(decompose=True)` returns `(L, D_inv)` of the per-entity mass-matrix factorization, but the method had **no docstring** and the factorization convention is easy to get wrong.

The stored factor is the **LTDL / reverse-pivot** form — `L` is unit lower-triangular and reconstructs M as:

```python
M = L.mT @ diag(1.0 / D_inv) @ L      #  M = Lᵀ D L   (NOT the textbook L D Lᵀ)
```

This is the convention the internal mass solve (`func_solve_mass_entity`) consumes (it eliminates DOFs last-to-first). Reconstructing with the textbook `M = L D Lᵀ` instead silently disagrees on the **off-diagonals** for any non-trivial mass matrix (it only happens to look right for near-diagonal M), which is a real foot-gun for anyone consuming this API.

This PR just adds a docstring spelling out:
- the convention `M = L.mT @ diag(1/D_inv) @ L`,
- the per-entity block-diagonal structure (one independent factor per articulated body),
- that only the strict-lower triangle of each block is meaningful.

No behavior change. (`get_mass_mat` itself is self-consistent — `decompose=True/False` agree — this is purely documentation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
