### PR TITLE
[MISC] Refactor and speed up tactile sensors.

### DIFF
--- a/examples/sensors/tactile_franka.py
+++ b/examples/sensors/tactile_franka.py
@@ -67,7 +67,6 @@ def _add_tactile_sensor(
         return scene.add_sensor(
             gs.sensors.KinematicTaxel(
                 probe_local_pos=probe_local_pos,
-                probe_local_normal=probe_normal,
                 probe_radius=0.002,
                 normal_stiffness=5000.0,
                 normal_damping=1.0,
@@ -87,7 +86,6 @@ def _add_tactile_sensor(
                 stiffness=10.0,
                 shear_coupling=1.0,
                 probe_local_normal=probe_normal,
-                probe_radius_noise=0.005,
                 **common,
             )
         )

--- a/examples/sensors/tactile_sandbox.py
+++ b/examples/sensors/tactile_sandbox.py
@@ -1,6 +1,6 @@
 """
 Interactive demo of tactile sensors on a fixed taxel pad (box or dome) with controllable objects.
-Sensor types: ContactDepthProbe, ElastomerTaxel, KinematicTaxel, ProximityTaxel.
+Sensor types: ContactDepthProbe, ContactProbe, ElastomerTaxel, KinematicTaxel, ProximityTaxel.
 
 Note that the sensor readings here have not been calibrated to any units, and is purely for visualization purposes.
 """
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
     from genesis.engine.entities.rigid_entity import RigidEntity
     from genesis.engine.sensors.base_sensor import Sensor
 
-KEY_DPOS = 0.005
+KEY_DPOS = 0.001
 FORCE_SCALE = 100.0
-ROT_FORCE_SCALE = 200.0
+ROT_FORCE_SCALE = 100.0
 
 GRID_SIZE = 20  # 20x20 taxels for square
 PROBE_RADIUS = 0.004
@@ -48,12 +48,14 @@ def _add_tactile_sensor(
     probe_local_pos: np.ndarray,
     probe_normal: tuple[float, float, float] | np.ndarray,
     track_link_idx: tuple[int, ...],
+    contact_depth_query: str | None,
 ) -> "Sensor":
     common = dict(
         entity_idx=entity.idx,
         link_idx_local=link_idx_local,
         draw_debug=True,
         probe_radius=PROBE_RADIUS,
+        contact_depth_query=contact_depth_query,
     )
     if sensor_type == "elastomer":
         return scene.add_sensor(
@@ -63,7 +65,8 @@ def _add_tactile_sensor(
                 track_link_idx=track_link_idx,
                 n_sample_points=2000,
                 dilate_scale=1.0,
-                shear_scale=100.0,
+                shear_scale=2.0,
+                normal_exponent=1.0,
                 **common,
             )
         )
@@ -76,32 +79,43 @@ def _add_tactile_sensor(
                 **common,
             )
         )
+    if sensor_type == "contact":
+        # Schmitt-trigger thresholds (contact depth in meters): a taxel latches on above contact_threshold and
+        # only releases once the depth drops back below the lower release_threshold.
+        return scene.add_sensor(
+            gs.sensors.ContactProbe(
+                probe_local_pos=probe_local_pos,
+                contact_threshold=0.004,
+                release_threshold=0.002,
+                **common,
+            )
+        )
     if sensor_type == "kinematic":
         return scene.add_sensor(
             gs.sensors.KinematicTaxel(
-                probe_local_pos=probe_local_pos,
-                probe_local_normal=probe_normal,
                 normal_stiffness=500.0,
                 normal_damping=1.0,
-                shear_scalar=5.0,
-                twist_scalar=5.0,
+                shear_scalar=4.0,
+                twist_scalar=4.0,
                 normal_exponent=1.5,
+                probe_local_pos=probe_local_pos,
                 **common,
             )
         )
 
-    common["probe_radius"] = PROBE_RADIUS * 2
-    common["debug_point_cloud_radius"] = 0.001
+    common["probe_radius"] = PROBE_RADIUS * 5
     if sensor_type == "proximity":
         return scene.add_sensor(
             gs.sensors.ProximityTaxel(
-                probe_local_pos=probe_local_pos,
                 track_link_idx=track_link_idx,
                 n_sample_points=4000,
-                stiffness=200.0,
-                shear_coupling=100.0,
+                stiffness=40.0,
+                shear_coupling=10.0,
                 probe_local_normal=probe_normal,
-                probe_radius_noise=0.0001,
+                debug_point_cloud_radius=0.0005,
+                debug_probe_color=(0.2, 0.6, 1.0),
+                debug_contact_color=(1.0, 0.2, 0.2),
+                probe_local_pos=probe_local_pos,
                 **common,
             )
         )
@@ -111,7 +125,6 @@ def _add_tactile_sensor(
 def _plot_tactile_sensor(
     scene: gs.Scene,
     sensor_type: str,
-    labels: tuple[str, ...],
     sensors: "tuple[Sensor, ...]",
     n_envs: int = 1,
     plot_normal: tuple[float, float, float] = (0.0, 0.0, -1.0),
@@ -122,24 +135,24 @@ def _plot_tactile_sensor(
 
     if sensor_type == "elastomer":
         for env_idx in range(n_envs):
-            for label, sensor in zip(labels, sensors):
+            for sensor in sensors:
                 scene.start_recording(
                     lambda s=sensor, i=env_idx: s.read()[i],
                     gs.recorders.MPLVectorFieldPlot(
-                        title=f"({label} {OBJ_PER_ENV_LABELS[env_idx]}) ElastomerTaxel marker displacements",
+                        title=f"({OBJ_PER_ENV_LABELS[env_idx]}) ElastomerTaxel marker displacements",
                         positions=sensor.probe_local_pos.reshape(-1, 3),
                         normal=plot_normal,
-                        scale_factor=1.0,
-                        max_magnitude=0.01,
+                        scale_factor=0.1,
+                        max_magnitude=0.1,
                     ),
                 )
     elif sensor_type == "kinematic":
         for env_idx in range(n_envs):
-            for label, sensor in zip(labels, sensors):
+            for sensor in sensors:
                 scene.start_recording(
-                    lambda s=sensor, i=env_idx: s.read().force[i],
+                    lambda s=sensor, i=env_idx: s.read().force[i].reshape(-1, 3),
                     gs.recorders.MPLVectorFieldPlot(
-                        title=f"({label} {OBJ_PER_ENV_LABELS[env_idx]}) KinematicTaxel force",
+                        title=f"({OBJ_PER_ENV_LABELS[env_idx]}) KinematicTaxel force",
                         positions=sensor.probe_local_pos.reshape(-1, 3),
                         normal=plot_normal,
                         scale_factor=0.01,
@@ -148,14 +161,14 @@ def _plot_tactile_sensor(
                 )
     elif sensor_type == "proximity":
         for env_idx in range(n_envs):
-            for label, sensor in zip(labels, sensors):
+            for sensor in sensors:
                 scene.start_recording(
-                    lambda s=sensor, i=env_idx: s.read().force[i],
+                    lambda s=sensor, i=env_idx: s.read().force[i].reshape(-1, 3),
                     gs.recorders.MPLVectorFieldPlot(
-                        title=f"({label} {OBJ_PER_ENV_LABELS[env_idx]}) ProximityTaxel force",
+                        title=f"({OBJ_PER_ENV_LABELS[env_idx]}) ProximityTaxel force",
                         positions=sensor.probe_local_pos.reshape(-1, 3),
                         normal=plot_normal,
-                        scale_factor=0.5,
+                        scale_factor=0.1,
                         max_magnitude=1.0,
                     ),
                 )
@@ -165,9 +178,19 @@ def _plot_tactile_sensor(
                 lambda i=env_idx: tuple(sensor.read()[i].max() for sensor in sensors),
                 gs.recorders.MPLLinePlot(
                     title=f"ContactDepthProbe max depth ({OBJ_PER_ENV_LABELS[env_idx]})",
-                    labels=labels,
                     x_label="step",
                     y_label="depth",
+                    history_length=200,
+                ),
+            )
+    elif sensor_type == "contact":
+        for env_idx in range(n_envs):
+            scene.start_recording(
+                lambda i=env_idx: tuple(sensor.read()[i].sum() for sensor in sensors),
+                gs.recorders.MPLLinePlot(
+                    title=f"ContactProbe taxels in contact ({OBJ_PER_ENV_LABELS[env_idx]})",
+                    x_label="step",
+                    y_label="# taxels",
                     history_length=200,
                 ),
             )
@@ -183,6 +206,10 @@ def _print_sensor_reading(sensor_type: str, sensor: "Sensor", t: float) -> None:
         max_depth = data.max()
         if max_depth > gs.EPS:
             print(f"t={t:.2f}s  max depth={max_depth:.4f}")
+    elif sensor_type == "contact":
+        n_contact = int(data.sum())
+        if n_contact > 0:
+            print(f"t={t:.2f}s  taxels in contact={n_contact}")
     elif sensor_type == "kinematic":
         magnitude = torch.linalg.norm(data.force, axis=-1).max()
         if magnitude > gs.EPS:
@@ -204,9 +231,15 @@ def main() -> None:
     parser.add_argument("--dome", action="store_true", help="Change the sensor object to a dome instead of a box")
     parser.add_argument(
         "--sensor",
-        choices=("elastomer", "depth", "kinematic", "proximity"),
+        choices=("elastomer", "depth", "contact", "kinematic", "proximity"),
         default="elastomer",
         help="Type of tactile sensor to use.",
+    )
+    parser.add_argument(
+        "--contact-depth-query",
+        choices=("sdf", "raycast"),
+        default=None,
+        help="Contact-depth backend for the tactile sensor (default: sensor's own default, currently sdf).",
     )
     args = parser.parse_args()
 
@@ -275,17 +308,16 @@ def main() -> None:
             ny=GRID_SIZE,
         )
 
-    # Procedural torus written to a temp .obj (avoids checking a 2k-line mesh into the repo).
     torus_path = os.path.join(tempfile.gettempdir(), "tactile_sandbox_torus.obj")
     if not os.path.exists(torus_path):
-        trimesh.creation.torus(major_radius=0.3, minor_radius=0.1).export(torus_path)
+        trimesh.creation.torus(major_radius=1.0, minor_radius=0.5).export(torus_path)
 
     obj = scene.add_entity(
         morph=[
             gs.morphs.Mesh(
                 file=torus_path,
-                euler=(90.0, 0.0, 0.0),
-                scale=OBJECT_SIZE,
+                scale=OBJECT_SIZE / 2,
+                convexify=False,
             ),
             gs.morphs.Sphere(
                 radius=OBJECT_SIZE / 2,
@@ -313,9 +345,10 @@ def main() -> None:
         probe_local_pos,
         probe_normal,
         track_link_idx=(obj.base_link_idx,),
+        contact_depth_query=args.contact_depth_query,
     )
     if args.vis and "PYTEST_VERSION" not in os.environ:
-        _plot_tactile_sensor(scene, args.sensor, ("",), (sensor,), n_envs=4, plot_normal=probe_normal_axis)
+        _plot_tactile_sensor(scene, args.sensor, (sensor,), n_envs=4, plot_normal=probe_normal_axis)
     scene.build(n_envs=4, env_spacing=(SENSOR_OBJ_SIZE * 1.2, SENSOR_OBJ_SIZE * 1.2))
 
     obj_init_pos = tensor_to_array(obj.get_pos())

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -499,12 +499,13 @@ def _kernel_build_sensor_candidate_geom_mask(
     sensor_candidate_geom_mask: qd.types.ndarray(),
 ):
     """
-    Scatter the per-(env, sensor) candidate-geom bitmask from the prefiltered contact list. Run only when the
-    sensor class is in ``contact_depth_query="raycast"`` mode; the BVH leaf loop consults this mask to skip
-    triangles whose owning geom isn't in the sensor's current contact list. Only the geom on the side opposite
-    the sensor link is marked (mirroring the SDF path's ``i_g = <other geom>`` selection); marking the sensor's
-    own geom would let the BVH closest-point test latch onto the sensor's own surface, pinning the reported
-    depth to ``probe_radius`` regardless of the pressing object.
+    Scatter the per-(env, sensor) candidate-geom bitmask from the prefiltered contact list.
+
+    Run only when the sensor class is in ``contact_depth_query="raycast"`` mode; the BVH leaf loop consults this mask
+    to skip triangles whose owning geom isn't in the sensor's current contact list. Only the geom on the side opposite
+    the sensor link is marked (mirroring the SDF path's ``i_g = <other geom>`` selection); marking the sensor's own
+    geom would let the BVH closest-point test latch onto the sensor's own surface, pinning the reported depth to
+    ``probe_radius`` regardless of the pressing object.
     """
     n_batches = sensor_n_contacts.shape[0]
     n_sensors = sensor_n_contacts.shape[1]
@@ -538,11 +539,13 @@ def _func_query_contact_depth_penetration_bvh(
     sensor_candidate_geom_mask: qd.types.ndarray(),
 ):
     """
-    BVH-based dual-radius probe penetration. Finds the signed distance to the nearest candidate triangle (sign
-    from the closest triangle's face normal: negative when the probe is inside the surface, like
-    ``_func_elastomer_min_signed_dist_bvh``) and returns ``max(0, R - sd)`` per radius. This matches the SDF
-    path's ``pen = R - sd`` -- in particular it keeps growing as the probe penetrates, rather than folding back
-    at ``R`` like an unsigned closest-point distance. Mirrors ``_func_query_contact_depth_penetration``'s return.
+    BVH-based dual-radius probe penetration.
+
+    Finds the signed distance to the nearest candidate triangle (sign from the closest triangle's face normal:
+    negative when the probe is inside the surface, like ``_func_elastomer_min_signed_dist_bvh``) and returns
+    ``max(0, R - sd)`` per radius. This matches the SDF path's ``pen = R - sd`` -- in particular it keeps growing as
+    the probe penetrates, rather than folding back at ``R`` like an unsigned closest-point distance. Mirrors
+    ``_func_query_contact_depth_penetration``'s return.
     """
     n_triangles = faces_info.verts_idx.shape[0]
     radius_query = qd.max(probe_radius_gt, probe_radius_m)
@@ -611,6 +614,7 @@ def _func_query_contact_depth_bvh(
 ):
     """
     BVH-based dual-radius probe query with contact normal and link, mirroring ``_func_query_contact_depth``'s return.
+
     Finds the nearest candidate triangle and its signed distance (sign from the face normal; negative when the probe
     is inside the surface), yielding ``pen = R - sd`` to match the SDF path. The returned contact normal is the
     nearest triangle's outward face normal, which the spring-damper model uses as the surface normal.
@@ -879,8 +883,11 @@ def _kernel_kinematic_taxel_bvh(
 
 
 class KinematicTactileSensorMixin(ContactDepthQuerySensorMixin, ProbeSensorMixin[ProbeSensorSharedMetadataT]):
-    """Contact-depth probe family (ContactDepthProbe, ContactProbe, KinematicTaxel). The class-wide SDF/raycast
-    backend is resolved and activated by ``ContactDepthQuerySensorMixin.build``; subclasses add their own metadata."""
+    """Contact-depth probe family (ContactDepthProbe, ContactProbe, KinematicTaxel).
+
+    The class-wide SDF/raycast backend is resolved and activated by ``ContactDepthQuerySensorMixin.build``;
+    subclasses add their own metadata.
+    """
 
 
 @dataclass
@@ -1027,13 +1034,13 @@ class ContactProbeSensor(
     ContactDepthProbeSensor, SimpleSensor[ContactProbeOptions, RaycastContext, ContactProbeMetadata, tuple]
 ):
     """
-    Returns boolean contact per probe with optional Schmitt-trigger hysteresis. Shares the depth-probe kernel.
+    Returns boolean contact per probe with optional Schmitt-trigger hysteresis.
 
-    The contact bit latches on when depth exceeds ``contact_threshold`` and releases when depth drops to or below
-    ``release_threshold``. When ``release_threshold`` is left unset (the default; it then falls back to
-    ``contact_threshold``), the latch is degenerate and behavior matches a stateless threshold. Latch state is read
-    from the per-branch return-space ring, so GT and measured branches latch independently and reset cleanly with
-    the env (the manager zeros the ring on reset).
+    Shares the depth-probe kernel. The contact bit latches on when depth exceeds ``contact_threshold`` and releases
+    when depth drops to or below ``release_threshold``. When ``release_threshold`` is left unset (the default; it then
+    falls back to ``contact_threshold``), the latch is degenerate and behavior matches a stateless threshold. Latch
+    state is read from the per-branch return-space ring, so GT and measured branches latch independently and reset
+    cleanly with the env (the manager zeros the ring on reset).
     """
 
     def build(self):

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
-import numpy as np
 import quadrants as qd
 import torch
 
@@ -9,20 +8,33 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 import genesis.utils.sdf as sdf
+from genesis.engine.bvh import STACK_SIZE as _BVH_STACK_SIZE
 from genesis.engine.solvers.rigid.collider.utils import func_point_in_geom_aabb
 from genesis.options.sensors import ContactDepthProbe as ContactDepthProbeOptions
 from genesis.options.sensors import ContactProbe as ContactProbeOptions
 from genesis.options.sensors import KinematicTaxel as KinematicTaxelOptions
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
+from genesis.utils.raycast_qd import (
+    closest_point_on_triangle,
+    get_triangle_vertices,
+    triangle_face_normal,
+)
+
+from .raycaster import RaycastContext
 
 from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, SimpleSensor, SimpleSensorMetadata
 from .probe import (
     ProbeSensorMetadataMixin,
     ProbeSensorMixin,
-    ProbesWithNormalSensorMetadataMixin,
-    ProbesWithNormalSensorMixin,
-    ProbesWithNormalSensorSharedMetadataT,
+    ProbeSensorSharedMetadataT,
     func_noised_probe_radius,
+    get_measured_bufs,
+)
+from .tactile_shared import (
+    ContactDepthQueryMetadataMixin,
+    ContactDepthQuerySensorMixin,
+    ContactPrefilterMetadataMixin,
+    func_sphere_intersects_aabb,
 )
 
 if TYPE_CHECKING:
@@ -36,72 +48,152 @@ if TYPE_CHECKING:
 @qd.func
 def _func_query_contact_depth_penetration(
     i_b: int,
+    i_s: int,
     probe_pos: qd.types.vector(3),
     probe_radius_gt: float,
     probe_radius_m: float,
-    sensor_link_idx: int,
     geoms_info: array_class.GeomsInfo,
     geoms_state: array_class.GeomsState,
-    collider_state: array_class.ColliderState,
+    sensor_geoms_idx: qd.types.ndarray(),
+    sensor_n_geoms: qd.types.ndarray(),
     sdf_info: array_class.SDFInfo,
 ):
     """
-    Max probe penetration from SDF for contacts involving the sensor link, dual-radius.
-
-    Returns ``(max_pen_gt, max_pen_m)`` from a single SDF pass: both penetrations come from the same ``sd`` per contact
-    via ``pen = radius - sd``. Callers that do not need the noised-radius branch pass ``probe_radius_m ==
-    probe_radius_gt`` and ignore the second return.
+    Max probe penetration from SDF over the sensor link's unique opposing geoms, dual-radius.
     """
     max_pen_gt = gs.qd_float(0.0)
     max_pen_m = gs.qd_float(0.0)
 
-    n_contacts = collider_state.n_contacts[i_b]
-    for i_c in range(n_contacts):
-        i_col = collider_state.contact_sort_idx[i_c, i_b]
-        c_link_a = collider_state.contact_data.link_a[i_col, i_b]
-        c_link_b = collider_state.contact_data.link_b[i_col, i_b]
-        c_geom_a = collider_state.contact_data.geom_a[i_col, i_b]
-        c_geom_b = collider_state.contact_data.geom_b[i_col, i_b]
-
-        for side in qd.static(range(2)):
-            c_link = c_link_a if side == 0 else c_link_b
-            i_g = c_geom_b if side == 0 else c_geom_a
-
-            if c_link == sensor_link_idx:
-                g_pos = geoms_state.pos[i_g, i_b]
-                g_quat = geoms_state.quat[i_g, i_b]
-                sd = sdf.sdf_func_world_local(geoms_info, sdf_info, probe_pos, i_g, g_pos, g_quat)
-                pen_gt = probe_radius_gt - sd
-                if pen_gt > max_pen_gt:
-                    max_pen_gt = pen_gt
-                pen_m = probe_radius_m - sd
-                if pen_m > max_pen_m:
-                    max_pen_m = pen_m
+    n_g = sensor_n_geoms[i_b, i_s]
+    for i_g_ in range(n_g):
+        i_g = sensor_geoms_idx[i_b, i_s, i_g_]
+        g_pos = geoms_state.pos[i_g, i_b]
+        g_quat = geoms_state.quat[i_g, i_b]
+        sd = sdf.sdf_func_world_local(geoms_info, sdf_info, probe_pos, i_g, g_pos, g_quat)
+        pen_gt = probe_radius_gt - sd
+        if pen_gt > max_pen_gt:
+            max_pen_gt = pen_gt
+        pen_m = probe_radius_m - sd
+        if pen_m > max_pen_m:
+            max_pen_m = pen_m
 
     return max_pen_gt, max_pen_m
+
+
+# Per-(env, sensor) cap on the prefiltered contact list consumed by the BVH-mask builder. Sensors track a
+# single rigid link; even with multicontact and many neighbouring geoms, the count of contacts touching one
+# link rarely exceeds a few hundred.
+_MAX_CONTACTS_PER_SENSOR = 1024
+
+# Per-(env, sensor) cap on the deduplicated opposing-geom list consumed by ``_func_query_contact_depth`` and
+# ``_func_query_contact_depth_penetration`` (the SDF path). Unlike the contact list, this counts *distinct*
+# contacting geoms, not contact points: one pressing object is a single entry regardless of how many contact
+# points multicontact emits. A single rigid sensor link touching >64 distinct geoms at once is implausible,
+# so 64 is generous; overflow silently truncates, matching ``_MAX_CONTACTS_PER_SENSOR``.
+_MAX_GEOMS_PER_SENSOR = 64
+
+
+@qd.kernel
+def _kernel_build_sensor_contact_idx(
+    sensor_link_idx: qd.types.ndarray(),
+    collider_state: array_class.ColliderState,
+    sensor_contacts_idx: qd.types.ndarray(),
+    sensor_n_contacts: qd.types.ndarray(),
+):
+    """
+    Per-(env, sensor) compact contact index for the KinematicTaxel pre-pass.
+
+    Parallelizes over ``(n_batches, n_sensors)`` so the main kernel's per-probe contact-list scan drops from
+    O(n_probes * n_contacts) to O(n_probes * sensor_n_contacts). Cap-overflows (count >= last dim of
+    ``sensor_contacts_idx``) silently truncate; see the module-level ``_MAX_CONTACTS_PER_SENSOR`` comment.
+    """
+    n_sensors = sensor_link_idx.shape[0]
+    n_batches = sensor_n_contacts.shape[0]
+    max_per_sensor = sensor_contacts_idx.shape[2]
+    for i_b, i_s in qd.ndrange(n_batches, n_sensors):
+        link = sensor_link_idx[i_s]
+        count = gs.qd_int(0)
+        n_c = collider_state.n_contacts[i_b]
+        for i_c in range(n_c):
+            if count >= max_per_sensor:
+                break
+            link_a = collider_state.contact_data.link_a[i_c, i_b]
+            link_b = collider_state.contact_data.link_b[i_c, i_b]
+            if link_a == link or link_b == link:
+                sensor_contacts_idx[i_b, i_s, count] = i_c
+                count = count + 1
+        sensor_n_contacts[i_b, i_s] = count
+
+
+@qd.kernel
+def _kernel_build_sensor_geom_idx(
+    sensor_link_idx: qd.types.ndarray(),
+    collider_state: array_class.ColliderState,
+    sensor_geoms_idx: qd.types.ndarray(),
+    sensor_n_geoms: qd.types.ndarray(),
+):
+    """
+    Per-(env, sensor) compact, deduplicated list of opposing contacting geoms for the SDF query path.
+
+    Parallelizes over ``(n_batches, n_sensors)``, recording each contact's opposing geom (the side not on the
+    sensor link). Deduping collapses the multicontact fan-out (tens of contacts on one pressing object -> one
+    geom) so the SDF path's per-probe loop runs once per distinct contacting geom, not once per contact point.
+    Cap-overflows (count >= last dim of ``sensor_geoms_idx``) silently truncate; see the module-level
+    ``_MAX_GEOMS_PER_SENSOR`` comment.
+    """
+    n_sensors = sensor_link_idx.shape[0]
+    n_batches = sensor_n_geoms.shape[0]
+    max_per_sensor = sensor_geoms_idx.shape[2]
+    for i_b, i_s in qd.ndrange(n_batches, n_sensors):
+        link = sensor_link_idx[i_s]
+        count = gs.qd_int(0)
+        n_c = collider_state.n_contacts[i_b]
+        for i_c in range(n_c):
+            link_a = collider_state.contact_data.link_a[i_c, i_b]
+            link_b = collider_state.contact_data.link_b[i_c, i_b]
+            # A self-contact (sensor link on both sides) is deduped naturally below.
+            for side in qd.static(range(2)):
+                c_link = link_a if side == 0 else link_b
+                if c_link == link:
+                    i_g = (
+                        collider_state.contact_data.geom_b[i_c, i_b]
+                        if side == 0
+                        else collider_state.contact_data.geom_a[i_c, i_b]
+                    )
+                    already = False
+                    for i_seen in range(count):
+                        if sensor_geoms_idx[i_b, i_s, i_seen] == i_g:
+                            already = True
+                    if not already and count < max_per_sensor:
+                        sensor_geoms_idx[i_b, i_s, count] = i_g
+                        count = count + 1
+        sensor_n_geoms[i_b, i_s] = count
 
 
 @qd.func
 def _func_query_contact_depth(
     i_b: int,
+    i_s: int,
     probe_pos: qd.types.vector(3),
     probe_radius_gt: float,
     probe_radius_m: float,
-    sensor_link_idx: int,
     geoms_info: array_class.GeomsInfo,
     geoms_state: array_class.GeomsState,
     rigid_global_info: array_class.RigidGlobalInfo,
     collider_static_config: qd.template(),
-    collider_state: array_class.ColliderState,
+    sensor_geoms_idx: qd.types.ndarray(),
+    sensor_n_geoms: qd.types.ndarray(),
     sdf_info: array_class.SDFInfo,
     eps: float,
 ):
     """
     Dual-radius probe query: single SDF + normal pass yielding both GT and noised-radius results.
 
-    Returns ``(max_pen_gt, contact_link_gt, contact_normal_gt, max_pen_m, contact_link_m, contact_normal_m)``. AABB
-    pre-filter expands by ``max(probe_radius_gt, probe_radius_m)`` so neither branch is silently skipped. Callers
-    without a noised radius pass ``probe_radius_m == probe_radius_gt``.
+    Iterates the per-(env, sensor) deduplicated opposing-geom list built by ``_kernel_build_sensor_geom_idx``;
+    every geom in that list contacts the sensor's tracked link, so the reported contact link is recovered as
+    ``geoms_info.link_idx[i_g]`` (the link owning the opposing geom). AABB pre-filter expands by
+    ``max(probe_radius_gt, probe_radius_m)`` so neither branch is
+    silently skipped. Callers without a noised radius pass ``probe_radius_m == probe_radius_gt``.
     """
     max_pen_gt = gs.qd_float(0.0)
     contact_link_gt = gs.qd_int(-1)
@@ -111,42 +203,85 @@ def _func_query_contact_depth(
     contact_normal_m = qd.Vector.zero(gs.qd_float, 3)
 
     aabb_expansion = qd.max(probe_radius_gt, probe_radius_m)
-    # Iterate over contacts directly from collider state; each contact may have the sensor link on either side.
-    n_contacts = collider_state.n_contacts[i_b]
-    for i_c in range(n_contacts):
-        i_col = collider_state.contact_sort_idx[i_c, i_b]
-        c_link_a = collider_state.contact_data.link_a[i_col, i_b]
-        c_link_b = collider_state.contact_data.link_b[i_col, i_b]
-        c_geom_a = collider_state.contact_data.geom_a[i_col, i_b]
-        c_geom_b = collider_state.contact_data.geom_b[i_col, i_b]
-
-        # Check if either side of this contact involves the sensor link.
-        for side in qd.static(range(2)):
-            c_link = c_link_a if side == 0 else c_link_b
-            i_g = c_geom_b if side == 0 else c_geom_a
-
-            if c_link == sensor_link_idx and func_point_in_geom_aabb(geoms_state, i_g, i_b, probe_pos, aabb_expansion):
-                g_pos = geoms_state.pos[i_g, i_b]
-                g_quat = geoms_state.quat[i_g, i_b]
-                sd = sdf.sdf_func_world_local(geoms_info, sdf_info, probe_pos, i_g, g_pos, g_quat)
-                pen_gt = probe_radius_gt - sd
-                pen_m = probe_radius_m - sd
-                # Compute the SDF normal at most once across both branches.
-                need_normal = (pen_gt > max_pen_gt and pen_gt > eps) or (pen_m > max_pen_m and pen_m > eps)
-                if need_normal:
-                    normal = sdf.sdf_func_normal_world_local(
-                        geoms_info, rigid_global_info, collider_static_config, sdf_info, probe_pos, i_g, g_pos, g_quat
-                    )
-                    if pen_gt > max_pen_gt and pen_gt > eps:
-                        max_pen_gt = pen_gt
-                        contact_link_gt = c_link_b if side == 0 else c_link_a
-                        contact_normal_gt = normal
-                    if pen_m > max_pen_m and pen_m > eps:
-                        max_pen_m = pen_m
-                        contact_link_m = c_link_b if side == 0 else c_link_a
-                        contact_normal_m = normal
+    n_g = sensor_n_geoms[i_b, i_s]
+    for i_g_ in range(n_g):
+        i_g = sensor_geoms_idx[i_b, i_s, i_g_]
+        if func_point_in_geom_aabb(geoms_state, i_g, i_b, probe_pos, aabb_expansion):
+            g_pos = geoms_state.pos[i_g, i_b]
+            g_quat = geoms_state.quat[i_g, i_b]
+            sd = sdf.sdf_func_world_local(geoms_info, sdf_info, probe_pos, i_g, g_pos, g_quat)
+            pen_gt = probe_radius_gt - sd
+            pen_m = probe_radius_m - sd
+            # Compute the SDF normal at most once across both branches.
+            need_normal = (pen_gt > max_pen_gt and pen_gt > eps) or (pen_m > max_pen_m and pen_m > eps)
+            if need_normal:
+                normal = sdf.sdf_func_normal_world_local(
+                    geoms_info, rigid_global_info, collider_static_config, sdf_info, probe_pos, i_g, g_pos, g_quat
+                )
+                contact_link = geoms_info.link_idx[i_g]
+                if pen_gt > max_pen_gt and pen_gt > eps:
+                    max_pen_gt = pen_gt
+                    contact_link_gt = contact_link
+                    contact_normal_gt = normal
+                if pen_m > max_pen_m and pen_m > eps:
+                    max_pen_m = pen_m
+                    contact_link_m = contact_link
+                    contact_normal_m = normal
 
     return max_pen_gt, contact_link_gt, contact_normal_gt, max_pen_m, contact_link_m, contact_normal_m
+
+
+@qd.func
+def _func_kinematic_spring_damper(
+    i_b: int,
+    max_penetration: float,
+    contact_link: int,
+    contact_normal: qd.types.vector(3),
+    sensor_link_idx: int,
+    probe_pos: qd.types.vector(3),
+    probe_pos_local: qd.types.vector(3),
+    link_quat: qd.types.vector(4),
+    normal_stiffness: float,
+    normal_damping: float,
+    normal_exponent: float,
+    shear_scalar: float,
+    twist_scalar: float,
+    links_state: array_class.LinksState,
+):
+    """
+    Kinematic spring-damper force / torque in the sensor link frame from a single probe's contact query.
+
+    Shared by the GT and measured branches of ``_kernel_kinematic_taxel`` (they differ only in which dual-radius
+    query result is fed in). Returns ``(force_local, torque_local)``; both zero when ``max_penetration <= 0``.
+    """
+    force_local = qd.Vector.zero(gs.qd_float, 3)
+    torque_local = qd.Vector.zero(gs.qd_float, 3)
+    if max_penetration > 0:
+        contact_normal_local = gu.qd_inv_transform_by_quat(contact_normal, link_quat)
+        s = qd.pow(max_penetration, normal_exponent)
+        force_local = contact_normal_local * (normal_stiffness * s)
+
+        if contact_link >= 0:
+            contact_vel = links_state.cd_vel[contact_link, i_b] + links_state.cd_ang[contact_link, i_b].cross(
+                probe_pos - links_state.root_COM[contact_link, i_b]
+            )
+            sensor_vel = links_state.cd_vel[sensor_link_idx, i_b] + links_state.cd_ang[sensor_link_idx, i_b].cross(
+                probe_pos - links_state.root_COM[sensor_link_idx, i_b]
+            )
+            rel_vel_world = contact_vel - sensor_vel
+            rel_vel_local = gu.qd_inv_transform_by_quat(rel_vel_world, link_quat)
+
+            vn_dot = rel_vel_local.dot(contact_normal_local)
+            v_t_local = rel_vel_local - contact_normal_local * vn_dot
+            force_local += contact_normal_local * (normal_damping * s * vn_dot) - shear_scalar * v_t_local
+
+            rel_ang_world = links_state.cd_ang[contact_link, i_b] - links_state.cd_ang[sensor_link_idx, i_b]
+            omega_n = rel_ang_world.dot(contact_normal)
+            torque_local = probe_pos_local.cross(force_local) - contact_normal_local * (twist_scalar * omega_n)
+        else:
+            torque_local = probe_pos_local.cross(force_local)
+
+    return force_local, torque_local
 
 
 @qd.kernel
@@ -155,6 +290,7 @@ def _kernel_kinematic_taxel(
     probe_sensor_idx: qd.types.ndarray(),
     probe_radii: qd.types.ndarray(),
     probe_radii_noise: qd.types.ndarray(),
+    probe_gains: qd.types.ndarray(),
     normal_stiffness: qd.types.ndarray(),
     normal_damping: qd.types.ndarray(),
     normal_exponent: qd.types.ndarray(),
@@ -164,7 +300,8 @@ def _kernel_kinematic_taxel(
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
     n_probes_per_sensor: qd.types.ndarray(),
-    collider_state: array_class.ColliderState,
+    sensor_geoms_idx: qd.types.ndarray(),
+    sensor_n_geoms: qd.types.ndarray(),
     collider_static_config: qd.template(),
     links_state: array_class.LinksState,
     geoms_state: array_class.GeomsState,
@@ -172,6 +309,7 @@ def _kernel_kinematic_taxel(
     rigid_global_info: array_class.RigidGlobalInfo,
     sdf_info: array_class.SDFInfo,
     eps: float,
+    measured_equals_gt: int,
     output_gt: qd.types.ndarray(),
     output_measured: qd.types.ndarray(),
 ):
@@ -180,6 +318,20 @@ def _kernel_kinematic_taxel(
 
     for i_p, i_b in qd.ndrange(total_n_probes, n_batches):
         i_s = probe_sensor_idx[i_p]
+        probe_idx_in_sensor = i_p - sensor_probe_start[i_s]
+        cache_start = sensor_cache_start[i_s]
+        n_probes = n_probes_per_sensor[i_s]
+        force_start = cache_start + probe_idx_in_sensor * 3
+        torque_start = cache_start + n_probes * 3 + probe_idx_in_sensor * 3
+
+        # Inactive filler probe (probe_radius == 0): reads zero force/torque, no contact query.
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            for j in qd.static(range(3)):
+                output_gt[force_start + j, i_b] = gs.qd_float(0.0)
+                output_gt[torque_start + j, i_b] = gs.qd_float(0.0)
+                output_measured[force_start + j, i_b] = gs.qd_float(0.0)
+                output_measured[torque_start + j, i_b] = gs.qd_float(0.0)
+            continue
 
         probe_pos_local = qd.Vector(
             [probe_positions_local[i_p, 0], probe_positions_local[i_p, 1], probe_positions_local[i_p, 2]]
@@ -207,90 +359,61 @@ def _kernel_kinematic_taxel(
             contact_normal_m,
         ) = _func_query_contact_depth(
             i_b,
+            i_s,
             probe_pos,
             probe_radius,
             probe_radius_m,
-            sensor_link_idx,
             geoms_info,
             geoms_state,
             rigid_global_info,
             collider_static_config,
-            collider_state,
+            sensor_geoms_idx,
+            sensor_n_geoms,
             sdf_info,
             eps,
         )
 
-        force_local_gt = qd.Vector.zero(gs.qd_float, 3)
-        torque_local_gt = qd.Vector.zero(gs.qd_float, 3)
-        if max_penetration_gt > 0:
-            contact_normal_local = gu.qd_inv_transform_by_quat(contact_normal_gt, link_quat)
-            s = qd.pow(max_penetration_gt, normal_exponent[i_s])
-            force_local_gt = contact_normal_local * (normal_stiffness[i_s] * s)
+        force_local_gt, torque_local_gt = _func_kinematic_spring_damper(
+            i_b,
+            max_penetration_gt,
+            contact_link_gt,
+            contact_normal_gt,
+            sensor_link_idx,
+            probe_pos,
+            probe_pos_local,
+            link_quat,
+            normal_stiffness[i_s],
+            normal_damping[i_s],
+            normal_exponent[i_s],
+            shear_scalar[i_s],
+            twist_scalar[i_s],
+            links_state,
+        )
 
-            if contact_link_gt >= 0:
-                contact_vel = links_state.cd_vel[contact_link_gt, i_b] + links_state.cd_ang[contact_link_gt, i_b].cross(
-                    probe_pos - links_state.root_COM[contact_link_gt, i_b]
-                )
-                sensor_vel = links_state.cd_vel[sensor_link_idx, i_b] + links_state.cd_ang[sensor_link_idx, i_b].cross(
-                    probe_pos - links_state.root_COM[sensor_link_idx, i_b]
-                )
-                rel_vel_world = contact_vel - sensor_vel
-                rel_vel_local = gu.qd_inv_transform_by_quat(rel_vel_world, link_quat)
+        force_local_m = force_local_gt
+        torque_local_m = torque_local_gt
+        if measured_equals_gt == 0:
+            # The measured branch differs from GT: either some probe has a noised sensing radius or a non-unit
+            # per-(env, probe) gain. Gain scales the measured penetration only; force / torque then scale as
+            # ``gain ** normal_exponent`` since they derive from ``s = max_penetration_m ** normal_exponent``.
+            max_penetration_m = max_penetration_m * probe_gains[i_b, i_p]
+            force_local_m, torque_local_m = _func_kinematic_spring_damper(
+                i_b,
+                max_penetration_m,
+                contact_link_m,
+                contact_normal_m,
+                sensor_link_idx,
+                probe_pos,
+                probe_pos_local,
+                link_quat,
+                normal_stiffness[i_s],
+                normal_damping[i_s],
+                normal_exponent[i_s],
+                shear_scalar[i_s],
+                twist_scalar[i_s],
+                links_state,
+            )
 
-                vn_dot = rel_vel_local.dot(contact_normal_local)
-                v_t_local = rel_vel_local - contact_normal_local * vn_dot
-                force_local_gt += (
-                    contact_normal_local * (normal_damping[i_s] * s * vn_dot) - shear_scalar[i_s] * v_t_local
-                )
-
-                rel_ang_world = links_state.cd_ang[contact_link_gt, i_b] - links_state.cd_ang[sensor_link_idx, i_b]
-                omega_n = rel_ang_world.dot(contact_normal_gt)
-                torque_local_gt = probe_pos_local.cross(force_local_gt) - contact_normal_local * (
-                    twist_scalar[i_s] * omega_n
-                )
-            else:
-                torque_local_gt = probe_pos_local.cross(force_local_gt)
-
-        force_local_m = qd.Vector.zero(gs.qd_float, 3)
-        torque_local_m = qd.Vector.zero(gs.qd_float, 3)
-        if not use_noised_radius:
-            for j in qd.static(range(3)):
-                force_local_m[j] = force_local_gt[j]
-                torque_local_m[j] = torque_local_gt[j]
-        elif max_penetration_m > 0:
-            contact_normal_local = gu.qd_inv_transform_by_quat(contact_normal_m, link_quat)
-            s = qd.pow(max_penetration_m, normal_exponent[i_s])
-            force_local_m = contact_normal_local * (normal_stiffness[i_s] * s)
-
-            if contact_link_m >= 0:
-                contact_vel = links_state.cd_vel[contact_link_m, i_b] + links_state.cd_ang[contact_link_m, i_b].cross(
-                    probe_pos - links_state.root_COM[contact_link_m, i_b]
-                )
-                sensor_vel = links_state.cd_vel[sensor_link_idx, i_b] + links_state.cd_ang[sensor_link_idx, i_b].cross(
-                    probe_pos - links_state.root_COM[sensor_link_idx, i_b]
-                )
-                rel_vel_world = contact_vel - sensor_vel
-                rel_vel_local = gu.qd_inv_transform_by_quat(rel_vel_world, link_quat)
-
-                vn_dot = rel_vel_local.dot(contact_normal_local)
-                v_t_local = rel_vel_local - contact_normal_local * vn_dot
-                force_local_m += (
-                    contact_normal_local * (normal_damping[i_s] * s * vn_dot) - shear_scalar[i_s] * v_t_local
-                )
-
-                rel_ang_world = links_state.cd_ang[contact_link_m, i_b] - links_state.cd_ang[sensor_link_idx, i_b]
-                omega_n = rel_ang_world.dot(contact_normal_m)
-                torque_local_m = probe_pos_local.cross(force_local_m) - contact_normal_local * (
-                    twist_scalar[i_s] * omega_n
-                )
-            else:
-                torque_local_m = probe_pos_local.cross(force_local_m)
-
-        probe_idx_in_sensor = i_p - sensor_probe_start[i_s]
-        cache_start = sensor_cache_start[i_s]
-        n_probes = n_probes_per_sensor[i_s]
-        force_start = cache_start + probe_idx_in_sensor * 3
-        torque_start = cache_start + n_probes * 3 + probe_idx_in_sensor * 3
         for j in qd.static(range(3)):
             output_gt[force_start + j, i_b] = force_local_gt[j]
             output_gt[torque_start + j, i_b] = torque_local_gt[j]
@@ -304,10 +427,12 @@ def _kernel_contact_depth_probe(
     probe_sensor_idx: qd.types.ndarray(),
     probe_radii: qd.types.ndarray(),
     probe_radii_noise: qd.types.ndarray(),
+    probe_gains: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
-    collider_state: array_class.ColliderState,
+    sensor_geoms_idx: qd.types.ndarray(),
+    sensor_n_geoms: qd.types.ndarray(),
     links_state: array_class.LinksState,
     geoms_state: array_class.GeomsState,
     geoms_info: array_class.GeomsInfo,
@@ -320,6 +445,13 @@ def _kernel_contact_depth_probe(
 
     for i_p, i_b in qd.ndrange(total_n_probes, n_batches):
         i_s = probe_sensor_idx[i_p]
+
+        # Inactive filler probe (probe_radius == 0): reads zero depth (which contact-probe interprets as no contact).
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            cache_idx = sensor_cache_start[i_s] + i_p - sensor_probe_start[i_s]
+            output_gt[cache_idx, i_b] = gs.qd_float(0.0)
+            output_measured[cache_idx, i_b] = gs.qd_float(0.0)
+            continue
 
         probe_pos_local = qd.Vector(
             [probe_positions_local[i_p, 0], probe_positions_local[i_p, 1], probe_positions_local[i_p, 2]]
@@ -339,71 +471,454 @@ def _kernel_contact_depth_probe(
 
         max_penetration_gt, max_penetration_m = _func_query_contact_depth_penetration(
             i_b,
+            i_s,
             probe_pos,
             probe_radius,
             probe_radius_m,
-            sensor_link_idx,
             geoms_info,
             geoms_state,
-            collider_state,
+            sensor_geoms_idx,
+            sensor_n_geoms,
             sdf_info,
         )
+        max_penetration_m = max_penetration_m * probe_gains[i_b, i_p]  # gain on measured branch only
         cache_idx = sensor_cache_start[i_s] + i_p - sensor_probe_start[i_s]
         output_gt[cache_idx, i_b] = max_penetration_gt
         output_measured[cache_idx, i_b] = max_penetration_m
 
 
-class KinematicTactileSensorMixin(ProbeSensorMixin[ProbesWithNormalSensorSharedMetadataT]):
-    def __init__(
-        self,
-        options: "SensorOptions",
-        idx: int,
-        shared_context,
-        shared_metadata,
-        manager: "SensorManager",
-    ):
-        super().__init__(options, idx, shared_context, shared_metadata, manager)
-        self._debug_objects: list = []
+# ============================ Raycast / BVH contact-depth path ============================
 
-    def build(self):
-        super().build()
-        self._shared_metadata.solver.collider.activate_sdf()
 
-    def _draw_debug_probes(self, context: "RasterizerContext", get_is_contact: Callable[[object], object]):
-        for obj in self._debug_objects:
-            context.clear_debug_object(obj)
-        self._debug_objects.clear()
+@qd.kernel
+def _kernel_build_sensor_candidate_geom_mask(
+    sensor_link_idx: qd.types.ndarray(),
+    sensor_contacts_idx: qd.types.ndarray(),
+    sensor_n_contacts: qd.types.ndarray(),
+    collider_state: array_class.ColliderState,
+    sensor_candidate_geom_mask: qd.types.ndarray(),
+):
+    """
+    Scatter the per-(env, sensor) candidate-geom bitmask from the prefiltered contact list. Run only when the
+    sensor class is in ``contact_depth_query="raycast"`` mode; the BVH leaf loop consults this mask to skip
+    triangles whose owning geom isn't in the sensor's current contact list. Only the geom on the side opposite
+    the sensor link is marked (mirroring the SDF path's ``i_g = <other geom>`` selection); marking the sensor's
+    own geom would let the BVH closest-point test latch onto the sensor's own surface, pinning the reported
+    depth to ``probe_radius`` regardless of the pressing object.
+    """
+    n_batches = sensor_n_contacts.shape[0]
+    n_sensors = sensor_n_contacts.shape[1]
+    n_geoms = sensor_candidate_geom_mask.shape[2]
+    for i_b, i_s in qd.ndrange(n_batches, n_sensors):
+        for i_g in range(n_geoms):
+            sensor_candidate_geom_mask[i_b, i_s, i_g] = False
+        link = sensor_link_idx[i_s]
+        n_c = sensor_n_contacts[i_b, i_s]
+        for i_c_ in range(n_c):
+            i_c = sensor_contacts_idx[i_b, i_s, i_c_]
+            if collider_state.contact_data.link_a[i_c, i_b] == link:
+                sensor_candidate_geom_mask[i_b, i_s, collider_state.contact_data.geom_b[i_c, i_b]] = True
+            if collider_state.contact_data.link_b[i_c, i_b] == link:
+                sensor_candidate_geom_mask[i_b, i_s, collider_state.contact_data.geom_a[i_c, i_b]] = True
 
-        envs_idx, n_debug_envs, _, probe_world = self._compute_probes_world_pos(context)
-        data = self.read_ground_truth(envs_idx)
-        is_contact = np.asarray(tensor_to_array(get_is_contact(data)), dtype=bool).reshape(-1)
-        probe_global_idx = int(self._shared_metadata.sensor_probe_start[self._idx])
-        probe_radius = float(self._shared_metadata.probe_radii[probe_global_idx])
-        for is_contact_state in (False, True):
-            (probes_idx,) = np.nonzero(is_contact == is_contact_state)
-            if probes_idx.size > 0:
-                spheres_obj = context.draw_debug_spheres(
-                    poss=probe_world[probes_idx],
-                    radius=probe_radius,
-                    color=self._options.debug_contact_color if is_contact_state else self._options.debug_probe_color,
-                )
-                self._debug_objects.append(spheres_obj)
+
+@qd.func
+def _func_query_contact_depth_penetration_bvh(
+    i_b: int,
+    i_s: int,
+    probe_pos: qd.types.vector(3),
+    probe_radius_gt: float,
+    probe_radius_m: float,
+    bvh_nodes: qd.template(),
+    bvh_morton_codes: qd.template(),
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    sensor_candidate_geom_mask: qd.types.ndarray(),
+):
+    """
+    BVH-based dual-radius probe penetration. Finds the signed distance to the nearest candidate triangle (sign
+    from the closest triangle's face normal: negative when the probe is inside the surface, like
+    ``_func_elastomer_min_signed_dist_bvh``) and returns ``max(0, R - sd)`` per radius. This matches the SDF
+    path's ``pen = R - sd`` -- in particular it keeps growing as the probe penetrates, rather than folding back
+    at ``R`` like an unsigned closest-point distance. Mirrors ``_func_query_contact_depth_penetration``'s return.
+    """
+    n_triangles = faces_info.verts_idx.shape[0]
+    radius_query = qd.max(probe_radius_gt, probe_radius_m)
+    best_dist_sq = radius_query * radius_query
+    best_signed = radius_query
+
+    node_stack = qd.Vector.zero(gs.qd_int, qd.static(_BVH_STACK_SIZE))
+    node_stack[0] = 0
+    stack_idx = 1
+
+    while stack_idx > 0:
+        stack_idx -= 1
+        node_idx = node_stack[stack_idx]
+        node = bvh_nodes[i_b, node_idx]
+
+        if not func_sphere_intersects_aabb(probe_pos, best_dist_sq, node.bound.min, node.bound.max):
+            continue
+
+        if node.left == -1:
+            sorted_leaf_idx = node_idx - (n_triangles - 1)
+            i_f = qd.cast(bvh_morton_codes[i_b, sorted_leaf_idx][1], gs.qd_int)
+            i_g = faces_info.geom_idx[i_f]
+            if not sensor_candidate_geom_mask[i_b, i_s, i_g]:
+                continue
+
+            tri = get_triangle_vertices(i_f, i_b, faces_info, verts_info, fixed_verts_state, free_verts_state)
+            v0 = tri[:, 0]
+            v1 = tri[:, 1]
+            v2 = tri[:, 2]
+
+            closest = closest_point_on_triangle(probe_pos, v0, v1, v2)
+            diff = probe_pos - closest
+            d_sq = diff.dot(diff)
+            if d_sq < best_dist_sq:
+                d = qd.sqrt(d_sq)
+                fn = triangle_face_normal(v0, v1, v2)
+                sign_v = qd.select(diff.dot(fn) >= gs.qd_float(0.0), gs.qd_float(1.0), gs.qd_float(-1.0))
+                best_signed = d * sign_v
+                best_dist_sq = d_sq
+        else:
+            if stack_idx < qd.static(_BVH_STACK_SIZE - 2):
+                node_stack[stack_idx] = node.left
+                node_stack[stack_idx + 1] = node.right
+                stack_idx += 2
+
+    max_pen_gt = qd.max(gs.qd_float(0.0), probe_radius_gt - best_signed)
+    max_pen_m = qd.max(gs.qd_float(0.0), probe_radius_m - best_signed)
+    return max_pen_gt, max_pen_m
+
+
+@qd.func
+def _func_query_contact_depth_bvh(
+    i_b: int,
+    i_s: int,
+    probe_pos: qd.types.vector(3),
+    probe_radius_gt: float,
+    probe_radius_m: float,
+    bvh_nodes: qd.template(),
+    bvh_morton_codes: qd.template(),
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    geoms_info: array_class.GeomsInfo,
+    sensor_candidate_geom_mask: qd.types.ndarray(),
+):
+    """
+    BVH-based dual-radius probe query with contact normal and link, mirroring ``_func_query_contact_depth``'s return.
+    Finds the nearest candidate triangle and its signed distance (sign from the face normal; negative when the probe
+    is inside the surface), yielding ``pen = R - sd`` to match the SDF path. The returned contact normal is the
+    nearest triangle's outward face normal, which the spring-damper model uses as the surface normal.
+    """
+    n_triangles = faces_info.verts_idx.shape[0]
+    radius_query = qd.max(probe_radius_gt, probe_radius_m)
+    best_dist_sq = radius_query * radius_query
+    best_signed = radius_query
+    contact_link = gs.qd_int(-1)
+    contact_normal = qd.Vector.zero(gs.qd_float, 3)
+
+    node_stack = qd.Vector.zero(gs.qd_int, qd.static(_BVH_STACK_SIZE))
+    node_stack[0] = 0
+    stack_idx = 1
+
+    while stack_idx > 0:
+        stack_idx -= 1
+        node_idx = node_stack[stack_idx]
+        node = bvh_nodes[i_b, node_idx]
+
+        if not func_sphere_intersects_aabb(probe_pos, best_dist_sq, node.bound.min, node.bound.max):
+            continue
+
+        if node.left == -1:
+            sorted_leaf_idx = node_idx - (n_triangles - 1)
+            i_f = qd.cast(bvh_morton_codes[i_b, sorted_leaf_idx][1], gs.qd_int)
+            i_g = faces_info.geom_idx[i_f]
+            if not sensor_candidate_geom_mask[i_b, i_s, i_g]:
+                continue
+
+            tri = get_triangle_vertices(i_f, i_b, faces_info, verts_info, fixed_verts_state, free_verts_state)
+            v0 = tri[:, 0]
+            v1 = tri[:, 1]
+            v2 = tri[:, 2]
+
+            closest = closest_point_on_triangle(probe_pos, v0, v1, v2)
+            diff = probe_pos - closest
+            d_sq = diff.dot(diff)
+            if d_sq < best_dist_sq:
+                d = qd.sqrt(d_sq)
+                fn = triangle_face_normal(v0, v1, v2)
+                sign_v = qd.select(diff.dot(fn) >= gs.qd_float(0.0), gs.qd_float(1.0), gs.qd_float(-1.0))
+                best_signed = d * sign_v
+                best_dist_sq = d_sq
+                contact_link = geoms_info.link_idx[i_g]
+                contact_normal = fn
+        else:
+            if stack_idx < qd.static(_BVH_STACK_SIZE - 2):
+                node_stack[stack_idx] = node.left
+                node_stack[stack_idx + 1] = node.right
+                stack_idx += 2
+
+    # Penetration only; the link / normal are meaningful only for the branch that actually reports contact.
+    max_pen_gt = qd.max(gs.qd_float(0.0), probe_radius_gt - best_signed)
+    max_pen_m = qd.max(gs.qd_float(0.0), probe_radius_m - best_signed)
+    contact_link_gt = contact_link if max_pen_gt > gs.qd_float(0.0) else gs.qd_int(-1)
+    contact_link_m = contact_link if max_pen_m > gs.qd_float(0.0) else gs.qd_int(-1)
+    contact_normal_gt = contact_normal if max_pen_gt > gs.qd_float(0.0) else qd.Vector.zero(gs.qd_float, 3)
+    contact_normal_m = contact_normal if max_pen_m > gs.qd_float(0.0) else qd.Vector.zero(gs.qd_float, 3)
+    return max_pen_gt, contact_link_gt, contact_normal_gt, max_pen_m, contact_link_m, contact_normal_m
+
+
+@qd.kernel(fastcache=False)
+def _kernel_contact_depth_probe_bvh(
+    probe_positions_local: qd.types.ndarray(),
+    probe_sensor_idx: qd.types.ndarray(),
+    probe_radii: qd.types.ndarray(),
+    probe_radii_noise: qd.types.ndarray(),
+    probe_gains: qd.types.ndarray(),
+    links_idx: qd.types.ndarray(),
+    sensor_cache_start: qd.types.ndarray(),
+    sensor_probe_start: qd.types.ndarray(),
+    sensor_candidate_geom_mask: qd.types.ndarray(),
+    bvh_nodes: qd.template(),
+    bvh_morton_codes: qd.template(),
+    links_state: array_class.LinksState,
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    output_gt: qd.types.ndarray(),
+    output_measured: qd.types.ndarray(),
+):
+    total_n_probes = probe_positions_local.shape[0]
+    n_batches = output_gt.shape[-1]
+
+    for i_p, i_b in qd.ndrange(total_n_probes, n_batches):
+        i_s = probe_sensor_idx[i_p]
+
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            cache_idx = sensor_cache_start[i_s] + i_p - sensor_probe_start[i_s]
+            output_gt[cache_idx, i_b] = gs.qd_float(0.0)
+            output_measured[cache_idx, i_b] = gs.qd_float(0.0)
+            continue
+
+        probe_pos_local = qd.Vector(
+            [probe_positions_local[i_p, 0], probe_positions_local[i_p, 1], probe_positions_local[i_p, 2]]
+        )
+
+        sensor_link_idx = links_idx[i_s]
+        link_pos = links_state.pos[sensor_link_idx, i_b]
+        link_quat = links_state.quat[sensor_link_idx, i_b]
+
+        probe_pos = link_pos + gu.qd_transform_by_quat(probe_pos_local, link_quat)
+
+        probe_radius = probe_radii[i_p]
+        probe_radius_noise = probe_radii_noise[i_p]
+        probe_radius_m = (
+            func_noised_probe_radius(probe_radius, probe_radius_noise) if probe_radius_noise > gs.EPS else probe_radius
+        )
+
+        max_penetration_gt, max_penetration_m = _func_query_contact_depth_penetration_bvh(
+            i_b,
+            i_s,
+            probe_pos,
+            probe_radius,
+            probe_radius_m,
+            bvh_nodes,
+            bvh_morton_codes,
+            faces_info,
+            verts_info,
+            fixed_verts_state,
+            free_verts_state,
+            sensor_candidate_geom_mask,
+        )
+        max_penetration_m = max_penetration_m * probe_gains[i_b, i_p]
+        cache_idx = sensor_cache_start[i_s] + i_p - sensor_probe_start[i_s]
+        output_gt[cache_idx, i_b] = max_penetration_gt
+        output_measured[cache_idx, i_b] = max_penetration_m
+
+
+@qd.kernel(fastcache=False)
+def _kernel_kinematic_taxel_bvh(
+    probe_positions_local: qd.types.ndarray(),
+    probe_sensor_idx: qd.types.ndarray(),
+    probe_radii: qd.types.ndarray(),
+    probe_radii_noise: qd.types.ndarray(),
+    probe_gains: qd.types.ndarray(),
+    normal_stiffness: qd.types.ndarray(),
+    normal_damping: qd.types.ndarray(),
+    normal_exponent: qd.types.ndarray(),
+    shear_scalar: qd.types.ndarray(),
+    twist_scalar: qd.types.ndarray(),
+    links_idx: qd.types.ndarray(),
+    sensor_cache_start: qd.types.ndarray(),
+    sensor_probe_start: qd.types.ndarray(),
+    n_probes_per_sensor: qd.types.ndarray(),
+    sensor_candidate_geom_mask: qd.types.ndarray(),
+    bvh_nodes: qd.template(),
+    bvh_morton_codes: qd.template(),
+    links_state: array_class.LinksState,
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    geoms_info: array_class.GeomsInfo,
+    measured_equals_gt: int,
+    output_gt: qd.types.ndarray(),
+    output_measured: qd.types.ndarray(),
+):
+    total_n_probes = probe_positions_local.shape[0]
+    n_batches = output_gt.shape[-1]
+
+    for i_p, i_b in qd.ndrange(total_n_probes, n_batches):
+        i_s = probe_sensor_idx[i_p]
+        probe_idx_in_sensor = i_p - sensor_probe_start[i_s]
+        cache_start = sensor_cache_start[i_s]
+        n_probes = n_probes_per_sensor[i_s]
+        force_start = cache_start + probe_idx_in_sensor * 3
+        torque_start = cache_start + n_probes * 3 + probe_idx_in_sensor * 3
+
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            for j in qd.static(range(3)):
+                output_gt[force_start + j, i_b] = gs.qd_float(0.0)
+                output_gt[torque_start + j, i_b] = gs.qd_float(0.0)
+                output_measured[force_start + j, i_b] = gs.qd_float(0.0)
+                output_measured[torque_start + j, i_b] = gs.qd_float(0.0)
+            continue
+
+        probe_pos_local = qd.Vector(
+            [probe_positions_local[i_p, 0], probe_positions_local[i_p, 1], probe_positions_local[i_p, 2]]
+        )
+
+        sensor_link_idx = links_idx[i_s]
+        link_pos = links_state.pos[sensor_link_idx, i_b]
+        link_quat = links_state.quat[sensor_link_idx, i_b]
+
+        probe_pos = link_pos + gu.qd_transform_by_quat(probe_pos_local, link_quat)
+
+        probe_radius = probe_radii[i_p]
+        probe_radius_noise = probe_radii_noise[i_p]
+        use_noised_radius = probe_radius_noise > gs.EPS
+        probe_radius_m = (
+            func_noised_probe_radius(probe_radius, probe_radius_noise) if use_noised_radius else probe_radius
+        )
+
+        (
+            max_penetration_gt,
+            contact_link_gt,
+            contact_normal_gt,
+            max_penetration_m,
+            contact_link_m,
+            contact_normal_m,
+        ) = _func_query_contact_depth_bvh(
+            i_b,
+            i_s,
+            probe_pos,
+            probe_radius,
+            probe_radius_m,
+            bvh_nodes,
+            bvh_morton_codes,
+            faces_info,
+            verts_info,
+            fixed_verts_state,
+            free_verts_state,
+            geoms_info,
+            sensor_candidate_geom_mask,
+        )
+
+        gained_pen_m = max_penetration_m * probe_gains[i_b, i_p]
+
+        force_gt, torque_gt = _func_kinematic_spring_damper(
+            i_b,
+            max_penetration_gt,
+            contact_link_gt,
+            contact_normal_gt,
+            sensor_link_idx,
+            probe_pos,
+            probe_pos_local,
+            link_quat,
+            normal_stiffness[i_s],
+            normal_damping[i_s],
+            normal_exponent[i_s],
+            shear_scalar[i_s],
+            twist_scalar[i_s],
+            links_state,
+        )
+        for j in qd.static(range(3)):
+            output_gt[force_start + j, i_b] = force_gt[j]
+            output_gt[torque_start + j, i_b] = torque_gt[j]
+
+        if measured_equals_gt == 1:
+            for j in qd.static(range(3)):
+                output_measured[force_start + j, i_b] = force_gt[j]
+                output_measured[torque_start + j, i_b] = torque_gt[j]
+        else:
+            force_m, torque_m = _func_kinematic_spring_damper(
+                i_b,
+                gained_pen_m,
+                contact_link_m,
+                contact_normal_m,
+                sensor_link_idx,
+                probe_pos,
+                probe_pos_local,
+                link_quat,
+                normal_stiffness[i_s],
+                normal_damping[i_s],
+                normal_exponent[i_s],
+                shear_scalar[i_s],
+                twist_scalar[i_s],
+                links_state,
+            )
+            for j in qd.static(range(3)):
+                output_measured[force_start + j, i_b] = force_m[j]
+                output_measured[torque_start + j, i_b] = torque_m[j]
+
+
+class KinematicTactileSensorMixin(ContactDepthQuerySensorMixin, ProbeSensorMixin[ProbeSensorSharedMetadataT]):
+    """Contact-depth probe family (ContactDepthProbe, ContactProbe, KinematicTaxel). The class-wide SDF/raycast
+    backend is resolved and activated by ``ContactDepthQuerySensorMixin.build``; subclasses add their own metadata."""
 
 
 @dataclass
-class ContactDepthProbeMetadata(ProbeSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata):
+class ContactDepthProbeMetadata(
+    ProbeSensorMetadataMixin,
+    ContactPrefilterMetadataMixin,
+    ContactDepthQueryMetadataMixin,
+    RigidSensorMetadataMixin,
+    SimpleSensorMetadata,
+):
     pass
 
 
 class ContactDepthProbeSensor(
     KinematicTactileSensorMixin[ContactDepthProbeMetadata],
     RigidSensorMixin[ContactDepthProbeMetadata],
-    SimpleSensor[ContactDepthProbeOptions, None, ContactDepthProbeMetadata, tuple],
+    SimpleSensor[ContactDepthProbeOptions, RaycastContext, ContactDepthProbeMetadata, tuple],
 ):
-    """Returns contact depth in meters per probe."""
+    """
+    Returns contact depth in meters per probe.
+    """
+
+    def build(self):
+        super().build()
+        # Re-allocate the per-(env, sensor) contact prefilter buffers to absorb the newly-registered sensor.
+        B = self._manager._sim._B
+        n_sensors_built = self._shared_metadata.n_probes_per_sensor.shape[0]
+        self._shared_metadata.sensor_contacts_idx = torch.zeros(
+            (B, n_sensors_built, _MAX_CONTACTS_PER_SENSOR), dtype=gs.tc_int, device=gs.device
+        )
+        self._shared_metadata.sensor_n_contacts = torch.zeros((B, n_sensors_built), dtype=gs.tc_int, device=gs.device)
+        self._shared_metadata.sensor_geoms_idx = torch.zeros(
+            (B, n_sensors_built, _MAX_GEOMS_PER_SENSOR), dtype=gs.tc_int, device=gs.device
+        )
+        self._shared_metadata.sensor_n_geoms = torch.zeros((B, n_sensors_built), dtype=gs.tc_int, device=gs.device)
 
     def _get_return_format(self) -> tuple[int, ...]:
-        return (self._n_probes,)
+        return self._probe_layout_shape
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
@@ -412,59 +927,127 @@ class ContactDepthProbeSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
-        shared_context: None,
+        shared_context: RaycastContext,
         shared_metadata: ContactDepthProbeMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
         measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
-
-        current_ground_truth_data_T.zero_()
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.zero_()
-        if shared_metadata.measured_scratch_T.shape != current_ground_truth_data_T.shape:
-            shared_metadata.measured_scratch_T = torch.empty_like(current_ground_truth_data_T)
-        measured_cols_b = shared_metadata.measured_scratch_T
-
-        _kernel_contact_depth_probe(
-            shared_metadata.probe_positions,
-            shared_metadata.probe_sensor_idx,
-            shared_metadata.probe_radii,
-            shared_metadata.probe_radii_noise,
-            shared_metadata.links_idx,
-            shared_metadata.sensor_cache_start,
-            shared_metadata.sensor_probe_start,
-            solver.collider._collider_state,
-            solver.links_state,
-            solver.geoms_state,
-            solver.geoms_info,
-            solver.collider._sdf._sdf_info,
-            current_ground_truth_data_T,
-            measured_cols_b,
+        measured, measured_cols_b = get_measured_bufs(
+            shared_metadata, current_ground_truth_data_T, measured_data_timeline
         )
+        if (shared_metadata.contact_depth_query or "sdf") == "sdf":
+            _kernel_build_sensor_geom_idx(
+                shared_metadata.links_idx,
+                solver.collider._collider_state,
+                shared_metadata.sensor_geoms_idx,
+                shared_metadata.sensor_n_geoms,
+            )
+            _kernel_contact_depth_probe(
+                shared_metadata.probe_positions,
+                shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
+                shared_metadata.probe_radii_noise,
+                shared_metadata.probe_gains,
+                shared_metadata.links_idx,
+                shared_metadata.sensor_cache_start,
+                shared_metadata.sensor_probe_start,
+                shared_metadata.sensor_geoms_idx,
+                shared_metadata.sensor_n_geoms,
+                solver.links_state,
+                solver.geoms_state,
+                solver.geoms_info,
+                solver.collider._sdf._sdf_info,
+                current_ground_truth_data_T,
+                measured_cols_b,
+            )
+        else:
+            _kernel_build_sensor_contact_idx(
+                shared_metadata.links_idx,
+                solver.collider._collider_state,
+                shared_metadata.sensor_contacts_idx,
+                shared_metadata.sensor_n_contacts,
+            )
+            B, n_sensors = shared_metadata.sensor_n_contacts.shape
+            mask_shape = (B, n_sensors, solver.n_geoms)
+            if tuple(shared_metadata.sensor_candidate_geom_mask.shape) != mask_shape:
+                shared_metadata.sensor_candidate_geom_mask = torch.zeros(mask_shape, dtype=gs.tc_bool, device=gs.device)
+            _kernel_build_sensor_candidate_geom_mask(
+                shared_metadata.links_idx,
+                shared_metadata.sensor_contacts_idx,
+                shared_metadata.sensor_n_contacts,
+                solver.collider._collider_state,
+                shared_metadata.sensor_candidate_geom_mask,
+            )
+            _kernel_contact_depth_probe_bvh(
+                shared_metadata.probe_positions,
+                shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
+                shared_metadata.probe_radii_noise,
+                shared_metadata.probe_gains,
+                shared_metadata.links_idx,
+                shared_metadata.sensor_cache_start,
+                shared_metadata.sensor_probe_start,
+                shared_metadata.sensor_candidate_geom_mask,
+                shared_context.collision_bvh_context.bvh.nodes,
+                shared_context.collision_bvh_context.bvh.morton_codes,
+                solver.links_state,
+                solver.faces_info,
+                solver.verts_info,
+                solver.fixed_verts_state,
+                solver.free_verts_state,
+                current_ground_truth_data_T,
+                measured_cols_b,
+            )
         if ground_truth_data_timeline is not None:
             ground_truth_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
         measured.copy_(measured_cols_b.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
-        self._draw_debug_probes(context, lambda depth: depth >= gs.EPS)
+        def mask(envs_idx):
+            depth = self.read_ground_truth(envs_idx)
+            if self._options.history_length > 0:
+                depth = depth.select(1 if self._manager._sim.n_envs > 0 else 0, -1)
+            return depth >= gs.EPS
+
+        self._draw_debug_probes(context, self._tactile_color_groups_fn(mask))
 
 
 @dataclass
 class ContactProbeMetadata(ContactDepthProbeMetadata):
     contact_threshold: torch.Tensor = make_tensor_field((0,))
-    # Per-probe threshold scattered into intermediate-cache layout, computed lazily on first `_post_process`.
+    release_threshold: torch.Tensor = make_tensor_field((0,))
+    # Per-probe thresholds scattered into intermediate-cache layout, computed lazily on first `_post_process`.
     threshold_row: torch.Tensor = make_tensor_field((0,))
+    release_threshold_row: torch.Tensor = make_tensor_field((0,))
 
 
-class ContactProbeSensor(ContactDepthProbeSensor, SimpleSensor[ContactProbeOptions, None, ContactProbeMetadata, tuple]):
-    """Returns boolean contact per probe (depth > threshold). Shares the depth-probe kernel."""
+class ContactProbeSensor(
+    ContactDepthProbeSensor, SimpleSensor[ContactProbeOptions, RaycastContext, ContactProbeMetadata, tuple]
+):
+    """
+    Returns boolean contact per probe with optional Schmitt-trigger hysteresis. Shares the depth-probe kernel.
+
+    The contact bit latches on when depth exceeds ``contact_threshold`` and releases when depth drops to or below
+    ``release_threshold``. When ``release_threshold`` is left unset (the default; it then falls back to
+    ``contact_threshold``), the latch is degenerate and behavior matches a stateless threshold. Latch state is read
+    from the per-branch return-space ring, so GT and measured branches latch independently and reset cleanly with
+    the env (the manager zeros the ring on reset).
+    """
 
     def build(self):
         super().build()
         self._shared_metadata.contact_threshold = concat_with_tensor(
             self._shared_metadata.contact_threshold, self._options.contact_threshold, expand=(1,)
+        )
+        release = (
+            self._options.contact_threshold
+            if self._options.release_threshold is None
+            else self._options.release_threshold
+        )
+        self._shared_metadata.release_threshold = concat_with_tensor(
+            self._shared_metadata.release_threshold, release, expand=(1,)
         )
 
     @classmethod
@@ -491,15 +1074,26 @@ class ContactProbeSensor(ContactDepthProbeSensor, SimpleSensor[ContactProbeOptio
             i_p = torch.arange(shared_metadata.total_n_probes, device=gs.device, dtype=gs.tc_int)
             i_s = shared_metadata.probe_sensor_idx
             cache_idx = shared_metadata.sensor_cache_start[i_s] + i_p - shared_metadata.sensor_probe_start[i_s]
-            row = torch.zeros((tensor.shape[1],), dtype=tensor.dtype, device=gs.device)
-            row.scatter_(
-                0, cache_idx.to(dtype=torch.int64), shared_metadata.contact_threshold[i_s].to(dtype=tensor.dtype)
-            )
-            shared_metadata.threshold_row = row
-        return tensor > shared_metadata.threshold_row.unsqueeze(0)
+            cache_idx_64 = cache_idx.to(dtype=torch.int64)
+            enter_row = torch.zeros((tensor.shape[1],), dtype=tensor.dtype, device=gs.device)
+            enter_row.scatter_(0, cache_idx_64, shared_metadata.contact_threshold[i_s].to(dtype=tensor.dtype))
+            release_row = torch.zeros((tensor.shape[1],), dtype=tensor.dtype, device=gs.device)
+            release_row.scatter_(0, cache_idx_64, shared_metadata.release_threshold[i_s].to(dtype=tensor.dtype))
+            shared_metadata.threshold_row = enter_row
+            shared_metadata.release_threshold_row = release_row
+        above_enter = tensor > shared_metadata.threshold_row.unsqueeze(0)
+        above_release = tensor > shared_metadata.release_threshold_row.unsqueeze(0)
+        prev_state = timeline.at(0, copy=False)
+        return above_enter | (prev_state & above_release)
 
     def _draw_debug(self, context: "RasterizerContext"):
-        self._draw_debug_probes(context, lambda data: data)
+        def mask(envs_idx):
+            contact = self.read_ground_truth(envs_idx)
+            if self._options.history_length > 0:
+                contact = contact.select(1 if self._manager._sim.n_envs > 0 else 0, -1)
+            return contact
+
+        self._draw_debug_probes(context, self._tactile_color_groups_fn(mask))
 
 
 class KinematicTaxelReturnType(NamedTuple):
@@ -516,7 +1110,13 @@ class KinematicTaxelReturnType(NamedTuple):
 
 
 @dataclass
-class KinematicTaxelMetadata(ProbesWithNormalSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata):
+class KinematicTaxelMetadata(
+    ProbeSensorMetadataMixin,
+    ContactPrefilterMetadataMixin,
+    ContactDepthQueryMetadataMixin,
+    RigidSensorMetadataMixin,
+    SimpleSensorMetadata,
+):
     normal_stiffness: torch.Tensor = make_tensor_field((0,))
     normal_damping: torch.Tensor = make_tensor_field((0,))
     normal_exponent: torch.Tensor = make_tensor_field((0,))
@@ -526,21 +1126,10 @@ class KinematicTaxelMetadata(ProbesWithNormalSensorMetadataMixin, RigidSensorMet
 
 class KinematicTaxelSensor(
     KinematicTactileSensorMixin[KinematicTaxelMetadata],
-    ProbesWithNormalSensorMixin[KinematicTaxelMetadata],
     RigidSensorMixin[KinematicTaxelMetadata],
-    SimpleSensor[KinematicTaxelOptions, None, KinematicTaxelMetadata, KinematicTaxelReturnType],
+    SimpleSensor[KinematicTaxelOptions, RaycastContext, KinematicTaxelMetadata, KinematicTaxelReturnType],
 ):
     """Kinematic taxels: spring-damper force and torque per probe from contact geometry and relative motion."""
-
-    def __init__(
-        self,
-        options: KinematicTaxelOptions,
-        idx: int,
-        shared_context,
-        shared_metadata,
-        manager: "SensorManager",
-    ):
-        super().__init__(options, idx, shared_context, shared_metadata, manager)
 
     def build(self):
         super().build()
@@ -561,8 +1150,22 @@ class KinematicTaxelSensor(
             self._shared_metadata.twist_scalar, float(self._options.twist_scalar), expand=(1,)
         )
 
+        # Re-allocate the per-(env, sensor) contact prefilter buffers to absorb the newly-registered sensor.
+        # Sized at build time; the per-step kernel writes into the same buffers without further allocation.
+        B = self._manager._sim._B
+        n_sensors_built = self._shared_metadata.n_probes_per_sensor.shape[0]
+        self._shared_metadata.sensor_contacts_idx = torch.zeros(
+            (B, n_sensors_built, _MAX_CONTACTS_PER_SENSOR), dtype=gs.tc_int, device=gs.device
+        )
+        self._shared_metadata.sensor_n_contacts = torch.zeros((B, n_sensors_built), dtype=gs.tc_int, device=gs.device)
+        self._shared_metadata.sensor_geoms_idx = torch.zeros(
+            (B, n_sensors_built, _MAX_GEOMS_PER_SENSOR), dtype=gs.tc_int, device=gs.device
+        )
+        self._shared_metadata.sensor_n_geoms = torch.zeros((B, n_sensors_built), dtype=gs.tc_int, device=gs.device)
+
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._n_probes, 3), (self._n_probes, 3)
+        shape = (*self._probe_layout_shape, 3)
+        return shape, shape
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
@@ -571,49 +1174,111 @@ class KinematicTaxelSensor(
     @classmethod
     def _update_current_timestep_data(
         cls,
-        shared_context: None,
+        shared_context: RaycastContext,
         shared_metadata: KinematicTaxelMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
         measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
-
-        current_ground_truth_data_T.zero_()
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.zero_()
-        if shared_metadata.measured_scratch_T.shape != current_ground_truth_data_T.shape:
-            shared_metadata.measured_scratch_T = torch.empty_like(current_ground_truth_data_T)
-        measured_cols_b = shared_metadata.measured_scratch_T
-
-        _kernel_kinematic_taxel(
-            shared_metadata.probe_positions,
-            shared_metadata.probe_sensor_idx,
-            shared_metadata.probe_radii,
-            shared_metadata.probe_radii_noise,
-            shared_metadata.normal_stiffness,
-            shared_metadata.normal_damping,
-            shared_metadata.normal_exponent,
-            shared_metadata.shear_scalar,
-            shared_metadata.twist_scalar,
-            shared_metadata.links_idx,
-            shared_metadata.sensor_cache_start,
-            shared_metadata.sensor_probe_start,
-            shared_metadata.n_probes_per_sensor,
-            solver.collider._collider_state,
-            solver.collider._collider_static_config,
-            solver.links_state,
-            solver.geoms_state,
-            solver.geoms_info,
-            solver._rigid_global_info,
-            solver.collider._sdf._sdf_info,
-            gs.EPS,
-            current_ground_truth_data_T,
-            measured_cols_b,
+        measured, measured_cols_b = get_measured_bufs(
+            shared_metadata, current_ground_truth_data_T, measured_data_timeline
         )
+        # The measured branch is provably identical to GT (and the kernel can skip recomputing it) when no probe
+        # has a noised sensing radius and no probe has a non-unit measured-branch gain.
+        measured_equals_gt = int(
+            not shared_metadata.has_any_probe_radius_noise and not shared_metadata.has_any_probe_gain
+        )
+        if (shared_metadata.contact_depth_query or "sdf") == "sdf":
+            _kernel_build_sensor_geom_idx(
+                shared_metadata.links_idx,
+                solver.collider._collider_state,
+                shared_metadata.sensor_geoms_idx,
+                shared_metadata.sensor_n_geoms,
+            )
+            _kernel_kinematic_taxel(
+                shared_metadata.probe_positions,
+                shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
+                shared_metadata.probe_radii_noise,
+                shared_metadata.probe_gains,
+                shared_metadata.normal_stiffness,
+                shared_metadata.normal_damping,
+                shared_metadata.normal_exponent,
+                shared_metadata.shear_scalar,
+                shared_metadata.twist_scalar,
+                shared_metadata.links_idx,
+                shared_metadata.sensor_cache_start,
+                shared_metadata.sensor_probe_start,
+                shared_metadata.n_probes_per_sensor,
+                shared_metadata.sensor_geoms_idx,
+                shared_metadata.sensor_n_geoms,
+                solver.collider._collider_static_config,
+                solver.links_state,
+                solver.geoms_state,
+                solver.geoms_info,
+                solver._rigid_global_info,
+                solver.collider._sdf._sdf_info,
+                gs.EPS,
+                measured_equals_gt,
+                current_ground_truth_data_T,
+                measured_cols_b,
+            )
+        else:
+            _kernel_build_sensor_contact_idx(
+                shared_metadata.links_idx,
+                solver.collider._collider_state,
+                shared_metadata.sensor_contacts_idx,
+                shared_metadata.sensor_n_contacts,
+            )
+            B, n_sensors = shared_metadata.sensor_n_contacts.shape
+            mask_shape = (B, n_sensors, solver.n_geoms)
+            if tuple(shared_metadata.sensor_candidate_geom_mask.shape) != mask_shape:
+                shared_metadata.sensor_candidate_geom_mask = torch.zeros(mask_shape, dtype=gs.tc_bool, device=gs.device)
+            _kernel_build_sensor_candidate_geom_mask(
+                shared_metadata.links_idx,
+                shared_metadata.sensor_contacts_idx,
+                shared_metadata.sensor_n_contacts,
+                solver.collider._collider_state,
+                shared_metadata.sensor_candidate_geom_mask,
+            )
+            _kernel_kinematic_taxel_bvh(
+                shared_metadata.probe_positions,
+                shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
+                shared_metadata.probe_radii_noise,
+                shared_metadata.probe_gains,
+                shared_metadata.normal_stiffness,
+                shared_metadata.normal_damping,
+                shared_metadata.normal_exponent,
+                shared_metadata.shear_scalar,
+                shared_metadata.twist_scalar,
+                shared_metadata.links_idx,
+                shared_metadata.sensor_cache_start,
+                shared_metadata.sensor_probe_start,
+                shared_metadata.n_probes_per_sensor,
+                shared_metadata.sensor_candidate_geom_mask,
+                shared_context.collision_bvh_context.bvh.nodes,
+                shared_context.collision_bvh_context.bvh.morton_codes,
+                solver.links_state,
+                solver.faces_info,
+                solver.verts_info,
+                solver.fixed_verts_state,
+                solver.free_verts_state,
+                solver.geoms_info,
+                measured_equals_gt,
+                current_ground_truth_data_T,
+                measured_cols_b,
+            )
         if ground_truth_data_timeline is not None:
             ground_truth_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
         measured.copy_(measured_cols_b.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
-        self._draw_debug_probes(context, lambda data: torch.linalg.norm(data.force, dim=-1) >= gs.EPS)
+        def mask(envs_idx):
+            force = self.read_ground_truth(envs_idx).force
+            if self._options.history_length > 0:
+                force = force.select(1 if self._manager._sim.n_envs > 0 else 0, -1)
+            return torch.linalg.norm(force, dim=-1) >= gs.EPS
+
+        self._draw_debug_probes(context, self._tactile_color_groups_fn(mask))

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -164,8 +164,9 @@ def _group_geoms_by_variant(
     geom_chunks: list[tuple[object, np.ndarray, np.ndarray]], batch_size: int
 ) -> list[tuple[torch.Tensor, list[tuple[object, np.ndarray, np.ndarray]]]]:
     """
-    Partition a link's geoms into heterogeneous-variant groups by ``active_envs_mask``. Geoms sharing
-    a mask are one variant; ``None`` masks (homogeneous) collapse into a single all-True group.
+    Partition a link's geoms into heterogeneous-variant groups by ``active_envs_mask``.
+
+    Geoms sharing a mask are one variant; ``None`` masks (homogeneous) collapse into a single all-True group.
     Returns ``[(mask, geom_chunks_for_variant), ...]`` preserving the original geom order within each group.
     """
     groups: dict[bytes, tuple[torch.Tensor, list[tuple[object, np.ndarray, np.ndarray]]]] = {}
@@ -245,9 +246,11 @@ _ELASTOMER_QUERY_AABB_MARGIN = 1e-3
 @dataclass
 class PointCloudBVH(BVHMetadata):
     """
-    BVH over the tracked point clouds of one sensor class. ``leaf_elem_idx`` entries are absolute
-    rows into ``pc_pos_link`` / ``pc_active_envs_mask`` / ``pc_normal_link`` so a leaf hit resolves
-    to per-point data with one indirection. See ``BVHMetadata`` for the shared scaffolding semantics.
+    BVH over the tracked point clouds of one sensor class.
+
+    ``leaf_elem_idx`` entries are absolute rows into ``pc_pos_link`` / ``pc_active_envs_mask`` / ``pc_normal_link``
+    so a leaf hit resolves to per-point data with one indirection. See ``BVHMetadata`` for the shared scaffolding
+    semantics.
     """
 
     # Inverse of sensor_chunk_start/count: chunk_sensor_idx[i_c] is the owning sensor's index. Enables
@@ -257,8 +260,9 @@ class PointCloudBVH(BVHMetadata):
 
     def append_sensor(self, *, pc_start_row: int, idx_cat: torch.Tensor, pos_cat: torch.Tensor) -> None:
         """
-        Build per-tracked-link chunks for one sensor and append into the flat tensors. Must be called
-        immediately after extending ``pc_pos_link`` by ``pos_cat`` so each leaf's element index
+        Build per-tracked-link chunks for one sensor and append into the flat tensors.
+
+        Must be called immediately after extending ``pc_pos_link`` by ``pos_cat`` so each leaf's element index
         (``pc_start_row + local_row``) addresses the freshly-grown rows.
         """
         n_local = int(pos_cat.shape[0])
@@ -968,9 +972,11 @@ def _func_elastomer_min_signed_dist_bvh(
 ) -> float:
     """
     BVH-based signed distance from ``probe_world`` to the nearest triangle of any geom flagged for this sensor in
-    ``track_geom_mask`` (shape ``(B, n_sensors, n_geoms)``). Sign is positive when the probe is outside the surface
-    (closest-triangle face-normal points away from probe), negative when inside. Mirrors the return contract of
-    ``_func_elastomer_min_sdf_over_active_geoms`` so callers consume ``max(0, -signed)`` identically.
+    ``track_geom_mask`` (shape ``(B, n_sensors, n_geoms)``).
+
+    Sign is positive when the probe is outside the surface (closest-triangle face-normal points away from probe),
+    negative when inside. Mirrors the return contract of ``_func_elastomer_min_sdf_over_active_geoms`` so callers
+    consume ``max(0, -signed)`` identically.
 
     Uses ``max_query_dist`` as the BVH cull radius: probes farther than that from every candidate triangle are
     treated as fully outside (returns ``+max_query_dist``), which downstream maps to depth = 0.
@@ -1041,9 +1047,10 @@ def _kernel_elastomer_probe_depth_bvh(
     probe_depth_buf: qd.types.ndarray(),
 ):
     """
-    Per-probe contact depth from the rigid solver's global collision BVH, gated by ``track_geom_mask``. Mirrors
-    ``_kernel_elastomer_probe_depth``'s output contract (write into ``probe_depth_buf``); the dilate accumulator
-    consumes the same buffer downstream.
+    Per-probe contact depth from the rigid solver's global collision BVH, gated by ``track_geom_mask``.
+
+    Mirrors ``_kernel_elastomer_probe_depth``'s output contract (write into ``probe_depth_buf``); the dilate
+    accumulator consumes the same buffer downstream.
     """
     total_n_probes = probe_positions_local.shape[0]
     n_batches = probe_depth_buf.shape[0]
@@ -1091,9 +1098,11 @@ def _kernel_elastomer_probe_depth(
     sdf_info: array_class.SDFInfo,
     probe_depth_buf: qd.types.ndarray(),
 ):
-    """Per-probe contact depth from track-geom SDF, parallel over (env, probe). Writes only
-    ``probe_depth_buf``; dilate accumulation is split into a separate target-major kernel that
-    runs without atomics."""
+    """Per-probe contact depth from track-geom SDF, parallel over (env, probe).
+
+    Writes only ``probe_depth_buf``; dilate accumulation is split into a separate target-major kernel that runs
+    without atomics.
+    """
     total_n_probes = probe_positions_local.shape[0]
     n_batches = probe_depth_buf.shape[0]
 
@@ -1140,11 +1149,13 @@ def _kernel_elastomer_dilate_accumulate(
     probe_depth_buf: qd.types.ndarray(),
     output: qd.types.ndarray(),
 ):
-    """Target-major dilate accumulator for non-grid sensors. Each (env, target_probe) thread sums
-    Gaussian contributions from every in-contact source probe of its sensor into a register and
-    writes once -- no atomic_add. Grid sensors are skipped (FFT path handles them).
-    Output write is an OVERWRITE because output was pre-zeroed at step start and no other writer
-    touches a non-grid sensor's range before shear-accumulate."""
+    """Target-major dilate accumulator for non-grid sensors.
+
+    Each (env, target_probe) thread sums Gaussian contributions from every in-contact source probe of its sensor
+    into a register and writes once -- no atomic_add. Grid sensors are skipped (FFT path handles them). Output write
+    is an OVERWRITE because output was pre-zeroed at step start and no other writer touches a non-grid sensor's range
+    before shear-accumulate.
+    """
     total_n_probes = probe_positions_local.shape[0]
     n_batches = probe_depth_buf.shape[0]
 
@@ -1392,10 +1403,11 @@ def _kernel_elastomer_surface_state_via_global_bvh(
     surface_candidate_buf: qd.types.ndarray(),
 ):
     """
-    Raycast variant of ``_kernel_elastomer_surface_state_bvh``: same outer (env, chunk) traversal over the point-cloud
-    BVH per tracked link, but the inner signed-distance query at each PC point uses
-    ``_func_elastomer_min_signed_dist_bvh`` over the rigid solver's global collision BVH (gated by
-    ``elastomer_candidate_geom_mask``) instead of the analytic SDF. Output contract matches the SDF variant so the
+    Raycast variant of ``_kernel_elastomer_surface_state_bvh``.
+
+    Same outer (env, chunk) traversal over the point-cloud BVH per tracked link, but the inner signed-distance query
+    at each PC point uses ``_func_elastomer_min_signed_dist_bvh`` over the rigid solver's global collision BVH (gated
+    by ``elastomer_candidate_geom_mask``) instead of the analytic SDF. Output contract matches the SDF variant so the
     dilate / shear pipeline downstream is unchanged.
     """
     n_batches = surface_pos_sensor_buf.shape[0]
@@ -1535,14 +1547,13 @@ def _kernel_elastomer_shear_accumulate(
     shear_active_pc_count: qd.types.ndarray(),
     output: qd.types.ndarray(),
 ):
-    """Target-major shear accumulator: per (env, target_probe), iterate over the sensor's compact
-    active surface-point index and sum Gaussian contributions into a register, then += the result
-    into ``output``. No atomic_add (each (i_b, i_p) thread owns its output slot).
+    """Target-major shear accumulator: per (env, target_probe), iterate over the sensor's compact active surface-point
+    index and sum Gaussian contributions into a register, then += the result into ``output``.
 
-    Consumes the compact index produced by ``_build_shear_active_pc_index`` (must run after the
-    surface-state kernel AND after the post-kernel ``surface_initialized_buf &= candidate`` cleanup).
-    Inner-loop cost is O(active_count[i_b, i_s]) rather than O(sensor_pc_n[i_s]), so the kernel scales
-    with contact density rather than total point-cloud size.
+    No atomic_add (each (i_b, i_p) thread owns its output slot). Consumes the compact index produced by
+    ``_build_shear_active_pc_index`` (must run after the surface-state kernel AND after the post-kernel
+    ``surface_initialized_buf &= candidate`` cleanup). Inner-loop cost is O(active_count[i_b, i_s]) rather than
+    O(sensor_pc_n[i_s]), so the kernel scales with contact density rather than total point-cloud size.
     """
     total_n_probes = probe_positions_local.shape[0]
     n_batches = surface_pos_sensor_buf.shape[0]
@@ -1612,7 +1623,9 @@ def _build_shear_active_pc_index(
     active_pc_count: torch.Tensor,
 ) -> None:
     """Build the compact per-(env, sensor) active surface-point index consumed by
-    ``_kernel_elastomer_shear_accumulate``. Mutates ``active_pc_idx`` and ``active_pc_count`` in place.
+    ``_kernel_elastomer_shear_accumulate``.
+
+    Mutates ``active_pc_idx`` and ``active_pc_count`` in place.
 
     For each sensor ``s`` with ``shear_scale[s] > 0``, gathers the indices of True entries in
     ``surface_initialized_buf[:, pc_start[s] : pc_start[s] + pc_n[s]]`` into the per-sensor compact slice

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -9,10 +9,16 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 import genesis.utils.sdf as sdf
+from genesis.engine.bvh import STACK_SIZE as _BVH_STACK_SIZE
 from genesis.options.sensors import ElastomerTaxel as ElastomerTaxelSensorOptions
 from genesis.options.sensors import ProximityTaxel as ProximityTaxelOptions
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
 from genesis.utils.point_cloud import sample_mesh_point_cloud
+from genesis.utils.raycast_qd import (
+    closest_point_on_triangle,
+    get_triangle_vertices,
+    triangle_face_normal,
+)
 
 from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, SimpleSensor, SimpleSensorMetadata
 from .probe import (
@@ -21,7 +27,30 @@ from .probe import (
     ProbesWithNormalSensorMetadataMixin,
     ProbesWithNormalSensorMixin,
     func_noised_probe_radius,
+    get_measured_bufs,
 )
+from .raycaster import RaycastContext
+from .tactile_shared import (
+    BVH_LEAF_SIZE,
+    BVH_STACK_SIZE,
+    BVHMetadata,
+    ContactDepthQueryMetadataMixin,
+    ContactDepthQuerySensorMixin,
+    GridFFTConvMetadataMixin,
+    build_static_chunk_bvh,
+    func_aabb_intersects_aabb,
+    func_sphere_intersects_aabb,
+    func_vec3_at,
+    get_mesh_geom_chunks,
+    next_pow2,
+    normalize_grid_probe_layout,
+    register_grid_fft_sensor,
+)
+
+# Conservative cap for global-BVH closest-point walks in raycast mode. Points farther than this from every candidate
+# triangle map to depth = 0 (so the elastomer "out of contact" branch fires). Sized to cover realistic elastomer
+# penetrations -- bumping it widens BVH traversal cost but doesn't change correctness for in-contact probes.
+_ELASTOMER_RAYCAST_QUERY_DIST = 0.1
 
 if TYPE_CHECKING:
     from genesis.options.sensors import SensorOptions
@@ -29,30 +58,6 @@ if TYPE_CHECKING:
     from genesis.vis.rasterizer_context import RasterizerContext
 
     from .sensor_manager import SensorManager
-
-
-def _get_mesh_geom_chunks(link, prefer_visual: bool) -> list[tuple[object, np.ndarray, np.ndarray]]:
-    """Return per-geom mesh chunks in link-local frame."""
-    if prefer_visual:
-        geoms = list(link.vgeoms) if link.vgeoms else list(link.geoms)
-        use_vverts = bool(link.vgeoms)
-    else:
-        geoms = list(link.geoms) if link.geoms else list(link.vgeoms)
-        use_vverts = not bool(link.geoms) and bool(link.vgeoms)
-
-    chunks: list[tuple[object, np.ndarray, np.ndarray]] = []
-    for geom in geoms:
-        if use_vverts:
-            verts = np.asarray(geom.init_vverts, dtype=np.float32)
-            faces = np.asarray(geom.init_vfaces, dtype=np.int32)
-        else:
-            verts = np.asarray(geom.init_verts, dtype=np.float32)
-            faces = np.asarray(geom.init_faces, dtype=np.int32)
-        if verts.size == 0 or faces.size == 0:
-            continue
-        verts_link = gu.transform_by_trans_quat(verts, geom.init_pos, geom.init_quat)
-        chunks.append((geom, verts_link.astype(np.float32, copy=False), np.asarray(faces, dtype=np.int32)))
-    return chunks
 
 
 def _n_sample_points_per_link(n_sample_points: int | list | tuple, n_links: int) -> list[int]:
@@ -74,6 +79,51 @@ def _n_sample_points_per_link(n_sample_points: int | list | tuple, n_links: int)
     return [base + (1 if i < rem else 0) for i in range(n_links)]
 
 
+class GridFFTMeta(NamedTuple):
+    """
+    Per-grid-FFT-sensor record for HydroShear dilation.
+
+    ``sensor_idx``/``g_ny``/``g_nx``/``probe_start``/``cache_start`` are the leading fields every grid-FFT sensor
+    shares (the contract ``register_grid_fft_sensor`` relies on); ``lambda_d``/``spacing_u``/``spacing_v`` are the
+    HydroShear kernel params consumed by ``_dilate_kernel_builder``.
+    """
+
+    sensor_idx: int
+    g_ny: int
+    g_nx: int
+    probe_start: int
+    cache_start: int
+    lambda_d: float
+    spacing_u: float
+    spacing_v: float
+
+
+def _build_candidate_geom_mask(
+    B: int,
+    n_sensors: int,
+    n_geoms: int,
+    geom_starts: torch.Tensor,
+    geom_ns: torch.Tensor,
+    geom_idx: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Build a ``(B, n_sensors, n_geoms)`` bool mask marking, per sensor, which scene geoms are candidates.
+
+    ``geom_idx`` is the flat per-sensor concatenation of candidate geom indices; ``geom_starts``/``geom_ns`` give
+    each sensor's slice into it. The mask is broadcast identically across all ``B`` environments.
+    """
+    mask = torch.zeros((B, n_sensors, n_geoms), dtype=gs.tc_bool, device=gs.device)
+    starts = tensor_to_array(geom_starts)
+    ns = tensor_to_array(geom_ns)
+    idx = tensor_to_array(geom_idx)
+    for i_s in range(n_sensors):
+        lo = int(starts[i_s])
+        hi = lo + int(ns[i_s])
+        if hi > lo:
+            mask[:, i_s, idx[lo:hi]] = True
+    return mask
+
+
 def _mesh_area(verts: np.ndarray, faces: np.ndarray) -> float:
     tris = verts[faces]
     cross = np.cross(tris[:, 1] - tris[:, 0], tris[:, 2] - tris[:, 0])
@@ -87,17 +137,17 @@ def _split_count_by_area(n_total: int, geom_chunks: list[tuple[object, np.ndarra
     if n_total <= 0:
         return [0] * n_chunks
 
-    areas = np.asarray([_mesh_area(verts, faces) for _, verts, faces in geom_chunks], dtype=np.float64)
+    areas = np.asarray([_mesh_area(verts, faces) for _, verts, faces in geom_chunks], dtype=gs.np_float)
     if float(areas.sum()) <= gs.EPS:
         areas.fill(1.0)
 
     if n_total < n_chunks:
-        counts = np.zeros(n_chunks, dtype=np.int64)
+        counts = np.zeros(n_chunks, dtype=gs.np_int)
         counts[np.argsort(-areas)[:n_total]] = 1
         return counts.tolist()
 
     raw_extra = (n_total - n_chunks) * areas / float(areas.sum())
-    extra = np.floor(raw_extra).astype(np.int64)
+    extra = np.floor(raw_extra).astype(gs.np_int)
     remainder = n_total - n_chunks - int(extra.sum())
     if remainder > 0:
         extra[np.argsort(-(raw_extra - extra))[:remainder]] += 1
@@ -110,11 +160,35 @@ def _active_envs_mask_tensor(geom, batch_size: int) -> torch.Tensor:
     return geom.active_envs_mask.to(device=gs.device, dtype=gs.tc_bool)
 
 
+def _group_geoms_by_variant(
+    geom_chunks: list[tuple[object, np.ndarray, np.ndarray]], batch_size: int
+) -> list[tuple[torch.Tensor, list[tuple[object, np.ndarray, np.ndarray]]]]:
+    """
+    Partition a link's geoms into heterogeneous-variant groups by ``active_envs_mask``. Geoms sharing
+    a mask are one variant; ``None`` masks (homogeneous) collapse into a single all-True group.
+    Returns ``[(mask, geom_chunks_for_variant), ...]`` preserving the original geom order within each group.
+    """
+    groups: dict[bytes, tuple[torch.Tensor, list[tuple[object, np.ndarray, np.ndarray]]]] = {}
+    for chunk in geom_chunks:
+        geom = chunk[0]
+        mask = _active_envs_mask_tensor(geom, batch_size)
+        key = tensor_to_array(mask).astype(np.bool_).tobytes()
+        if key not in groups:
+            groups[key] = (mask, [])
+        groups[key][1].append(chunk)
+    return list(groups.values())
+
+
 def _sample_track_links_point_cloud_tensors(
     solver, track_link_idx: np.ndarray, n_sample_points: int | list | tuple, prefer_visual: bool
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     FPS-sample meshes on ``track_link_idx`` into concatenated link-local positions and normals.
+
+    The per-link budget from ``n_sample_points`` is allocated to every heterogeneous variant on a link
+    (geoms grouped by ``active_envs_mask``), so each parallel environment sees the full requested point
+    count regardless of which variant is active. Within a variant, the budget is split across geoms by
+    surface area.
 
     Returns
     -------
@@ -134,23 +208,25 @@ def _sample_track_links_point_cloud_tensors(
         n_pts = n_per_link[i_l]
         link_idx = int(track_link_idx[i_l])
         link = solver.links[link_idx]
-        geom_chunks = _get_mesh_geom_chunks(link, prefer_visual)
+        geom_chunks = get_mesh_geom_chunks(link, prefer_visual)
         if not geom_chunks:
             gs.raise_exception(f"No mesh geometry on tracked link index {link_idx}.")
-        for n_geom_pts, (geom, verts, faces) in zip(_split_count_by_area(n_pts, geom_chunks), geom_chunks):
-            if n_geom_pts <= 0:
-                continue
-            # Fixed seed: the cache key already discriminates between meshes (vertices+faces hashed), so the same mesh
-            # always resolves to the same sample, which keeps tactile readings reproducible across build/reset cycles.
-            pts_np, nrm_np = sample_mesh_point_cloud(
-                verts, faces, n_geom_pts, seed=0, use_cache=True, return_normals=True
-            )
+        for variant_mask, variant_chunks in _group_geoms_by_variant(geom_chunks, solver._B):
+            for n_geom_pts, (geom, verts, faces) in zip(_split_count_by_area(n_pts, variant_chunks), variant_chunks):
+                if n_geom_pts <= 0:
+                    continue
+                # Fixed seed: the cache key already discriminates between meshes (vertices+faces hashed), so the same
+                # mesh always resolves to the same sample, which keeps tactile readings reproducible across
+                # build/reset cycles.
+                pts_np, nrm_np = sample_mesh_point_cloud(
+                    verts, faces, n_geom_pts, seed=0, use_cache=True, return_normals=True
+                )
 
-            li = torch.full((pts_np.shape[0],), link_idx, dtype=gs.tc_int, device=gs.device)
-            link_idx_chunks.append(li)
-            pos_chunks.append(torch.tensor(pts_np, dtype=gs.tc_float, device=gs.device))
-            nrm_chunks.append(torch.tensor(nrm_np, dtype=gs.tc_float, device=gs.device))
-            active_chunks.append(_active_envs_mask_tensor(geom, solver._B).expand(pts_np.shape[0], solver._B))
+                li = torch.full((pts_np.shape[0],), link_idx, dtype=gs.tc_int, device=gs.device)
+                link_idx_chunks.append(li)
+                pos_chunks.append(torch.tensor(pts_np, dtype=gs.tc_float, device=gs.device))
+                nrm_chunks.append(torch.tensor(nrm_np, dtype=gs.tc_float, device=gs.device))
+                active_chunks.append(variant_mask.expand(pts_np.shape[0], solver._B))
 
     if not pos_chunks:
         gs.raise_exception("PointCloudTactile sensor produced an empty object point cloud.")
@@ -163,161 +239,74 @@ def _sample_track_links_point_cloud_tensors(
     )
 
 
-_POINT_CLOUD_BVH_LEAF_SIZE = 8
-_POINT_CLOUD_BVH_STACK_SIZE = 32
 _ELASTOMER_QUERY_AABB_MARGIN = 1e-3
 
 
-def _build_static_chunk_bvh(points: np.ndarray, global_rows: np.ndarray, leaf_size: int):
-    """Median-split AABB BVH over ``points`` (a single tracked link's local-frame point cloud).
-
-    Leaves carry the caller-provided ``global_rows`` (absolute rows into ``pc_pos_link``); the
-    kernel can therefore index directly into the per-class point-cloud tensors with no extra
-    indirection. Internal nodes use -1 for ``node_left`` / ``node_right``.
-    """
-    node_min: list[np.ndarray] = []
-    node_max: list[np.ndarray] = []
-    node_left: list[int] = []
-    node_right: list[int] = []
-    node_point_start: list[int] = []
-    node_point_n: list[int] = []
-    point_idx: list[int] = []
-
-    def _alloc() -> int:
-        i = len(node_min)
-        node_min.append(np.zeros(3, dtype=np.float32))
-        node_max.append(np.zeros(3, dtype=np.float32))
-        node_left.append(-1)
-        node_right.append(-1)
-        node_point_start.append(-1)
-        node_point_n.append(0)
-        return i
-
-    def _build(rows: np.ndarray, pts: np.ndarray) -> int:
-        nid = _alloc()
-        bmin = pts.min(axis=0).astype(np.float32)
-        bmax = pts.max(axis=0).astype(np.float32)
-        node_min[nid] = bmin
-        node_max[nid] = bmax
-        if rows.shape[0] <= leaf_size:
-            start = len(point_idx)
-            point_idx.extend(int(r) for r in rows)
-            node_point_start[nid] = start
-            node_point_n[nid] = int(rows.shape[0])
-            return nid
-        axis = int(np.argmax(bmax - bmin))
-        order = np.argsort(pts[:, axis], kind="stable")
-        mid = order.shape[0] // 2
-        node_left[nid] = _build(rows[order[:mid]], pts[order[:mid]])
-        node_right[nid] = _build(rows[order[mid:]], pts[order[mid:]])
-        return nid
-
-    if points.shape[0] == 0:
-        return (
-            np.zeros((0, 3), dtype=np.float32),
-            np.zeros((0, 3), dtype=np.float32),
-            np.zeros((0,), dtype=np.int32),
-            np.zeros((0,), dtype=np.int32),
-            np.zeros((0,), dtype=np.int32),
-            np.zeros((0,), dtype=np.int32),
-            np.zeros((0,), dtype=np.int32),
-        )
-
-    root = _build(global_rows.astype(np.int32, copy=False), points.astype(np.float32, copy=False))
-    assert root == 0
-    return (
-        np.stack(node_min, axis=0),
-        np.stack(node_max, axis=0),
-        np.asarray(node_left, dtype=np.int32),
-        np.asarray(node_right, dtype=np.int32),
-        np.asarray(node_point_start, dtype=np.int32),
-        np.asarray(node_point_n, dtype=np.int32),
-        np.asarray(point_idx, dtype=np.int32),
-    )
-
-
 @dataclass
-class PointCloudBVH:
-    """Static link-local BVH over the tracked point clouds of one sensor class.
-
-    One chunk per (sensor, tracked_link); each chunk is built once in that link's LOCAL frame at
-    scene-build time and never rebuilt. Queries must transform into a chunk's link-local frame at
-    query time. Chunk nodes are flat-packed across all chunks: chunk_node_start/n delimits each
-    chunk's contiguous run; node_left/right are ABSOLUTE indices into the flat node tensors (-1
-    for leaves). Leaves' point_idx values are absolute rows into pc_pos_link / pc_active_envs_mask
-    / pc_normal_link, so a leaf hit resolves to per-point data with one indirection.
+class PointCloudBVH(BVHMetadata):
+    """
+    BVH over the tracked point clouds of one sensor class. ``leaf_elem_idx`` entries are absolute
+    rows into ``pc_pos_link`` / ``pc_active_envs_mask`` / ``pc_normal_link`` so a leaf hit resolves
+    to per-point data with one indirection. See ``BVHMetadata`` for the shared scaffolding semantics.
     """
 
-    sensor_chunk_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    sensor_chunk_n: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-
-    chunk_link_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    # Inverse of sensor_chunk_start/n: chunk_sensor_idx[i_c] is the owning sensor's index. Enables
-    # (env, chunk)-parallel kernels without redundant per-thread scans of sensor_chunk_start.
+    # Inverse of sensor_chunk_start/count: chunk_sensor_idx[i_c] is the owning sensor's index. Enables
+    # (env, chunk)-parallel kernels (e.g. ElastomerTaxel surface state) without rescanning sensor_chunk_start
+    # in every thread; ProximityTaxel parallelizes per-probe and does not consume this field.
     chunk_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    chunk_node_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    chunk_node_n: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-
-    node_min: torch.Tensor = make_tensor_field((0, 3))
-    node_max: torch.Tensor = make_tensor_field((0, 3))
-    node_left: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    node_right: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    node_point_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    node_point_n: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-
-    point_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
 
     def append_sensor(self, *, pc_start_row: int, idx_cat: torch.Tensor, pos_cat: torch.Tensor) -> None:
-        """Build per-tracked-link chunks for one sensor and append into the flat tensors.
-
-        Must be called immediately after extending ``pc_pos_link`` by ``pos_cat`` — each leaf's
-        ``point_idx`` entry is ``pc_start_row + local_row`` and must address the freshly-grown
-        rows.
+        """
+        Build per-tracked-link chunks for one sensor and append into the flat tensors. Must be called
+        immediately after extending ``pc_pos_link`` by ``pos_cat`` so each leaf's element index
+        (``pc_start_row + local_row``) addresses the freshly-grown rows.
         """
         n_local = int(pos_cat.shape[0])
         if n_local == 0:
             gs.raise_exception("PointCloudBVH.append_sensor called with empty point cloud.")
 
-        idx_np = tensor_to_array(idx_cat).astype(np.int64)
-        pos_np = tensor_to_array(pos_cat).astype(np.float32, copy=False)
+        idx_np = tensor_to_array(idx_cat).astype(gs.np_int)
+        pos_np = tensor_to_array(pos_cat).astype(gs.np_float, copy=False)
         unique_links = np.unique(idx_np)
 
         chunk_start_for_sensor = int(self.chunk_link_idx.shape[0])
         node_offset = int(self.node_min.shape[0])
-        point_offset = int(self.point_idx.shape[0])
+        point_offset = int(self.leaf_elem_idx.shape[0])
 
         new_chunk_link_idx: list[int] = []
         new_chunk_node_start: list[int] = []
-        new_chunk_node_n: list[int] = []
+        new_chunk_node_count: list[int] = []
         all_node_min: list[np.ndarray] = []
         all_node_max: list[np.ndarray] = []
         all_node_left: list[np.ndarray] = []
         all_node_right: list[np.ndarray] = []
-        all_node_point_start: list[np.ndarray] = []
-        all_node_point_n: list[np.ndarray] = []
-        all_point_idx: list[np.ndarray] = []
+        all_node_leaf_start: list[np.ndarray] = []
+        all_node_leaf_count: list[np.ndarray] = []
+        all_leaf_elem_idx: list[np.ndarray] = []
 
         for link_idx in unique_links:
-            local_rows = np.nonzero(idx_np == int(link_idx))[0].astype(np.int32)
-            global_rows = (int(pc_start_row) + local_rows).astype(np.int32)
+            local_rows = np.nonzero(idx_np == int(link_idx))[0].astype(gs.np_int)
+            global_rows = (int(pc_start_row) + local_rows).astype(gs.np_int)
             pts_link = pos_np[local_rows]
 
-            nmin, nmax, nleft, nright, npstart, npn, pidx = _build_static_chunk_bvh(
-                pts_link, global_rows, _POINT_CLOUD_BVH_LEAF_SIZE
+            # Point cloud: AABB per element is degenerate (the point itself), so pass the points as both
+            # centroids and the per-element min/max bounds.
+            nmin, nmax, nleft, nright, npstart, npn, pidx = build_static_chunk_bvh(
+                pts_link, pts_link, pts_link, global_rows, BVH_LEAF_SIZE
             )
 
             new_chunk_link_idx.append(int(link_idx))
             new_chunk_node_start.append(node_offset)
-            new_chunk_node_n.append(int(nmin.shape[0]))
+            new_chunk_node_count.append(int(nmin.shape[0]))
 
             all_node_min.append(nmin)
             all_node_max.append(nmax)
             # Rebase intra-chunk child / leaf-start indices into the flat tensors' absolute space.
-            all_node_left.append(np.where(nleft >= 0, nleft + node_offset, nleft).astype(np.int32))
-            all_node_right.append(np.where(nright >= 0, nright + node_offset, nright).astype(np.int32))
-            all_node_point_start.append(np.where(npn > 0, npstart + point_offset, npstart).astype(np.int32))
-            all_node_point_n.append(npn)
-            all_point_idx.append(pidx)
+            all_node_left.append(np.where(nleft >= 0, nleft + node_offset, nleft).astype(gs.np_int))
+            all_node_right.append(np.where(nright >= 0, nright + node_offset, nright).astype(gs.np_int))
+            all_node_leaf_start.append(np.where(npn > 0, npstart + point_offset, npstart).astype(gs.np_int))
+            all_node_leaf_count.append(npn)
+            all_leaf_elem_idx.append(pidx)
 
             node_offset += int(nmin.shape[0])
             point_offset += int(pidx.shape[0])
@@ -326,12 +315,12 @@ class PointCloudBVH:
         nx = torch.tensor(np.concatenate(all_node_max, axis=0), dtype=gs.tc_float, device=gs.device)
         nl = torch.tensor(np.concatenate(all_node_left, axis=0), dtype=gs.tc_int, device=gs.device)
         nr = torch.tensor(np.concatenate(all_node_right, axis=0), dtype=gs.tc_int, device=gs.device)
-        nps = torch.tensor(np.concatenate(all_node_point_start, axis=0), dtype=gs.tc_int, device=gs.device)
-        npn_t = torch.tensor(np.concatenate(all_node_point_n, axis=0), dtype=gs.tc_int, device=gs.device)
-        pidx_t = torch.tensor(np.concatenate(all_point_idx, axis=0), dtype=gs.tc_int, device=gs.device)
+        nps = torch.tensor(np.concatenate(all_node_leaf_start, axis=0), dtype=gs.tc_int, device=gs.device)
+        npn_t = torch.tensor(np.concatenate(all_node_leaf_count, axis=0), dtype=gs.tc_int, device=gs.device)
+        pidx_t = torch.tensor(np.concatenate(all_leaf_elem_idx, axis=0), dtype=gs.tc_int, device=gs.device)
         cli = torch.tensor(new_chunk_link_idx, dtype=gs.tc_int, device=gs.device)
         cns = torch.tensor(new_chunk_node_start, dtype=gs.tc_int, device=gs.device)
-        cnn = torch.tensor(new_chunk_node_n, dtype=gs.tc_int, device=gs.device)
+        cnn = torch.tensor(new_chunk_node_count, dtype=gs.tc_int, device=gs.device)
         # Sensor index for this batch of chunks = current sensor count (the entry we're about to add).
         sensor_idx_for_chunks = int(self.sensor_chunk_start.shape[0])
         csi = torch.full((len(unique_links),), sensor_idx_for_chunks, dtype=gs.tc_int, device=gs.device)
@@ -340,51 +329,15 @@ class PointCloudBVH:
         self.node_max = concat_with_tensor(self.node_max, nx, expand=(nx.shape[0], 3))
         self.node_left = concat_with_tensor(self.node_left, nl, expand=(nl.shape[0],))
         self.node_right = concat_with_tensor(self.node_right, nr, expand=(nr.shape[0],))
-        self.node_point_start = concat_with_tensor(self.node_point_start, nps, expand=(nps.shape[0],))
-        self.node_point_n = concat_with_tensor(self.node_point_n, npn_t, expand=(npn_t.shape[0],))
-        self.point_idx = concat_with_tensor(self.point_idx, pidx_t, expand=(pidx_t.shape[0],))
+        self.node_leaf_start = concat_with_tensor(self.node_leaf_start, nps, expand=(nps.shape[0],))
+        self.node_leaf_count = concat_with_tensor(self.node_leaf_count, npn_t, expand=(npn_t.shape[0],))
+        self.leaf_elem_idx = concat_with_tensor(self.leaf_elem_idx, pidx_t, expand=(pidx_t.shape[0],))
         self.chunk_link_idx = concat_with_tensor(self.chunk_link_idx, cli, expand=(cli.shape[0],))
         self.chunk_sensor_idx = concat_with_tensor(self.chunk_sensor_idx, csi, expand=(csi.shape[0],))
         self.chunk_node_start = concat_with_tensor(self.chunk_node_start, cns, expand=(cns.shape[0],))
-        self.chunk_node_n = concat_with_tensor(self.chunk_node_n, cnn, expand=(cnn.shape[0],))
+        self.chunk_node_count = concat_with_tensor(self.chunk_node_count, cnn, expand=(cnn.shape[0],))
         self.sensor_chunk_start = concat_with_tensor(self.sensor_chunk_start, chunk_start_for_sensor, expand=(1,))
-        self.sensor_chunk_n = concat_with_tensor(self.sensor_chunk_n, len(unique_links), expand=(1,))
-
-
-@qd.func
-def _func_vec3_at(values: qd.types.ndarray(), i: int) -> qd.types.vector(3):
-    return qd.Vector([values[i, 0], values[i, 1], values[i, 2]], dt=float)
-
-
-@qd.func
-def _func_sphere_intersects_aabb(center, radius_sq, bmin, bmax):  # -> bool
-    """Squared-distance sphere-vs-AABB test: returns True iff the closest point of the AABB to
-    ``center`` is within ``radius_sq``. Used by ProximityTaxel BVH traversal."""
-    d_sq = gs.qd_float(0.0)
-    for k in qd.static(range(3)):
-        v = center[k]
-        lo = bmin[k]
-        hi = bmax[k]
-        if v < lo:
-            d = lo - v
-            d_sq = d_sq + d * d
-        elif v > hi:
-            d = v - hi
-            d_sq = d_sq + d * d
-    return d_sq <= radius_sq
-
-
-@qd.func
-def _func_aabb_intersects_aabb(amin, amax, bmin, bmax):  # -> bool
-    """Standard 6-axis AABB-vs-AABB overlap test. Used by ElastomerTaxel BVH traversal."""
-    return (
-        amin[0] <= bmax[0]
-        and amax[0] >= bmin[0]
-        and amin[1] <= bmax[1]
-        and amax[1] >= bmin[1]
-        and amin[2] <= bmax[2]
-        and amax[2] >= bmin[2]
-    )
+        self.sensor_chunk_count = concat_with_tensor(self.sensor_chunk_count, len(unique_links), expand=(1,))
 
 
 @qd.kernel
@@ -397,20 +350,21 @@ def _kernel_point_cloud_proximity_taxel_bvh(
     sensor_probe_start: qd.types.ndarray(),
     n_probes_per_sensor: qd.types.ndarray(),
     bvh_sensor_chunk_start: qd.types.ndarray(),
-    bvh_sensor_chunk_n: qd.types.ndarray(),
+    bvh_sensor_chunk_count: qd.types.ndarray(),
     bvh_chunk_link_idx: qd.types.ndarray(),
     bvh_chunk_node_start: qd.types.ndarray(),
     bvh_node_min: qd.types.ndarray(),
     bvh_node_max: qd.types.ndarray(),
     bvh_node_left: qd.types.ndarray(),
     bvh_node_right: qd.types.ndarray(),
-    bvh_node_point_start: qd.types.ndarray(),
-    bvh_node_point_n: qd.types.ndarray(),
-    bvh_point_idx: qd.types.ndarray(),
+    bvh_node_leaf_start: qd.types.ndarray(),
+    bvh_node_leaf_count: qd.types.ndarray(),
+    bvh_leaf_elem_idx: qd.types.ndarray(),
     pc_pos_link: qd.types.ndarray(),
     pc_active_envs_mask: qd.types.ndarray(),
     probe_radii: qd.types.ndarray(),
     probe_radii_noise: qd.types.ndarray(),
+    probe_gains: qd.types.ndarray(),
     stiffness: qd.types.ndarray(),
     shear_coupling: qd.types.ndarray(),
     proximity_density_scale: qd.types.ndarray(),
@@ -440,10 +394,10 @@ def _kernel_point_cloud_proximity_taxel_bvh(
         s_ang = links_state.cd_ang[sensor_link_idx, i_b]
         s_com = links_state.root_COM[sensor_link_idx, i_b]
 
-        probe_local = _func_vec3_at(probe_positions_local, i_p)
+        probe_local = func_vec3_at(probe_positions_local, i_p)
         probe_world = s_pos + gu.qd_transform_by_quat(probe_local, s_quat)
 
-        a_loc = _func_vec3_at(probe_local_normal, i_p)
+        a_loc = func_vec3_at(probe_local_normal, i_p)
         a_w = gu.qd_transform_by_quat(a_loc, s_quat)
         a_norm = qd.sqrt(a_w.dot(a_w)) + eps
         for j in qd.static(range(3)):
@@ -471,7 +425,7 @@ def _kernel_point_cloud_proximity_taxel_bvh(
         tau_w_m = qd.Vector.zero(gs.qd_float, 3)
 
         chunk_start = bvh_sensor_chunk_start[i_s]
-        n_chunks = bvh_sensor_chunk_n[i_s]
+        n_chunks = bvh_sensor_chunk_count[i_s]
         for c_off in range(n_chunks):
             i_c = chunk_start + c_off
             track_link_idx = bvh_chunk_link_idx[i_c]
@@ -483,26 +437,26 @@ def _kernel_point_cloud_proximity_taxel_bvh(
             # BVH nodes live in tracked-link local frame: bring the probe sphere center over.
             probe_link = gu.qd_inv_transform_by_trans_quat(probe_world, track_pos, track_quat)
 
-            stack = qd.Vector.zero(gs.qd_int, qd.static(_POINT_CLOUD_BVH_STACK_SIZE))
+            stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
             stack[0] = bvh_chunk_node_start[i_c]
             stack_idx = 1
 
             while stack_idx > 0:
                 stack_idx -= 1
                 n = stack[stack_idx]
-                bmin = _func_vec3_at(bvh_node_min, n)
-                bmax = _func_vec3_at(bvh_node_max, n)
-                if not _func_sphere_intersects_aabb(probe_link, R_query_sq, bmin, bmax):
+                bmin = func_vec3_at(bvh_node_min, n)
+                bmax = func_vec3_at(bvh_node_max, n)
+                if not func_sphere_intersects_aabb(probe_link, R_query_sq, bmin, bmax):
                     continue
                 left = bvh_node_left[n]
                 if left == -1:
-                    pstart = bvh_node_point_start[n]
-                    pn = bvh_node_point_n[n]
+                    pstart = bvh_node_leaf_start[n]
+                    pn = bvh_node_leaf_count[n]
                     for j in range(pn):
-                        i_o = bvh_point_idx[pstart + j]
+                        i_o = bvh_leaf_elem_idx[pstart + j]
                         if not pc_active_envs_mask[i_o, i_b]:
                             continue
-                        pos_l = _func_vec3_at(pc_pos_link, i_o)
+                        pos_l = func_vec3_at(pc_pos_link, i_o)
                         d_link = pos_l - probe_link
                         dsq = d_link.dot(d_link)
                         dist = qd.sqrt(dsq)
@@ -539,16 +493,26 @@ def _kernel_point_cloud_proximity_taxel_bvh(
                                         tau_w_m[k2] = tau_w_m[k2] + P_i_m * ctmp[k2]
                 else:
                     right = bvh_node_right[n]
-                    stack[stack_idx] = left
-                    stack_idx += 1
-                    stack[stack_idx] = right
-                    stack_idx += 1
+                    # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
+                    # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
+                    if stack_idx < qd.static(BVH_STACK_SIZE - 2):
+                        stack[stack_idx] = left
+                        stack[stack_idx + 1] = right
+                        stack_idx += 2
 
         if not use_noised_radius:
             sum_p_m = sum_p_gt
             for j in qd.static(range(3)):
                 fv_m[j] = fv_gt[j]
                 tau_w_m[j] = tau_w_gt[j]
+
+        # Per-(env, probe) gain on the measured-branch accumulated penetration. Force and torque computed from
+        # these accumulators downstream scale linearly with gain because they're proportional to ``sum_p``.
+        gain_m = probe_gains[i_b, i_p]
+        sum_p_m = sum_p_m * gain_m
+        for j in qd.static(range(3)):
+            fv_m[j] = fv_m[j] * gain_m
+            tau_w_m[j] = tau_w_m[j] * gain_m
 
         taxel_signal_buf[i_p, i_b] = sum_p_m
 
@@ -594,7 +558,7 @@ def _kernel_point_cloud_proximity_taxel_bvh(
 
 @dataclass
 class PointCloudTactileSharedMetadata(ProbeSensorMetadataMixin, RigidSensorMetadataMixin, SimpleSensorMetadata):
-    """Shared sensor-manager state for point-cloud–tracked tactile sensors (probes + merged track PC)."""
+    """Shared sensor-manager state for point-cloud-tracked tactile sensors (probes + merged track PC)."""
 
     pc_link_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     pc_pos_link: torch.Tensor = make_tensor_field((0, 3))
@@ -620,7 +584,6 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
         manager: "SensorManager",
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
-        self._debug_objects: list = []
         self._probe_start_idx = -1
         self._debug_pc_chunks: list[tuple[int, torch.Tensor, torch.Tensor]] | None = None
 
@@ -662,7 +625,7 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
             self._shared_metadata.sensor_pc_n, self._shared_metadata.pc_pos_link.shape[0] - pc_start_row, expand=(1,)
         )
 
-        # BVH growth follows pc_pos_link growth in lockstep: each leaf's point_idx is an absolute
+        # BVH growth follows pc_pos_link growth in lockstep: each leaf's leaf_elem_idx is an absolute
         # row into the just-grown pc_pos_link.
         self._shared_metadata.pc_bvh.append_sensor(
             pc_start_row=pc_start_row,
@@ -671,38 +634,24 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
         )
 
     def _draw_debug_probes(
-        self, context: "RasterizerContext", get_magnitude_1d: Callable[[list[int] | None], np.ndarray]
-    ) -> None:
-        for obj in self._debug_objects:
-            context.clear_debug_object(obj)
-        self._debug_objects.clear()
-
-        envs_idx, n_debug_envs, env_offsets, probe_world = self._compute_probes_world_pos(context)
-
-        magnitude = get_magnitude_1d(envs_idx).reshape(-1)
-        for is_contact in (False, True):
-            (probes_idx,) = np.nonzero(magnitude >= gs.EPS if is_contact else magnitude < gs.EPS)
-            if probes_idx.size == 0:
-                continue
-            spheres_obj = context.draw_debug_spheres(
-                poss=probe_world[probes_idx],
-                radius=self._shared_metadata.probe_radii[self._probe_start_idx].item(),
-                color=self._options.debug_contact_color if is_contact else self._options.debug_probe_color,
-            )
-            self._debug_objects.append(spheres_obj)
+        self,
+        context: "RasterizerContext",
+        color_groups_fn: Callable[[list[int] | None], list[tuple]] | None = None,
+    ) -> tuple[list[int] | None, int, np.ndarray | None]:
+        envs_idx, n_debug_envs, env_offsets = super()._draw_debug_probes(context, color_groups_fn)
 
         if self._debug_pc_chunks is None:
-            return
+            return envs_idx, n_debug_envs, env_offsets
         world_chunks: list[np.ndarray] = []
         for link_idx, pos_local, active_envs_mask in self._debug_pc_chunks:
-            trk_link = self._shared_metadata.solver.links[link_idx]
+            track_link = self._shared_metadata.solver.links[link_idx]
             if envs_idx is not None:
                 active_mask = tensor_to_array(active_envs_mask[:, envs_idx].T).astype(bool)
                 if not active_mask.any():
                     continue
-                trk_pos = trk_link.get_pos(envs_idx, relative=False)[:, None, :]
-                trk_quat = trk_link.get_quat(envs_idx, relative=False)[:, None, :]
-                pc_world = gu.transform_by_trans_quat(pos_local[None, :, :], trk_pos, trk_quat)
+                track_pos = track_link.get_pos(envs_idx, relative=False)[:, None, :]
+                track_quat = track_link.get_quat(envs_idx, relative=False)[:, None, :]
+                pc_world = gu.transform_by_trans_quat(pos_local[None, :, :], track_pos, track_quat)
                 pc_world = tensor_to_array(pc_world) + env_offsets[:, None, :]
                 world_chunks.append(pc_world[active_mask])
             else:
@@ -710,18 +659,18 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
                 pos_active = pos_local[active_mask]
                 if pos_active.numel() == 0:
                     continue
-                trk_pos = trk_link.get_pos(envs_idx, relative=False).reshape(3)
-                trk_quat = trk_link.get_quat(envs_idx, relative=False).reshape(4)
-                world_chunks.append(tensor_to_array(gu.transform_by_trans_quat(pos_active, trk_pos, trk_quat)))
-        if not world_chunks:
-            return
-        pc_world = np.concatenate(world_chunks, axis=0)
-        pc_obj = context.draw_debug_spheres(
-            poss=pc_world,
-            radius=float(self._options.debug_point_cloud_radius),
-            color=self._options.debug_point_cloud_color,
-        )
-        self._debug_objects.append(pc_obj)
+                track_pos = track_link.get_pos(envs_idx, relative=False).reshape(3)
+                track_quat = track_link.get_quat(envs_idx, relative=False).reshape(4)
+                world_chunks.append(tensor_to_array(gu.transform_by_trans_quat(pos_active, track_pos, track_quat)))
+        if world_chunks:
+            self._debug_objects.append(
+                context.draw_debug_spheres(
+                    poss=np.concatenate(world_chunks, axis=0),
+                    radius=float(self._options.debug_point_cloud_radius),
+                    color=self._options.debug_point_cloud_color,
+                )
+            )
+        return envs_idx, n_debug_envs, env_offsets
 
     def _debug_probe_buffer_magnitudes(self, buffer: torch.Tensor, envs_idx: list[int] | None) -> np.ndarray:
         values = buffer[self._probe_start_idx : self._probe_start_idx + self._n_probes]
@@ -738,7 +687,10 @@ class ProximityTaxelReturnType(NamedTuple):
 
 
 @dataclass
-class ProximityTaxelMetadata(PointCloudTactileSharedMetadata, ProbesWithNormalSensorMetadataMixin):
+class ProximityTaxelMetadata(
+    PointCloudTactileSharedMetadata,
+    ProbesWithNormalSensorMetadataMixin,
+):
     stiffness: torch.Tensor = make_tensor_field((0,))
     shear_coupling: torch.Tensor = make_tensor_field((0,))
     proximity_density_scale: torch.Tensor = make_tensor_field((0, 0))
@@ -776,7 +728,8 @@ class ProximityTaxelSensor(
         )
 
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return ((self._n_probes, 3), (self._n_probes, 3))
+        shape = (*self._probe_layout_shape, 3)
+        return shape, shape
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
@@ -797,13 +750,9 @@ class ProximityTaxelSensor(
         measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
-        current_ground_truth_data_T.zero_()
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.zero_()
-        if shared_metadata.measured_scratch_T.shape != current_ground_truth_data_T.shape:
-            shared_metadata.measured_scratch_T = torch.empty_like(current_ground_truth_data_T)
-        measured_cols_b = shared_metadata.measured_scratch_T
-
+        measured, measured_cols_b = get_measured_bufs(
+            shared_metadata, current_ground_truth_data_T, measured_data_timeline
+        )
         bvh = shared_metadata.pc_bvh
         _kernel_point_cloud_proximity_taxel_bvh(
             shared_metadata.probe_positions,
@@ -814,20 +763,21 @@ class ProximityTaxelSensor(
             shared_metadata.sensor_probe_start,
             shared_metadata.n_probes_per_sensor,
             bvh.sensor_chunk_start,
-            bvh.sensor_chunk_n,
+            bvh.sensor_chunk_count,
             bvh.chunk_link_idx,
             bvh.chunk_node_start,
             bvh.node_min,
             bvh.node_max,
             bvh.node_left,
             bvh.node_right,
-            bvh.node_point_start,
-            bvh.node_point_n,
-            bvh.point_idx,
+            bvh.node_leaf_start,
+            bvh.node_leaf_count,
+            bvh.leaf_elem_idx,
             shared_metadata.pc_pos_link,
             shared_metadata.pc_active_envs_mask,
             shared_metadata.probe_radii,
             shared_metadata.probe_radii_noise,
+            shared_metadata.probe_gains,
             shared_metadata.stiffness,
             shared_metadata.shear_coupling,
             shared_metadata.proximity_density_scale,
@@ -844,97 +794,12 @@ class ProximityTaxelSensor(
     def _draw_debug(self, context: "RasterizerContext"):
         self._draw_debug_probes(
             context,
-            lambda envs_idx: self._debug_probe_buffer_magnitudes(self._shared_metadata.taxel_signal_buf, envs_idx),
+            self._tactile_color_groups_fn(
+                lambda envs_idx: (
+                    self._debug_probe_buffer_magnitudes(self._shared_metadata.taxel_signal_buf, envs_idx) >= gs.EPS
+                ),
+            ),
         )
-
-
-_GRID_TOL = 1.0e-5
-
-
-def _next_pow2(n: int) -> int:
-    """Smallest power of 2 >= n (1 if n==0)."""
-    if n <= 1:
-        return 1
-    p = 1
-    while p < n:
-        p *= 2
-    return p
-
-
-def _expand_probe_normals(normals: np.ndarray, n_probes: int, probe_shape: tuple[int, ...]) -> np.ndarray:
-    normals = np.asarray(normals, dtype=gs.np_float)
-    if normals.ndim == 1:
-        return np.broadcast_to(normals, (n_probes, 3)).copy()
-    if normals.shape == (*probe_shape, 3):
-        return normals.reshape(n_probes, 3).copy()
-    if normals.shape == (n_probes, 3):
-        return normals.copy()
-    gs.raise_exception(
-        "ElastomerTaxel probe_local_normal must be one normal or match probe_local_pos shape. "
-        f"Got normal shape {normals.shape} for probe shape {probe_shape}."
-    )
-
-
-def _normalize_elastomer_probe_layout(
-    probe_pos: np.ndarray, probe_normals: np.ndarray, is_grid: bool
-) -> tuple[np.ndarray, np.ndarray, bool, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    probe_shape = probe_pos.shape[:-1]
-    flat = probe_pos.reshape(-1, 3)
-    normals = _expand_probe_normals(probe_normals, flat.shape[0], probe_shape)
-
-    normal_norms = np.linalg.norm(normals, axis=1)
-    if np.any(normal_norms < gs.EPS):
-        gs.raise_exception("ElastomerTaxel probe_local_normal entries must be non-zero.")
-    normals = normals / normal_norms[:, None]
-
-    use_grid_fft = False
-    grid_normal = np.zeros(3, dtype=gs.np_float)
-    tangent_u = np.zeros(3, dtype=gs.np_float)
-    tangent_v = np.zeros(3, dtype=gs.np_float)
-    grid_spacing = np.zeros(2, dtype=gs.np_float)
-
-    if is_grid:
-        if len(probe_shape) != 2:
-            gs.raise_exception("ElastomerTaxel grid probe_local_pos must have shape (ny, nx, 3).")
-        ny, nx = int(probe_shape[0]), int(probe_shape[1])
-        if nx >= 2 and ny >= 2:
-            grid = probe_pos.reshape(ny, nx, 3)
-            step_u = grid[0, 1] - grid[0, 0]
-            step_v = grid[1, 0] - grid[0, 0]
-            spacing_u = float(np.linalg.norm(step_u))
-            spacing_v = float(np.linalg.norm(step_v))
-            if spacing_u >= gs.EPS and spacing_v >= gs.EPS:
-                tangent_u_candidate = (step_u / spacing_u).astype(gs.np_float)
-                tangent_v_candidate = (step_v / spacing_v).astype(gs.np_float)
-                normal_candidate = normals[0].astype(gs.np_float, copy=False)
-                normals_are_uniform = bool(np.all(normals @ normal_candidate >= 1.0 - _GRID_TOL))
-                axes_are_orthogonal = abs(float(tangent_u_candidate @ tangent_v_candidate)) <= _GRID_TOL
-                axes_in_plane = (
-                    abs(float(tangent_u_candidate @ normal_candidate)) <= _GRID_TOL
-                    and abs(float(tangent_v_candidate @ normal_candidate)) <= _GRID_TOL
-                )
-                expected = (
-                    grid[0, 0]
-                    + np.arange(nx, dtype=gs.np_float)[None, :, None] * step_u[None, None, :]
-                    + np.arange(ny, dtype=gs.np_float)[:, None, None] * step_v[None, None, :]
-                )
-                is_regular = bool(np.max(np.linalg.norm(grid - expected, axis=-1)) <= _GRID_TOL)
-                use_grid_fft = normals_are_uniform and axes_are_orthogonal and axes_in_plane and is_regular
-                if use_grid_fft:
-                    grid_normal = normal_candidate
-                    tangent_u = tangent_u_candidate
-                    tangent_v = tangent_v_candidate
-                    grid_spacing = np.array((spacing_u, spacing_v), dtype=gs.np_float)
-
-    return (
-        flat.astype(gs.np_float, copy=False),
-        normals.astype(gs.np_float, copy=False),
-        use_grid_fft,
-        grid_normal.astype(gs.np_float, copy=False),
-        tangent_u.astype(gs.np_float, copy=False),
-        tangent_v.astype(gs.np_float, copy=False),
-        grid_spacing.astype(gs.np_float, copy=False),
-    )
 
 
 @qd.func
@@ -1008,17 +873,18 @@ def _func_elastomer_update_surface_anchor(
 @qd.func
 def _func_elastomer_direct_dilate_contribution(
     source_pos: qd.types.vector(3),
-    source_normal: qd.types.vector(3),
     target_pos: qd.types.vector(3),
     target_normal: qd.types.vector(3),
     depth: float,
     lam: float,
     scale: float,
+    normal_exponent: float,
 ) -> qd.types.vector(3):
-    source_contact_pos = source_pos - source_normal * depth
-    diff = target_pos - source_contact_pos
-    planar_diff = _func_elastomer_tangent(diff, target_normal)
-    return diff * depth * qd.exp(-lam * planar_diff.dot(planar_diff)) * scale
+    # Tangential marker spreading is linear in penetration depth; the out-of-plane bulge follows a
+    # ``depth ** normal_exponent`` power law (mirrors the FFT path's H / H**normal_exponent channel split).
+    planar_diff = _func_elastomer_tangent(target_pos - source_pos, target_normal)
+    falloff = qd.exp(-lam * planar_diff.dot(planar_diff)) * scale
+    return (planar_diff * depth + target_normal * qd.pow(depth, normal_exponent)) * falloff
 
 
 @qd.func
@@ -1062,19 +928,158 @@ def _collect_collision_geom_idx(solver, track_link_idx: np.ndarray) -> tuple[tor
 def _precompute_hydroshear_dilate_kernel_fft(
     lambda_d: float, grid_spacing: tuple[float, float], fft_n: tuple[int, int], device: torch.device, dtype: torch.dtype
 ) -> torch.Tensor:
-    i = torch.arange(fft_n[0], dtype=dtype, device=device)
-    j = torch.arange(fft_n[1], dtype=dtype, device=device)
-    xx, yy = torch.meshgrid((i - fft_n[0] // 2) * grid_spacing[0], (j - fft_n[1] // 2) * grid_spacing[1], indexing="ij")
-    g = torch.exp(torch.tensor(-lambda_d, dtype=dtype, device=device) * (xx * xx + yy * yy))
-    k = torch.stack((xx * g, yy * g, g), dim=0)
+    """Real FFT of the 3-plane HydroShear dilation kernel ``(Ku, Kv, Kn)``.
+
+    ``fft_n`` is ``(fft_ny, fft_nx)`` row-major: axis 0 spans the tangent_v direction, axis 1 the tangent_u
+    direction. ``grid_spacing`` is ``(spacing_u, spacing_v)``. The output is a complex
+    ``(3, fft_ny, fft_nx // 2 + 1)`` half-spectrum ready to multiply against ``rfft2(field)``.
+    """
+    iv = torch.arange(fft_n[0], dtype=dtype, device=device)
+    iu = torch.arange(fft_n[1], dtype=dtype, device=device)
+    vv, uu = torch.meshgrid(
+        (iv - fft_n[0] // 2) * grid_spacing[1], (iu - fft_n[1] // 2) * grid_spacing[0], indexing="ij"
+    )
+    g = torch.exp(torch.tensor(-lambda_d, dtype=dtype, device=device) * (uu * uu + vv * vv))
+    k = torch.stack((uu * g, vv * g, g), dim=0)
     k = torch.fft.ifftshift(k, dim=(-2, -1))
-    return torch.fft.fft2(k)
+    return torch.fft.rfft2(k)
+
+
+def _dilate_kernel_builder(meta_entry: GridFFTMeta, fft_n: tuple[int, int]) -> torch.Tensor:
+    """``register_grid_fft_sensor`` kernel builder for HydroShear dilation: 3 planes ``(Ku, Kv, Kn)``."""
+    return _precompute_hydroshear_dilate_kernel_fft(
+        meta_entry.lambda_d, (meta_entry.spacing_u, meta_entry.spacing_v), fft_n, gs.device, gs.tc_float
+    )
+
+
+@qd.func
+def _func_elastomer_min_signed_dist_bvh(
+    i_b: int,
+    i_s: int,
+    probe_world: qd.types.vector(3),
+    max_query_dist: float,
+    bvh_nodes: qd.template(),
+    bvh_morton_codes: qd.template(),
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    track_geom_mask: qd.types.ndarray(),
+) -> float:
+    """
+    BVH-based signed distance from ``probe_world`` to the nearest triangle of any geom flagged for this sensor in
+    ``track_geom_mask`` (shape ``(B, n_sensors, n_geoms)``). Sign is positive when the probe is outside the surface
+    (closest-triangle face-normal points away from probe), negative when inside. Mirrors the return contract of
+    ``_func_elastomer_min_sdf_over_active_geoms`` so callers consume ``max(0, -signed)`` identically.
+
+    Uses ``max_query_dist`` as the BVH cull radius: probes farther than that from every candidate triangle are
+    treated as fully outside (returns ``+max_query_dist``), which downstream maps to depth = 0.
+    """
+    n_triangles = faces_info.verts_idx.shape[0]
+    best_dist = max_query_dist
+    best_dist_sq = best_dist * best_dist
+    best_signed = max_query_dist
+
+    node_stack = qd.Vector.zero(gs.qd_int, qd.static(_BVH_STACK_SIZE))
+    node_stack[0] = 0
+    stack_idx = 1
+
+    while stack_idx > 0:
+        stack_idx -= 1
+        node_idx = node_stack[stack_idx]
+        node = bvh_nodes[i_b, node_idx]
+
+        if not func_sphere_intersects_aabb(probe_world, best_dist_sq, node.bound.min, node.bound.max):
+            continue
+
+        if node.left == -1:
+            sorted_leaf_idx = node_idx - (n_triangles - 1)
+            i_f = qd.cast(bvh_morton_codes[i_b, sorted_leaf_idx][1], gs.qd_int)
+            i_g = faces_info.geom_idx[i_f]
+            if not track_geom_mask[i_b, i_s, i_g]:
+                continue
+
+            tri = get_triangle_vertices(i_f, i_b, faces_info, verts_info, fixed_verts_state, free_verts_state)
+            v0 = tri[:, 0]
+            v1 = tri[:, 1]
+            v2 = tri[:, 2]
+            closest = closest_point_on_triangle(probe_world, v0, v1, v2)
+            diff = probe_world - closest
+            d_sq = diff.dot(diff)
+            if d_sq < best_dist_sq:
+                d = qd.sqrt(d_sq)
+                fn = triangle_face_normal(v0, v1, v2)
+                # Sign: probe outside if (probe - closest) aligns with outward face normal.
+                sign_v = qd.select(diff.dot(fn) >= gs.qd_float(0.0), gs.qd_float(1.0), gs.qd_float(-1.0))
+                best_signed = d * sign_v
+                best_dist = d
+                best_dist_sq = d_sq
+        else:
+            if stack_idx < qd.static(_BVH_STACK_SIZE - 2):
+                node_stack[stack_idx] = node.left
+                node_stack[stack_idx + 1] = node.right
+                stack_idx += 2
+
+    return best_signed
+
+
+@qd.kernel(fastcache=False)
+def _kernel_elastomer_probe_depth_bvh(
+    probe_positions_local: qd.types.ndarray(),
+    probe_sensor_idx: qd.types.ndarray(),
+    probe_radii: qd.types.ndarray(),
+    links_idx: qd.types.ndarray(),
+    track_geom_mask: qd.types.ndarray(),
+    max_query_dist: float,
+    bvh_nodes: qd.template(),
+    bvh_morton_codes: qd.template(),
+    links_state: array_class.LinksState,
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    probe_depth_buf: qd.types.ndarray(),
+):
+    """
+    Per-probe contact depth from the rigid solver's global collision BVH, gated by ``track_geom_mask``. Mirrors
+    ``_kernel_elastomer_probe_depth``'s output contract (write into ``probe_depth_buf``); the dilate accumulator
+    consumes the same buffer downstream.
+    """
+    total_n_probes = probe_positions_local.shape[0]
+    n_batches = probe_depth_buf.shape[0]
+
+    for i_b, i_p in qd.ndrange(n_batches, total_n_probes):
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            probe_depth_buf[i_b, i_p] = gs.qd_float(0.0)
+            continue
+        i_s = probe_sensor_idx[i_p]
+        sensor_link_idx = links_idx[i_s]
+        link_pos = links_state.pos[sensor_link_idx, i_b]
+        link_quat = links_state.quat[sensor_link_idx, i_b]
+        probe_local = func_vec3_at(probe_positions_local, i_p)
+        probe_world = link_pos + gu.qd_transform_by_quat(probe_local, link_quat)
+
+        signed = _func_elastomer_min_signed_dist_bvh(
+            i_b,
+            i_s,
+            probe_world,
+            max_query_dist,
+            bvh_nodes,
+            bvh_morton_codes,
+            faces_info,
+            verts_info,
+            fixed_verts_state,
+            free_verts_state,
+            track_geom_mask,
+        )
+        probe_depth_buf[i_b, i_p] = qd.max(gs.qd_float(0.0), -signed)
 
 
 @qd.kernel(fastcache=True)
 def _kernel_elastomer_probe_depth(
     probe_positions_local: qd.types.ndarray(),
     probe_sensor_idx: qd.types.ndarray(),
+    probe_radii: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),
     sensor_track_geom_start: qd.types.ndarray(),
     sensor_track_geom_n: qd.types.ndarray(),
@@ -1093,11 +1098,15 @@ def _kernel_elastomer_probe_depth(
     n_batches = probe_depth_buf.shape[0]
 
     for i_b, i_p in qd.ndrange(n_batches, total_n_probes):
+        # Inactive filler probe: no SDF query, contributes no dilation.
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            probe_depth_buf[i_b, i_p] = gs.qd_float(0.0)
+            continue
         i_s = probe_sensor_idx[i_p]
         sensor_link_idx = links_idx[i_s]
         link_pos = links_state.pos[sensor_link_idx, i_b]
         link_quat = links_state.quat[sensor_link_idx, i_b]
-        probe_local = _func_vec3_at(probe_positions_local, i_p)
+        probe_local = func_vec3_at(probe_positions_local, i_p)
         probe_world = link_pos + gu.qd_transform_by_quat(probe_local, link_quat)
 
         min_sdf = _func_elastomer_min_sdf_over_active_geoms(
@@ -1121,11 +1130,13 @@ def _kernel_elastomer_dilate_accumulate(
     probe_positions_local: qd.types.ndarray(),
     probe_local_normal: qd.types.ndarray(),
     probe_sensor_idx: qd.types.ndarray(),
+    probe_radii: qd.types.ndarray(),
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
     n_probes_per_sensor: qd.types.ndarray(),
     lambda_d: qd.types.ndarray(),
     dilate_scale: qd.types.ndarray(),
+    normal_exponent: qd.types.ndarray(),
     probe_depth_buf: qd.types.ndarray(),
     output: qd.types.ndarray(),
 ):
@@ -1146,10 +1157,17 @@ def _kernel_elastomer_dilate_accumulate(
         cache_start = sensor_cache_start[i_s]
         lam = lambda_d[i_s]
         scale = dilate_scale[i_s]
+        n_exp = normal_exponent[i_s]
         _i_p = i_p - probe_start
 
-        target_local = _func_vec3_at(probe_positions_local, i_p)
-        target_normal = _func_vec3_at(probe_local_normal, i_p)
+        # Inactive filler probe (probe_radius == 0): reads zero, no dilation accumulated.
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            for k in qd.static(range(3)):
+                output[cache_start + _i_p * 3 + k, i_b] = gs.qd_float(0.0)
+            continue
+
+        target_local = func_vec3_at(probe_positions_local, i_p)
+        target_normal = func_vec3_at(probe_local_normal, i_p)
 
         acc = qd.Vector.zero(gs.qd_float, 3)
         for j in range(n_probes):
@@ -1158,13 +1176,13 @@ def _kernel_elastomer_dilate_accumulate(
             if src_depth <= gs.qd_float(0.0):
                 continue
             contribution = _func_elastomer_direct_dilate_contribution(
-                _func_vec3_at(probe_positions_local, j_p),
-                _func_vec3_at(probe_local_normal, j_p),
+                func_vec3_at(probe_positions_local, j_p),
                 target_local,
                 target_normal,
                 src_depth,
                 lam,
                 scale,
+                n_exp,
             )
             for k in qd.static(range(3)):
                 acc[k] = acc[k] + contribution[k]
@@ -1187,9 +1205,9 @@ def _kernel_elastomer_surface_state_bvh(
     bvh_node_max: qd.types.ndarray(),
     bvh_node_left: qd.types.ndarray(),
     bvh_node_right: qd.types.ndarray(),
-    bvh_node_point_start: qd.types.ndarray(),
-    bvh_node_point_n: qd.types.ndarray(),
-    bvh_point_idx: qd.types.ndarray(),
+    bvh_node_leaf_start: qd.types.ndarray(),
+    bvh_node_leaf_count: qd.types.ndarray(),
+    bvh_leaf_elem_idx: qd.types.ndarray(),
     pc_pos_link: qd.types.ndarray(),
     pc_active_envs_mask: qd.types.ndarray(),
     sdf_enter: qd.types.ndarray(),
@@ -1208,10 +1226,10 @@ def _kernel_elastomer_surface_state_bvh(
     """Per-(env, chunk): compute the chunk-local query AABB in registers, BVH-traverse, and write
     per-candidate surface state.
 
-    Merges what was previously two kernels (per-chunk AABB fill + BVH traversal) so the AABB stays
-    in thread-local state instead of round-tripping through a (B, n_chunks, 3) buffer. No probe
-    work happens here -- the shear contribution is accumulated in a separate target-major kernel
-    that reads surface_pos_sensor_buf / surface_depth_buf / surface_entry_pos_sensor_buf.
+    The AABB fill and BVH traversal share one kernel so the AABB stays in thread-local state instead of
+    round-tripping through a (B, n_chunks, 3) buffer. No probe work happens here -- the shear contribution is
+    accumulated in a separate target-major kernel that reads surface_pos_sensor_buf / surface_depth_buf /
+    surface_entry_pos_sensor_buf.
     """
     n_batches = surface_pos_sensor_buf.shape[0]
     n_chunks = bvh_chunk_sensor_idx.shape[0]
@@ -1274,28 +1292,28 @@ def _kernel_elastomer_surface_state_bvh(
         sensor_pos = links_state.pos[sensor_link_idx, i_b]
         sensor_quat = links_state.quat[sensor_link_idx, i_b]
 
-        stack = qd.Vector.zero(gs.qd_int, qd.static(_POINT_CLOUD_BVH_STACK_SIZE))
+        stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
         stack[0] = bvh_chunk_node_start[i_c]
         stack_idx = 1
 
         while stack_idx > 0:
             stack_idx -= 1
             n = stack[stack_idx]
-            bmin = _func_vec3_at(bvh_node_min, n)
-            bmax = _func_vec3_at(bvh_node_max, n)
-            if not _func_aabb_intersects_aabb(bmin, bmax, qmin, qmax):
+            bmin = func_vec3_at(bvh_node_min, n)
+            bmax = func_vec3_at(bvh_node_max, n)
+            if not func_aabb_intersects_aabb(bmin, bmax, qmin, qmax):
                 continue
             left = bvh_node_left[n]
             if left == -1:
-                pstart = bvh_node_point_start[n]
-                pn = bvh_node_point_n[n]
+                pstart = bvh_node_leaf_start[n]
+                pn = bvh_node_leaf_count[n]
                 for j in range(pn):
-                    i_o = bvh_point_idx[pstart + j]
+                    i_o = bvh_leaf_elem_idx[pstart + j]
                     if not pc_active_envs_mask[i_o, i_b]:
                         continue
                     surface_candidate_buf[i_b, i_o] = True
 
-                    point_link = _func_vec3_at(pc_pos_link, i_o)
+                    point_link = func_vec3_at(pc_pos_link, i_o)
                     point_world = track_pos + gu.qd_transform_by_quat(point_link, track_quat)
                     point_sensor = gu.qd_inv_transform_by_trans_quat(point_world, sensor_pos, sensor_quat)
                     for k in qd.static(range(3)):
@@ -1327,10 +1345,175 @@ def _kernel_elastomer_surface_state_bvh(
                     )
             else:
                 right = bvh_node_right[n]
-                stack[stack_idx] = left
-                stack_idx += 1
-                stack[stack_idx] = right
-                stack_idx += 1
+                # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
+                # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
+                if stack_idx < qd.static(BVH_STACK_SIZE - 2):
+                    stack[stack_idx] = left
+                    stack[stack_idx + 1] = right
+                    stack_idx += 2
+
+
+@qd.kernel(fastcache=False)
+def _kernel_elastomer_surface_state_via_global_bvh(
+    links_idx: qd.types.ndarray(),
+    sensor_elastomer_geom_start: qd.types.ndarray(),
+    sensor_elastomer_geom_n: qd.types.ndarray(),
+    elastomer_geom_idx: qd.types.ndarray(),
+    elastomer_geom_active_envs_mask: qd.types.ndarray(),
+    elastomer_candidate_geom_mask: qd.types.ndarray(),
+    bvh_chunk_sensor_idx: qd.types.ndarray(),
+    bvh_chunk_link_idx: qd.types.ndarray(),
+    bvh_chunk_node_start: qd.types.ndarray(),
+    bvh_node_min: qd.types.ndarray(),
+    bvh_node_max: qd.types.ndarray(),
+    bvh_node_left: qd.types.ndarray(),
+    bvh_node_right: qd.types.ndarray(),
+    bvh_node_leaf_start: qd.types.ndarray(),
+    bvh_node_leaf_count: qd.types.ndarray(),
+    bvh_leaf_elem_idx: qd.types.ndarray(),
+    pc_pos_link: qd.types.ndarray(),
+    pc_active_envs_mask: qd.types.ndarray(),
+    sdf_enter: qd.types.ndarray(),
+    sdf_exit: qd.types.ndarray(),
+    aabb_margin: float,
+    max_query_dist: float,
+    global_bvh_nodes: qd.template(),
+    global_bvh_morton_codes: qd.template(),
+    links_state: array_class.LinksState,
+    geoms_state: array_class.GeomsState,
+    faces_info: array_class.FacesInfo,
+    verts_info: array_class.VertsInfo,
+    fixed_verts_state: array_class.VertsState,
+    free_verts_state: array_class.VertsState,
+    surface_pos_sensor_buf: qd.types.ndarray(),
+    surface_entry_pos_sensor_buf: qd.types.ndarray(),
+    surface_depth_buf: qd.types.ndarray(),
+    surface_initialized_buf: qd.types.ndarray(),
+    surface_candidate_buf: qd.types.ndarray(),
+):
+    """
+    Raycast variant of ``_kernel_elastomer_surface_state_bvh``: same outer (env, chunk) traversal over the point-cloud
+    BVH per tracked link, but the inner signed-distance query at each PC point uses
+    ``_func_elastomer_min_signed_dist_bvh`` over the rigid solver's global collision BVH (gated by
+    ``elastomer_candidate_geom_mask``) instead of the analytic SDF. Output contract matches the SDF variant so the
+    dilate / shear pipeline downstream is unchanged.
+    """
+    n_batches = surface_pos_sensor_buf.shape[0]
+    n_chunks = bvh_chunk_sensor_idx.shape[0]
+
+    for i_b, i_c in qd.ndrange(n_batches, n_chunks):
+        i_s = bvh_chunk_sensor_idx[i_c]
+
+        wmin = qd.Vector([gs.qd_float(1e30), gs.qd_float(1e30), gs.qd_float(1e30)], dt=gs.qd_float)
+        wmax = qd.Vector([gs.qd_float(-1e30), gs.qd_float(-1e30), gs.qd_float(-1e30)], dt=gs.qd_float)
+        any_active = False
+        gm_start = sensor_elastomer_geom_start[i_s]
+        gm_n = sensor_elastomer_geom_n[i_s]
+        for i_gm in range(gm_start, gm_start + gm_n):
+            if not elastomer_geom_active_envs_mask[i_gm, i_b]:
+                continue
+            i_g = elastomer_geom_idx[i_gm]
+            gmin = geoms_state.aabb_min[i_g, i_b]
+            gmax = geoms_state.aabb_max[i_g, i_b]
+            for k in qd.static(range(3)):
+                if gmin[k] < wmin[k]:
+                    wmin[k] = gmin[k]
+                if gmax[k] > wmax[k]:
+                    wmax[k] = gmax[k]
+            any_active = True
+
+        if not any_active:
+            continue
+
+        expand = sdf_exit[i_s] + gs.qd_float(aabb_margin)
+        for k in qd.static(range(3)):
+            wmin[k] = wmin[k] - expand
+            wmax[k] = wmax[k] + expand
+
+        track_link_idx = bvh_chunk_link_idx[i_c]
+        track_pos = links_state.pos[track_link_idx, i_b]
+        track_quat = links_state.quat[track_link_idx, i_b]
+        qmin = qd.Vector([gs.qd_float(1e30), gs.qd_float(1e30), gs.qd_float(1e30)], dt=gs.qd_float)
+        qmax = qd.Vector([gs.qd_float(-1e30), gs.qd_float(-1e30), gs.qd_float(-1e30)], dt=gs.qd_float)
+        for cx in qd.static(range(2)):
+            for cy in qd.static(range(2)):
+                for cz in qd.static(range(2)):
+                    cw_x = wmax[0] if cx == 1 else wmin[0]
+                    cw_y = wmax[1] if cy == 1 else wmin[1]
+                    cw_z = wmax[2] if cz == 1 else wmin[2]
+                    corner_world = qd.Vector([cw_x, cw_y, cw_z], dt=gs.qd_float)
+                    corner_link = gu.qd_inv_transform_by_trans_quat(corner_world, track_pos, track_quat)
+                    for k in qd.static(range(3)):
+                        if corner_link[k] < qmin[k]:
+                            qmin[k] = corner_link[k]
+                        if corner_link[k] > qmax[k]:
+                            qmax[k] = corner_link[k]
+
+        sensor_link_idx = links_idx[i_s]
+        sensor_pos = links_state.pos[sensor_link_idx, i_b]
+        sensor_quat = links_state.quat[sensor_link_idx, i_b]
+
+        stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
+        stack[0] = bvh_chunk_node_start[i_c]
+        stack_idx = 1
+
+        while stack_idx > 0:
+            stack_idx -= 1
+            n = stack[stack_idx]
+            bmin = func_vec3_at(bvh_node_min, n)
+            bmax = func_vec3_at(bvh_node_max, n)
+            if not func_aabb_intersects_aabb(bmin, bmax, qmin, qmax):
+                continue
+            left = bvh_node_left[n]
+            if left == -1:
+                pstart = bvh_node_leaf_start[n]
+                pn = bvh_node_leaf_count[n]
+                for j in range(pn):
+                    i_o = bvh_leaf_elem_idx[pstart + j]
+                    if not pc_active_envs_mask[i_o, i_b]:
+                        continue
+                    surface_candidate_buf[i_b, i_o] = True
+
+                    point_link = func_vec3_at(pc_pos_link, i_o)
+                    point_world = track_pos + gu.qd_transform_by_quat(point_link, track_quat)
+                    point_sensor = gu.qd_inv_transform_by_trans_quat(point_world, sensor_pos, sensor_quat)
+                    for k in qd.static(range(3)):
+                        surface_pos_sensor_buf[i_b, i_o, k] = point_sensor[k]
+
+                    min_sdf = _func_elastomer_min_signed_dist_bvh(
+                        i_b,
+                        i_s,
+                        point_world,
+                        max_query_dist,
+                        global_bvh_nodes,
+                        global_bvh_morton_codes,
+                        faces_info,
+                        verts_info,
+                        fixed_verts_state,
+                        free_verts_state,
+                        elastomer_candidate_geom_mask,
+                    )
+
+                    surface_depth_buf[i_b, i_o] = qd.max(gs.qd_float(0.0), -min_sdf)
+
+                    _func_elastomer_update_surface_anchor(
+                        i_b,
+                        i_o,
+                        min_sdf,
+                        point_sensor,
+                        sdf_enter[i_s],
+                        sdf_exit[i_s],
+                        surface_entry_pos_sensor_buf,
+                        surface_initialized_buf,
+                    )
+            else:
+                right = bvh_node_right[n]
+                # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
+                # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
+                if stack_idx < qd.static(BVH_STACK_SIZE - 2):
+                    stack[stack_idx] = left
+                    stack[stack_idx + 1] = right
+                    stack_idx += 2
 
 
 @qd.kernel(fastcache=True)
@@ -1338,26 +1521,28 @@ def _kernel_elastomer_shear_accumulate(
     probe_positions_local: qd.types.ndarray(),
     probe_local_normal: qd.types.ndarray(),
     probe_sensor_idx: qd.types.ndarray(),
+    probe_radii: qd.types.ndarray(),
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
     sensor_pc_start: qd.types.ndarray(),
-    sensor_pc_n: qd.types.ndarray(),
     lambda_s: qd.types.ndarray(),
     shear_scale: qd.types.ndarray(),
     eps: float,
     surface_pos_sensor_buf: qd.types.ndarray(),
     surface_entry_pos_sensor_buf: qd.types.ndarray(),
     surface_depth_buf: qd.types.ndarray(),
-    surface_initialized_buf: qd.types.ndarray(),
+    shear_active_pc_idx: qd.types.ndarray(),
+    shear_active_pc_count: qd.types.ndarray(),
     output: qd.types.ndarray(),
 ):
-    """Target-major shear accumulator: per (env, target_probe), iterate over the sensor's pc rows
-    that are flagged ``surface_initialized`` and sum Gaussian contributions into a register, then
-    += the result into ``output``. No atomic_add (each (i_b, i_p) thread owns its output slot).
+    """Target-major shear accumulator: per (env, target_probe), iterate over the sensor's compact
+    active surface-point index and sum Gaussian contributions into a register, then += the result
+    into ``output``. No atomic_add (each (i_b, i_p) thread owns its output slot).
 
-    Must run after the surface-state kernel AND after the Patch-3 torch cleanup that invalidates
-    ``surface_initialized_buf`` for BVH-pruned points -- otherwise stale True flags from prior
-    steps would corrupt this step's accumulation.
+    Consumes the compact index produced by ``_build_shear_active_pc_index`` (must run after the
+    surface-state kernel AND after the post-kernel ``surface_initialized_buf &= candidate`` cleanup).
+    Inner-loop cost is O(active_count[i_b, i_s]) rather than O(sensor_pc_n[i_s]), so the kernel scales
+    with contact density rather than total point-cloud size.
     """
     total_n_probes = probe_positions_local.shape[0]
     n_batches = surface_pos_sensor_buf.shape[0]
@@ -1367,19 +1552,21 @@ def _kernel_elastomer_shear_accumulate(
         scale = shear_scale[i_s]
         if scale <= gs.qd_float(0.0):
             continue
+        # Inactive filler probe: dilate already wrote 0 to this output slot.
+        if probe_radii[i_p] <= gs.qd_float(0.0):
+            continue
         lam = lambda_s[i_s]
         cache_start = sensor_cache_start[i_s]
         _i_p = i_p - sensor_probe_start[i_s]
         pc_start = sensor_pc_start[i_s]
-        pc_end = pc_start + sensor_pc_n[i_s]
+        n_active = shear_active_pc_count[i_b, i_s]
 
-        probe_local = _func_vec3_at(probe_positions_local, i_p)
-        probe_normal = _func_vec3_at(probe_local_normal, i_p)
+        probe_local = func_vec3_at(probe_positions_local, i_p)
+        probe_normal = func_vec3_at(probe_local_normal, i_p)
 
         acc = qd.Vector.zero(gs.qd_float, 3)
-        for i_o in range(pc_start, pc_end):
-            if not surface_initialized_buf[i_b, i_o]:
-                continue
+        for j in range(n_active):
+            i_o = shear_active_pc_idx[i_b, pc_start + j]
             depth = surface_depth_buf[i_b, i_o]
             if depth <= eps:
                 continue
@@ -1416,12 +1603,59 @@ def _kernel_elastomer_shear_accumulate(
             output[cache_start + _i_p * 3 + k, i_b] = output[cache_start + _i_p * 3 + k, i_b] + acc[k]
 
 
+def _build_shear_active_pc_index(
+    surface_initialized_buf: torch.Tensor,
+    sensor_pc_start: torch.Tensor,
+    sensor_pc_n: torch.Tensor,
+    shear_scale: torch.Tensor,
+    active_pc_idx: torch.Tensor,
+    active_pc_count: torch.Tensor,
+) -> None:
+    """Build the compact per-(env, sensor) active surface-point index consumed by
+    ``_kernel_elastomer_shear_accumulate``. Mutates ``active_pc_idx`` and ``active_pc_count`` in place.
+
+    For each sensor ``s`` with ``shear_scale[s] > 0``, gathers the indices of True entries in
+    ``surface_initialized_buf[:, pc_start[s] : pc_start[s] + pc_n[s]]`` into the per-sensor compact slice
+    ``active_pc_idx[:, pc_start[s] : pc_start[s] + active_count[:, s]]``; the per-(env, sensor) active
+    count is written to ``active_pc_count[:, s]``. Sensors with ``shear_scale == 0`` are skipped and
+    their count is left at zero so the kernel's outer early-exit handles them with no extra work.
+
+    Uses exclusive cumsum + ``torch.nonzero`` for the per-sensor scatter so per-env Python loops are
+    avoided; cost is ~O(B * total_n_surface) torch ops over the whole pass.
+    """
+    active_pc_count.zero_()
+    n_sensors = sensor_pc_start.shape[0]
+    if n_sensors == 0:
+        return
+    # Single host sync up front so the per-sensor loop is metadata-only on the Python side.
+    pc_starts = sensor_pc_start.tolist()
+    pc_ns = sensor_pc_n.tolist()
+    scales = shear_scale.tolist()
+    idx_dtype = active_pc_idx.dtype
+    for i_s in range(n_sensors):
+        if scales[i_s] <= 0.0:
+            continue
+        pc_start = int(pc_starts[i_s])
+        pc_n = int(pc_ns[i_s])
+        if pc_n == 0:
+            continue
+        mask = surface_initialized_buf[:, pc_start : pc_start + pc_n]  # (B, pc_n) bool
+        int_mask = mask.to(idx_dtype)
+        write_pos = torch.cumsum(int_mask, dim=1) - int_mask  # exclusive cumsum
+        active_pc_count[:, i_s] = int_mask.sum(dim=1)
+        bs, js = torch.nonzero(mask, as_tuple=True)
+        if bs.numel() > 0:
+            active_pc_idx[bs, pc_start + write_pos[bs, js]] = (pc_start + js).to(idx_dtype)
+
+
 def _elastomer_taxel_grid_fft_dilate(
-    fft_grid_meta: list[tuple[int, int, int, int, int, float, float, float]],
-    fft_grid_kernels_stacked: torch.Tensor,
+    grid_fft_meta: list[GridFFTMeta],
+    grid_fft_kernels_stacked: torch.Tensor,
     probe_depth_buf: torch.Tensor,
-    fft_depth_buffer: torch.Tensor,
+    probe_radii: torch.Tensor,
+    grid_fft_buffer: torch.Tensor,
     dilate_scale: torch.Tensor,
+    normal_exponent: torch.Tensor,
     grid_normal: torch.Tensor,
     grid_tangent_u: torch.Tensor,
     grid_tangent_v: torch.Tensor,
@@ -1431,59 +1665,74 @@ def _elastomer_taxel_grid_fft_dilate(
     """
     Elastomer marker dilation via 2D FFT in the validated probe tangent basis.
 
-    All grid sensors share the global ``fft_max_n`` (= last two dims of ``fft_depth_buffer``); their
-    kernels are stacked into ``fft_grid_kernels_stacked`` of shape (n_grid, 3, fft_max_n[0],
-    fft_max_n[1]). The four heavy FFTs (fft of H, fft of H*H, ifft for Kx/Ky/Kn) thus run as
-    batched ops over the grid-sensor axis, dropping launches from 4·n_grid to 4. The H-fill and
-    write-back stages remain per-sensor (small Python loops over view/copy and per-sensor tangent
-    decomposition).
+    All grid sensors share the global ``grid_fft_max_n`` (= last two dims of ``grid_fft_buffer``); their
+    kernels are stacked into ``grid_fft_kernels_stacked`` of shape (n_grid, 3, fft_ny, fft_nx). The four heavy
+    FFTs (fft of H, fft of H**normal_exponent, ifft for Ku/Kv/Kn) thus run as batched ops over the grid-sensor
+    axis, dropping
+    launches from 4*n_grid to 4. The H-fill and write-back stages remain per-sensor (small Python loops over
+    view/copy and per-sensor tangent decomposition). Grid axes are ``(ny, nx)`` row-major throughout (matching
+    the probe flat index ``iy * nx + ix``), so no transpose is needed on either the fill or write-back side.
     """
-    if not fft_grid_meta:
+    if not grid_fft_meta:
         return
     n_batches = probe_depth_buf.shape[0]
+    fft_ny, fft_nx = grid_fft_buffer.shape[-2], grid_fft_buffer.shape[-1]
 
-    # 1) Fill the (B, n_grid, fft_max_nx, fft_max_ny) depth buffer. Per-sensor view+copy only.
-    fft_depth_buffer.zero_()
-    for grid_pos, (_, g_nx, g_ny, probe_start, _, _, _, _) in enumerate(fft_grid_meta):
-        depth_slice = probe_depth_buf[:, probe_start : probe_start + g_nx * g_ny]
-        fft_depth_buffer[:, grid_pos, :g_nx, :g_ny].copy_(depth_slice.view(n_batches, g_ny, g_nx).transpose(1, 2))
+    # 1) Fill the active region of the (B, n_grid, fft_ny, fft_nx) depth buffer. The zero-padding region is never
+    # written here and stays zero from allocation, so no per-step ``zero_()`` is needed.
+    for grid_pos, meta in enumerate(grid_fft_meta):
+        depth_slice = probe_depth_buf[:, meta.probe_start : meta.probe_start + meta.g_ny * meta.g_nx]
+        grid_fft_buffer[:, grid_pos, : meta.g_ny, : meta.g_nx].copy_(depth_slice.view(n_batches, meta.g_ny, meta.g_nx))
 
-    # 2) Batched FFTs across (B, n_grid). Broadcast over B when multiplying by per-sensor kernels.
-    H_fft = torch.fft.fft2(fft_depth_buffer)
-    H2_fft = torch.fft.fft2(fft_depth_buffer * fft_depth_buffer)
-    Kx_all = fft_grid_kernels_stacked[:, 0]  # (n_grid, fft_max_nx, fft_max_ny) complex
-    Ky_all = fft_grid_kernels_stacked[:, 1]
-    Kn_all = fft_grid_kernels_stacked[:, 2]
-    disp_u_all = torch.fft.ifft2(H_fft * Kx_all).real  # (B, n_grid, fft_max_nx, fft_max_ny)
-    disp_v_all = torch.fft.ifft2(H_fft * Ky_all).real
-    disp_n_all = torch.fft.ifft2(H2_fft * Kn_all).real
+    # 2) Batched real FFTs across (B, n_grid). Inputs are real so ``rfft2`` (half spectrum) is ~2x cheaper than the
+    # full complex ``fft2``. Kernels broadcast over B when multiplying.
+    H_fft = torch.fft.rfft2(grid_fft_buffer)
+    # The normal channel follows depth ** normal_exponent, so it convolves the per-grid powered depth field;
+    # the tangential (u, v) channels stay linear in depth and convolve the raw field H.
+    exps = normal_exponent[[meta.sensor_idx for meta in grid_fft_meta]].reshape(1, -1, 1, 1)
+    Hp_fft = torch.fft.rfft2(grid_fft_buffer.pow(exps))
+    Ku_all = grid_fft_kernels_stacked[:, 0]  # (n_grid, fft_ny, fft_nx // 2 + 1) complex
+    Kv_all = grid_fft_kernels_stacked[:, 1]
+    Kn_all = grid_fft_kernels_stacked[:, 2]
+    disp_u_all = torch.fft.irfft2(H_fft * Ku_all, s=(fft_ny, fft_nx))  # (B, n_grid, fft_ny, fft_nx)
+    disp_v_all = torch.fft.irfft2(H_fft * Kv_all, s=(fft_ny, fft_nx))
+    disp_n_all = torch.fft.irfft2(Hp_fft * Kn_all, s=(fft_ny, fft_nx))
 
-    # 3) Per-sensor write-back: slice to (g_nx, g_ny), apply scale + tangent decomposition, copy
+    # 3) Per-sensor write-back: slice to (g_ny, g_nx), apply scale + tangent decomposition, copy
     # into the sensor's output range. Tangent vectors are per-sensor so can't trivially batch here.
-    for grid_pos, meta in enumerate(fft_grid_meta):
-        sensor_idx, g_nx, g_ny, _, cache_start, _, _, _ = meta
+    for grid_pos, meta in enumerate(grid_fft_meta):
+        sensor_idx, g_ny, g_nx = meta.sensor_idx, meta.g_ny, meta.g_nx
+        probe_start, cache_start = meta.probe_start, meta.cache_start
         scale_s = dilate_scale[sensor_idx]
-        disp_u = disp_u_all[:, grid_pos, :g_nx, :g_ny] * scale_s
-        disp_v = disp_v_all[:, grid_pos, :g_nx, :g_ny] * scale_s
-        disp_n = disp_n_all[:, grid_pos, :g_nx, :g_ny] * scale_s
-        # Cache order is probe flat index iy*nx+ix; (g_nx, g_ny) transpose(1, 2).reshape gives (g_ny, g_nx) -> iy*nx+ix.
-        disp_u_flat = disp_u.transpose(1, 2).reshape(n_batches, -1)
-        disp_v_flat = disp_v.transpose(1, 2).reshape(n_batches, -1)
-        disp_n_flat = disp_n.transpose(1, 2).reshape(n_batches, -1)
-        grid_size = g_nx * g_ny * 3
+        disp_u = disp_u_all[:, grid_pos, :g_ny, :g_nx] * scale_s
+        disp_v = disp_v_all[:, grid_pos, :g_ny, :g_nx] * scale_s
+        disp_n = disp_n_all[:, grid_pos, :g_ny, :g_nx] * scale_s
+        # (B, g_ny, g_nx) reshapes directly to the probe flat index iy*nx+ix -- no transpose.
+        disp_u_flat = disp_u.reshape(n_batches, -1)
+        disp_v_flat = disp_v.reshape(n_batches, -1)
+        disp_n_flat = disp_n.reshape(n_batches, -1)
+        grid_size = g_ny * g_nx * 3
         out_block = grid_dilate_out_buffer[:, :grid_size]
         tangent_u = grid_tangent_u[sensor_idx]
         tangent_v = grid_tangent_v[sensor_idx]
         normal = grid_normal[sensor_idx]
+        # Zero inactive filler probes (probe_radius == 0): they are non-sources, but the FFT still smears
+        # neighbour dilation into their cells, so mask the per-probe write-back.
+        active = (probe_radii[probe_start : probe_start + g_ny * g_nx] > 0.0).to(disp_u_flat.dtype)
         for k in range(3):
             out_block[:, k:grid_size:3] = (
                 disp_u_flat * tangent_u[k] + disp_v_flat * tangent_v[k] + disp_n_flat * normal[k]
-            )
+            ) * active
         output[cache_start : cache_start + grid_size].copy_(out_block.T)
 
 
 @dataclass
-class ElastomerTaxelSensorMetadata(PointCloudTactileSharedMetadata, ProbesWithNormalSensorMetadataMixin):
+class ElastomerTaxelSensorMetadata(
+    GridFFTConvMetadataMixin,
+    ContactDepthQueryMetadataMixin,
+    PointCloudTactileSharedMetadata,
+    ProbesWithNormalSensorMetadataMixin,
+):
     track_geom_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     track_geom_active_envs_mask: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_bool)
     sensor_track_geom_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
@@ -1494,10 +1743,16 @@ class ElastomerTaxelSensorMetadata(PointCloudTactileSharedMetadata, ProbesWithNo
     sensor_elastomer_geom_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     sensor_elastomer_geom_n: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
 
+    # Per-(B, sensor, geom) bitmask of elastomer (sensor-own) geoms, used by the global-BVH surface-state kernel
+    # to gate triangles back to the sensor's elastomer surface. Separate from ``sensor_candidate_geom_mask`` which
+    # gates by tracked-object geoms for the probe-depth kernel.
+    elastomer_candidate_geom_mask: torch.Tensor = make_tensor_field((0, 0, 0), dtype_factory=lambda: gs.tc_bool)
+
     lambda_d: torch.Tensor = make_tensor_field((0,))
     lambda_s: torch.Tensor = make_tensor_field((0,))
     dilate_scale: torch.Tensor = make_tensor_field((0,))
     shear_scale: torch.Tensor = make_tensor_field((0,))
+    normal_exponent: torch.Tensor = make_tensor_field((0,))
     elastomer_contact_sdf_enter: torch.Tensor = make_tensor_field((0,))
     elastomer_contact_sdf_exit: torch.Tensor = make_tensor_field((0,))
 
@@ -1512,27 +1767,23 @@ class ElastomerTaxelSensorMetadata(PointCloudTactileSharedMetadata, ProbesWithNo
     # stale surface_initialized / surface_entry_pos for points the BVH skipped this step.
     surface_candidate_buf: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_bool)
 
-    is_grid: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_bool)
+    # Compact per-(env, sensor) active surface-point index, rebuilt every step right after the
+    # ``surface_initialized_buf &= candidate`` cleanup and consumed by ``_kernel_elastomer_shear_accumulate``.
+    # For sensor ``s`` in env ``i_b``, the first ``shear_active_pc_count[i_b, s]`` entries of
+    # ``shear_active_pc_idx[i_b, sensor_pc_start[s]:]`` hold the global pc-row indices whose
+    # ``surface_initialized_buf`` is True. Sensors with ``shear_scale == 0`` have count = 0.
+    shear_active_pc_idx: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
+    shear_active_pc_count: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
+
+    # Per-sensor flag selecting the FFT dilation path vs the direct (non-grid) dilation kernel.
     use_grid_fft: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_bool)
-    grid_n: torch.Tensor = make_tensor_field((0, 2), dtype_factory=lambda: gs.tc_int)
-    grid_spacing: torch.Tensor = make_tensor_field((0, 2))
+    # Per-grid-FFT-sensor tangent basis, consumed by the dilation write-back. See ``GridFFTMeta`` for the per-sensor
+    # ``grid_fft_meta`` record layout.
     grid_normal: torch.Tensor = make_tensor_field((0, 3))
     grid_tangent_u: torch.Tensor = make_tensor_field((0, 3))
     grid_tangent_v: torch.Tensor = make_tensor_field((0, 3))
-    # Stacked complex FFT kernels for all grid-FFT sensors, shape (n_grid, 3, fft_max_n[0],
-    # fft_max_n[1]). All sensors share fft_max_n so torch.fft.fft2 batches across the grid axis
-    # in a single launch. When a new grid sensor expands fft_max_n at build time, prior sensors'
-    # kernels are recomputed at the new size so the stack stays uniform.
-    fft_grid_kernels_stacked: torch.Tensor = make_tensor_field((0, 0, 0, 0), dtype_factory=lambda: torch.complex64)
-    fft_depth_buffer: torch.Tensor = make_tensor_field((0, 0, 0, 0))
+    # Scratch for the per-sensor tangent-decomposition write-back, lazily grown to the largest grid.
     grid_dilate_out_buffer: torch.Tensor = make_tensor_field((0, 0))
-    # Per-grid-FFT-sensor metadata captured at build time. Tuple fields:
-    # (sensor_idx, g_nx, g_ny, probe_start, cache_start, lambda_d, spacing_u, spacing_v).
-    # Indexed positionally to match rows of fft_grid_kernels_stacked / sensor axis of
-    # fft_depth_buffer. Iterating it directly avoids per-step .item() device syncs.
-    fft_grid_meta: list[tuple[int, int, int, int, int, float, float, float]] = field(default_factory=list)
-    # Global max FFT size across all grid sensors. Mutated only at build time.
-    fft_max_n: tuple[int, int] = (0, 0)
 
     # True iff at least one configured ElastomerTaxel has shear_scale > 0. Set during build by OR-ing
     # each sensor's value, so per-step gating avoids an O(n_sensors) reduction + device sync.
@@ -1540,10 +1791,11 @@ class ElastomerTaxelSensorMetadata(PointCloudTactileSharedMetadata, ProbesWithNo
 
 
 class ElastomerTaxelSensor(
+    ContactDepthQuerySensorMixin,
     PointCloudTactileSensorMixin[ElastomerTaxelSensorMetadata],
     ProbesWithNormalSensorMixin[ElastomerTaxelSensorMetadata],
     RigidSensorMixin[ElastomerTaxelSensorMetadata],
-    SimpleSensor[ElastomerTaxelSensorOptions, None, ElastomerTaxelSensorMetadata],
+    SimpleSensor[ElastomerTaxelSensorOptions, RaycastContext, ElastomerTaxelSensorMetadata],
 ):
     def __init__(
         self,
@@ -1554,33 +1806,36 @@ class ElastomerTaxelSensor(
         manager: "SensorManager",
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
-
-        self._is_grid = self._probe_local_pos.ndim > 2
-        self._shape = self._probe_local_pos.shape[:-1]
-
-        (probe_pos, probe_normals, use_grid_fft, grid_normal, grid_tangent_u, grid_tangent_v, grid_spacing) = (
-            _normalize_elastomer_probe_layout(
+        # FFT-grid eligibility check (flat pos/normals are already populated by the base mixins). 2D layouts with
+        # non-degenerate spacing use the FFT dilation path; strictly irregular grids still take that path with
+        # averaged metadata and only emit a warning.
+        self._is_grid = len(self._probe_layout_shape) == 2
+        _, _, self._use_grid_fft, is_grid_regular, grid_normal, grid_tangent_u, grid_tangent_v, grid_spacing = (
+            normalize_grid_probe_layout(
                 np.asarray(options.probe_local_pos, dtype=gs.np_float),
                 np.asarray(options.probe_local_normal, dtype=gs.np_float),
                 self._is_grid,
             )
         )
-        self._probe_local_pos = torch.tensor(probe_pos, dtype=gs.tc_float, device=gs.device)
-        self._probe_local_normal = torch.tensor(probe_normals, dtype=gs.tc_float, device=gs.device)
-        self._use_grid_fft = use_grid_fft
         self._grid_normal = torch.tensor(grid_normal, dtype=gs.tc_float, device=gs.device)
         self._grid_tangent_u = torch.tensor(grid_tangent_u, dtype=gs.tc_float, device=gs.device)
         self._grid_tangent_v = torch.tensor(grid_tangent_v, dtype=gs.tc_float, device=gs.device)
         self._grid_spacing = torch.tensor(grid_spacing, dtype=gs.tc_float, device=gs.device)
 
+        if self._use_grid_fft and not is_grid_regular:
+            gs.logger.warning(
+                "ElastomerTaxel grid is not strictly regular (uniform spacing, uniform normals, orthogonal "
+                "tangents); FFT dilation will use averaged spacing and normal as a best-fit approximation."
+            )
+
     def build(self):
         super().build()
 
         solver = self._shared_metadata.solver
-        solver.collider.activate_sdf()
         B = self._manager._sim._B
         if self._link is None:
             gs.raise_exception("ElastomerTaxel must be attached to a rigid link with collision geometry.")
+        # The class-wide contact_depth_query backend is resolved + activated by ContactDepthQuerySensorMixin.build.
 
         elastomer_geom_start_row = self._shared_metadata.elastomer_geom_idx.shape[0]
         elastomer_geom_idx, elastomer_geom_active_envs_mask = _collect_collision_geom_idx(
@@ -1628,11 +1883,12 @@ class ElastomerTaxelSensor(
         self._shared_metadata.dilate_scale = concat_with_tensor(
             self._shared_metadata.dilate_scale, float(self._options.dilate_scale), expand=(1,)
         )
+        self._shared_metadata.normal_exponent = concat_with_tensor(
+            self._shared_metadata.normal_exponent, float(self._options.normal_exponent), expand=(1,)
+        )
         self._shared_metadata.shear_scale = concat_with_tensor(
             self._shared_metadata.shear_scale, float(self._options.shear_scale), expand=(1,)
         )
-        if float(self._options.shear_scale) > 0.0:
-            self._shared_metadata.any_shear = True
         self._shared_metadata.elastomer_contact_sdf_enter = concat_with_tensor(
             self._shared_metadata.elastomer_contact_sdf_enter,
             float(self._options.elastomer_contact_sdf_enter),
@@ -1643,6 +1899,8 @@ class ElastomerTaxelSensor(
             float(self._options.elastomer_contact_sdf_exit),
             expand=(1,),
         )
+        if float(self._options.shear_scale) > 0.0:
+            self._shared_metadata.any_shear = True
 
         self._shared_metadata.probe_depth_buf = torch.zeros(
             (B, self._shared_metadata.total_n_probes), dtype=gs.tc_float, device=gs.device
@@ -1663,61 +1921,72 @@ class ElastomerTaxelSensor(
             (B, total_n_surface), dtype=gs.tc_bool, device=gs.device
         )
 
-        self._shared_metadata.is_grid = concat_with_tensor(self._shared_metadata.is_grid, self._is_grid, expand=(1,))
+        # Compact active-point index for the shear accumulator. Re-allocated on each ElastomerTaxel build so the
+        # ``(B, total_n_surface)`` idx buffer and ``(B, n_sensors)`` count buffer absorb the newly registered sensor.
+        # Both are allocated unconditionally (zero-init); the per-step build at ``_build_shear_active_pc_index``
+        # leaves entries for non-shear sensors at count == 0, so unread regions remain harmless zeros.
+        n_sensors_built = self._shared_metadata.n_probes_per_sensor.shape[0]
+        self._shared_metadata.shear_active_pc_idx = torch.zeros((B, total_n_surface), dtype=gs.tc_int, device=gs.device)
+        self._shared_metadata.shear_active_pc_count = torch.zeros(
+            (B, n_sensors_built), dtype=gs.tc_int, device=gs.device
+        )
+
+        # Build the (B, n_sensors, n_geoms) candidate-geom masks scattered from track_geom_idx (probe-depth) and
+        # elastomer_geom_idx (surface-anchor). Only needed in raycast mode but allocated cheaply (bool, total
+        # scene-geom count) so we tolerate the small idle cost in sdf mode.
+        if self._shared_metadata.contact_depth_query == "raycast":
+            n_geoms = solver.n_geoms
+            self._shared_metadata.sensor_candidate_geom_mask = _build_candidate_geom_mask(
+                B,
+                n_sensors_built,
+                n_geoms,
+                self._shared_metadata.sensor_track_geom_start,
+                self._shared_metadata.sensor_track_geom_n,
+                self._shared_metadata.track_geom_idx,
+            )
+            self._shared_metadata.elastomer_candidate_geom_mask = _build_candidate_geom_mask(
+                B,
+                n_sensors_built,
+                n_geoms,
+                self._shared_metadata.sensor_elastomer_geom_start,
+                self._shared_metadata.sensor_elastomer_geom_n,
+                self._shared_metadata.elastomer_geom_idx,
+            )
+
         self._shared_metadata.use_grid_fft = concat_with_tensor(
             self._shared_metadata.use_grid_fft, self._use_grid_fft, expand=(1,)
         )
 
-        grid_n = torch.tensor((0, 0), dtype=gs.tc_int, device=gs.device)
-        grid_spacing = torch.tensor((0.0, 0.0), dtype=gs.tc_float, device=gs.device)
         grid_normal = torch.zeros(3, dtype=gs.tc_float, device=gs.device)
         grid_tangent_u = torch.zeros(3, dtype=gs.tc_float, device=gs.device)
         grid_tangent_v = torch.zeros(3, dtype=gs.tc_float, device=gs.device)
         if self._use_grid_fft:
-            nx, ny = int(self._shape[1]), int(self._shape[0])
-            grid_n = torch.tensor((nx, ny), dtype=gs.tc_int, device=gs.device)
-            grid_spacing = self._grid_spacing
+            nx, ny = int(self._probe_layout_shape[1]), int(self._probe_layout_shape[0])
             grid_normal = self._grid_normal
             grid_tangent_u = self._grid_tangent_u
             grid_tangent_v = self._grid_tangent_v
-            spacing_u, spacing_v = float(grid_spacing[0].item()), float(grid_spacing[1].item())
-            this_fft_n = tuple(_next_pow2(2 * n - 1) for n in (nx, ny))
+            spacing_u, spacing_v = float(self._grid_spacing[0].item()), float(self._grid_spacing[1].item())
+            # FFT size is (ny, nx) row-major. Sizing each axis to ``2n - 1`` (the full linear-convolution support)
+            # rounded up to a power of 2 guarantees zero circular wraparound regardless of the dilation kernel's
+            # decay -- the ``x*g`` / ``y*g`` first-moment kernels decay slower than the Gaussian itself.
+            this_fft_n = (next_pow2(2 * ny - 1), next_pow2(2 * nx - 1))
             cache_start_py = int(self._shared_metadata.sensor_cache_start[self._idx].item())
-            self._shared_metadata.fft_grid_meta.append(
-                (
-                    self._idx,
-                    nx,
-                    ny,
-                    self._probe_start_idx,
-                    cache_start_py,
-                    float(self._options.lambda_d),
-                    spacing_u,
-                    spacing_v,
-                )
-            )
-
-            # Expand the global FFT size if this sensor needs more padding. When that happens, all
-            # prior grid sensors' kernels are rebuilt at the new size (their FFTs depend on the
-            # transform length, so frequency-domain padding wouldn't be equivalent).
-            prev_max = self._shared_metadata.fft_max_n
-            new_max = (max(prev_max[0], this_fft_n[0]), max(prev_max[1], this_fft_n[1]))
-            self._shared_metadata.fft_max_n = new_max
-            n_grid = len(self._shared_metadata.fft_grid_meta)
-            stacked = torch.empty(
-                (n_grid, 3, new_max[0], new_max[1]),
-                dtype=torch.complex64,
-                device=gs.device,
-            )
-            for grid_pos, (_, _, _, _, _, lam_d, sp_u, sp_v) in enumerate(self._shared_metadata.fft_grid_meta):
-                stacked[grid_pos] = _precompute_hydroshear_dilate_kernel_fft(
-                    lam_d, (sp_u, sp_v), new_max, gs.device, gs.tc_float
-                )
-            self._shared_metadata.fft_grid_kernels_stacked = stacked
-
-            # fft_depth_buffer is keyed by grid-sensor position (not raw sensor i_s), sized at the
-            # current global max FFT size. Reallocate every time we add a grid sensor.
-            self._shared_metadata.fft_depth_buffer = torch.zeros(
-                (B, n_grid, new_max[0], new_max[1]), dtype=gs.tc_float, device=gs.device
+            register_grid_fft_sensor(
+                self._shared_metadata,
+                meta_entry=GridFFTMeta(
+                    sensor_idx=self._idx,
+                    g_ny=ny,
+                    g_nx=nx,
+                    probe_start=self._probe_start_idx,
+                    cache_start=cache_start_py,
+                    lambda_d=float(self._options.lambda_d),
+                    spacing_u=spacing_u,
+                    spacing_v=spacing_v,
+                ),
+                this_fft_n=this_fft_n,
+                kernel_builder=_dilate_kernel_builder,
+                n_buffer_channels=0,
+                batch_size=B,
             )
             grid_size = nx * ny * 3
             out_buf = self._shared_metadata.grid_dilate_out_buffer
@@ -1728,10 +1997,6 @@ class ElastomerTaxelSensor(
                     device=gs.device,
                 )
 
-        self._shared_metadata.grid_n = concat_with_tensor(self._shared_metadata.grid_n, grid_n, expand=(1, 2))
-        self._shared_metadata.grid_spacing = concat_with_tensor(
-            self._shared_metadata.grid_spacing, grid_spacing, expand=(1, 2)
-        )
         self._shared_metadata.grid_normal = concat_with_tensor(
             self._shared_metadata.grid_normal, grid_normal, expand=(1, 3)
         )
@@ -1743,7 +2008,7 @@ class ElastomerTaxelSensor(
         )
 
     def _get_return_format(self) -> tuple[int, ...]:
-        return (self._n_probes, 3)
+        return (*self._probe_layout_shape, 3)
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
@@ -1752,15 +2017,15 @@ class ElastomerTaxelSensor(
     @classmethod
     def reset(cls, shared_metadata: ElastomerTaxelSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
         super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
-        # Only the hysteresis flag needs clearing on env reset. probe_depth_buf is overwritten every
-        # step; surface_pos/entry/depth are only consumed where surface_initialized=True so they're
-        # implicitly invalidated by clearing it; surface_candidate_buf is .zero_()'d at step start.
+        # probe_depth_buf is overwritten every step; surface_pos/entry/depth are only consumed where
+        # surface_initialized=True so they're implicitly invalidated by clearing it; surface_candidate_buf
+        # is .zero_()'d at step start.
         shared_metadata.surface_initialized_buf[envs_idx, :] = False
 
     @classmethod
     def _update_current_timestep_data(
         cls,
-        shared_context: None,
+        shared_context: RaycastContext,
         shared_metadata: ElastomerTaxelSensorMetadata,
         current_ground_truth_data_T: torch.Tensor,
         ground_truth_data_timeline: "TensorRingBuffer | None",
@@ -1768,46 +2033,69 @@ class ElastomerTaxelSensor(
     ):
         solver = shared_metadata.solver
         # No pre-zeros: probe_depth is fully overwritten by _kernel_elastomer_probe_depth;
-        # current_ground_truth_data_T is fully overwritten by FFT-dilate ∪ dilate-accumulate (then
+        # current_ground_truth_data_T is fully overwritten by FFT-dilate union dilate-accumulate (then
         # shear-accumulate += on top); surface_depth_buf is only read where surface_initialized=True,
         # which is set in lockstep with that same depth write; measured is .copy_'d at the end.
         measured = measured_data_timeline.at(0, copy=False)
 
-        _kernel_elastomer_probe_depth(
-            shared_metadata.probe_positions,
-            shared_metadata.probe_sensor_idx,
-            shared_metadata.links_idx,
-            shared_metadata.sensor_track_geom_start,
-            shared_metadata.sensor_track_geom_n,
-            shared_metadata.track_geom_idx,
-            shared_metadata.track_geom_active_envs_mask,
-            solver.links_state,
-            solver.geoms_state,
-            solver.geoms_info,
-            solver.collider._sdf._sdf_info,
-            shared_metadata.probe_depth_buf,
-        )
+        if (shared_metadata.contact_depth_query or "sdf") == "sdf":
+            _kernel_elastomer_probe_depth(
+                shared_metadata.probe_positions,
+                shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
+                shared_metadata.links_idx,
+                shared_metadata.sensor_track_geom_start,
+                shared_metadata.sensor_track_geom_n,
+                shared_metadata.track_geom_idx,
+                shared_metadata.track_geom_active_envs_mask,
+                solver.links_state,
+                solver.geoms_state,
+                solver.geoms_info,
+                solver.collider._sdf._sdf_info,
+                shared_metadata.probe_depth_buf,
+            )
+        else:
+            _kernel_elastomer_probe_depth_bvh(
+                shared_metadata.probe_positions,
+                shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
+                shared_metadata.links_idx,
+                shared_metadata.sensor_candidate_geom_mask,
+                _ELASTOMER_RAYCAST_QUERY_DIST,
+                shared_context.collision_bvh_context.bvh.nodes,
+                shared_context.collision_bvh_context.bvh.morton_codes,
+                solver.links_state,
+                solver.faces_info,
+                solver.verts_info,
+                solver.fixed_verts_state,
+                solver.free_verts_state,
+                shared_metadata.probe_depth_buf,
+            )
         _kernel_elastomer_dilate_accumulate(
             shared_metadata.use_grid_fft,
             shared_metadata.probe_positions,
             shared_metadata.probe_local_normal,
             shared_metadata.probe_sensor_idx,
+            shared_metadata.probe_radii,
             shared_metadata.sensor_cache_start,
             shared_metadata.sensor_probe_start,
             shared_metadata.n_probes_per_sensor,
             shared_metadata.lambda_d,
             shared_metadata.dilate_scale,
+            shared_metadata.normal_exponent,
             shared_metadata.probe_depth_buf,
             current_ground_truth_data_T,
         )
         # FFT runs after the qd dilate kernel: on Metal, write-only kernel outputs zero unwritten slots on copy-back,
         # which would erase the grid range the FFT just wrote.
         _elastomer_taxel_grid_fft_dilate(
-            shared_metadata.fft_grid_meta,
-            shared_metadata.fft_grid_kernels_stacked,
+            shared_metadata.grid_fft_meta,
+            shared_metadata.grid_fft_kernels_stacked,
             shared_metadata.probe_depth_buf,
-            shared_metadata.fft_depth_buffer,
+            shared_metadata.probe_radii,
+            shared_metadata.grid_fft_buffer,
             shared_metadata.dilate_scale,
+            shared_metadata.normal_exponent,
             shared_metadata.grid_normal,
             shared_metadata.grid_tangent_u,
             shared_metadata.grid_tangent_v,
@@ -1817,60 +2105,109 @@ class ElastomerTaxelSensor(
         if shared_metadata.any_shear:
             bvh = shared_metadata.pc_bvh
             shared_metadata.surface_candidate_buf.zero_()
-            _kernel_elastomer_surface_state_bvh(
-                shared_metadata.links_idx,
-                shared_metadata.sensor_elastomer_geom_start,
-                shared_metadata.sensor_elastomer_geom_n,
-                shared_metadata.elastomer_geom_idx,
-                shared_metadata.elastomer_geom_active_envs_mask,
-                bvh.chunk_sensor_idx,
-                bvh.chunk_link_idx,
-                bvh.chunk_node_start,
-                bvh.node_min,
-                bvh.node_max,
-                bvh.node_left,
-                bvh.node_right,
-                bvh.node_point_start,
-                bvh.node_point_n,
-                bvh.point_idx,
-                shared_metadata.pc_pos_link,
-                shared_metadata.pc_active_envs_mask,
-                shared_metadata.elastomer_contact_sdf_enter,
-                shared_metadata.elastomer_contact_sdf_exit,
-                _ELASTOMER_QUERY_AABB_MARGIN,
-                solver.links_state,
-                solver.geoms_state,
-                solver.geoms_info,
-                solver.collider._sdf._sdf_info,
-                shared_metadata.surface_pos_sensor_buf,
-                shared_metadata.surface_entry_pos_sensor_buf,
-                shared_metadata.surface_depth_buf,
-                shared_metadata.surface_initialized_buf,
-                shared_metadata.surface_candidate_buf,
-            )
+            if (shared_metadata.contact_depth_query or "sdf") == "sdf":
+                _kernel_elastomer_surface_state_bvh(
+                    shared_metadata.links_idx,
+                    shared_metadata.sensor_elastomer_geom_start,
+                    shared_metadata.sensor_elastomer_geom_n,
+                    shared_metadata.elastomer_geom_idx,
+                    shared_metadata.elastomer_geom_active_envs_mask,
+                    bvh.chunk_sensor_idx,
+                    bvh.chunk_link_idx,
+                    bvh.chunk_node_start,
+                    bvh.node_min,
+                    bvh.node_max,
+                    bvh.node_left,
+                    bvh.node_right,
+                    bvh.node_leaf_start,
+                    bvh.node_leaf_count,
+                    bvh.leaf_elem_idx,
+                    shared_metadata.pc_pos_link,
+                    shared_metadata.pc_active_envs_mask,
+                    shared_metadata.elastomer_contact_sdf_enter,
+                    shared_metadata.elastomer_contact_sdf_exit,
+                    _ELASTOMER_QUERY_AABB_MARGIN,
+                    solver.links_state,
+                    solver.geoms_state,
+                    solver.geoms_info,
+                    solver.collider._sdf._sdf_info,
+                    shared_metadata.surface_pos_sensor_buf,
+                    shared_metadata.surface_entry_pos_sensor_buf,
+                    shared_metadata.surface_depth_buf,
+                    shared_metadata.surface_initialized_buf,
+                    shared_metadata.surface_candidate_buf,
+                )
+            else:
+                _kernel_elastomer_surface_state_via_global_bvh(
+                    shared_metadata.links_idx,
+                    shared_metadata.sensor_elastomer_geom_start,
+                    shared_metadata.sensor_elastomer_geom_n,
+                    shared_metadata.elastomer_geom_idx,
+                    shared_metadata.elastomer_geom_active_envs_mask,
+                    shared_metadata.elastomer_candidate_geom_mask,
+                    bvh.chunk_sensor_idx,
+                    bvh.chunk_link_idx,
+                    bvh.chunk_node_start,
+                    bvh.node_min,
+                    bvh.node_max,
+                    bvh.node_left,
+                    bvh.node_right,
+                    bvh.node_leaf_start,
+                    bvh.node_leaf_count,
+                    bvh.leaf_elem_idx,
+                    shared_metadata.pc_pos_link,
+                    shared_metadata.pc_active_envs_mask,
+                    shared_metadata.elastomer_contact_sdf_enter,
+                    shared_metadata.elastomer_contact_sdf_exit,
+                    _ELASTOMER_QUERY_AABB_MARGIN,
+                    _ELASTOMER_RAYCAST_QUERY_DIST,
+                    shared_context.collision_bvh_context.bvh.nodes,
+                    shared_context.collision_bvh_context.bvh.morton_codes,
+                    solver.links_state,
+                    solver.geoms_state,
+                    solver.faces_info,
+                    solver.verts_info,
+                    solver.fixed_verts_state,
+                    solver.free_verts_state,
+                    shared_metadata.surface_pos_sensor_buf,
+                    shared_metadata.surface_entry_pos_sensor_buf,
+                    shared_metadata.surface_depth_buf,
+                    shared_metadata.surface_initialized_buf,
+                    shared_metadata.surface_candidate_buf,
+                )
             # Invalidate stale surface state for points the BVH did not visit. surface_initialized
             # and entry-pos survive across steps; depth/pos are gated by initialized downstream so
-            # they don't need clearing. The shear accumulator below gates on surface_initialized_buf
-            # -- without this step, stale True from a prior step would corrupt accumulation.
+            # they don't need clearing. The shear accumulator below reads from a compact index
+            # rebuilt from surface_initialized -- without this step, stale True from a prior step
+            # would inject phantom contributions.
             cand = shared_metadata.surface_candidate_buf
             shared_metadata.surface_initialized_buf &= cand
-            # Implicit bool→float broadcast zeros entries where cand=False, no `~` allocation.
+            # Implicit bool->float broadcast zeros entries where cand=False, no `~` allocation.
             shared_metadata.surface_entry_pos_sensor_buf.mul_(cand.unsqueeze(-1))
+            _build_shear_active_pc_index(
+                shared_metadata.surface_initialized_buf,
+                shared_metadata.sensor_pc_start,
+                shared_metadata.sensor_pc_n,
+                shared_metadata.shear_scale,
+                shared_metadata.shear_active_pc_idx,
+                shared_metadata.shear_active_pc_count,
+            )
             _kernel_elastomer_shear_accumulate(
                 shared_metadata.probe_positions,
                 shared_metadata.probe_local_normal,
                 shared_metadata.probe_sensor_idx,
+                shared_metadata.probe_radii,
                 shared_metadata.sensor_cache_start,
                 shared_metadata.sensor_probe_start,
                 shared_metadata.sensor_pc_start,
-                shared_metadata.sensor_pc_n,
                 shared_metadata.lambda_s,
                 shared_metadata.shear_scale,
                 gs.EPS,
                 shared_metadata.surface_pos_sensor_buf,
                 shared_metadata.surface_entry_pos_sensor_buf,
                 shared_metadata.surface_depth_buf,
-                shared_metadata.surface_initialized_buf,
+                shared_metadata.shear_active_pc_idx,
+                shared_metadata.shear_active_pc_count,
                 current_ground_truth_data_T,
             )
 
@@ -1879,6 +2216,10 @@ class ElastomerTaxelSensor(
         measured.copy_(current_ground_truth_data_T.T)
 
     def _draw_debug(self, context: "RasterizerContext"):
-        self._draw_debug_probes(
-            context, lambda envs_idx: tensor_to_array(torch.linalg.norm(self.read_ground_truth(envs_idx), dim=-1))
-        )
+        def mask(envs_idx):
+            disp = self.read_ground_truth(envs_idx)
+            if self._options.history_length > 0:
+                disp = disp.select(1 if self._manager._sim.n_envs > 0 else 0, -1)
+            return torch.linalg.norm(disp, dim=-1) >= gs.EPS
+
+        self._draw_debug_probes(context, self._tactile_color_groups_fn(mask))

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -34,6 +34,7 @@ from .tactile_shared import (
     BVH_LEAF_SIZE,
     BVH_STACK_SIZE,
     BVHMetadata,
+    ChunkedBVHData,
     ContactDepthQueryMetadataMixin,
     ContactDepthQuerySensorMixin,
     GridFFTConvMetadataMixin,
@@ -353,17 +354,7 @@ def _kernel_point_cloud_proximity_taxel_bvh(
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
     n_probes_per_sensor: qd.types.ndarray(),
-    bvh_sensor_chunk_start: qd.types.ndarray(),
-    bvh_sensor_chunk_count: qd.types.ndarray(),
-    bvh_chunk_link_idx: qd.types.ndarray(),
-    bvh_chunk_node_start: qd.types.ndarray(),
-    bvh_node_min: qd.types.ndarray(),
-    bvh_node_max: qd.types.ndarray(),
-    bvh_node_left: qd.types.ndarray(),
-    bvh_node_right: qd.types.ndarray(),
-    bvh_node_leaf_start: qd.types.ndarray(),
-    bvh_node_leaf_count: qd.types.ndarray(),
-    bvh_leaf_elem_idx: qd.types.ndarray(),
+    bvh: ChunkedBVHData,
     pc_pos_link: qd.types.ndarray(),
     pc_active_envs_mask: qd.types.ndarray(),
     probe_radii: qd.types.ndarray(),
@@ -428,11 +419,11 @@ def _kernel_point_cloud_proximity_taxel_bvh(
         fv_m = qd.Vector.zero(gs.qd_float, 3)
         tau_w_m = qd.Vector.zero(gs.qd_float, 3)
 
-        chunk_start = bvh_sensor_chunk_start[i_s]
-        n_chunks = bvh_sensor_chunk_count[i_s]
+        chunk_start = bvh.sensor_chunk_start[i_s]
+        n_chunks = bvh.sensor_chunk_count[i_s]
         for c_off in range(n_chunks):
             i_c = chunk_start + c_off
-            track_link_idx = bvh_chunk_link_idx[i_c]
+            track_link_idx = bvh.chunk_link_idx[i_c]
             track_pos = links_state.pos[track_link_idx, i_b]
             track_quat = links_state.quat[track_link_idx, i_b]
             rcom_o = links_state.root_COM[track_link_idx, i_b]
@@ -442,22 +433,22 @@ def _kernel_point_cloud_proximity_taxel_bvh(
             probe_link = gu.qd_inv_transform_by_trans_quat(probe_world, track_pos, track_quat)
 
             stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
-            stack[0] = bvh_chunk_node_start[i_c]
+            stack[0] = bvh.chunk_node_start[i_c]
             stack_idx = 1
 
             while stack_idx > 0:
                 stack_idx -= 1
                 n = stack[stack_idx]
-                bmin = func_vec3_at(bvh_node_min, n)
-                bmax = func_vec3_at(bvh_node_max, n)
+                bmin = func_vec3_at(bvh.node_min, n)
+                bmax = func_vec3_at(bvh.node_max, n)
                 if not func_sphere_intersects_aabb(probe_link, R_query_sq, bmin, bmax):
                     continue
-                left = bvh_node_left[n]
+                left = bvh.node_left[n]
                 if left == -1:
-                    pstart = bvh_node_leaf_start[n]
-                    pn = bvh_node_leaf_count[n]
+                    pstart = bvh.node_leaf_start[n]
+                    pn = bvh.node_leaf_count[n]
                     for j in range(pn):
-                        i_o = bvh_leaf_elem_idx[pstart + j]
+                        i_o = bvh.leaf_elem_idx[pstart + j]
                         if not pc_active_envs_mask[i_o, i_b]:
                             continue
                         pos_l = func_vec3_at(pc_pos_link, i_o)
@@ -496,7 +487,7 @@ def _kernel_point_cloud_proximity_taxel_bvh(
                                         fv_m[k2] = fv_m[k2] + P_i_m * v_t[k2]
                                         tau_w_m[k2] = tau_w_m[k2] + P_i_m * ctmp[k2]
                 else:
-                    right = bvh_node_right[n]
+                    right = bvh.node_right[n]
                     # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
                     # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
                     if stack_idx < qd.static(BVH_STACK_SIZE - 2):
@@ -766,17 +757,7 @@ class ProximityTaxelSensor(
             shared_metadata.sensor_cache_start,
             shared_metadata.sensor_probe_start,
             shared_metadata.n_probes_per_sensor,
-            bvh.sensor_chunk_start,
-            bvh.sensor_chunk_count,
-            bvh.chunk_link_idx,
-            bvh.chunk_node_start,
-            bvh.node_min,
-            bvh.node_max,
-            bvh.node_left,
-            bvh.node_right,
-            bvh.node_leaf_start,
-            bvh.node_leaf_count,
-            bvh.leaf_elem_idx,
+            bvh.kernel_bvh,
             shared_metadata.pc_pos_link,
             shared_metadata.pc_active_envs_mask,
             shared_metadata.probe_radii,
@@ -1210,15 +1191,7 @@ def _kernel_elastomer_surface_state_bvh(
     elastomer_geom_idx: qd.types.ndarray(),
     elastomer_geom_active_envs_mask: qd.types.ndarray(),
     bvh_chunk_sensor_idx: qd.types.ndarray(),
-    bvh_chunk_link_idx: qd.types.ndarray(),
-    bvh_chunk_node_start: qd.types.ndarray(),
-    bvh_node_min: qd.types.ndarray(),
-    bvh_node_max: qd.types.ndarray(),
-    bvh_node_left: qd.types.ndarray(),
-    bvh_node_right: qd.types.ndarray(),
-    bvh_node_leaf_start: qd.types.ndarray(),
-    bvh_node_leaf_count: qd.types.ndarray(),
-    bvh_leaf_elem_idx: qd.types.ndarray(),
+    bvh: ChunkedBVHData,
     pc_pos_link: qd.types.ndarray(),
     pc_active_envs_mask: qd.types.ndarray(),
     sdf_enter: qd.types.ndarray(),
@@ -1278,7 +1251,7 @@ def _kernel_elastomer_surface_state_bvh(
             wmax[k] = wmax[k] + expand
 
         # 3) Transform 8 corners into the chunk's tracked-link local frame to get qmin/qmax.
-        track_link_idx = bvh_chunk_link_idx[i_c]
+        track_link_idx = bvh.chunk_link_idx[i_c]
         track_pos = links_state.pos[track_link_idx, i_b]
         track_quat = links_state.quat[track_link_idx, i_b]
         qmin = qd.Vector([gs.qd_float(1e30), gs.qd_float(1e30), gs.qd_float(1e30)], dt=gs.qd_float)
@@ -1304,22 +1277,22 @@ def _kernel_elastomer_surface_state_bvh(
         sensor_quat = links_state.quat[sensor_link_idx, i_b]
 
         stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
-        stack[0] = bvh_chunk_node_start[i_c]
+        stack[0] = bvh.chunk_node_start[i_c]
         stack_idx = 1
 
         while stack_idx > 0:
             stack_idx -= 1
             n = stack[stack_idx]
-            bmin = func_vec3_at(bvh_node_min, n)
-            bmax = func_vec3_at(bvh_node_max, n)
+            bmin = func_vec3_at(bvh.node_min, n)
+            bmax = func_vec3_at(bvh.node_max, n)
             if not func_aabb_intersects_aabb(bmin, bmax, qmin, qmax):
                 continue
-            left = bvh_node_left[n]
+            left = bvh.node_left[n]
             if left == -1:
-                pstart = bvh_node_leaf_start[n]
-                pn = bvh_node_leaf_count[n]
+                pstart = bvh.node_leaf_start[n]
+                pn = bvh.node_leaf_count[n]
                 for j in range(pn):
-                    i_o = bvh_leaf_elem_idx[pstart + j]
+                    i_o = bvh.leaf_elem_idx[pstart + j]
                     if not pc_active_envs_mask[i_o, i_b]:
                         continue
                     surface_candidate_buf[i_b, i_o] = True
@@ -1355,7 +1328,7 @@ def _kernel_elastomer_surface_state_bvh(
                         surface_initialized_buf,
                     )
             else:
-                right = bvh_node_right[n]
+                right = bvh.node_right[n]
                 # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
                 # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
                 if stack_idx < qd.static(BVH_STACK_SIZE - 2):
@@ -1373,15 +1346,7 @@ def _kernel_elastomer_surface_state_via_global_bvh(
     elastomer_geom_active_envs_mask: qd.types.ndarray(),
     elastomer_candidate_geom_mask: qd.types.ndarray(),
     bvh_chunk_sensor_idx: qd.types.ndarray(),
-    bvh_chunk_link_idx: qd.types.ndarray(),
-    bvh_chunk_node_start: qd.types.ndarray(),
-    bvh_node_min: qd.types.ndarray(),
-    bvh_node_max: qd.types.ndarray(),
-    bvh_node_left: qd.types.ndarray(),
-    bvh_node_right: qd.types.ndarray(),
-    bvh_node_leaf_start: qd.types.ndarray(),
-    bvh_node_leaf_count: qd.types.ndarray(),
-    bvh_leaf_elem_idx: qd.types.ndarray(),
+    bvh: ChunkedBVHData,
     pc_pos_link: qd.types.ndarray(),
     pc_active_envs_mask: qd.types.ndarray(),
     sdf_enter: qd.types.ndarray(),
@@ -1442,7 +1407,7 @@ def _kernel_elastomer_surface_state_via_global_bvh(
             wmin[k] = wmin[k] - expand
             wmax[k] = wmax[k] + expand
 
-        track_link_idx = bvh_chunk_link_idx[i_c]
+        track_link_idx = bvh.chunk_link_idx[i_c]
         track_pos = links_state.pos[track_link_idx, i_b]
         track_quat = links_state.quat[track_link_idx, i_b]
         qmin = qd.Vector([gs.qd_float(1e30), gs.qd_float(1e30), gs.qd_float(1e30)], dt=gs.qd_float)
@@ -1466,22 +1431,22 @@ def _kernel_elastomer_surface_state_via_global_bvh(
         sensor_quat = links_state.quat[sensor_link_idx, i_b]
 
         stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
-        stack[0] = bvh_chunk_node_start[i_c]
+        stack[0] = bvh.chunk_node_start[i_c]
         stack_idx = 1
 
         while stack_idx > 0:
             stack_idx -= 1
             n = stack[stack_idx]
-            bmin = func_vec3_at(bvh_node_min, n)
-            bmax = func_vec3_at(bvh_node_max, n)
+            bmin = func_vec3_at(bvh.node_min, n)
+            bmax = func_vec3_at(bvh.node_max, n)
             if not func_aabb_intersects_aabb(bmin, bmax, qmin, qmax):
                 continue
-            left = bvh_node_left[n]
+            left = bvh.node_left[n]
             if left == -1:
-                pstart = bvh_node_leaf_start[n]
-                pn = bvh_node_leaf_count[n]
+                pstart = bvh.node_leaf_start[n]
+                pn = bvh.node_leaf_count[n]
                 for j in range(pn):
-                    i_o = bvh_leaf_elem_idx[pstart + j]
+                    i_o = bvh.leaf_elem_idx[pstart + j]
                     if not pc_active_envs_mask[i_o, i_b]:
                         continue
                     surface_candidate_buf[i_b, i_o] = True
@@ -1519,7 +1484,7 @@ def _kernel_elastomer_surface_state_via_global_bvh(
                         surface_initialized_buf,
                     )
             else:
-                right = bvh_node_right[n]
+                right = bvh.node_right[n]
                 # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
                 # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
                 if stack_idx < qd.static(BVH_STACK_SIZE - 2):
@@ -2126,15 +2091,7 @@ class ElastomerTaxelSensor(
                     shared_metadata.elastomer_geom_idx,
                     shared_metadata.elastomer_geom_active_envs_mask,
                     bvh.chunk_sensor_idx,
-                    bvh.chunk_link_idx,
-                    bvh.chunk_node_start,
-                    bvh.node_min,
-                    bvh.node_max,
-                    bvh.node_left,
-                    bvh.node_right,
-                    bvh.node_leaf_start,
-                    bvh.node_leaf_count,
-                    bvh.leaf_elem_idx,
+                    bvh.kernel_bvh,
                     shared_metadata.pc_pos_link,
                     shared_metadata.pc_active_envs_mask,
                     shared_metadata.elastomer_contact_sdf_enter,
@@ -2159,15 +2116,7 @@ class ElastomerTaxelSensor(
                     shared_metadata.elastomer_geom_active_envs_mask,
                     shared_metadata.elastomer_candidate_geom_mask,
                     bvh.chunk_sensor_idx,
-                    bvh.chunk_link_idx,
-                    bvh.chunk_node_start,
-                    bvh.node_min,
-                    bvh.node_max,
-                    bvh.node_left,
-                    bvh.node_right,
-                    bvh.node_leaf_start,
-                    bvh.node_leaf_count,
-                    bvh.leaf_elem_idx,
+                    bvh.kernel_bvh,
                     shared_metadata.pc_pos_link,
                     shared_metadata.pc_active_envs_mask,
                     shared_metadata.elastomer_contact_sdf_enter,

--- a/genesis/engine/sensors/probe.py
+++ b/genesis/engine/sensors/probe.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Callable, Generic, TypeVar
 
 import numpy as np
 import quadrants as qd
@@ -11,6 +11,7 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_
 
 if TYPE_CHECKING:
     from genesis.options.sensors.options import SensorOptions
+    from genesis.utils.ring_buffer import TensorRingBuffer
     from genesis.vis.rasterizer_context import RasterizerContext
 
     from .sensor_manager import SensorManager
@@ -34,17 +35,35 @@ class ProbeSensorMetadataMixin:
     total_n_probes: int = 0
     probe_positions: torch.Tensor = make_tensor_field((0, 3))
     probe_radii: torch.Tensor = make_tensor_field((0,))
+    # No-op scaffolding kept for the kernels' dual-radius / gain machinery: always zeros / ones so the
+    # measured branch equals ground truth. ``has_any_*`` stay False.
     probe_radii_noise: torch.Tensor = make_tensor_field((0,))
+    has_any_probe_radius_noise: bool = False
+    has_any_probe_gain: bool = False
     n_probes_per_sensor: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     probe_sensor_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     sensor_cache_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     sensor_probe_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
-    # Class-level scratch for the kernel-writes-(cols, B) -> ring-slot-(B, cols) transpose-copy pattern. Lazy-allocated
-    # on first hot-path call to avoid per-step `torch.empty_like` allocations.
+
     measured_scratch_T: torch.Tensor = make_tensor_field((0, 0))
+
+    probe_gains: torch.Tensor = make_tensor_field((0, 0))
 
 
 ProbeSensorSharedMetadataT = TypeVar("ProbeSensorSharedMetadataT", bound=ProbeSensorMetadataMixin)
+
+
+def get_measured_bufs(
+    shared_metadata: "ProbeSensorMetadataMixin",
+    current_ground_truth_data_T: torch.Tensor,
+    measured_data_timeline: "TensorRingBuffer",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    current_ground_truth_data_T.zero_()
+    measured_slot = measured_data_timeline.at(0, copy=False)
+    measured_slot.zero_()
+    if shared_metadata.measured_scratch_T.shape != current_ground_truth_data_T.shape:
+        shared_metadata.measured_scratch_T = torch.empty_like(current_ground_truth_data_T)
+    return measured_slot, shared_metadata.measured_scratch_T
 
 
 class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
@@ -58,9 +77,12 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
         shared_metadata,
         manager: "SensorManager",
     ):
-        # `_get_return_format` runs inside `super().__init__`, so `_probe_local_pos` / `_n_probes` must already be set.
-        self._probe_local_pos = torch.tensor(options.probe_local_pos, dtype=gs.tc_float, device=gs.device)
-        self._n_probes = int(np.prod(self._probe_local_pos.shape[:-1]))
+        # `_get_return_format` runs inside `super().__init__`, so the probe layout fields must be set first.
+        raw_pos = torch.tensor(options.probe_local_pos, dtype=gs.tc_float, device=gs.device)
+        self._probe_layout_shape = raw_pos.shape[:-1]
+        self._n_probes = int(np.prod(self._probe_layout_shape))
+        self._probe_local_pos = raw_pos.reshape(self._n_probes, 3).contiguous()
+        self._debug_objects: list = []
         super().__init__(options, idx, shared_context, shared_metadata, manager)
 
     def build(self) -> None:
@@ -88,14 +110,26 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
         if isinstance(self._options.probe_radius, float):
             probe_radii = torch.full((self._n_probes,), self._options.probe_radius, dtype=gs.tc_float, device=gs.device)
         else:
-            probe_radii = torch.tensor(self._options.probe_radius, dtype=gs.tc_float, device=gs.device)
+            probe_radii = torch.tensor(self._options.probe_radius, dtype=gs.tc_float, device=gs.device).reshape(
+                self._n_probes
+            )
         self._shared_metadata.probe_radii = concat_with_tensor(
             self._shared_metadata.probe_radii, probe_radii, expand=(self._n_probes,)
         )
+        # No-op scaffolding (always zeros): the kernels' dual-radius machinery reads this; zero noise means the
+        # measured radius equals the nominal radius (measured branch == ground truth).
         self._shared_metadata.probe_radii_noise = concat_with_tensor(
             self._shared_metadata.probe_radii_noise,
-            torch.full((self._n_probes,), self._options.probe_radius_noise, dtype=gs.tc_float, device=gs.device),
+            torch.zeros((self._n_probes,), dtype=gs.tc_float, device=gs.device),
             expand=(self._n_probes,),
+        )
+        # No-op scaffolding (always ones): the kernels multiply the measured-branch signal by this per-probe gain.
+        B = self._manager._sim._B
+        self._shared_metadata.probe_gains = concat_with_tensor(
+            self._shared_metadata.probe_gains,
+            torch.ones((B, self._n_probes), dtype=gs.tc_float, device=gs.device),
+            expand=(B, self._n_probes),
+            dim=1,
         )
 
     @property
@@ -135,6 +169,127 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
             )
         return envs_idx, n_debug_envs, env_offsets, probe_world.reshape(-1, 3)
 
+    def _draw_probe_spheres(
+        self,
+        context: "RasterizerContext",
+        probe_world: np.ndarray,
+        rgb,
+        probe_radii: np.ndarray | None = None,
+        probe_radii_noise: np.ndarray | None = None,
+    ) -> list:
+        """
+        Draw a small opaque center sphere and a translucent outer sensing sphere at each ``probe_world`` position.
+
+        ``probe_world`` is ``(N, 3)`` (already tiled over rendered envs). ``probe_radii`` and ``probe_radii_noise``
+        are the matching ``(N,)`` per-position nominal sensing radius and additive uniform noise; both default to
+        the per-probe values from shared metadata, tiled to match ``probe_world``. When noise is positive, each
+        outer sphere is drawn at a fresh sample ``clip(r + U(-noise, +noise), 0, inf)`` rounded to the nearest
+        ``noise`` magnitude so the unique-radius batches stay small. Returns the created debug objects.
+        """
+        options = self._options
+        rgb = tuple(float(c) for c in rgb)
+        center_color = (*rgb, 1.0)
+        objs = [
+            context.draw_debug_spheres(
+                poss=probe_world,
+                radius=float(options.debug_probe_center_radius),
+                color=center_color,
+            )
+        ]
+        if options.debug_probe_sphere_opacity <= 0.0:
+            return objs
+        outer_color = (*rgb, float(options.debug_probe_sphere_opacity))
+        probe_start = int(self._shared_metadata.sensor_probe_start[self._idx].item())
+        probe_slice = slice(probe_start, probe_start + self._n_probes)
+        n_tile = probe_world.shape[0] // self._n_probes if self._n_probes > 0 else 0
+        n_tile = max(n_tile, 1)
+        if probe_radii is None:
+            per_probe = tensor_to_array(self._shared_metadata.probe_radii[probe_slice]).reshape(-1)
+            probe_radii = np.tile(per_probe, n_tile)
+        if probe_radii_noise is None:
+            per_probe_noise = tensor_to_array(self._shared_metadata.probe_radii_noise[probe_slice]).reshape(-1)
+            probe_radii_noise = np.tile(per_probe_noise, n_tile)
+        nz = probe_radii_noise > 0.0
+        if nz.any():
+            jitter = np.random.uniform(-1.0, 1.0, size=probe_radii.shape) * probe_radii_noise
+            noisy = np.maximum(0.0, probe_radii + jitter)
+            rounded = probe_radii.astype(float, copy=True)
+            rounded[nz] = np.round(noisy[nz] / probe_radii_noise[nz]) * probe_radii_noise[nz]
+            probe_radii = rounded
+        for r in np.unique(probe_radii):
+            if r <= 0.0:
+                continue
+            mask = probe_radii == r
+            objs.append(
+                context.draw_debug_spheres(
+                    poss=probe_world[mask],
+                    radius=float(r),
+                    color=outer_color,
+                )
+            )
+        return objs
+
+    def _draw_debug_probes(
+        self,
+        context: "RasterizerContext",
+        color_groups_fn: Callable[[list[int] | None], list[tuple]] | None = None,
+    ) -> tuple[list[int] | None, int, np.ndarray | None]:
+        """
+        Generic per-probe debug renderer. Clears prior debug objects, then for each provided color group draws the
+        two-sphere marker (small opaque center + translucent outer sensing sphere) on the selected probe positions.
+
+        ``color_groups_fn(envs_idx)`` returns a list of ``(rgb, mask)`` pairs, where ``rgb`` is a length-3 sequence
+        and ``mask`` is a flat ``(n_debug_envs * n_probes,)`` bool array (or tensor castable to bool) selecting
+        which probe positions take that color. Passing ``None`` falls back to a single group covering every probe
+        in the sensor's ``debug_probe_color`` (no contact-state assumption -- usable by any probe sensor).
+
+        Returns ``(envs_idx, n_debug_envs, env_offsets)`` so subclasses can extend the drawing with additional
+        debug geometry without recomputing the env layout.
+        """
+        for obj in self._debug_objects:
+            context.clear_debug_object(obj)
+        self._debug_objects.clear()
+
+        envs_idx, n_debug_envs, env_offsets, probe_world = self._compute_probes_world_pos(context)
+        probe_start = int(self._shared_metadata.sensor_probe_start[self._idx].item())
+        probe_slice = slice(probe_start, probe_start + self._n_probes)
+        n_tile = max(n_debug_envs, 1)
+        radii_tiled = np.tile(tensor_to_array(self._shared_metadata.probe_radii[probe_slice]).reshape(-1), n_tile)
+        noise_tiled = np.tile(tensor_to_array(self._shared_metadata.probe_radii_noise[probe_slice]).reshape(-1), n_tile)
+        if color_groups_fn is None:
+            groups = [(self._options.debug_probe_color, np.ones(probe_world.shape[0], dtype=bool))]
+        else:
+            groups = color_groups_fn(envs_idx)
+        for rgb, mask in groups:
+            mask_arr = tensor_to_array(mask, dtype=bool).reshape(-1)
+            (probes_idx,) = np.nonzero(mask_arr)
+            if probes_idx.size == 0:
+                continue
+            self._debug_objects.extend(
+                self._draw_probe_spheres(
+                    context, probe_world[probes_idx], rgb, radii_tiled[probes_idx], noise_tiled[probes_idx]
+                )
+            )
+        return envs_idx, n_debug_envs, env_offsets
+
+    def _tactile_color_groups_fn(
+        self, get_is_contact_flat: Callable[[list[int] | None], object]
+    ) -> Callable[[list[int] | None], list[tuple]]:
+        """
+        Build a ``color_groups_fn`` for the common tactile split: not-in-contact probes get ``debug_probe_color``
+        and in-contact probes get ``debug_contact_color``. The sensor's options must expose
+        ``debug_contact_color`` (i.e. inherit ``TactileProbeSensorOptionsMixin``).
+        """
+
+        def fn(envs_idx):
+            is_contact = tensor_to_array(get_is_contact_flat(envs_idx), dtype=bool).reshape(-1)
+            return [
+                (self._options.debug_probe_color, ~is_contact),
+                (self._options.debug_contact_color, is_contact),
+            ]
+
+        return fn
+
 
 @dataclass
 class ProbesWithNormalSensorMetadataMixin(ProbeSensorMetadataMixin):
@@ -160,9 +315,11 @@ class ProbesWithNormalSensorMixin(ProbeSensorMixin[ProbesWithNormalSensorSharedM
         manager: "SensorManager",
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
-        self._probe_local_normal = torch.tensor(self._options.probe_local_normal, dtype=gs.tc_float, device=gs.device)
-        if self._probe_local_normal.ndim == 1:
-            self._probe_local_normal = self._probe_local_normal.expand(self._n_probes, 3).contiguous()
+        raw_normal = torch.tensor(self._options.probe_local_normal, dtype=gs.tc_float, device=gs.device)
+        if raw_normal.ndim == 1:
+            self._probe_local_normal = raw_normal.expand(self._n_probes, 3).contiguous()
+        else:
+            self._probe_local_normal = raw_normal.reshape(self._n_probes, 3).contiguous()
 
     def build(self) -> None:
         super().build()

--- a/genesis/engine/sensors/probe.py
+++ b/genesis/engine/sensors/probe.py
@@ -235,8 +235,10 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
         color_groups_fn: Callable[[list[int] | None], list[tuple]] | None = None,
     ) -> tuple[list[int] | None, int, np.ndarray | None]:
         """
-        Generic per-probe debug renderer. Clears prior debug objects, then for each provided color group draws the
-        two-sphere marker (small opaque center + translucent outer sensing sphere) on the selected probe positions.
+        Generic per-probe debug renderer.
+
+        Clears prior debug objects, then for each provided color group draws the two-sphere marker (small opaque
+        center + translucent outer sensing sphere) on the selected probe positions.
 
         ``color_groups_fn(envs_idx)`` returns a list of ``(rgb, mask)`` pairs, where ``rgb`` is a length-3 sequence
         and ``mask`` is a flat ``(n_debug_envs * n_probes,)`` bool array (or tensor castable to bool) selecting
@@ -277,8 +279,9 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
     ) -> Callable[[list[int] | None], list[tuple]]:
         """
         Build a ``color_groups_fn`` for the common tactile split: not-in-contact probes get ``debug_probe_color``
-        and in-contact probes get ``debug_contact_color``. The sensor's options must expose
-        ``debug_contact_color`` (i.e. inherit ``TactileProbeSensorOptionsMixin``).
+        and in-contact probes get ``debug_contact_color``.
+
+        The sensor's options must expose ``debug_contact_color`` (i.e. inherit ``TactileProbeSensorOptionsMixin``).
         """
 
         def fn(envs_idx):

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -82,7 +82,10 @@ class RaycastContext(SharedSensorContext):
 
     @property
     def bvh_contexts(self) -> list[BVHContext]:
-        """The per-(solver, mesh-type) BVHs. Raises if inactive: only a consumer that activated it may read them."""
+        """The per-(solver, mesh-type) BVHs.
+
+        Raises if inactive: only a consumer that activated it may read them.
+        """
         if not self._active:
             raise gs.GenesisException("RaycastContext queried before activation; no sensor declared a raycast need.")
         return self._bvh_contexts
@@ -90,6 +93,7 @@ class RaycastContext(SharedSensorContext):
     @staticmethod
     def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
         """Build a per-vface mask (int8, shape (n_vfaces,)) selecting vfaces opted into visual raycasting.
+
         A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
         """
         n_vfaces = solver.vfaces_info.vgeom_idx.shape[0]
@@ -106,9 +110,11 @@ class RaycastContext(SharedSensorContext):
 
     def activate(self):
         """
-        Build the per-(solver, mesh-type) BVHs on first activation; idempotent. Rigid solvers get a collision BVH
-        covering all collision faces; any solver with entities opting in via ``material.use_visual_raycasting`` gets a
-        visual BVH masked to those vfaces. Collision and visual entries coexist (the cast kernels merge in place).
+        Build the per-(solver, mesh-type) BVHs on first activation; idempotent.
+
+        Rigid solvers get a collision BVH covering all collision faces; any solver with entities opting in via
+        ``material.use_visual_raycasting`` gets a visual BVH masked to those vfaces. Collision and visual entries
+        coexist (the cast kernels merge in place).
         """
         if self._active:
             return

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -76,6 +76,9 @@ class RaycastContext(SharedSensorContext):
     def __init__(self, sim):
         super().__init__(sim)
         self._bvh_contexts: list[BVHContext] = []
+        # The rigid collision BVH context -- the single entry with no per-vface raycast mask (raycast_mask is None).
+        # Resolved once in ``activate`` (the entry list is fixed after that); ``None`` until then / if no rigid solver.
+        self.collision_bvh_context: BVHContext | None = None
 
     @property
     def bvh_contexts(self) -> list[BVHContext]:
@@ -130,6 +133,8 @@ class RaycastContext(SharedSensorContext):
                     aabb = AABB(n_batches=n_envs, n_aabbs=n_vfaces)
                     bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
                     self._bvh_contexts.append(BVHContext(solver, bvh, aabb, mask, maybe_static))
+
+        self.collision_bvh_context = next((c for c in self._bvh_contexts if c.raycast_mask is None), None)
 
         # Lazily watch each static BVH (collision or visual) for GEOMETRY changes. ``update`` polls its
         # rebuild_subscriber so an explicit set_pos / set_quat / set_vverts on the otherwise-immovable geometry forces

--- a/genesis/engine/sensors/surface_distance_probe.py
+++ b/genesis/engine/sensors/surface_distance_probe.py
@@ -39,19 +39,21 @@ if TYPE_CHECKING:
 @dataclass
 class TriangleMeshBVH(BVHMetadata):
     """
-    BVH over tracked mesh triangles for one sensor class. ``leaf_elem_idx`` entries are absolute rows
-    into ``tri_verts``, a flat per-class table of link-local triangle vertices (shape ``(total_n_tri,
-    3, 3)``: per triangle, three xyz vertex positions). See ``BVHMetadata`` for the shared scaffolding
-    semantics. Rigid-link assumption: built once at scene init, never rebuilt.
+    BVH over tracked mesh triangles for one sensor class.
+
+    ``leaf_elem_idx`` entries are absolute rows into ``tri_verts``, a flat per-class table of link-local triangle
+    vertices (shape ``(total_n_tri, 3, 3)``: per triangle, three xyz vertex positions). See ``BVHMetadata`` for the
+    shared scaffolding semantics. Rigid-link assumption: built once at scene init, never rebuilt.
     """
 
     tri_verts: torch.Tensor = make_tensor_field((0, 3, 3))
 
     def append_sensor(self, track_link_idx: np.ndarray, solver) -> None:
         """
-        Build per-tracked-link chunks for one sensor (link-local triangle BVH) and append into the flat
-        tensors. Sensors with no tracked-link geometry register zero chunks; the kernel's per-sensor
-        chunk loop iterates ``[0, sensor_chunk_count[i_s])`` and is a no-op for those.
+        Build per-tracked-link chunks for one sensor (link-local triangle BVH) and append into the flat tensors.
+
+        Sensors with no tracked-link geometry register zero chunks; the kernel's per-sensor chunk loop iterates
+        ``[0, sensor_chunk_count[i_s])`` and is a no-op for those.
         """
         new_chunk_link_idx: list[int] = []
         new_chunk_node_start: list[int] = []

--- a/genesis/engine/sensors/surface_distance_probe.py
+++ b/genesis/engine/sensors/surface_distance_probe.py
@@ -23,6 +23,7 @@ from .tactile_shared import (
     BVH_LEAF_SIZE,
     BVH_STACK_SIZE,
     BVHMetadata,
+    ChunkedBVHData,
     build_static_chunk_bvh,
     func_sphere_intersects_aabb,
     func_vec3_at,
@@ -180,17 +181,7 @@ def _kernel_surface_distance_probe_bvh(
     links_idx: qd.types.ndarray(),
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
-    bvh_sensor_chunk_start: qd.types.ndarray(),
-    bvh_sensor_chunk_count: qd.types.ndarray(),
-    bvh_chunk_link_idx: qd.types.ndarray(),
-    bvh_chunk_node_start: qd.types.ndarray(),
-    bvh_node_min: qd.types.ndarray(),
-    bvh_node_max: qd.types.ndarray(),
-    bvh_node_left: qd.types.ndarray(),
-    bvh_node_right: qd.types.ndarray(),
-    bvh_node_leaf_start: qd.types.ndarray(),
-    bvh_node_leaf_count: qd.types.ndarray(),
-    bvh_leaf_elem_idx: qd.types.ndarray(),
+    bvh: ChunkedBVHData,
     bvh_tri_verts: qd.types.ndarray(),
     links_state: array_class.LinksState,
     positions_gt: qd.types.ndarray(),
@@ -231,35 +222,35 @@ def _kernel_surface_distance_probe_bvh(
         best_dist_sq_m = max_r_m * max_r_m
         best_point_m = probe_world
 
-        chunk_start = bvh_sensor_chunk_start[i_s]
-        n_chunks = bvh_sensor_chunk_count[i_s]
+        chunk_start = bvh.sensor_chunk_start[i_s]
+        n_chunks = bvh.sensor_chunk_count[i_s]
         for c_off in range(n_chunks):
             i_c = chunk_start + c_off
-            track_link_idx = bvh_chunk_link_idx[i_c]
+            track_link_idx = bvh.chunk_link_idx[i_c]
             track_pos = links_state.pos[track_link_idx, i_b]
             track_quat = links_state.quat[track_link_idx, i_b]
             # BVH lives in the tracked link's local frame; bring the probe over.
             probe_link = gu.qd_inv_transform_by_trans_quat(probe_world, track_pos, track_quat)
 
             stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
-            stack[0] = bvh_chunk_node_start[i_c]
+            stack[0] = bvh.chunk_node_start[i_c]
             stack_idx = 1
 
             while stack_idx > 0:
                 stack_idx -= 1
                 n = stack[stack_idx]
-                bmin = func_vec3_at(bvh_node_min, n)
-                bmax = func_vec3_at(bvh_node_max, n)
+                bmin = func_vec3_at(bvh.node_min, n)
+                bmax = func_vec3_at(bvh.node_max, n)
                 # Cull when min distance from probe to AABB exceeds the conservative current best.
                 cull_radius_sq = qd.max(best_dist_sq_gt, best_dist_sq_m)
                 if not func_sphere_intersects_aabb(probe_link, cull_radius_sq, bmin, bmax):
                     continue
-                left = bvh_node_left[n]
+                left = bvh.node_left[n]
                 if left == -1:
-                    fstart = bvh_node_leaf_start[n]
-                    fn = bvh_node_leaf_count[n]
+                    fstart = bvh.node_leaf_start[n]
+                    fn = bvh.node_leaf_count[n]
                     for j in range(fn):
-                        i_f = bvh_leaf_elem_idx[fstart + j]
+                        i_f = bvh.leaf_elem_idx[fstart + j]
                         v0 = qd.Vector(
                             [bvh_tri_verts[i_f, 0, 0], bvh_tri_verts[i_f, 0, 1], bvh_tri_verts[i_f, 0, 2]],
                             dt=gs.qd_float,
@@ -285,7 +276,7 @@ def _kernel_surface_distance_probe_bvh(
                                 best_dist_sq_m = dist_sq
                                 best_point_m = closest_world
                 else:
-                    right = bvh_node_right[n]
+                    right = bvh.node_right[n]
                     # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
                     # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
                     if stack_idx < qd.static(BVH_STACK_SIZE - 2):
@@ -424,17 +415,7 @@ class SurfaceDistanceProbeSensor(
             shared_metadata.links_idx,
             shared_metadata.sensor_cache_start,
             shared_metadata.sensor_probe_start,
-            bvh.sensor_chunk_start,
-            bvh.sensor_chunk_count,
-            bvh.chunk_link_idx,
-            bvh.chunk_node_start,
-            bvh.node_min,
-            bvh.node_max,
-            bvh.node_left,
-            bvh.node_right,
-            bvh.node_leaf_start,
-            bvh.node_leaf_count,
-            bvh.leaf_elem_idx,
+            bvh.kernel_bvh,
             bvh.tri_verts,
             solver.links_state,
             shared_metadata.nearest_positions,

--- a/genesis/engine/sensors/surface_distance_probe.py
+++ b/genesis/engine/sensors/surface_distance_probe.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -8,13 +8,26 @@ import torch
 import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
-from genesis.engine.solvers.rigid.abd.forward_kinematics import func_update_all_verts
 from genesis.options.sensors import SurfaceDistanceProbe as SurfaceDistanceProbeOptions
 from genesis.utils.misc import concat_with_tensor, make_tensor_field, tensor_to_array
-from genesis.utils.raycast_qd import get_triangle_vertices
+from genesis.utils.raycast_qd import closest_point_on_triangle
 
 from .base_sensor import RigidSensorMetadataMixin, RigidSensorMixin, SimpleSensor, SimpleSensorMetadata
-from .probe import ProbeSensorMetadataMixin, ProbeSensorMixin, func_noised_probe_radius
+from .probe import (
+    ProbeSensorMetadataMixin,
+    ProbeSensorMixin,
+    func_noised_probe_radius,
+    get_measured_bufs,
+)
+from .tactile_shared import (
+    BVH_LEAF_SIZE,
+    BVH_STACK_SIZE,
+    BVHMetadata,
+    build_static_chunk_bvh,
+    func_sphere_intersects_aabb,
+    func_vec3_at,
+    get_mesh_geom_chunks,
+)
 
 if TYPE_CHECKING:
     from genesis.utils.ring_buffer import TensorRingBuffer
@@ -23,68 +36,141 @@ if TYPE_CHECKING:
     from .sensor_manager import SensorManager
 
 
-@qd.func
-def _func_closest_point_on_triangle(point: gs.qd_vec3, v0: gs.qd_vec3, v1: gs.qd_vec3, v2: gs.qd_vec3) -> gs.qd_vec3:
+@dataclass
+class TriangleMeshBVH(BVHMetadata):
     """
-    Find the point on the surface of a triangle closest to a given point.
-
-    Reference: Christer Ericson, *Real-Time Collision Detection*, §5.1.5.
+    BVH over tracked mesh triangles for one sensor class. ``leaf_elem_idx`` entries are absolute rows
+    into ``tri_verts``, a flat per-class table of link-local triangle vertices (shape ``(total_n_tri,
+    3, 3)``: per triangle, three xyz vertex positions). See ``BVHMetadata`` for the shared scaffolding
+    semantics. Rigid-link assumption: built once at scene init, never rebuilt.
     """
-    ab = v1 - v0
-    ac = v2 - v0
-    ap = point - v0
 
-    d1 = ab.dot(ap)
-    d2 = ac.dot(ap)
+    tri_verts: torch.Tensor = make_tensor_field((0, 3, 3))
 
-    # Region A (vertex v0)
-    closest = v0
-    if not (d1 <= 0.0 and d2 <= 0.0):
-        bp = point - v1
-        d3 = ab.dot(bp)
-        d4 = ac.dot(bp)
+    def append_sensor(self, track_link_idx: np.ndarray, solver) -> None:
+        """
+        Build per-tracked-link chunks for one sensor (link-local triangle BVH) and append into the flat
+        tensors. Sensors with no tracked-link geometry register zero chunks; the kernel's per-sensor
+        chunk loop iterates ``[0, sensor_chunk_count[i_s])`` and is a no-op for those.
+        """
+        new_chunk_link_idx: list[int] = []
+        new_chunk_node_start: list[int] = []
+        new_chunk_node_count: list[int] = []
+        chunk_node_min: list[np.ndarray] = []
+        chunk_node_max: list[np.ndarray] = []
+        chunk_node_left: list[np.ndarray] = []
+        chunk_node_right: list[np.ndarray] = []
+        chunk_node_leaf_start: list[np.ndarray] = []
+        chunk_node_leaf_count: list[np.ndarray] = []
+        chunk_leaf_elem_idx: list[np.ndarray] = []
+        chunk_tri_verts: list[np.ndarray] = []
 
-        # Region B (vertex v1)
-        if d3 >= 0.0 and d4 <= d3:
-            closest = v1
-        else:
-            cp = point - v2
-            d5 = ab.dot(cp)
-            d6 = ac.dot(cp)
+        chunk_start_for_sensor = int(self.chunk_link_idx.shape[0])
+        node_offset = int(self.node_min.shape[0])
+        leaf_offset = int(self.leaf_elem_idx.shape[0])
+        tri_offset = int(self.tri_verts.shape[0])
 
-            # Region C (vertex v2)
-            if d6 >= 0.0 and d5 <= d6:
-                closest = v2
-            else:
-                vc = d1 * d4 - d3 * d2
-                # Region AB (edge v0-v1)
-                if vc <= 0.0 and d1 >= 0.0 and d3 <= 0.0:
-                    w = d1 / (d1 - d3)
-                    closest = v0 + w * ab
-                else:
-                    vb = d5 * d2 - d1 * d6
-                    # Region AC (edge v0-v2)
-                    if vb <= 0.0 and d2 >= 0.0 and d6 <= 0.0:
-                        w = d2 / (d2 - d6)
-                        closest = v0 + w * ac
-                    else:
-                        va = d3 * d6 - d5 * d4
-                        # Region BC (edge v1-v2)
-                        if va <= 0.0 and (d4 - d3) >= 0.0 and (d5 - d6) >= 0.0:
-                            w = (d4 - d3) / ((d4 - d3) + (d5 - d6))
-                            closest = v1 + w * (v2 - v1)
-                        else:
-                            # Inside the triangle face
-                            denom = 1.0 / (va + vb + vc)
-                            v = vb * denom
-                            w = vc * denom
-                            closest = v0 + v * ab + w * ac
+        for i_l in range(int(track_link_idx.shape[0])):
+            link_idx = int(track_link_idx[i_l])
+            link = solver.links[link_idx]
+            geom_chunks = get_mesh_geom_chunks(link, prefer_visual=False)
+            if not geom_chunks:
+                continue
+            # Concatenate triangles from all geoms of this link into one chunk.
+            tri_v0_list: list[np.ndarray] = []
+            tri_v1_list: list[np.ndarray] = []
+            tri_v2_list: list[np.ndarray] = []
+            for _geom, verts_link, faces in geom_chunks:
+                tri_v0_list.append(verts_link[faces[:, 0]])
+                tri_v1_list.append(verts_link[faces[:, 1]])
+                tri_v2_list.append(verts_link[faces[:, 2]])
+            v0 = np.concatenate(tri_v0_list, axis=0).astype(gs.np_float, copy=False)
+            v1 = np.concatenate(tri_v1_list, axis=0).astype(gs.np_float, copy=False)
+            v2 = np.concatenate(tri_v2_list, axis=0).astype(gs.np_float, copy=False)
+            n_tri = int(v0.shape[0])
+            if n_tri == 0:
+                continue
 
-    return closest
+            centroids = (v0 + v1 + v2) / 3.0
+            aabb_mins = np.minimum(np.minimum(v0, v1), v2)
+            aabb_maxs = np.maximum(np.maximum(v0, v1), v2)
+
+            tri_stack = np.stack((v0, v1, v2), axis=1)  # (n_tri, 3, 3)
+            global_rows = (tri_offset + np.arange(n_tri, dtype=gs.np_int)).astype(gs.np_int)
+
+            nmin, nmax, nleft, nright, lstart, lcount, eidx = build_static_chunk_bvh(
+                centroids, aabb_mins, aabb_maxs, global_rows, BVH_LEAF_SIZE
+            )
+
+            new_chunk_link_idx.append(link_idx)
+            new_chunk_node_start.append(node_offset)
+            new_chunk_node_count.append(int(nmin.shape[0]))
+
+            chunk_node_min.append(nmin)
+            chunk_node_max.append(nmax)
+            # Rebase intra-chunk child / leaf-start indices into the flat tensors' absolute space.
+            chunk_node_left.append(np.where(nleft >= 0, nleft + node_offset, nleft).astype(gs.np_int))
+            chunk_node_right.append(np.where(nright >= 0, nright + node_offset, nright).astype(gs.np_int))
+            chunk_node_leaf_start.append(np.where(lcount > 0, lstart + leaf_offset, lstart).astype(gs.np_int))
+            chunk_node_leaf_count.append(lcount)
+            chunk_leaf_elem_idx.append(eidx)
+            chunk_tri_verts.append(tri_stack.astype(gs.np_float, copy=False))
+
+            node_offset += int(nmin.shape[0])
+            leaf_offset += int(eidx.shape[0])
+            tri_offset += n_tri
+
+        if not new_chunk_link_idx:
+            # No tracked links contributed geometry; record zero chunks for this sensor.
+            self.sensor_chunk_start = concat_with_tensor(self.sensor_chunk_start, chunk_start_for_sensor, expand=(1,))
+            self.sensor_chunk_count = concat_with_tensor(self.sensor_chunk_count, 0, expand=(1,))
+            return
+
+        node_min_cat = torch.tensor(np.concatenate(chunk_node_min, axis=0), dtype=gs.tc_float, device=gs.device)
+        node_max_cat = torch.tensor(np.concatenate(chunk_node_max, axis=0), dtype=gs.tc_float, device=gs.device)
+        node_left_cat = torch.tensor(np.concatenate(chunk_node_left, axis=0), dtype=gs.tc_int, device=gs.device)
+        node_right_cat = torch.tensor(np.concatenate(chunk_node_right, axis=0), dtype=gs.tc_int, device=gs.device)
+        node_leaf_start_cat = torch.tensor(
+            np.concatenate(chunk_node_leaf_start, axis=0), dtype=gs.tc_int, device=gs.device
+        )
+        node_leaf_count_cat = torch.tensor(
+            np.concatenate(chunk_node_leaf_count, axis=0), dtype=gs.tc_int, device=gs.device
+        )
+        leaf_elem_idx_cat = torch.tensor(np.concatenate(chunk_leaf_elem_idx, axis=0), dtype=gs.tc_int, device=gs.device)
+        tri_verts_cat = torch.tensor(np.concatenate(chunk_tri_verts, axis=0), dtype=gs.tc_float, device=gs.device)
+        chunk_link_idx_cat = torch.tensor(new_chunk_link_idx, dtype=gs.tc_int, device=gs.device)
+        chunk_node_start_cat = torch.tensor(new_chunk_node_start, dtype=gs.tc_int, device=gs.device)
+        chunk_node_count_cat = torch.tensor(new_chunk_node_count, dtype=gs.tc_int, device=gs.device)
+
+        self.node_min = concat_with_tensor(self.node_min, node_min_cat, expand=(node_min_cat.shape[0], 3))
+        self.node_max = concat_with_tensor(self.node_max, node_max_cat, expand=(node_max_cat.shape[0], 3))
+        self.node_left = concat_with_tensor(self.node_left, node_left_cat, expand=(node_left_cat.shape[0],))
+        self.node_right = concat_with_tensor(self.node_right, node_right_cat, expand=(node_right_cat.shape[0],))
+        self.node_leaf_start = concat_with_tensor(
+            self.node_leaf_start, node_leaf_start_cat, expand=(node_leaf_start_cat.shape[0],)
+        )
+        self.node_leaf_count = concat_with_tensor(
+            self.node_leaf_count, node_leaf_count_cat, expand=(node_leaf_count_cat.shape[0],)
+        )
+        self.leaf_elem_idx = concat_with_tensor(
+            self.leaf_elem_idx, leaf_elem_idx_cat, expand=(leaf_elem_idx_cat.shape[0],)
+        )
+        self.tri_verts = concat_with_tensor(self.tri_verts, tri_verts_cat, expand=(tri_verts_cat.shape[0], 3, 3))
+        self.chunk_link_idx = concat_with_tensor(
+            self.chunk_link_idx, chunk_link_idx_cat, expand=(chunk_link_idx_cat.shape[0],)
+        )
+        self.chunk_node_start = concat_with_tensor(
+            self.chunk_node_start, chunk_node_start_cat, expand=(chunk_node_start_cat.shape[0],)
+        )
+        self.chunk_node_count = concat_with_tensor(
+            self.chunk_node_count, chunk_node_count_cat, expand=(chunk_node_count_cat.shape[0],)
+        )
+        self.sensor_chunk_start = concat_with_tensor(self.sensor_chunk_start, chunk_start_for_sensor, expand=(1,))
+        self.sensor_chunk_count = concat_with_tensor(self.sensor_chunk_count, len(new_chunk_link_idx), expand=(1,))
 
 
 @qd.kernel
-def _kernel_surface_distance_probe(
+def _kernel_surface_distance_probe_bvh(
     probe_positions_local: qd.types.ndarray(),
     probe_radii: qd.types.ndarray(),
     probe_radii_noise: qd.types.ndarray(),
@@ -92,29 +178,35 @@ def _kernel_surface_distance_probe(
     links_idx: qd.types.ndarray(),
     sensor_cache_start: qd.types.ndarray(),
     sensor_probe_start: qd.types.ndarray(),
-    track_link_start: qd.types.ndarray(),
-    track_link_end: qd.types.ndarray(),
-    track_link_flat: qd.types.ndarray(),
-    static_rigid_sim_config: qd.template(),
+    bvh_sensor_chunk_start: qd.types.ndarray(),
+    bvh_sensor_chunk_count: qd.types.ndarray(),
+    bvh_chunk_link_idx: qd.types.ndarray(),
+    bvh_chunk_node_start: qd.types.ndarray(),
+    bvh_node_min: qd.types.ndarray(),
+    bvh_node_max: qd.types.ndarray(),
+    bvh_node_left: qd.types.ndarray(),
+    bvh_node_right: qd.types.ndarray(),
+    bvh_node_leaf_start: qd.types.ndarray(),
+    bvh_node_leaf_count: qd.types.ndarray(),
+    bvh_leaf_elem_idx: qd.types.ndarray(),
+    bvh_tri_verts: qd.types.ndarray(),
     links_state: array_class.LinksState,
-    links_info: array_class.LinksInfo,
-    geoms_info: array_class.GeomsInfo,
-    geoms_state: array_class.GeomsState,
-    faces_info: array_class.FacesInfo,
-    verts_info: array_class.VertsInfo,
-    fixed_verts_state: array_class.VertsState,
-    free_verts_state: array_class.VertsState,
     positions_gt: qd.types.ndarray(),
     positions_measured: qd.types.ndarray(),
     output_gt: qd.types.ndarray(),
     output_measured: qd.types.ndarray(),
 ):
+    """
+    BVH-accelerated surface-distance query.
+
+    Per ``(probe, env)``: transform the probe into each tracked-link's local frame, traverse the
+    per-(sensor, tracked-link) static BVH with a fixed-depth stack, cull nodes via sphere-vs-AABB with
+    radius squared = current best (the larger of GT / measured branch), and on leaf nodes call
+    closest-point-on-triangle against the stored link-local vertices. The closest world-frame point is
+    written to ``positions_*`` and the distance to ``output_*``.
+    """
     total_n_probes = probe_positions_local.shape[0]
     n_batches = output_gt.shape[-1]
-
-    func_update_all_verts(
-        geoms_state, geoms_info, verts_info, free_verts_state, fixed_verts_state, static_rigid_sim_config
-    )
 
     for i_p, i_b in qd.ndrange(total_n_probes, n_batches):
         i_s = probe_sensor_idx[i_p]
@@ -122,14 +214,12 @@ def _kernel_surface_distance_probe(
         link_pos = links_state.pos[sensor_link_idx, i_b]
         link_quat = links_state.quat[sensor_link_idx, i_b]
 
-        probe_pos_local = qd.Vector(
-            [probe_positions_local[i_p, 0], probe_positions_local[i_p, 1], probe_positions_local[i_p, 2]]
-        )
-        probe_pos = link_pos + gu.qd_transform_by_quat(probe_pos_local, link_quat)
+        probe_local = func_vec3_at(probe_positions_local, i_p)
+        probe_world = link_pos + gu.qd_transform_by_quat(probe_local, link_quat)
 
         max_r_gt = probe_radii[i_p]
         best_dist_sq_gt = max_r_gt * max_r_gt
-        best_point_gt = probe_pos
+        best_point_gt = probe_world
 
         probe_radius_noise = probe_radii_noise[i_p]
         use_noised_radius = probe_radius_noise > gs.EPS
@@ -137,37 +227,69 @@ def _kernel_surface_distance_probe(
         if use_noised_radius:
             max_r_m = func_noised_probe_radius(max_r_gt, probe_radius_noise)
         best_dist_sq_m = max_r_m * max_r_m
-        best_point_m = probe_pos
+        best_point_m = probe_world
 
-        start = track_link_start[i_s]
-        end = track_link_end[i_s]
+        chunk_start = bvh_sensor_chunk_start[i_s]
+        n_chunks = bvh_sensor_chunk_count[i_s]
+        for c_off in range(n_chunks):
+            i_c = chunk_start + c_off
+            track_link_idx = bvh_chunk_link_idx[i_c]
+            track_pos = links_state.pos[track_link_idx, i_b]
+            track_quat = links_state.quat[track_link_idx, i_b]
+            # BVH lives in the tracked link's local frame; bring the probe over.
+            probe_link = gu.qd_inv_transform_by_trans_quat(probe_world, track_pos, track_quat)
 
-        for k in range(start, end):
-            i_l = track_link_flat[k]
-            I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
-            geom_start = links_info.geom_start[I_l]
-            geom_end = links_info.geom_end[I_l]
+            stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
+            stack[0] = bvh_chunk_node_start[i_c]
+            stack_idx = 1
 
-            for i_g in range(geom_start, geom_end):
-                face_start = geoms_info.face_start[i_g]
-                face_end = geoms_info.face_end[i_g]
-
-                for i_f in range(face_start, face_end):
-                    tri_verts = get_triangle_vertices(
-                        i_f, i_b, faces_info, verts_info, fixed_verts_state, free_verts_state
-                    )
-                    v0 = tri_verts[:, 0]
-                    v1 = tri_verts[:, 1]
-                    v2 = tri_verts[:, 2]
-                    closest = _func_closest_point_on_triangle(probe_pos, v0, v1, v2)
-                    diff = closest - probe_pos
-                    dist_sq = diff.dot(diff)
-                    if dist_sq < best_dist_sq_gt:
-                        best_dist_sq_gt = dist_sq
-                        best_point_gt = closest
-                    if use_noised_radius and dist_sq < best_dist_sq_m:
-                        best_dist_sq_m = dist_sq
-                        best_point_m = closest
+            while stack_idx > 0:
+                stack_idx -= 1
+                n = stack[stack_idx]
+                bmin = func_vec3_at(bvh_node_min, n)
+                bmax = func_vec3_at(bvh_node_max, n)
+                # Cull when min distance from probe to AABB exceeds the conservative current best.
+                cull_radius_sq = qd.max(best_dist_sq_gt, best_dist_sq_m)
+                if not func_sphere_intersects_aabb(probe_link, cull_radius_sq, bmin, bmax):
+                    continue
+                left = bvh_node_left[n]
+                if left == -1:
+                    fstart = bvh_node_leaf_start[n]
+                    fn = bvh_node_leaf_count[n]
+                    for j in range(fn):
+                        i_f = bvh_leaf_elem_idx[fstart + j]
+                        v0 = qd.Vector(
+                            [bvh_tri_verts[i_f, 0, 0], bvh_tri_verts[i_f, 0, 1], bvh_tri_verts[i_f, 0, 2]],
+                            dt=gs.qd_float,
+                        )
+                        v1 = qd.Vector(
+                            [bvh_tri_verts[i_f, 1, 0], bvh_tri_verts[i_f, 1, 1], bvh_tri_verts[i_f, 1, 2]],
+                            dt=gs.qd_float,
+                        )
+                        v2 = qd.Vector(
+                            [bvh_tri_verts[i_f, 2, 0], bvh_tri_verts[i_f, 2, 1], bvh_tri_verts[i_f, 2, 2]],
+                            dt=gs.qd_float,
+                        )
+                        closest_link = closest_point_on_triangle(probe_link, v0, v1, v2)
+                        diff = closest_link - probe_link
+                        dist_sq = diff.dot(diff)
+                        if dist_sq < best_dist_sq_gt or (use_noised_radius and dist_sq < best_dist_sq_m):
+                            # Transform the hit back to world frame and record on whichever branch tightened.
+                            closest_world = track_pos + gu.qd_transform_by_quat(closest_link, track_quat)
+                            if dist_sq < best_dist_sq_gt:
+                                best_dist_sq_gt = dist_sq
+                                best_point_gt = closest_world
+                            if use_noised_radius and dist_sq < best_dist_sq_m:
+                                best_dist_sq_m = dist_sq
+                                best_point_m = closest_world
+                else:
+                    right = bvh_node_right[n]
+                    # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
+                    # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
+                    if stack_idx < qd.static(BVH_STACK_SIZE - 2):
+                        stack[stack_idx] = left
+                        stack[stack_idx + 1] = right
+                        stack_idx += 2
 
         best_dist_gt = qd.sqrt(best_dist_sq_gt)
         best_dist_m = best_dist_gt
@@ -179,24 +301,27 @@ def _kernel_surface_distance_probe(
 
         probe_idx_in_sensor = i_p - sensor_probe_start[i_s]
         cache_start = sensor_cache_start[i_s]
-        probe_global_idx = sensor_probe_start[i_s] + probe_idx_in_sensor
 
         output_gt[cache_start + probe_idx_in_sensor, i_b] = best_dist_gt
         output_measured[cache_start + probe_idx_in_sensor, i_b] = best_dist_m
         for j in qd.static(range(3)):
-            positions_gt[i_b, probe_global_idx, j] = best_point_gt[j]
-            positions_measured[i_b, probe_global_idx, j] = best_point_m[j]
+            positions_gt[i_b, i_p, j] = best_point_gt[j]
+            positions_measured[i_b, i_p, j] = best_point_m[j]
 
 
 @dataclass
 class SurfaceDistanceProbeSensorMetadataMixin(ProbeSensorMetadataMixin):
-    """Shared metadata for surface distance probe sensors: tracked links and nearest-point buffer."""
+    """
+    Shared metadata for surface distance probe sensors: tracked-link bookkeeping, nearest-point buffer,
+    and the per-class static triangle-mesh BVH consumed by ``_kernel_surface_distance_probe_bvh``.
+    """
 
     track_link_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     track_link_end: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     track_link_flat: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     nearest_positions: torch.Tensor = make_tensor_field((0, 0, 3))
     nearest_positions_measured: torch.Tensor = make_tensor_field((0, 0, 3))
+    bvh: TriangleMeshBVH = field(default_factory=TriangleMeshBVH)
 
 
 @dataclass
@@ -222,11 +347,12 @@ class SurfaceDistanceProbeSensor(
         manager: "SensorManager",
     ):
         super().__init__(options, idx, shared_context, shared_metadata, manager)
-        self._debug_objects: list = []
         self._nearest_points_slice: slice | None = None
 
-    def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
-        return (self._n_probes,)
+    def _get_return_format(self) -> tuple[int, ...]:
+        # Mirror the probe layout so a grid ``probe_local_pos`` (M, N, 3) reads back as (..., M, N), consistent with
+        # the other grid tactile sensors; a flat layout stays (..., n_probes). The cache is flat either way.
+        return self._probe_layout_shape
 
     @classmethod
     def _get_cache_dtype(cls) -> torch.dtype:
@@ -262,6 +388,10 @@ class SurfaceDistanceProbeSensor(
         slice_start = self._shared_metadata.sensor_probe_start[self._idx]
         self._nearest_points_slice = slice(slice_start, slice_start + self._n_probes)
 
+        # Build the per-(sensor, tracked-link) triangle BVH in link-local frame. Rigid links don't deform,
+        # so this is a one-shot scene-build cost; per-step queries traverse the static structure.
+        self._shared_metadata.bvh.append_sensor(track_link_idx, self._shared_metadata.solver)
+
     @classmethod
     def reset(cls, shared_metadata: SurfaceDistanceProbeMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
         super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
@@ -280,14 +410,11 @@ class SurfaceDistanceProbeSensor(
         measured_data_timeline: "TensorRingBuffer",
     ):
         solver = shared_metadata.solver
-        current_ground_truth_data_T.zero_()
-        measured = measured_data_timeline.at(0, copy=False)
-        measured.zero_()
-        if shared_metadata.measured_scratch_T.shape != current_ground_truth_data_T.shape:
-            shared_metadata.measured_scratch_T = torch.empty_like(current_ground_truth_data_T)
-        measured_cols_b = shared_metadata.measured_scratch_T
-
-        _kernel_surface_distance_probe(
+        measured, measured_cols_b = get_measured_bufs(
+            shared_metadata, current_ground_truth_data_T, measured_data_timeline
+        )
+        bvh = shared_metadata.bvh
+        _kernel_surface_distance_probe_bvh(
             shared_metadata.probe_positions,
             shared_metadata.probe_radii,
             shared_metadata.probe_radii_noise,
@@ -295,18 +422,19 @@ class SurfaceDistanceProbeSensor(
             shared_metadata.links_idx,
             shared_metadata.sensor_cache_start,
             shared_metadata.sensor_probe_start,
-            shared_metadata.track_link_start,
-            shared_metadata.track_link_end,
-            shared_metadata.track_link_flat,
-            solver._static_rigid_sim_config,
+            bvh.sensor_chunk_start,
+            bvh.sensor_chunk_count,
+            bvh.chunk_link_idx,
+            bvh.chunk_node_start,
+            bvh.node_min,
+            bvh.node_max,
+            bvh.node_left,
+            bvh.node_right,
+            bvh.node_leaf_start,
+            bvh.node_leaf_count,
+            bvh.leaf_elem_idx,
+            bvh.tri_verts,
             solver.links_state,
-            solver.links_info,
-            solver.geoms_info,
-            solver.geoms_state,
-            solver.faces_info,
-            solver.verts_info,
-            solver.fixed_verts_state,
-            solver.free_verts_state,
             shared_metadata.nearest_positions,
             shared_metadata.nearest_positions_measured,
             current_ground_truth_data_T,
@@ -322,33 +450,43 @@ class SurfaceDistanceProbeSensor(
             context.clear_debug_object(obj)
         self._debug_objects.clear()
 
-        link_pos = self._link.get_pos(env_idx, relative=False).squeeze()
-        link_quat = self._link.get_quat(env_idx, relative=False).squeeze()
-        probe_world = tensor_to_array(gu.transform_by_trans_quat(self._probe_local_pos, link_pos, link_quat))
+        # Single env: drop the leading env axis to a bare (3,) / (4,); squeeze(0) leaves an unbatched vector untouched.
+        link_pos = self._link.get_pos(env_idx, relative=False).squeeze(0)
+        link_quat = self._link.get_quat(env_idx, relative=False).squeeze(0)
+        probe_world = tensor_to_array(
+            gu.transform_by_trans_quat(self._probe_local_pos.reshape(-1, 3), link_pos, link_quat)
+        ).reshape(-1, 3)
         points = tensor_to_array(self.nearest_points[env_idx]).reshape(-1, 3)
 
+        rgb = tuple(float(c) for c in self._options.debug_probe_color)
+        line_color = (*rgb, 1.0)
+        self._debug_objects.extend(self._draw_probe_spheres(context, probe_world, rgb))
         self._debug_objects.append(
             context.draw_debug_spheres(
-                poss=np.concatenate([probe_world, points]),
-                radius=self._options.debug_sphere_radius,
-                color=self._options.debug_probe_color,
+                poss=points,
+                radius=float(self._options.debug_probe_center_radius),
+                color=line_color,
             )
         )
         for i in range(len(probe_world)):
-            line_obj = context.draw_debug_line(
-                probe_world[i],
-                points[i],
-                radius=self._options.debug_sphere_radius / 4.0,
-                color=self._options.debug_probe_color,
+            self._debug_objects.append(
+                context.draw_debug_line(
+                    probe_world[i],
+                    points[i],
+                    radius=float(self._options.debug_probe_center_radius) / 4.0,
+                    color=line_color,
+                )
             )
-            self._debug_objects.append(line_obj)
 
     @property
     def nearest_points(self) -> torch.Tensor:
-        """Nearest mesh points for the measured (noisy-radius) query, aligned with ``read()``."""
-        return self._shared_metadata.nearest_positions_measured[..., self._nearest_points_slice, :]
+        """Nearest mesh points for the measured (noisy-radius) query, aligned with ``read()`` -- a grid
+        ``probe_local_pos`` (M, N, 3) reads back as (..., M, N, 3), a flat layout as (..., n_probes, 3)."""
+        points = self._shared_metadata.nearest_positions_measured[..., self._nearest_points_slice, :]
+        return points.reshape(*points.shape[:-2], *self._probe_layout_shape, 3)
 
     @property
     def nearest_points_ground_truth(self) -> torch.Tensor:
-        """Nearest mesh points for the nominal-radius ground-truth query."""
-        return self._shared_metadata.nearest_positions[..., self._nearest_points_slice, :]
+        """Nearest mesh points for the nominal-radius ground-truth query, aligned with ``read_ground_truth()``."""
+        points = self._shared_metadata.nearest_positions[..., self._nearest_points_slice, :]
+        return points.reshape(*points.shape[:-2], *self._probe_layout_shape, 3)

--- a/genesis/engine/sensors/tactile_shared.py
+++ b/genesis/engine/sensors/tactile_shared.py
@@ -158,8 +158,9 @@ def func_vec3_at(values: qd.types.ndarray(), i: int) -> qd.types.vector(3):
 @qd.func
 def func_sphere_intersects_aabb(center, radius_sq, bmin, bmax):  # -> bool
     """
-    Squared-distance sphere-vs-AABB test: True iff the closest AABB point to ``center`` is within
-    ``radius_sq``. Reused as a closest-point cull by passing ``radius_sq = current_best_dist_sq``.
+    Squared-distance sphere-vs-AABB test: True iff the closest AABB point to ``center`` is within ``radius_sq``.
+
+    Reused as a closest-point cull by passing ``radius_sq = current_best_dist_sq``.
     """
     d_sq = gs.qd_float(0.0)
     for k in qd.static(range(3)):
@@ -482,12 +483,13 @@ def resolve_contact_depth_query(metadata: ContactDepthQueryMetadataMixin, mode: 
 
 class ContactDepthQuerySensorMixin:
     """
-    Sensor-side counterpart to ``ContactDepthQueryMetadataMixin``. Its ``build()`` resolves the class-wide
-    contact-depth backend (raising if this class's sensors disagree) and activates only the chosen backend: the
-    shared ``RaycastContext`` BVH in raycast mode, else the collider SDF. Mixing this in (alongside the metadata
-    mixin) means subclasses get the resolution from the super-``build()`` chain and need not call
-    ``resolve_contact_depth_query`` themselves. Requires ``_shared_metadata``, ``_options.contact_depth_query``, and
-    a ``_shared_context`` ``RaycastContext``.
+    Sensor-side counterpart to ``ContactDepthQueryMetadataMixin``.
+
+    Its ``build()`` resolves the class-wide contact-depth backend (raising if this class's sensors disagree) and
+    activates only the chosen backend: the shared ``RaycastContext`` BVH in raycast mode, else the collider SDF.
+    Mixing this in (alongside the metadata mixin) means subclasses get the resolution from the super-``build()`` chain
+    and need not call ``resolve_contact_depth_query`` themselves. Requires ``_shared_metadata``,
+    ``_options.contact_depth_query``, and a ``_shared_context`` ``RaycastContext``.
     """
 
     def build(self):

--- a/genesis/engine/sensors/tactile_shared.py
+++ b/genesis/engine/sensors/tactile_shared.py
@@ -1,0 +1,499 @@
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, NamedTuple
+
+import numpy as np
+import quadrants as qd
+import torch
+
+import genesis as gs
+import genesis.utils.geom as gu
+from genesis.utils.misc import concat_with_tensor, make_tensor_field
+
+if TYPE_CHECKING:
+    from genesis.utils.ring_buffer import TensorRingBuffer
+
+
+_GRID_TOL = 1.0e-5  # Tolerance for grid-regularity / orthogonality / normal-uniformity checks.
+
+
+def next_pow2(n: int) -> int:
+    """
+    Smallest power of 2 >= ``n`` (1 if ``n == 0``).
+    """
+    if n <= 1:
+        return 1
+    p = 1
+    while p < n:
+        p *= 2
+    return p
+
+
+# ==================== BVH helpers (shared by point-cloud and triangle-mesh sensors) ====================
+
+
+BVH_LEAF_SIZE = 8
+BVH_STACK_SIZE = 32
+
+
+def get_mesh_geom_chunks(link, prefer_visual: bool) -> list[tuple[object, np.ndarray, np.ndarray]]:
+    """
+    Return per-geom mesh chunks ``(geom, verts_link, faces)`` in link-local frame.
+
+    ``prefer_visual`` picks vgeoms over geoms when both exist; falls back to the other type when the
+    preferred one is absent. Empty meshes are dropped from the list.
+    """
+    if prefer_visual:
+        geoms = list(link.vgeoms) if link.vgeoms else list(link.geoms)
+        use_vverts = bool(link.vgeoms)
+    else:
+        geoms = list(link.geoms) if link.geoms else list(link.vgeoms)
+        use_vverts = not bool(link.geoms) and bool(link.vgeoms)
+
+    chunks: list[tuple[object, np.ndarray, np.ndarray]] = []
+    for geom in geoms:
+        # init_*verts / init_*faces come from loaded mesh data whose dtype is not under our control, so coerce here.
+        if use_vverts:
+            verts = np.asarray(geom.init_vverts, dtype=gs.np_float)
+            faces = np.asarray(geom.init_vfaces, dtype=gs.np_int)
+        else:
+            verts = np.asarray(geom.init_verts, dtype=gs.np_float)
+            faces = np.asarray(geom.init_faces, dtype=gs.np_int)
+        if verts.size == 0 or faces.size == 0:
+            continue
+        verts_link = gu.transform_by_trans_quat(verts, geom.init_pos, geom.init_quat)
+        chunks.append((geom, verts_link.astype(gs.np_float, copy=False), faces))
+    return chunks
+
+
+def build_static_chunk_bvh(
+    centroids: np.ndarray,
+    aabb_mins: np.ndarray,
+    aabb_maxs: np.ndarray,
+    global_rows: np.ndarray,
+    leaf_size: int,
+) -> tuple[np.ndarray, ...]:
+    """
+    Median-split AABB BVH over a static set of elements (points, triangles, etc.) in link-local frame.
+
+    Split decisions use ``centroids`` along the longest-spread axis; node AABBs union the per-element
+    ``aabb_mins``/``aabb_maxs``. For point-cloud BVHs, callers pass ``centroids == aabb_mins == aabb_maxs``
+    (the points themselves); for triangle BVHs, callers pass per-triangle centroid + min/max bounds.
+
+    Leaves carry the caller-provided ``global_rows`` (absolute rows into the sensor-class element table);
+    the kernel indexes directly into that table with no extra indirection. Internal nodes use -1 for
+    ``node_left`` / ``node_right``. Returns ``(node_min, node_max, node_left, node_right, node_elem_start,
+    node_elem_n, elem_idx)``.
+    """
+    node_min: list[np.ndarray] = []
+    node_max: list[np.ndarray] = []
+    node_left: list[int] = []
+    node_right: list[int] = []
+    node_elem_start: list[int] = []
+    node_elem_n: list[int] = []
+    elem_idx: list[int] = []
+
+    def _alloc() -> int:
+        i = len(node_min)
+        node_min.append(np.zeros(3, dtype=gs.np_float))
+        node_max.append(np.zeros(3, dtype=gs.np_float))
+        node_left.append(-1)
+        node_right.append(-1)
+        node_elem_start.append(-1)
+        node_elem_n.append(0)
+        return i
+
+    def _build(rows: np.ndarray, cents: np.ndarray, a_mins: np.ndarray, a_maxs: np.ndarray) -> int:
+        nid = _alloc()
+        bmin = a_mins.min(axis=0).astype(gs.np_float)
+        bmax = a_maxs.max(axis=0).astype(gs.np_float)
+        node_min[nid] = bmin
+        node_max[nid] = bmax
+        if rows.shape[0] <= leaf_size:
+            start = len(elem_idx)
+            elem_idx.extend(int(r) for r in rows)
+            node_elem_start[nid] = start
+            node_elem_n[nid] = int(rows.shape[0])
+            return nid
+        axis = int(np.argmax(bmax - bmin))
+        order = np.argsort(cents[:, axis], kind="stable")
+        mid = order.shape[0] // 2
+        node_left[nid] = _build(rows[order[:mid]], cents[order[:mid]], a_mins[order[:mid]], a_maxs[order[:mid]])
+        node_right[nid] = _build(rows[order[mid:]], cents[order[mid:]], a_mins[order[mid:]], a_maxs[order[mid:]])
+        return nid
+
+    if centroids.shape[0] == 0:
+        return (
+            np.zeros((0, 3), dtype=gs.np_float),
+            np.zeros((0, 3), dtype=gs.np_float),
+            np.zeros((0,), dtype=gs.np_int),
+            np.zeros((0,), dtype=gs.np_int),
+            np.zeros((0,), dtype=gs.np_int),
+            np.zeros((0,), dtype=gs.np_int),
+            np.zeros((0,), dtype=gs.np_int),
+        )
+
+    root = _build(
+        global_rows.astype(gs.np_int, copy=False),
+        centroids.astype(gs.np_float, copy=False),
+        aabb_mins.astype(gs.np_float, copy=False),
+        aabb_maxs.astype(gs.np_float, copy=False),
+    )
+    assert root == 0
+    return (
+        np.stack(node_min, axis=0),
+        np.stack(node_max, axis=0),
+        np.asarray(node_left, dtype=gs.np_int),
+        np.asarray(node_right, dtype=gs.np_int),
+        np.asarray(node_elem_start, dtype=gs.np_int),
+        np.asarray(node_elem_n, dtype=gs.np_int),
+        np.asarray(elem_idx, dtype=gs.np_int),
+    )
+
+
+@qd.func
+def func_vec3_at(values: qd.types.ndarray(), i: int) -> qd.types.vector(3):
+    return qd.Vector([values[i, 0], values[i, 1], values[i, 2]], dt=float)
+
+
+@qd.func
+def func_sphere_intersects_aabb(center, radius_sq, bmin, bmax):  # -> bool
+    """
+    Squared-distance sphere-vs-AABB test: True iff the closest AABB point to ``center`` is within
+    ``radius_sq``. Reused as a closest-point cull by passing ``radius_sq = current_best_dist_sq``.
+    """
+    d_sq = gs.qd_float(0.0)
+    for k in qd.static(range(3)):
+        v = center[k]
+        lo = bmin[k]
+        hi = bmax[k]
+        if v < lo:
+            d = lo - v
+            d_sq = d_sq + d * d
+        elif v > hi:
+            d = v - hi
+            d_sq = d_sq + d * d
+    return d_sq <= radius_sq
+
+
+@qd.func
+def func_aabb_intersects_aabb(amin, amax, bmin, bmax):  # -> bool
+    """
+    Standard 6-axis AABB-vs-AABB overlap test.
+    """
+    return (
+        amin[0] <= bmax[0]
+        and amax[0] >= bmin[0]
+        and amin[1] <= bmax[1]
+        and amax[1] >= bmin[1]
+        and amin[2] <= bmax[2]
+        and amax[2] >= bmin[2]
+    )
+
+
+@dataclass
+class BVHMetadata:
+    """
+    Element-agnostic scaffolding for a static, link-local, chunked AABB BVH shared across one sensor class.
+
+    One *chunk* per (sensor, tracked_link): each chunk is a small subtree built once at scene init in the
+    tracked link's local frame and never rebuilt. Subclasses (PointCloudBVH, TriangleMeshBVH) layer on
+    element-specific payload tables; ``leaf_elem_idx`` entries are absolute rows into those tables.
+
+    Per-sensor slice into the chunk arrays:
+        ``chunks[sensor_chunk_start[s] : sensor_chunk_start[s] + sensor_chunk_count[s]]``
+    Per-chunk slice into the flat node arrays:
+        ``nodes[chunk_node_start[c] : chunk_node_start[c] + chunk_node_count[c]]``
+    Per-leaf slice into ``leaf_elem_idx``:
+        ``leaf_elem_idx[node_leaf_start[n] : node_leaf_start[n] + node_leaf_count[n]]``
+    ``node_left == -1`` marks a leaf; otherwise ``node_left``/``node_right`` are absolute child indices.
+    """
+
+    sensor_chunk_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    sensor_chunk_count: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+    chunk_link_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    chunk_node_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    chunk_node_count: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+    node_min: torch.Tensor = make_tensor_field((0, 3))
+    node_max: torch.Tensor = make_tensor_field((0, 3))
+    node_left: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    node_right: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+    node_leaf_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    node_leaf_count: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    leaf_elem_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+
+# ============================ FFT helpers ============================
+
+
+@dataclass
+class GridFFTConvMetadataMixin:
+    """
+    Shared per-sensor-class state for the per-grid 2D-FFT convolution passes.
+
+    Attributes
+    ----------
+    grid_fft_meta : list of NamedTuple
+        Per-grid-FFT-sensor metadata records. The leading 5 fields are always
+        ``(sensor_idx, g_ny, g_nx, probe_start, cache_start)``; sensors append their kernel params after that
+        (e.g. ``GridFFTMeta`` for HydroShear dilation).
+    grid_fft_max_n : (int, int)
+        Global FFT size ``(fft_ny, fft_nx)``, the elementwise max over all registered grid sensors. Build-time only.
+    grid_fft_kernels_stacked : torch.Tensor
+        Stacked complex ``rfft2`` kernels (half spectrum), shape ``(n_grid, n_planes, fft_ny, fft_nx // 2 + 1)``.
+        Recomputed when the FFT size grows.
+    grid_fft_buffer : torch.Tensor
+        Reused per-step real buffer: ``(B, n_grid, n_channels, fft_ny, fft_nx)`` when registered with
+        ``n_buffer_channels > 0``, else ``(B, n_grid, fft_ny, fft_nx)``. Reallocated on each registration.
+    any_grid_fft : bool
+        Python fast-path flag; True iff at least one grid-FFT sensor is registered.
+    """
+
+    grid_fft_meta: list[NamedTuple] = field(default_factory=list)
+    grid_fft_max_n: tuple[int, int] = (0, 0)
+    grid_fft_kernels_stacked: torch.Tensor = make_tensor_field((0, 0, 0, 0), dtype_factory=lambda: torch.complex64)
+    grid_fft_buffer: torch.Tensor = make_tensor_field((0, 0, 0, 0))
+    any_grid_fft: bool = False
+
+
+def register_grid_fft_sensor(
+    metadata: GridFFTConvMetadataMixin,
+    meta_entry: NamedTuple,
+    this_fft_n: tuple[int, int],
+    kernel_builder: Callable[[NamedTuple, tuple[int, int]], torch.Tensor],
+    n_buffer_channels: int,
+    batch_size: int,
+) -> None:
+    """
+    Register one grid-shaped sensor for FFT convolution; (re)build the stacked kernels and the per-step buffer.
+
+    Parameters
+    ----------
+    meta_entry : NamedTuple
+        Metadata record appended to ``grid_fft_meta``; its leading 5 fields must be
+        ``(sensor_idx, g_ny, g_nx, probe_start, cache_start)``, followed by any sensor-specific kernel params.
+    this_fft_n : (int, int)
+        The ``(ny, nx)`` FFT size this sensor needs. The shared ``grid_fft_max_n`` grows to the elementwise max;
+        when it grows, every prior sensor's kernel is recomputed at the new size (frequency-domain padding is not
+        equivalent to spatial zero-padding).
+    kernel_builder : callable
+        ``kernel_builder(meta_entry, fft_n) -> (n_planes, fft_ny, fft_nx // 2 + 1)`` complex tensor (an ``rfft2``
+        half spectrum). Must be deterministic from the meta record, since it is re-invoked whenever the FFT size grows.
+    n_buffer_channels : int
+        When ``> 0``, allocate a 5D ``(B, n_grid, n_buffer_channels, ny, nx)`` per-step buffer; else a 4D
+        ``(B, n_grid, ny, nx)`` one.
+    """
+    metadata.grid_fft_meta.append(meta_entry)
+    cur = metadata.grid_fft_max_n
+    new_n = (max(cur[0], this_fft_n[0]), max(cur[1], this_fft_n[1]))
+    metadata.grid_fft_max_n = new_n
+    n_grid = len(metadata.grid_fft_meta)
+    metadata.grid_fft_kernels_stacked = torch.stack([kernel_builder(m, new_n) for m in metadata.grid_fft_meta], dim=0)
+    buffer_shape = (
+        (batch_size, n_grid, n_buffer_channels, new_n[0], new_n[1])
+        if n_buffer_channels > 0
+        else (batch_size, n_grid, new_n[0], new_n[1])
+    )
+    metadata.grid_fft_buffer = torch.zeros(buffer_shape, dtype=gs.tc_float, device=gs.device)
+    metadata.any_grid_fft = True
+
+
+def expand_probe_normals(normals: np.ndarray, n_probes: int, probe_shape: tuple[int, ...]) -> np.ndarray:
+    """Broadcast ``normals`` to a flat ``(n_probes, 3)`` array.
+
+    Accepts a single shared normal of shape ``(3,)``, a grid-shaped ``(*probe_shape, 3)`` array, or an already-flat
+    ``(n_probes, 3)``. Any other shape raises.
+    """
+    normals = np.asarray(normals, dtype=gs.np_float)
+    if normals.ndim == 1:
+        return np.broadcast_to(normals, (n_probes, 3)).copy()
+    if normals.shape == (*probe_shape, 3):
+        return normals.reshape(n_probes, 3).copy()
+    if normals.shape == (n_probes, 3):
+        return normals.copy()
+    gs.raise_exception(
+        "probe_local_normal must be one normal or match probe_local_pos shape. "
+        f"Got normal shape {normals.shape} for probe shape {probe_shape}."
+    )
+
+
+def normalize_grid_probe_layout(
+    probe_pos: np.ndarray, probe_normals: np.ndarray, is_grid: bool
+) -> tuple[np.ndarray, np.ndarray, bool, bool, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Validate a probe layout and extract grid-FFT metadata when the layout qualifies.
+
+    Returns ``(flat_positions, flat_normals, use_grid_fft, is_grid_regular, grid_normal, tangent_u, tangent_v,
+    grid_spacing)``.
+
+    ``use_grid_fft`` is True when the layout has shape ``(ny, nx, 3)`` with ``ny, nx >= 2`` and non-degenerate
+    spacing along both axes -- the FFT path is usable and the grid metadata is populated as a best-fit
+    approximation (average step vectors over all adjacent pairs, average unit normal over all probes).
+
+    ``is_grid_regular`` is True when, in addition, the layout is strictly regular: normals uniform within
+    tolerance, tangents orthogonal, both tangents in the plane perpendicular to the normal, and all probes lie
+    on the regular ``(spacing_u, spacing_v)`` rectangle implied by the averaged steps. Callers that proceed
+    with FFT on an irregular layout (``use_grid_fft`` and not ``is_grid_regular``) should warn the user.
+
+    When ``use_grid_fft`` is False, the tangent / spacing / normal entries are zero.
+    """
+    probe_shape = probe_pos.shape[:-1]
+    flat = probe_pos.reshape(-1, 3)
+    normals = expand_probe_normals(probe_normals, flat.shape[0], probe_shape)
+
+    normal_norms = np.linalg.norm(normals, axis=1)
+    if np.any(normal_norms < gs.EPS):
+        gs.raise_exception("probe_local_normal entries must be non-zero.")
+    normals = normals / normal_norms[:, None]
+
+    use_grid_fft = False
+    is_grid_regular = False
+    grid_normal = np.zeros(3, dtype=gs.np_float)
+    tangent_u = np.zeros(3, dtype=gs.np_float)
+    tangent_v = np.zeros(3, dtype=gs.np_float)
+    grid_spacing = np.zeros(2, dtype=gs.np_float)
+
+    if is_grid:
+        if len(probe_shape) != 2:
+            gs.raise_exception("Grid probe_local_pos must have shape (ny, nx, 3).")
+        ny, nx = int(probe_shape[0]), int(probe_shape[1])
+        if nx >= 2 and ny >= 2:
+            grid = probe_pos.reshape(ny, nx, 3)
+            # Averaged step vectors across all adjacent pairs along each axis -- robust to local jitter.
+            avg_step_u = (grid[:, 1:, :] - grid[:, :-1, :]).reshape(-1, 3).mean(axis=0)
+            avg_step_v = (grid[1:, :, :] - grid[:-1, :, :]).reshape(-1, 3).mean(axis=0)
+            spacing_u = float(np.linalg.norm(avg_step_u))
+            spacing_v = float(np.linalg.norm(avg_step_v))
+            if spacing_u >= gs.EPS and spacing_v >= gs.EPS:
+                tangent_u_candidate = (avg_step_u / spacing_u).astype(gs.np_float)
+                tangent_v_candidate = (avg_step_v / spacing_v).astype(gs.np_float)
+                # Average unit normal across all probes. If they cancel out (e.g. opposing normals), fall back
+                # to the first probe's normal so downstream FFT still has a defined orientation.
+                avg_normal = normals.mean(axis=0)
+                normal_norm = float(np.linalg.norm(avg_normal))
+                if normal_norm < gs.EPS:
+                    normal_candidate = normals[0].astype(gs.np_float, copy=False)
+                else:
+                    normal_candidate = (avg_normal / normal_norm).astype(gs.np_float)
+
+                normals_are_uniform = bool(np.all(normals @ normal_candidate >= 1.0 - _GRID_TOL))
+                axes_are_orthogonal = abs(float(tangent_u_candidate @ tangent_v_candidate)) <= _GRID_TOL
+                axes_in_plane = (
+                    abs(float(tangent_u_candidate @ normal_candidate)) <= _GRID_TOL
+                    and abs(float(tangent_v_candidate @ normal_candidate)) <= _GRID_TOL
+                )
+                expected = (
+                    grid[0, 0]
+                    + np.arange(nx, dtype=gs.np_float)[None, :, None] * avg_step_u[None, None, :]
+                    + np.arange(ny, dtype=gs.np_float)[:, None, None] * avg_step_v[None, None, :]
+                )
+                is_regular = bool(np.max(np.linalg.norm(grid - expected, axis=-1)) <= _GRID_TOL)
+
+                use_grid_fft = True
+                is_grid_regular = normals_are_uniform and axes_are_orthogonal and axes_in_plane and is_regular
+                grid_normal = normal_candidate
+                tangent_u = tangent_u_candidate
+                tangent_v = tangent_v_candidate
+                grid_spacing = np.array((spacing_u, spacing_v), dtype=gs.np_float)
+
+    return (
+        flat.astype(gs.np_float, copy=False),
+        normals.astype(gs.np_float, copy=False),
+        use_grid_fft,
+        is_grid_regular,
+        grid_normal.astype(gs.np_float, copy=False),
+        tangent_u.astype(gs.np_float, copy=False),
+        tangent_v.astype(gs.np_float, copy=False),
+        grid_spacing.astype(gs.np_float, copy=False),
+    )
+
+
+# ============================ Contact prefilter ============================
+
+
+@dataclass
+class ContactPrefilterMetadataMixin:
+    """
+    Per-(env, sensor) prefilter buffers shared by tactile sensors whose kernels query the collider's contacts per
+    probe (KinematicTaxel, ContactDepthProbe), populated each step in ``kinematic_tactile.py``:
+
+    - ``sensor_contacts_idx`` / ``sensor_n_contacts``: compact list of contact indices whose ``link_a`` or
+      ``link_b`` matches the sensor's tracked link (``_kernel_build_sensor_contact_idx``). Feeds the raycast
+      path's BVH-mask builder. Shape ``(B, n_sensors, max_contacts)`` / ``(B, n_sensors)``; the per-sensor cap
+      (``_MAX_CONTACTS_PER_SENSOR``) is read off ``sensor_contacts_idx.shape[2]``.
+    - ``sensor_geoms_idx`` / ``sensor_n_geoms``: compact *deduplicated* list of the opposing contacting geoms
+      for the same link (``_kernel_build_sensor_geom_idx``). Feeds the SDF path so each probe queries one SDF
+      per distinct geom instead of one per contact point. Shape ``(B, n_sensors, max_geoms)`` /
+      ``(B, n_sensors)``; the cap (``_MAX_GEOMS_PER_SENSOR``) is read off ``sensor_geoms_idx.shape[2]``.
+    """
+
+    sensor_contacts_idx: torch.Tensor = make_tensor_field((0, 0, 0), dtype_factory=lambda: gs.tc_int)
+    sensor_n_contacts: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
+    sensor_geoms_idx: torch.Tensor = make_tensor_field((0, 0, 0), dtype_factory=lambda: gs.tc_int)
+    sensor_n_geoms: torch.Tensor = make_tensor_field((0, 0), dtype_factory=lambda: gs.tc_int)
+
+
+# ============================ Contact depth query mode (SDF vs raycast) ============================
+
+
+@dataclass
+class ContactDepthQueryMetadataMixin:
+    """
+    Shared per-sensor-class state for the contact-depth query backend.
+
+    ``contact_depth_query`` is the resolved mode for every sensor of this class - ``"sdf"`` or ``"raycast"``. The
+    backend is dispatched once per sensor class (a single kernel covers all of the class's sensors), so every sensor
+    must agree: each sensor's ``build()`` calls ``resolve_contact_depth_query``, which records the first non-``None``
+    mode and raises if a later sensor requests a different one. ``None`` defers to whatever another sensor set;
+    ``None`` at update time falls back to ``"sdf"``.
+
+    When mode is ``"raycast"``, the collision/visual BVHs come from the shared ``RaycastContext`` (the sensor's
+    ``shared_context``), built lazily on raycast opt-in and refreshed once per step by ``SensorManager``.
+    ``sensor_candidate_geom_mask`` is a per-(env, sensor, geom) bool gate - scattered per step from the contact
+    prefilter (KinematicTactile family) or once at build from ``sensor_track_geom_idx`` (ElastomerTaxel) - so BVH
+    leaves whose ``faces_info.geom_idx`` falls outside the mask are skipped.
+    """
+
+    contact_depth_query: str | None = None
+    sensor_candidate_geom_mask: torch.Tensor = make_tensor_field((0, 0, 0), dtype_factory=lambda: gs.tc_bool)
+
+
+def resolve_contact_depth_query(metadata: ContactDepthQueryMetadataMixin, mode: str | None, sensor_name: str) -> None:
+    """
+    Record the class-wide contact-depth backend for one sensor, rejecting a conflict with an earlier sensor.
+
+    The backend is dispatched per sensor class, so every sensor of a class must agree on ``"sdf"`` vs ``"raycast"``.
+    ``mode is None`` defers to whatever another sensor set (default ``"sdf"``); a different non-``None`` ``mode``
+    raises rather than silently switching the whole class by build order.
+    """
+    if mode is None:
+        return
+    existing = metadata.contact_depth_query
+    if existing is not None and existing != mode:
+        gs.raise_exception(
+            f"{sensor_name} sensors disagree on contact_depth_query ({existing!r} vs {mode!r}). All sensors of a "
+            "tactile class share one contact-depth backend; use the same mode for every sensor of this class (build "
+            "separate scenes to compare backends)."
+        )
+    metadata.contact_depth_query = mode
+
+
+class ContactDepthQuerySensorMixin:
+    """
+    Sensor-side counterpart to ``ContactDepthQueryMetadataMixin``. Its ``build()`` resolves the class-wide
+    contact-depth backend (raising if this class's sensors disagree) and activates only the chosen backend: the
+    shared ``RaycastContext`` BVH in raycast mode, else the collider SDF. Mixing this in (alongside the metadata
+    mixin) means subclasses get the resolution from the super-``build()`` chain and need not call
+    ``resolve_contact_depth_query`` themselves. Requires ``_shared_metadata``, ``_options.contact_depth_query``, and
+    a ``_shared_context`` ``RaycastContext``.
+    """
+
+    def build(self):
+        super().build()
+        resolve_contact_depth_query(self._shared_metadata, self._options.contact_depth_query, type(self).__name__)
+        if self._shared_metadata.contact_depth_query == "raycast":
+            self._shared_context.activate()  # builds the BVH lazily, only on raycast opt-in
+        else:
+            self._shared_metadata.solver.collider.activate_sdf()

--- a/genesis/engine/sensors/tactile_shared.py
+++ b/genesis/engine/sensors/tactile_shared.py
@@ -191,6 +191,28 @@ def func_aabb_intersects_aabb(amin, amax, bmin, bmax):  # -> bool
     )
 
 
+@dataclass(eq=True, kw_only=False, frozen=True)
+class ChunkedBVHData:
+    """
+    Bundle of the flat ``BVHMetadata`` scaffolding tensors passed to a traversal kernel as one argument.
+
+    See ``BVHMetadata`` for the field semantics. Element payload tables (``tri_verts``, point-cloud
+    positions, ...) stay separate kernel arguments because they differ per sensor class.
+    """
+
+    sensor_chunk_start: qd.types.ndarray()
+    sensor_chunk_count: qd.types.ndarray()
+    chunk_link_idx: qd.types.ndarray()
+    chunk_node_start: qd.types.ndarray()
+    node_min: qd.types.ndarray()
+    node_max: qd.types.ndarray()
+    node_left: qd.types.ndarray()
+    node_right: qd.types.ndarray()
+    node_leaf_start: qd.types.ndarray()
+    node_leaf_count: qd.types.ndarray()
+    leaf_elem_idx: qd.types.ndarray()
+
+
 @dataclass
 class BVHMetadata:
     """
@@ -224,6 +246,30 @@ class BVHMetadata:
     node_leaf_start: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     node_leaf_count: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
     leaf_elem_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+    # Cached scaffolding bundle for kernel calls, built once on first use (the BVH is static after scene init).
+    _kernel_bvh: "ChunkedBVHData | None" = field(default=None, init=False, compare=False, repr=False)
+
+    @property
+    def kernel_bvh(self) -> ChunkedBVHData:
+        """
+        The scaffolding fields bundled into a single ``ChunkedBVHData`` traversal-kernel argument.
+        """
+        if self._kernel_bvh is None:
+            self._kernel_bvh = ChunkedBVHData(
+                sensor_chunk_start=self.sensor_chunk_start,
+                sensor_chunk_count=self.sensor_chunk_count,
+                chunk_link_idx=self.chunk_link_idx,
+                chunk_node_start=self.chunk_node_start,
+                node_min=self.node_min,
+                node_max=self.node_max,
+                node_left=self.node_left,
+                node_right=self.node_right,
+                node_leaf_start=self.node_leaf_start,
+                node_leaf_count=self.node_leaf_count,
+                leaf_elem_idx=self.leaf_elem_idx,
+            )
+        return self._kernel_bvh
 
 
 # ============================ FFT helpers ============================

--- a/genesis/options/recorders.py
+++ b/genesis/options/recorders.py
@@ -9,6 +9,7 @@ from genesis.typing import (
     PositiveFloat,
     PositiveInt,
     PositiveVec2IType,
+    StrArrayType,
     Vec3FArrayType,
     Vec3FType,
 )

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -13,15 +13,19 @@ from genesis.typing import (
     NonNegativeInt,
     OptionalIArrayType,
     PositiveFArrayType,
+    PositiveFGridType,
     PositiveFloat,
     PositiveVec3IType,
     RotationMatrixType,
+    UnitInterval,
     UnitIntervalVec3Type,
     UnitIntervalVec4Type,
     UnitVec3FArrayType,
+    UnitVec3FGridType,
     UnitVec3FType,
     Vec2FType,
     Vec3FArrayType,
+    Vec3FGridType,
     Vec3FType,
     Vec4FType,
     is_sequence,
@@ -37,6 +41,7 @@ if TYPE_CHECKING:
     from genesis.engine.sensors.imu import IMUSensor
     from genesis.engine.sensors.raycaster import RaycasterSensor
     from genesis.engine.sensors.surface_distance_probe import SurfaceDistanceProbeSensor
+    from genesis.engine.sensors.temperature import TemperatureGridSensor
 
     NonNegativeUnboundedFloat = float
     LaxNonNegativeUnboundedVec3FType = Vec3FType | float
@@ -214,25 +219,36 @@ class ProbeSensorOptionsMixin(SensorOptions[SensorT]):
 
     Parameters
     ----------
-    probe_local_pos : array-like[array-like[float, float, float]]
-        Probe positions in link-local frame. One ``(x, y, z)`` per probe.
-    probe_radius : float | array-like[float]
-        Probe sensing radius in meters. A scalar is shared by every probe; an array must match the probe count.
-    probe_radius_noise : float
-        Additive radius noise in meters used by kernels whose measured branch depends on effective probe radius.
-    debug_probe_color : array-like[float, float, float, float]
-        RGBA color for inactive debug probe spheres.
+    probe_local_pos : array-like[array-like[float, float, float]] or shape ``(M, N, 3)`` grid
+        Probe positions in link-local frame. Either a flat ``(N, 3)`` set or a 2D grid ``(M, N, 3)``; the
+        ``read()`` output is reshaped back to match this layout.
+    probe_radius : float | array-like[float] or shape ``(M, N)`` grid
+        Probe sensing radius in meters. A scalar is shared by every probe; an array (or grid) must match the
+        layout of ``probe_local_pos``.
+    debug_probe_color : array-like[float, float, float]
+        RGB color for debug probe spheres (no alpha; the center sphere is drawn opaque and the outer sphere uses
+        ``debug_probe_sphere_opacity``).
+    debug_probe_center_radius : float
+        Radius in meters of the small opaque marker sphere drawn at each probe position.
+    debug_probe_sphere_opacity : float
+        Alpha (0..1) of the outer translucent sphere drawn at each probe's sensing radius. Set to ``0.0`` to skip.
     """
 
-    probe_local_pos: Vec3FArrayType = ((0.0, 0.0, 0.0),)
-    probe_radius: PositiveFArrayType | PositiveFloat = 0.01
-    probe_radius_noise: NonNegativeFloat = 0.0
-    debug_probe_color: UnitIntervalVec4Type = (0.2, 0.6, 1.0, 0.6)
+    probe_local_pos: Vec3FArrayType | Vec3FGridType = ((0.0, 0.0, 0.0),)
+    probe_radius: PositiveFloat | PositiveFArrayType | PositiveFGridType = 0.01
+    debug_probe_color: UnitIntervalVec3Type = (0.2, 0.4, 1.0)
+    debug_probe_center_radius: PositiveFloat = 0.0008
+    debug_probe_sphere_opacity: UnitInterval = 0.3
 
     def model_post_init(self, context: Any) -> None:
         super().model_post_init(context)
-        n_probes = np.array(self.probe_local_pos).reshape(-1, 3).shape[0]
-        _check_len_match(self.probe_radius, n_probes, "probe_radius", "probe_local_pos")
+        n_probes = int(np.prod(np.asarray(self.probe_local_pos).shape[:-1]))
+        if isinstance(self.probe_radius, Sequence):
+            if np.asarray(self.probe_radius).size != n_probes:
+                gs.raise_exception(
+                    f"probe_radius shape {np.asarray(self.probe_radius).shape} must contain "
+                    f"{n_probes} entries to match probe_local_pos."
+                )
 
 
 class ProbesWithNormalSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
@@ -240,16 +256,25 @@ class ProbesWithNormalSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
     Probe options for sensors that also define one normal per probe, or one shared normal.
     """
 
-    probe_local_normal: UnitVec3FArrayType | UnitVec3FType = (0.0, 0.0, 1.0)
+    probe_local_normal: UnitVec3FType | UnitVec3FArrayType | UnitVec3FGridType = (0.0, 0.0, 1.0)
+
+    @property
+    def _is_probe_local_normal_required(self) -> bool:
+        """Override in subclasses where ``probe_local_normal`` is only consumed by an opt-in mode (e.g. raycast
+        contact-depth queries). When ``False``, the per-probe shape validation in ``model_post_init`` is skipped --
+        sensors that never read the normal don't surface confusing length errors for the default value."""
+        return True
 
     def model_post_init(self, context: Any) -> None:
         super().model_post_init(context)
-        n_probes = np.array(self.probe_local_pos).reshape(-1, 3).shape[0]
-        normals = np.array(self.probe_local_normal)
-        if normals.ndim > 1 and normals.reshape(-1, 3).shape[0] != n_probes:
+        if not self._is_probe_local_normal_required:
+            return
+        n_probes = int(np.prod(np.asarray(self.probe_local_pos).shape[:-1]))
+        normals = np.asarray(self.probe_local_normal)
+        if normals.ndim > 1 and normals.size // 3 != n_probes:
             gs.raise_exception(
-                "probe_local_normal must be one normal or match probe_local_pos length. "
-                f"Got {normals.reshape(-1, 3).shape[0]} normals and {n_probes} probe positions."
+                "probe_local_normal must be one normal or contain one normal per probe. "
+                f"Got normal shape {normals.shape} for {n_probes} probes."
             )
 
 
@@ -360,11 +385,11 @@ class TemperatureProperties(NamedTuple):
     base_temperature: float
         The base temperature of the material in Celsius.
     conductivity: float
-        The conductivity of the material in W/(m·K)
+        The conductivity of the material in W/(m*K)
     density: float
         The density of the material in kilograms per cubic meter.
     specific_heat: float
-        The specific heat of the material in J/(kg·C).
+        The specific heat of the material in J/(kg*C).
     emissivity: float
         The emissivity of the material, between 0 and 1.
     """
@@ -388,10 +413,10 @@ class TemperatureGrid(RigidSensorOptionsMixin["TemperatureGridSensor"], SimpleSe
         used as the default for links not present in the dict; if omitted, unlisted links are ignored in contacts.
         This parameter is shared across all Temperature sensors (dicts will be merged).
     ambient_temperature: float
-        The ambient temperature in Celsius. Default is 21°C.
+        The ambient temperature in Celsius. Default is 21 degrees C.
         This parameter is shared across all Temperature sensors (the last one set will be used).
     convection_coefficient: float
-        Convection coefficient h in W/(m²·K) for surface cooling. Default 1.0.
+        Convection coefficient h in W/(m^2*K) for surface cooling. Default 1.0.
         This parameter is shared across all Temperature sensors (the last one set will be used).
     simulate_all_link_temperatures: bool
         If True, the temperatures of all links with temperature properties will be simulated.
@@ -539,17 +564,13 @@ class SurfaceDistanceProbe(
         Probe positions in link-local frame. One (x, y, z) per probe.
     probe_radius : float | array-like[float]
         Maximum sensing range in meters. When no mesh is within this distance, distance is clamped to the probe
-        radius and nearest points is the probe position. Default: 10.0.
+        radius and nearest points is the probe position. Default: 0.5. Also controls the outer debug sphere.
     track_link_idx : array-like[int]
         Global link indices (solver link space) whose mesh geoms are used for distance queries.
-    debug_sphere_radius: float, optional
-        The radius of each debug sphere drawn in the scene. Defaults to 0.008.
     """
 
-    probe_radius: PositiveFArrayType | PositiveFloat = 10.0
+    probe_radius: PositiveFArrayType | PositiveFloat = 0.5
     track_link_idx: IArrayType = Field(default_factory=tuple)
-
-    debug_sphere_radius: PositiveFloat = 0.008
 
     def validate_scene(self, scene: "Scene"):
         super().validate_scene(scene)

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -121,9 +121,10 @@ class SensorOptions(Options, Generic[SensorT]):
 
 class KinematicSensorOptionsMixin(SensorOptions[SensorT]):
     """
-    Base options class for sensors attached to a KinematicEntity (or any subclass, including RigidEntity). Use this
-    base for sensors whose output is purely kinematic and does not depend on physics-derived quantities like contact
-    forces or inertial dynamics.
+    Base options class for sensors attached to a KinematicEntity (or any subclass, including RigidEntity).
+
+    Use this base for sensors whose output is purely kinematic and does not depend on physics-derived quantities like
+    contact forces or inertial dynamics.
 
     Parameters
     ----------
@@ -176,8 +177,9 @@ class RigidSensorOptionsMixin(KinematicSensorOptionsMixin[SensorT]):
 class RigidEntitySensorOptionsMixin(RigidSensorOptionsMixin[SensorT]):
     """
     Options for a sensor bound to a whole RigidEntity (e.g. joint-space sensors), where the attachment is mandatory:
-    entity_idx must refer to an existing RigidEntity, static sensors are not allowed. The link offset parameters are
-    inherited from RigidSensorOptionsMixin but ignored by joint-space sensors.
+    entity_idx must refer to an existing RigidEntity, static sensors are not allowed.
+
+    The link offset parameters are inherited from RigidSensorOptionsMixin but ignored by joint-space sensors.
     """
 
     def validate_scene(self, scene: "Scene"):
@@ -261,8 +263,11 @@ class ProbesWithNormalSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
     @property
     def _is_probe_local_normal_required(self) -> bool:
         """Override in subclasses where ``probe_local_normal`` is only consumed by an opt-in mode (e.g. raycast
-        contact-depth queries). When ``False``, the per-probe shape validation in ``model_post_init`` is skipped --
-        sensors that never read the normal don't surface confusing length errors for the default value."""
+        contact-depth queries).
+
+        When ``False``, the per-probe shape validation in ``model_post_init`` is skipped -- sensors that never read
+        the normal don't surface confusing length errors for the default value.
+        """
         return True
 
     def model_post_init(self, context: Any) -> None:
@@ -404,6 +409,7 @@ class TemperatureProperties(NamedTuple):
 class TemperatureGrid(RigidSensorOptionsMixin["TemperatureGridSensor"], SimpleSensorOptions["TemperatureGridSensor"]):
     """
     Sensor that returns the temperature in Celsius of the associated RigidLink in its local frame.
+
     Temperature is computed based on object contacts and their material properties provided to these options.
 
     Parameters
@@ -551,6 +557,7 @@ class SurfaceDistanceProbe(
 ):
     """
     Surface distance probe that reports nearest distances from probe positions to tracked mesh surfaces.
+
     The read() output will provide the distances, and the nearest points can be accessed with `sensor.nearest_points`.
 
     Attached to a rigid entity link. Takes a list of local probe positions and a list of global link indices

--- a/genesis/options/sensors/tactile.py
+++ b/genesis/options/sensors/tactile.py
@@ -71,6 +71,8 @@ class TactileProbeSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
 
 class PointCloudTactileSensorMixin(TactileProbeSensorOptionsMixin[SensorT]):
     """
+    Options mixin for tactile sensors that sample a point cloud from tracked link meshes.
+
     Parameters
     ----------
     track_link_idx : array-like[int]
@@ -229,6 +231,7 @@ class ElastomerTaxel(
 ):
     """
     An elastomer tactile sensor that implements HydroShear-style marker displacement from Genesis SDF queries.
+
     The tracked rigid links are sampled into indenter on-surface points for shear history, while marker dilation is
     queried directly from the tracked geometry SDF.
 

--- a/genesis/options/sensors/tactile.py
+++ b/genesis/options/sensors/tactile.py
@@ -1,19 +1,19 @@
-from typing import TYPE_CHECKING, Annotated, Any, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
+import numpy as np
 from pydantic import Field, StrictBool
 
 import genesis as gs
 from genesis.typing import (
+    FArrayType,
+    FGridType,
     IArrayType,
     NonNegativeFloat,
     NonNegativeInt,
-    NumericType,
     PositiveFloat,
     PositiveInt,
+    UnitIntervalVec3Type,
     UnitIntervalVec4Type,
-    UnitVec3FArrayType,
-    UnitVec3FType,
-    Vec3FArrayType,
 )
 
 from .options import (
@@ -33,29 +33,40 @@ if TYPE_CHECKING:
         ProximityTaxelSensor,
     )
 
-    Vec3FGridType = Sequence[Sequence[Sequence[NumericType]]]
-    UnitVec3FGridType = Sequence[Sequence[Sequence[NumericType]]]
-else:
-    Vec3FGridType = Annotated[tuple[Vec3FArrayType, ...], Field(min_length=1, strict=False)]
-    UnitVec3FGridType = Annotated[tuple[UnitVec3FArrayType, ...], Field(min_length=1, strict=False)]
+
+def _validate_filler_probe_radius(probe_radius, sensor_name: str) -> None:
+    """
+    Validate a ``probe_radius`` that permits 0-valued (inactive padding for grid) entries.
+    """
+    radii = np.atleast_1d(np.asarray(probe_radius, dtype=float))
+    if np.any(radii < 0.0):
+        gs.raise_exception(f"{sensor_name} probe_radius entries must be non-negative. Got {probe_radius}.")
+    if not np.any(radii > 0.0):
+        gs.raise_exception(f"{sensor_name} requires at least one positive probe_radius. Got {probe_radius}.")
 
 
 class TactileProbeSensorOptionsMixin(ProbeSensorOptionsMixin[SensorT]):
     """
-    Tactile probe sensors use SDF contact-depth queries around each probe position instead of physics solver
-    contact impulses. This allows fast contact sensing at arbitrary probe locations without affecting simulation.
-
-    Note
-    ----
-    If this sensor is attached to a fixed entity, it will not detect contacts with other fixed entities.
+    Tactile probe sensors estimate contact from geometric depth queries (SDF or raycast) around each probe position
+    rather than reading the physics solver's contact impulses, so they sense at arbitrary probe locations without
+    affecting simulation.
 
     Parameters
     ----------
-    debug_contact_color: array-like[float, float, float, float]
-        The color of the debug contact. Defaults to (1.0, 0.2, 0.0, 0.8).
+    debug_contact_color: array-like[float, float, float]
+        RGB color of the debug probe spheres while in contact.
+    contact_depth_query : {"sdf", "raycast"} or None, optional
+        Per-probe contact-depth backend. ``"sdf"`` queries the per-geom analytic SDF grid (fast, exact for primitives,
+        requires SDF activation). ``"raycast"`` walks the rigid solver's per-frame collision-mesh BVH and takes the
+        signed distance to the nearest candidate triangle (sign from the triangle's face normal, negative inside),
+        so ``pen = R - signed_distance`` matches the SDF backend while handling arbitrary meshes uniformly (shares
+        the BVH with ``RaycasterSensor``). ``None`` (default) defers the choice: all sensors of the same class must
+        agree, and the resolved mode is ``"sdf"`` if no sensor of that class sets it.
     """
 
-    debug_contact_color: UnitIntervalVec4Type = (1.0, 0.2, 0.0, 0.8)
+    debug_contact_color: UnitIntervalVec3Type = (1.0, 0.2, 0.0)
+
+    contact_depth_query: Literal["sdf", "raycast"] | None = None
 
 
 class PointCloudTactileSensorMixin(TactileProbeSensorOptionsMixin[SensorT]):
@@ -65,7 +76,10 @@ class PointCloudTactileSensorMixin(TactileProbeSensorOptionsMixin[SensorT]):
     track_link_idx : array-like[int]
         Global link indices whose mesh geometry is used to sample a point cloud from.
     n_sample_points: int | array-like[int]
-        Total FPS samples split across ``track_link_idx``, or one count per tracked link.
+        Total FPS samples split across ``track_link_idx``, or one count per tracked link. Per-variant
+        counts are not supported: when a tracked link belongs to a heterogeneous entity, the per-link
+        count is allocated to every variant on that link (so each parallel environment sees the full
+        count regardless of which variant is active).
     use_visual_mesh : bool
         Whether to use the visual mesh when sampling the point cloud.
     debug_point_cloud_color : array-like[float, float, float, float]
@@ -90,13 +104,39 @@ class ContactProbe(
     """
     Returns boolean contact per probe based on the contact depth threshold.
 
+    Note
+    ----
+    The depth query only runs against geometry the rigid solver reports as in contact with the sensor's link (the
+    depth itself comes from an SDF/raycast query, not the contact impulse, but contact *existence* is gated by the
+    solver). Since the solver skips collision between two fixed entities, a sensor on a fixed entity will not detect
+    contacts with other fixed entities.
+
     Parameters
     ----------
+    probe_radius : float | array-like[float] or shape ``(M, N)`` grid
+        Probe sensing radius in meters. A scalar is shared by every probe; an array (or grid) must match the
+        layout of ``probe_local_pos``. Array entries of ``0`` mark inactive filler probes -- they always read
+        ``False`` and skip the SDF query -- so an irregular taxel set can be padded into a regular grid.
     contact_threshold: float
-        A probe is considered in contact if the penetration depth is greater than or equal to this threshold (meters).
+        Penetration depth (meters) at or above which a probe latches into contact.
+    release_threshold: float, optional
+        Penetration depth (meters) at or below which a latched probe releases (Schmitt-trigger hysteresis). Must be
+        ``<= contact_threshold``. Defaults to ``contact_threshold`` (no hysteresis).
     """
 
+    # Permits 0-valued (inactive filler) entries; see _validate_filler_probe_radius.
+    probe_radius: PositiveFloat | FArrayType | FGridType = 0.01
+
     contact_threshold: NonNegativeFloat = 0.0001
+    release_threshold: NonNegativeFloat | None = None
+
+    def model_post_init(self, context: Any) -> None:
+        super().model_post_init(context)
+        _validate_filler_probe_radius(self.probe_radius, "ContactProbe")
+        if self.release_threshold is not None and self.release_threshold > self.contact_threshold:
+            gs.raise_exception(
+                f"release_threshold ({self.release_threshold}) must be <= contact_threshold ({self.contact_threshold})."
+            )
 
 
 class ContactDepthProbe(
@@ -106,6 +146,13 @@ class ContactDepthProbe(
 ):
     """
     Returns contact depth in meters per probe.
+
+    Note
+    ----
+    The depth query only runs against geometry the rigid solver reports as in contact with the sensor's link (the
+    depth itself comes from an SDF/raycast query, not the contact impulse, but contact *existence* is gated by the
+    solver). Since the solver skips collision between two fixed entities, a sensor on a fixed entity will not detect
+    contacts with other fixed entities.
     """
 
 
@@ -113,27 +160,37 @@ class KinematicTaxel(
     RigidSensorOptionsMixin["KinematicTaxelSensor"],
     SimpleSensorOptions["KinematicTaxelSensor"],
     TactileProbeSensorOptionsMixin["KinematicTaxelSensor"],
-    ProbesWithNormalSensorOptionsMixin["KinematicTaxelSensor"],
 ):
     """
-    A tactile sensor which estimates force and torque per taxel by querying contact depth relative to given probe
-    normals and within the radius of the probe positions along a rigid entity link and the relative velocity of the
-    probe and the entity in contact.
+    A tactile sensor which estimates force and torque per taxel by querying contact depth within the radius of the
+    probe positions along a rigid entity link and the relative velocity of the probe and the entity in contact.
 
-    The returned force is a spring-damper estimate based on contact depth and relative motion:
-        v_n = dot(relative_velocity, probe_normal) * probe_normal
+    The force and torque are aligned with the contact surface normal ``n`` at each probe -- the SDF gradient in
+    ``"sdf"`` mode, or the nearest-triangle face normal in ``"raycast"`` mode. The returned force is a spring-damper
+    estimate based on contact depth and relative motion:
+        v_n = dot(relative_velocity, n) * n
         v_t = relative_velocity - v_n
         s = penetration ** normal_exponent
-        F = (-normal_stiffness * s * probe_normal) - (normal_damping * s * v_n) - (shear_scalar * v_t)
-        T = cross(probe_local_pos, F) - twist_scalar * dot(relative_angular_velocity, probe_normal) * probe_normal
+        F = (normal_stiffness * s * n) + (normal_damping * s * dot(relative_velocity, n) * n) - (shear_scalar * v_t)
+        T = cross(probe_local_pos, F) - twist_scalar * dot(relative_angular_velocity, n) * n
     as opposed to the actual impulse force on the link from the contact obtained from the physics solver.
 
     Note
     ----
-    If this sensor is attached to a fixed entity, it will not detect contacts with other fixed entities.
+    The depth query only runs against geometry the rigid solver reports as in contact with the sensor's link (the
+    force/torque come from the spring-damper estimate above, not the contact impulse, but contact *existence* is
+    gated by the solver). Since the solver skips collision between two fixed entities, a sensor on a fixed entity
+    will not detect contacts with other fixed entities.
+
+    ``probe_local_pos`` may be either an arbitrary set of probes with shape ``(N, 3)`` or a grid-shaped set with shape
+    ``(M, N, 3)``. A probe whose ``probe_radius`` is 0 is treated as an inactive filler -- it reads 0 force/torque and
+    is skipped -- so an irregular taxel set can be padded into a regular grid.
 
     Parameters
     ----------
+    probe_radius : float | array-like[float]
+        Probe sensing radius in meters. A scalar is shared by every probe; an array must match the probe count.
+        Array entries of 0 mark inactive filler probes (see the grid note above); at least one must be positive.
     normal_stiffness : float
         Stiffness for normal force estimation based on contact penetration depth and spring-damper model.
     normal_damping : float
@@ -147,6 +204,9 @@ class KinematicTaxel(
         Coefficient for twist torque estimation based on relative angular velocity of the probe and entity in contact.
     """
 
+    # Permits 0-valued (inactive filler) entries; see _validate_filler_probe_radius.
+    probe_radius: PositiveFloat | FArrayType | FGridType = 0.01
+
     normal_stiffness: NonNegativeFloat = 1000.0
     normal_damping: NonNegativeFloat = 1.0
     normal_exponent: NonNegativeFloat = 1.0
@@ -156,6 +216,7 @@ class KinematicTaxel(
     def model_post_init(self, context: Any) -> None:
         super().model_post_init(context)
 
+        _validate_filler_probe_radius(self.probe_radius, "KinematicTaxel")
         if self.normal_exponent < 1.0:
             gs.raise_exception(f"normal_exponent must be greater than or equal to 1.0. Got {self.normal_exponent}.")
 
@@ -175,7 +236,9 @@ class ElastomerTaxel(
     ----
     ``probe_local_pos`` may be either an arbitrary set of probes with shape ``(N, 3)`` or a grid-shaped set with shape
     ``(M, N, 3)``. Regular planar grids with one shared normal use FFT acceleration for dilation; other layouts use the
-    direct dilation path. Shear is computed directly.
+    direct dilation path. Shear is computed directly. A probe whose ``probe_radius`` is 0 is treated as an inactive
+    filler -- it reads 0 and is excluded from dilation/shear -- so an irregular taxel set can be padded into a
+    regular grid for FFT acceleration.
 
     Parameters
     ----------
@@ -184,18 +247,29 @@ class ElastomerTaxel(
     probe_local_normal : array-like[float, float, float] or array-like[array-like[float, float, float]]
         Unit direction(s) in link-local frame: one normal for all probes, or one normal per probe matching
         ``probe_local_pos``.
+    probe_radius : float | array-like[float]
+        Probe sensing radius in meters. A scalar is shared by every probe; an array must match the probe count.
+        Array entries of 0 mark inactive filler probes (see the grid note above); at least one must be positive.
     track_link_idx : array-like[int]
         Global rigid link indices whose collision geometry is queried by SDF and whose mesh is sampled for shear.
     n_sample_points: int | array-like[int]
         Total surface samples split across ``track_link_idx``, or one count per tracked link.
     lambda_d: float
-        Exponential coefficient for dilation spread.
+        Gaussian falloff coefficient (in 1/m^2) for the dilation kernel ``exp(-lambda_d * r^2)`` that smears each
+        in-contact probe's normal/tangential bulge across its neighbors. Larger values give sharper, more localized
+        markers; smaller values smear the bulge across more probes.
     lambda_s: float
-        Exponential coefficient for shear spread from tracked surface points.
+        Gaussian falloff coefficient (in 1/m^2) for the shear kernel ``exp(-lambda_s * r^2)`` that spreads each
+        anchored tracked-surface point's tangential displacement to nearby probes. Larger values keep shear tightly
+        local to the contact patch; smaller values produce a softer, more diffuse shear response.
     dilate_scale: float
         Scalar gain applied to dilation displacement.
     shear_scale: float
         Scalar gain applied to shear displacement.
+    normal_exponent: float
+        Exponent of the penetration-depth power law for the normal (out-of-plane) marker dilation: the normal
+        bulge scales as ``depth ** normal_exponent``. Must be >= 1.0. Default ``2.0`` (the HydroShear quadratic
+        normal response). Tangential dilation and shear stay linear in depth regardless of this value.
     elastomer_contact_sdf_enter: float
         Positive margin on signed distance: a tracked surface point starts anchoring shear when its elastomer SDF
         value is below ``-elastomer_contact_sdf_enter``.
@@ -210,21 +284,25 @@ class ElastomerTaxel(
     should represent the compliant contact surface.
     """
 
-    probe_local_pos: Vec3FArrayType | Vec3FGridType = ((0.0, 0.0, 0.0),)
-    probe_local_normal: UnitVec3FArrayType | UnitVec3FGridType | UnitVec3FType = (0.0, 0.0, 1.0)
+    # Permits 0-valued (inactive filler) entries; see _validate_filler_probe_radius.
+    probe_radius: PositiveFloat | FArrayType | FGridType = 0.01
 
     lambda_d: NonNegativeFloat = 700.0
     lambda_s: NonNegativeFloat = 300.0
     dilate_scale: NonNegativeFloat = 1.0
     shear_scale: NonNegativeFloat = 1.0
+    normal_exponent: NonNegativeFloat = 2.0
 
     elastomer_contact_sdf_enter: NonNegativeFloat = 1e-5
     elastomer_contact_sdf_exit: NonNegativeFloat = 1e-4
 
     def model_post_init(self, context: Any) -> None:
         super().model_post_init(context)
+        _validate_filler_probe_radius(self.probe_radius, "ElastomerTaxel")
         if len(self.track_link_idx) == 0:
             gs.raise_exception("ElastomerTaxel requires at least one tracked link in track_link_idx.")
+        if self.normal_exponent < 1.0:
+            gs.raise_exception(f"normal_exponent must be greater than or equal to 1.0. Got {self.normal_exponent}.")
 
 
 class ProximityTaxel(
@@ -237,11 +315,10 @@ class ProximityTaxel(
     A tactile sensor which estimates force and torque per taxel from proximity to point clouds sampled on tracked
     meshes within a **spherical** sensing volume of nominal ``probe_radius`` around each taxel.
 
-    For each taxel, every tracked point inside that sphere contributes a penetration depth ``P_i = R_eff - ||p_i - o||``
-    where ``R_eff`` is drawn each simulation step when ``probe_radius_noise`` is non-zero (additive uniform noise
-    in meters around the sensing radius, clipped nonnegative). Normal force is aligned with ``probe_local_normal``;
-    shear uses tangential relative velocity. Generic SimpleSensor imperfections (bias, resolution, etc.) still apply.
-    Outputs are in link-local frame.
+    For each taxel, every tracked point inside that sphere contributes a penetration depth ``P_i = R - ||p_i - o||``
+    where ``R`` is the sensing radius. Normal force is aligned with ``probe_local_normal``; shear uses tangential
+    relative velocity. Generic SimpleSensor imperfections (bias, resolution, etc.) still apply. Outputs are in
+    link-local frame.
 
     Parameters
     ----------

--- a/genesis/typing.py
+++ b/genesis/typing.py
@@ -104,6 +104,10 @@ if TYPE_CHECKING:
     UnitVec3FArrayType = Vec3FArrayType
     Vec3FLaxArrayType = Vec3FArrayType | Vec3FType
     UnitVec3FLaxArrayType = Vec3FLaxArrayType
+    FGridType = Sequence[Sequence[NumericType]] | np.ndarray
+    PositiveFGridType = FGridType
+    Vec3FGridType = Sequence[Sequence[Sequence[NumericType]]] | np.ndarray
+    UnitVec3FGridType = Vec3FGridType
     RotationMatrixType = Vec3FArrayType
     Matrix3x3Type = Sequence[Sequence[NumericType]] | np.ndarray
     Matrix4x4Type = Sequence[Sequence[NumericType]] | np.ndarray
@@ -165,6 +169,10 @@ else:
     StrArrayType = Annotated[tuple[str, ...], Field(strict=False)]
     Vec3FArrayType = Annotated[tuple[Vec3FType, ...], Field(min_length=1, strict=False)]
     UnitVec3FArrayType = Annotated[tuple[UnitVec3FType, ...], Field(min_length=1, strict=False)]
+    FGridType = Annotated[tuple[FArrayType, ...], Field(min_length=1, strict=False)]
+    PositiveFGridType = Annotated[tuple[PositiveFArrayType, ...], Field(min_length=1, strict=False)]
+    Vec3FGridType = Annotated[tuple[Vec3FArrayType, ...], Field(min_length=1, strict=False)]
+    UnitVec3FGridType = Annotated[tuple[UnitVec3FArrayType, ...], Field(min_length=1, strict=False)]
     Vec3FLaxArrayType = Annotated[
         tuple[Vec3FType, ...],
         BeforeValidator(lambda v: v if is_sequence(v) and len(v) > 0 and is_sequence(v[0]) else (v,)),

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -198,6 +198,7 @@ def ray_aabb_intersection(
 ):
     """
     Fast ray-AABB intersection test.
+
     Returns the t value of intersection, or -1.0 if no intersection.
     """
     result = -1.0
@@ -234,7 +235,9 @@ def closest_point_on_triangle(
     v2: qd.types.vector(3),
 ) -> qd.types.vector(3):
     """
-    Closest point on a triangle to a query point. Reference: Christer Ericson, Real-Time Collision Detection 5.1.5.
+    Closest point on a triangle to a query point.
+
+    Reference: Christer Ericson, Real-Time Collision Detection section 5.1.5.
     """
     ab = v1 - v0
     ac = v2 - v0
@@ -471,8 +474,11 @@ def update_visual_aabbs(
     face_mask: qd.types.ndarray(),
     aabb_state: qd.template(),
 ):
-    """Update per-vface AABBs from the visual mesh. face_mask gates inclusion: 0 keeps the AABB inverted
-    (unhittable) so vfaces from entities not opted into raycasting are skipped by ray queries."""
+    """Update per-vface AABBs from the visual mesh.
+
+    face_mask gates inclusion: 0 keeps the AABB inverted (unhittable) so vfaces from entities not opted into
+    raycasting are skipped by ray queries.
+    """
     _B = vgeoms_state.pos.shape[1]
     n_vfaces = vfaces_info.vverts_idx.shape[0]
     for i_b, i_f in qd.ndrange(_B, n_vfaces):
@@ -625,10 +631,11 @@ def kernel_cast_rays(
     is_merge: qd.template(),
     shared_bvh: qd.template(),
 ):
-    """Cast rays against a collision-mesh BVH, accelerated by a BVH. See write_ray_hit for `is_merge` semantics.
+    """Cast rays against a collision-mesh BVH.
 
-    The result `output_hits` is a 2D array of shape (total_cache_size, n_env) where in the first dimension each
-    sensor's data is stored as [sensor_points (n_points * 3), sensor_ranges (n_points)].
+    See write_ray_hit for `is_merge` semantics. The result `output_hits` is a 2D array of shape (total_cache_size,
+    n_env) where in the first dimension each sensor's data is stored as [sensor_points (n_points * 3), sensor_ranges
+    (n_points)].
 
     shared_bvh is a compile-time flag set when the collision geometry is identical across envs; the cast then reads a
     single BVH copy (batch 0) for every env. It also selects the thread -> (ray, env) mapping below, so the homogeneous
@@ -722,7 +729,10 @@ def kernel_cast_rays_visual(
     is_merge: qd.template(),
     shared_bvh: qd.template(),
 ):
-    """Visual-mesh variant of kernel_cast_rays. See kernel_cast_rays for shared_bvh and the thread mapping."""
+    """Visual-mesh variant of kernel_cast_rays.
+
+    See kernel_cast_rays for shared_bvh and the thread mapping.
+    """
     n_points = ray_starts.shape[0]
     n_envs = output_hits.shape[-1]
     for i_flat in range(n_points * n_envs):

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -108,10 +108,7 @@ def bvh_ray_cast(
                 if hit_result.w > 0.0 and hit_result.x < closest_distance and hit_result.x >= 0.0:
                     closest_distance = hit_result.x
                     hit_face = i_f
-                    # Compute triangle normal
-                    edge1 = v1 - v0
-                    edge2 = v2 - v0
-                    hit_normal = edge1.cross(edge2).normalized()
+                    hit_normal = triangle_face_normal(v0, v1, v2)
             else:  # Internal node
                 # Push children onto stack
                 if stack_idx < qd.static(STACK_SIZE - 2):
@@ -227,6 +224,71 @@ def ray_aabb_intersection(
         result = t_near
 
     return result
+
+
+@qd.func
+def closest_point_on_triangle(
+    point: qd.types.vector(3),
+    v0: qd.types.vector(3),
+    v1: qd.types.vector(3),
+    v2: qd.types.vector(3),
+) -> qd.types.vector(3):
+    """
+    Closest point on a triangle to a query point. Reference: Christer Ericson, Real-Time Collision Detection 5.1.5.
+    """
+    ab = v1 - v0
+    ac = v2 - v0
+    ap = point - v0
+
+    d1 = ab.dot(ap)
+    d2 = ac.dot(ap)
+
+    closest = v0
+    if not (d1 <= 0.0 and d2 <= 0.0):
+        bp = point - v1
+        d3 = ab.dot(bp)
+        d4 = ac.dot(bp)
+
+        if d3 >= 0.0 and d4 <= d3:
+            closest = v1
+        else:
+            cp = point - v2
+            d5 = ab.dot(cp)
+            d6 = ac.dot(cp)
+
+            if d6 >= 0.0 and d5 <= d6:
+                closest = v2
+            else:
+                vc = d1 * d4 - d3 * d2
+                if vc <= 0.0 and d1 >= 0.0 and d3 <= 0.0:
+                    w = d1 / (d1 - d3)
+                    closest = v0 + w * ab
+                else:
+                    vb = d5 * d2 - d1 * d6
+                    if vb <= 0.0 and d2 >= 0.0 and d6 <= 0.0:
+                        w = d2 / (d2 - d6)
+                        closest = v0 + w * ac
+                    else:
+                        va = d3 * d6 - d5 * d4
+                        if va <= 0.0 and (d4 - d3) >= 0.0 and (d5 - d6) >= 0.0:
+                            w = (d4 - d3) / ((d4 - d3) + (d5 - d6))
+                            closest = v1 + w * (v2 - v1)
+                        else:
+                            denom = 1.0 / (va + vb + vc)
+                            v = vb * denom
+                            w = vc * denom
+                            closest = v0 + v * ab + w * ac
+    return closest
+
+
+@qd.func
+def triangle_face_normal(
+    v0: qd.types.vector(3),
+    v1: qd.types.vector(3),
+    v2: qd.types.vector(3),
+) -> qd.types.vector(3):
+    """Outward unit normal of the triangle (v0, v1, v2) under right-hand winding."""
+    return (v1 - v0).cross(v2 - v0).normalized()
 
 
 @qd.func
@@ -390,9 +452,7 @@ def bvh_ray_cast_visual(
                 if hit_result.w > 0.0 and hit_result.x < closest_distance and hit_result.x >= 0.0:
                     closest_distance = hit_result.x
                     hit_face = i_f
-                    edge1 = v1 - v0
-                    edge2 = v2 - v0
-                    hit_normal = edge1.cross(edge2).normalized()
+                    hit_normal = triangle_face_normal(v0, v1, v2)
             else:
                 if stack_idx < qd.static(STACK_SIZE - 2):
                     node_stack[stack_idx] = node.left

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1595,7 +1595,7 @@ def test_temperature_grid_sensor_contact_and_reset(show_viewer, tol, n_envs):
     for _ in range(50):
         scene.step()
     data = sensor.read()
-    assert (data > BASE_TEMP + DIFF_TEMP).all(), f"Hot box should have heated the grid by at least {DIFF_TEMP}°C"
+    assert (data > BASE_TEMP + DIFF_TEMP).all(), f"Hot box should have heated the grid by at least {DIFF_TEMP} C"
     assert (data[..., GRID_CENTER[0], GRID_CENTER[1], GRID_CENTER[2]] > data[0, 0, 0]).all(), (
         "Center cell should be hotter than corner"
     )
@@ -1610,7 +1610,7 @@ def test_temperature_grid_sensor_contact_and_reset(show_viewer, tol, n_envs):
     for _ in range(50):
         scene.step()
     data = sensor.read()
-    assert (data < BASE_TEMP - DIFF_TEMP).all(), f"Cold box should have cooled the grid by at least {DIFF_TEMP}°C"
+    assert (data < BASE_TEMP - DIFF_TEMP).all(), f"Cold box should have cooled the grid by at least {DIFF_TEMP} C"
     assert (data[..., GRID_CENTER[0], GRID_CENTER[1], GRID_CENTER[2]] < data[0, 0, 0]).all(), (
         "Center cell should be colder than corner"
     )
@@ -1817,11 +1817,6 @@ def test_surface_distance_sensor_box_sphere(show_viewer, tol, n_envs):
     )
 
 
-def _as_env_batch(data, n_envs: int) -> torch.Tensor:
-    data = torch.as_tensor(data, device=gs.device)
-    return data.unsqueeze(0) if n_envs == 0 else data
-
-
 # ------------------------------------------------------------------------------------------
 # ----------------------------------- Tactile Sensors --------------------------------------
 # ------------------------------------------------------------------------------------------
@@ -1870,17 +1865,19 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
         (-BOX_SIZE / 4, -BOX_SIZE / 4, BOX_SIZE / 2),
         (0.0, 0.0, -BOX_SIZE / 2),
     )
-    probe_normals = (
-        (0.0, 0.0, 1.0),
-        (0.0, 0.0, 1.0),
-        (0.0, 0.0, 1.0),
-        (0.0, 0.0, -1.0),
-    )
     probe_radii = (
         PROBE_RADIUS,
         PROBE_RADIUS / 10.0,
         BOX_SIZE / 3.0,
         PROBE_RADIUS,
+    )
+    # Outward surface normal at each probe; the contact normal the sensor reports is the opposite (the other
+    # object's surface), so expected KinematicTaxel force aligns with -probe_normals. Not a sensor input.
+    probe_normals = (
+        (0.0, 0.0, 1.0),
+        (0.0, 0.0, 1.0),
+        (0.0, 0.0, 1.0),
+        (0.0, 0.0, -1.0),
     )
     common_kwargs = dict(
         entity_idx=box.idx,
@@ -1894,28 +1891,27 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
             **common_kwargs,
         )
     )
-    depth_probe = scene.add_sensor(gs.sensors.ContactDepthProbe(**common_kwargs))
-    noisy_radius_depth_probe = scene.add_sensor(
+    depth_probe = scene.add_sensor(
         gs.sensors.ContactDepthProbe(
-            probe_radius_noise=0.25,
             **common_kwargs,
-        )
+        ),
+    )
+    taxel_kwargs = dict(
+        normal_stiffness=STIFFNESS,
+        normal_damping=0.0,
+        shear_scalar=0.0,
+        twist_scalar=0.0,
+        **common_kwargs,
     )
     taxel = scene.add_sensor(
         gs.sensors.KinematicTaxel(
-            probe_local_normal=probe_normals,
-            normal_stiffness=STIFFNESS,
-            normal_damping=0.0,
-            shear_scalar=0.0,
-            twist_scalar=0.0,
-            **common_kwargs,
-        )
+            **taxel_kwargs,
+        ),
     )
     sphere_taxel = scene.add_sensor(
         gs.sensors.KinematicTaxel(
             entity_idx=sphere.idx,
             probe_local_pos=((0.0, 0.0, -SPHERE_RADIUS),),
-            probe_local_normal=((0.0, 0.0, -1.0),),
             probe_radius=PROBE_RADIUS,
             normal_stiffness=STIFFNESS,
             normal_damping=0.0,
@@ -1928,13 +1924,12 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
     scene.build(n_envs=n_envs)
     scene.step()
 
-    depth = _as_env_batch(depth_probe.read_ground_truth(), n_envs)
-    contact = _as_env_batch(contact_probe.read_ground_truth(), n_envs)
-    force = _as_env_batch(taxel.read_ground_truth().force, n_envs)
-    torque = _as_env_batch(taxel.read_ground_truth().torque, n_envs)
+    depth = depth_probe.read_ground_truth()
+    contact = contact_probe.read_ground_truth()
+    force = taxel.read_ground_truth().force
+    torque = taxel.read_ground_truth().torque
 
     assert_equal(contact, depth > CONTACT_THRESHOLD)
-    assert _as_env_batch(noisy_radius_depth_probe.read(), n_envs).shape == depth.shape
     # Check that the box's bottom probe (idx 3) detects the ground.
     assert (depth[..., 3] > tol).all(), "Bottom probe should detect the ground."
     assert (force[..., 3, 2] > tol).all(), "Bottom taxel force should point upward."
@@ -1952,10 +1947,10 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
     sphere.set_pos((0.0, 0.0, box_top_z + SPHERE_RADIUS - PENETRATION))
     scene.step()
 
-    depth = _as_env_batch(depth_probe.read_ground_truth(), n_envs)
-    contact = _as_env_batch(contact_probe.read_ground_truth(), n_envs)
-    force = _as_env_batch(taxel.read_ground_truth().force, n_envs)
-    sphere_force = _as_env_batch(sphere_taxel.read_ground_truth().force, n_envs)
+    depth = depth_probe.read_ground_truth()
+    contact = contact_probe.read_ground_truth()
+    force = taxel.read_ground_truth().force
+    sphere_force = sphere_taxel.read_ground_truth().force
 
     assert_equal(contact, depth > CONTACT_THRESHOLD)
     assert (depth[..., 0] > tol).all(), "Top center probe should detect the sphere."
@@ -1968,6 +1963,100 @@ def test_kinematic_contact_probe_box_sphere_support(show_viewer, tol, n_envs):
     sphere.set_pos((0.0, 0.0, box_top_z + SPHERE_RADIUS + PROBE_RADIUS + 0.2))
     scene.step()
     assert_allclose(sphere_taxel.read_ground_truth().force, 0.0, tol=gs.EPS)
+
+
+@pytest.mark.required
+def test_contact_probe_hysteresis(show_viewer):
+    # ContactProbe with release_threshold < contact_threshold latches like a Schmitt trigger. Depth-probe
+    # semantics: depth = probe_radius - sd(probe, geom). With the probe at the box center (link-local origin) and
+    # the box descending into the ground plane, sd = box.z and depth = probe_radius - box.z.
+    n_envs = 0
+    BOX_SIZE = 0.2
+    # Place probe 0.05m above the box bottom; reported depth = probe_radius - probe.z. With probe_radius = 0.060,
+    # depth = 0.010 at zero penetration and grows linearly with penetration p.
+    PROBE_LOCAL_Z = -BOX_SIZE / 2 + 0.05
+    PROBE_RADIUS = 0.060
+    ENTER = 0.030  # triggered at p ~= 0.020
+    RELEASE = 0.015  # triggered at p ~= 0.005
+
+    # box.z values; box.z = BOX_SIZE/2 - p gives penetration p.
+    BOX_Z_OFF = 1.0  # well above plane -> no contact -> depth = 0
+    BOX_Z_BELOW_RELEASE = 0.099  # p = 0.001 -> depth = 0.011 (< RELEASE)
+    BOX_Z_IN_BAND = 0.090  # p = 0.010 -> depth = 0.020 (RELEASE < d < ENTER)
+    BOX_Z_ABOVE_ENTER = 0.070  # p = 0.030 -> depth = 0.040 (> ENTER)
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(gravity=(0.0, 0.0, 0.0)),
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    box = scene.add_entity(
+        gs.morphs.Box(
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+            pos=(0.0, 0.0, BOX_Z_OFF),
+            fixed=False,
+        ),
+    )
+
+    common = dict(
+        entity_idx=box.idx,
+        probe_local_pos=((0.0, 0.0, PROBE_LOCAL_Z),),
+        probe_radius=PROBE_RADIUS,
+        draw_debug=show_viewer,
+    )
+    hyst_probe = scene.add_sensor(
+        gs.sensors.ContactProbe(
+            contact_threshold=ENTER,
+            release_threshold=RELEASE,
+            **common,
+        ),
+    )
+    plain_probe = scene.add_sensor(
+        gs.sensors.ContactProbe(
+            contact_threshold=ENTER,
+            **common,
+        ),
+    )
+
+    scene.build(n_envs=n_envs)
+
+    def step_at(box_z):
+        box.set_pos((0.0, 0.0, box_z))
+        scene.step()
+        h = hyst_probe.read_ground_truth()
+        p = plain_probe.read_ground_truth()
+        return h.reshape(-1), p.reshape(-1)
+
+    # 1. No contact.
+    h, p = step_at(BOX_Z_OFF)
+    assert not h.any() and not p.any()
+
+    # 2. Depth in band before any latch: both False (not latched).
+    h, p = step_at(BOX_Z_IN_BAND)
+    assert not h.any() and not p.any()
+
+    # 3. Depth above enter: both latch True.
+    h, p = step_at(BOX_Z_ABOVE_ENTER)
+    assert h.all() and p.all()
+
+    # 4. Lift to band: hyst stays latched, plain releases (depth < enter).
+    h, p = step_at(BOX_Z_IN_BAND)
+    assert h.all() and not p.any()
+
+    # 5. Lift to below release: hyst clears.
+    h, p = step_at(BOX_Z_BELOW_RELEASE)
+    assert not h.any() and not p.any()
+
+    # 6. Back into band: still False (not latched).
+    h, p = step_at(BOX_Z_IN_BAND)
+    assert not h.any() and not p.any()
+
+    # 7. Reset clears latch even if depth is in band.
+    step_at(BOX_Z_ABOVE_ENTER)
+    scene.reset()
+    h, p = step_at(BOX_Z_IN_BAND)
+    assert not h.any() and not p.any()
 
 
 @pytest.mark.required
@@ -2053,9 +2142,9 @@ def test_elastomer_sensor_sphere_ground_dilate_shear(show_viewer, tol, n_envs):
     scene.build(n_envs=n_envs)
     scene.step()
 
-    dilate_data = _as_env_batch(dilate_sensor.read_ground_truth(), n_envs)
-    shear_data = _as_env_batch(shear_sensor.read_ground_truth(), n_envs)
-    combined_data = _as_env_batch(combined_sensor.read_ground_truth(), n_envs)
+    dilate_data = dilate_sensor.read_ground_truth()
+    shear_data = shear_sensor.read_ground_truth()
+    combined_data = combined_sensor.read_ground_truth()
     normal_projection = (dilate_data * normals).sum(dim=-1)
     assert (normal_projection[..., 0] > tol).all(), "Bottom marker should dilate along its outward normal."
     assert torch.linalg.norm(dilate_data, dim=-1).max() > tol
@@ -2065,9 +2154,9 @@ def test_elastomer_sensor_sphere_ground_dilate_shear(show_viewer, tol, n_envs):
     sphere.set_pos((LATERAL_SHIFT, 0.0, sphere_init_pos[2]))
     scene.step()
 
-    dilate_data = _as_env_batch(dilate_sensor.read_ground_truth(), n_envs)
-    shear_data = _as_env_batch(shear_sensor.read_ground_truth(), n_envs)
-    combined_data = _as_env_batch(combined_sensor.read_ground_truth(), n_envs)
+    dilate_data = dilate_sensor.read_ground_truth()
+    shear_data = shear_sensor.read_ground_truth()
+    combined_data = combined_sensor.read_ground_truth()
     shear_normal_projection = (shear_data * normals).sum(dim=-1)
     shear_tangent = shear_data - shear_normal_projection.unsqueeze(-1) * normals
     assert torch.linalg.norm(shear_tangent, dim=-1).max() > tol
@@ -2161,6 +2250,25 @@ def test_elastomer_sensor_grid_box_sphere(show_viewer, tol, n_envs):
             **sensor_kwargs,
         )
     )
+    # A non-default normal_exponent (cubic instead of the default quadratic normal dilation), one per path.
+    cubic_grid_sensor = scene.add_sensor(
+        gs.sensors.ElastomerTaxel(
+            probe_local_pos=probe_local_pos,
+            dilate_scale=1.0,
+            shear_scale=0.0,
+            normal_exponent=3.0,
+            **sensor_kwargs,
+        )
+    )
+    cubic_flat_sensor = scene.add_sensor(
+        gs.sensors.ElastomerTaxel(
+            probe_local_pos=probe_local_pos.reshape(-1, 3),
+            dilate_scale=1.0,
+            shear_scale=0.0,
+            normal_exponent=3.0,
+            **sensor_kwargs,
+        )
+    )
     assert elastomer_grid_sensor._is_grid and elastomer_grid_sensor._use_grid_fft
     assert not elastomer_sensor._is_grid and not elastomer_sensor._use_grid_fft
     assert_allclose(elastomer_sensor.probe_local_pos, elastomer_grid_sensor.probe_local_pos, tol=gs.EPS)
@@ -2169,12 +2277,20 @@ def test_elastomer_sensor_grid_box_sphere(show_viewer, tol, n_envs):
     scene.step()
 
     # Test dilate displacement: grid sensor should match the flat-layout sensor and detect contact magnitude.
-    grid_data = elastomer_grid_sensor.read_ground_truth()
+    # The grid-input sensor reports (..., ny, nx, 3); flatten the grid axes for comparison with the flat sensor.
+    grid_data = torch.as_tensor(elastomer_grid_sensor.read_ground_truth(), device=gs.device).flatten(-3, -2)
     flat_data = elastomer_sensor.read_ground_truth()
     assert_allclose(flat_data, grid_data, tol=tol)
-    assert torch.linalg.norm(torch.as_tensor(grid_data, device=gs.device), dim=-1).max() > tol
+    assert torch.linalg.norm(grid_data, dim=-1).max() > tol
     assert_allclose(shear_sensor.read_ground_truth(), 0.0, tol=tol)
     assert_allclose(combined_sensor.read_ground_truth(), flat_data, tol=tol)
+
+    # normal_exponent reshapes only the out-of-plane channel: the grid-FFT and direct paths still agree, and the
+    # cubic-normal response differs from the default quadratic one (sub-unit depths here, so depth**3 < depth**2).
+    cubic_data = torch.as_tensor(cubic_grid_sensor.read_ground_truth(), device=gs.device).flatten(-3, -2)
+    assert_allclose(cubic_flat_sensor.read_ground_truth(), cubic_data, tol=tol)
+    cubic_diff = cubic_data - grid_data
+    assert torch.linalg.norm(cubic_diff, dim=-1).max() > tol, "normal_exponent=3 should change the dilation output"
 
     # Test combined displacement: dilate + shear contributions should add when the box slides laterally.
     box.set_pos((LATERAL_SHIFT, 0.0, SPHERE_RADIUS * 2 + BOX_SIZE / 2 - PENETRATION))
@@ -2193,6 +2309,119 @@ def test_elastomer_sensor_grid_box_sphere(show_viewer, tol, n_envs):
 
 
 @pytest.mark.slow  # ~200s
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_tactile_filler_probes_radius_zero(show_viewer, tol, n_envs):
+    # probe_radius == 0 marks inactive filler probes on ElastomerTaxel / KinematicTaxel: they read 0 and are
+    # excluded from dilation / force, letting an irregular taxel set be padded into a regular grid for FFT.
+    SPHERE_RADIUS = 0.1
+    BOX_SIZE = 0.1
+    PENETRATION = 0.01
+    GRID = (8, 8)
+    RADIUS = 0.02
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, 0.0),
+        ),
+        profiling_options=gs.options.ProfilingOptions(
+            show_FPS=False,
+        ),
+        show_viewer=show_viewer,
+    )
+    sphere = scene.add_entity(
+        gs.morphs.Sphere(
+            radius=SPHERE_RADIUS,
+            pos=(0.0, 0.0, SPHERE_RADIUS),
+            fixed=True,
+        )
+    )
+    box = scene.add_entity(
+        gs.morphs.Box(
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+            pos=(0.0, 0.0, SPHERE_RADIUS * 2 + BOX_SIZE / 2 - PENETRATION),
+            fixed=False,
+        )
+    )
+    grid_pos = gu.generate_grid_points_on_plane(
+        lo=(-BOX_SIZE / 2, -BOX_SIZE / 2, -BOX_SIZE / 2),
+        hi=(BOX_SIZE / 2, BOX_SIZE / 2, -BOX_SIZE / 2),
+        normal=(0.0, 0.0, -1.0),
+        nx=GRID[0],
+        ny=GRID[1],
+    )
+    flat_pos = grid_pos.reshape(-1, 3)
+    # Mark a 2x2 corner block (flat indices iy*nx+ix) as inactive fillers; the rest sense normally.
+    filler_idx = [0, 1, GRID[0], GRID[0] + 1]
+    radii = np.full(flat_pos.shape[0], RADIUS)
+    radii[filler_idx] = 0.0
+    active_mask = radii > 0.0
+
+    elastomer_kwargs = dict(
+        entity_idx=box.idx,
+        probe_local_normal=(0.0, 0.0, -1.0),
+        track_link_idx=(sphere.base_link_idx,),
+        n_sample_points=600,
+        lambda_s=0.0,
+        shear_scale=0.0,
+        dilate_scale=1.0,
+        draw_debug=show_viewer,
+    )
+    elastomer_grid = scene.add_sensor(
+        gs.sensors.ElastomerTaxel(
+            probe_local_pos=grid_pos,
+            probe_radius=radii.tolist(),
+            **elastomer_kwargs,
+        )
+    )
+    elastomer_active = scene.add_sensor(
+        gs.sensors.ElastomerTaxel(
+            probe_local_pos=flat_pos[active_mask],
+            probe_radius=RADIUS,
+            **elastomer_kwargs,
+        )
+    )
+    kinematic_kwargs = dict(
+        entity_idx=box.idx,
+        normal_stiffness=500.0,
+        draw_debug=show_viewer,
+    )
+    kinematic_grid = scene.add_sensor(
+        gs.sensors.KinematicTaxel(
+            probe_local_pos=grid_pos,
+            probe_radius=radii.tolist(),
+            **kinematic_kwargs,
+        )
+    )
+    kinematic_full = scene.add_sensor(
+        gs.sensors.KinematicTaxel(
+            probe_local_pos=grid_pos,
+            probe_radius=RADIUS,
+            **kinematic_kwargs,
+        )
+    )
+    assert elastomer_grid._use_grid_fft
+    scene.build(n_envs=n_envs)
+    scene.step()
+
+    # ElastomerTaxel (FFT dilation): filler probes read 0; active probes match a sensor built from only the
+    # active probes -- the fillers contribute no dilation, so the active readings are unchanged by their padding.
+    # The grid-input sensor reports (..., ny, nx, 3); flatten the grid axes for filler-index comparison.
+    grid_data = torch.as_tensor(elastomer_grid.read_ground_truth(), device=gs.device).flatten(-3, -2)
+    active_data = torch.as_tensor(elastomer_active.read_ground_truth(), device=gs.device)
+    assert torch.linalg.norm(grid_data, dim=-1).max() > tol, "active elastomer probes should detect contact"
+    assert_allclose(grid_data[..., filler_idx, :], 0.0, tol=gs.EPS)
+    assert_allclose(grid_data[..., active_mask, :], active_data, tol=tol)
+
+    # KinematicTaxel: filler probes read 0 force; active probes match the all-active grid (per-probe force).
+    # KinematicTaxel reports a grid-shaped (..., ny, nx, 3) reading; flatten the grid axes to the flat index.
+    kin_grid = torch.as_tensor(kinematic_grid.read().force, device=gs.device).flatten(-3, -2)
+    kin_full = torch.as_tensor(kinematic_full.read().force, device=gs.device).flatten(-3, -2)
+    assert torch.linalg.norm(kin_full, dim=-1).max() > tol, "active kinematic probes should detect contact"
+    assert_allclose(kin_grid[..., filler_idx, :], 0.0, tol=gs.EPS)
+    assert_allclose(kin_grid[..., active_mask, :], kin_full[..., active_mask, :], tol=tol)
+
+
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_proximity_sensor_box_on_box(show_viewer, tol, n_envs):
@@ -2229,7 +2458,6 @@ def test_proximity_sensor_box_on_box(show_viewer, tol, n_envs):
             probe_local_pos=((0.0, 0.0, -BOX_SIZE / 2), (BOX_SIZE / 4, 0.0, -BOX_SIZE / 2)),
             probe_local_normal=(0.0, 0.0, -1.0),
             probe_radius=0.06,
-            probe_radius_noise=0.1,
             track_link_idx=(support.base_link_idx,),
             n_sample_points=600,
             stiffness=100.0,
@@ -2241,12 +2469,12 @@ def test_proximity_sensor_box_on_box(show_viewer, tol, n_envs):
     scene.build(n_envs=n_envs)
     scene.step()
 
-    force_norm = torch.linalg.norm(_as_env_batch(sensor.read_ground_truth().force, n_envs), dim=-1)
+    force_norm = torch.linalg.norm(sensor.read_ground_truth().force, dim=-1)
     assert (force_norm > tol).all()
 
     taxel_box.set_pos((0.0, 0.0, BOX_SIZE + BOX_SIZE / 2 + 0.2))
     scene.step()
-    force_norm = torch.linalg.norm(_as_env_batch(sensor.read_ground_truth().force, n_envs), dim=-1)
+    force_norm = torch.linalg.norm(sensor.read_ground_truth().force, dim=-1)
     assert_allclose(force_norm, 0.0, tol=gs.EPS)
 
 
@@ -2309,7 +2537,6 @@ def test_tactile_sensors_heterogeneous_object(show_viewer, tol):
     depth_probe = scene.add_sensor(gs.sensors.ContactDepthProbe(**common))
     kinematic_taxel = scene.add_sensor(
         gs.sensors.KinematicTaxel(
-            probe_local_normal=(0.0, 0.0, 1.0),
             normal_stiffness=100.0,
             normal_damping=0.0,
             shear_scalar=0.0,
@@ -2345,6 +2572,16 @@ def test_tactile_sensors_heterogeneous_object(show_viewer, tol):
     )
 
     scene.build(n_envs=2)
+
+    # Per-variant sampling: each heterogeneous variant must receive the full n_sample_points budget so
+    # every parallel env sees the requested point count regardless of which variant is active there.
+    for pc_sensor, n_requested in ((proximity_taxel, 800), (elastomer_taxel, 800)):
+        meta = pc_sensor._shared_metadata
+        pc_start = int(meta.sensor_pc_start[pc_sensor._idx].item())
+        pc_end = pc_start + int(meta.sensor_pc_n[pc_sensor._idx].item())
+        per_env_active = meta.pc_active_envs_mask[pc_start:pc_end].sum(dim=0)
+        assert_equal(per_env_active, torch.full_like(per_env_active, n_requested))
+
     obj.set_pos(
         [
             [0.0, 0.0, PAD_TOP_Z + OBJECT_Z_SIZE / 2 - PENETRATION],
@@ -2368,6 +2605,91 @@ def test_tactile_sensors_heterogeneous_object(show_viewer, tol):
     assert (elastomer_norm[0, 0] > tol) and (elastomer_norm[1, 0] > tol)
     assert elastomer_norm[0, 1] > elastomer_norm[1, 1] + gs.EPS
     assert surface_distance[0, 1] < surface_distance[1, 1]
+
+
+@pytest.mark.required
+def test_tactile_contact_depth_query_sdf_vs_raycast_parity(show_viewer):
+    # SDF and raycast contact-depth backends should agree on a face-on contact across the probe sensors. The backend
+    # is class-wide (all sensors of a class share one mode), so each mode is built in its own scene and compared.
+    PAD_SIZE = (0.2, 0.2, 0.05)
+    PAD_TOP_Z = PAD_SIZE[2]
+    BALL_R = 0.04
+    PROBE_R = 0.01
+    CENTER_PROBE = (0.0, 0.0, PAD_SIZE[2] / 2)
+
+    def build_and_read(mode):
+        # Build a scene whose probe sensors all use mode, press the ball in, and return CPU-side readings.
+        scene = gs.Scene(
+            sim_options=gs.options.SimOptions(gravity=(0.0, 0.0, 0.0)),
+            profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+            show_viewer=show_viewer,
+        )
+        pad = scene.add_entity(
+            gs.morphs.Box(
+                size=PAD_SIZE,
+                pos=(0.0, 0.0, PAD_SIZE[2] / 2),
+                fixed=True,
+            )
+        )
+        ball = scene.add_entity(
+            gs.morphs.Sphere(
+                radius=BALL_R,
+                pos=(0.0, 0.0, 0.4),
+            )
+        )
+
+        common = dict(entity_idx=pad.idx, probe_local_pos=(CENTER_PROBE,), probe_radius=PROBE_R)
+        depth = scene.add_sensor(gs.sensors.ContactDepthProbe(contact_depth_query=mode, **common))
+        kin = scene.add_sensor(
+            gs.sensors.KinematicTaxel(
+                normal_stiffness=100.0,
+                normal_damping=0.0,
+                shear_scalar=0.0,
+                twist_scalar=0.0,
+                contact_depth_query=mode,
+                **common,
+            )
+        )
+        elast = scene.add_sensor(
+            gs.sensors.ElastomerTaxel(
+                entity_idx=pad.idx,
+                probe_local_pos=(CENTER_PROBE,),
+                probe_local_normal=(0.0, 0.0, 1.0),
+                probe_radius=PROBE_R,
+                track_link_idx=(ball.base_link_idx,),
+                n_sample_points=200,
+                contact_depth_query=mode,
+            )
+        )
+        scene.build(n_envs=0)
+
+        ball.set_pos((0.0, 0.0, PAD_TOP_Z + BALL_R - 0.005))  # 5mm penetration
+        scene.step()
+        # Materialize on CPU so the readings survive the next scene build.
+        return (
+            tensor_to_array(depth.read_ground_truth()),
+            tensor_to_array(kin.read_ground_truth().force).reshape(-1, 3),
+            tensor_to_array(elast.read_ground_truth()),
+        )
+
+    sdf_d, sdf_f, sdf_e = build_and_read("sdf")
+    ray_d, ray_f, ray_e = build_and_read("raycast")
+
+    # ContactDepthProbe -- both backends report a positive depth of the same order. They do not match tightly: SDF
+    # uses the ball's analytic sphere SDF while raycast hits its faceted mesh, so the depths differ by a
+    # mesh-discretization margin (a few tenths of the probe radius).
+    assert (sdf_d > gs.EPS).all() and (ray_d > gs.EPS).all()
+    assert_allclose(sdf_d, ray_d, tol=0.5 * PROBE_R)
+
+    # KinematicTaxel force: both modes report a force in the same direction with magnitude within mesh-discretization
+    # tolerance of each other.
+    assert np.linalg.norm(sdf_f, axis=-1).item() > 0
+    assert np.linalg.norm(ray_f, axis=-1).item() > 0
+    cos_sim = (sdf_f * ray_f).sum(axis=-1) / (np.linalg.norm(sdf_f, axis=-1) * np.linalg.norm(ray_f, axis=-1) + gs.EPS)
+    assert (cos_sim > 0.9).all(), f"force direction mismatch: cos_sim={cos_sim}"
+
+    # ElastomerTaxel dilate displacement: face-on contact, identical on both modes when geom is a sphere primitive.
+    assert_allclose(sdf_e, ray_e, tol=0.1 * PROBE_R)
 
 
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Rework the tactile sensor backends (KinematicTaxel, ContactProbe, ContactDepthProbe, ProximityTaxel, ElastomerTaxel) for performance:
- Shared static-chunk BVH + raycast/SDF query infrastructure (new tactile_shared.py), contact prefiltering and candidate-geom masking.
- SDF-vs-raycast contact-depth query modes; point-cloud sampling and per-chunk BVH for proximity/elastomer sensors.

## Related Issue

## Motivation and Context
- Sublinear scaling with number of probes 
- Split PR with https://github.com/Genesis-Embodied-AI/genesis-world/pull/2813 
- Note that all tactile noise related changes is in the above PR

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
<img width="147" height="127" alt="Screenshot 2026-05-26 at 10 49 39" src="https://github.com/user-attachments/assets/464afe5a-cfa5-4405-9dd2-526b2544a4c2" />

Before:
<img width="319" height="448" alt="Screenshot 2026-05-26 at 10 48 44" src="https://github.com/user-attachments/assets/1b299c00-0b34-4b6c-881a-ea31871959ba" />

After:
<img width="377" height="504" alt="Screenshot 2026-05-26 at 10 49 12" src="https://github.com/user-attachments/assets/1ba89f7d-d24d-47df-bddf-de493fdf6f4e" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly: https://github.com/Genesis-Embodied-AI/genesis-doc/pull/121
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
