### PR TITLE
[FEATURE] Add pruning-aware sizing of contact constraint buffers using 'max_contacts' option.

### DIFF
--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -659,7 +659,7 @@ class TemperatureGridSensor(
         )
 
         # Contact area buffers
-        n_c_max = int(solver.collider._collider_info.max_contact_pairs[None])
+        n_c_max = int(solver.collider._collider_info.max_candidate_contacts[None])
         self._shared_metadata.contact_area_buffer = torch.zeros(
             (n_c_max, solver._B), device=gs.device, dtype=gs.tc_float
         )

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -95,6 +95,8 @@ class Collider:
         self._diff_pos_tolerance = 1e-2
         self._diff_normal_tolerance = 1e-2
         self._prune_deep_penetration_ratio = 3.0
+        self._prune_max_contacts_per_link_pair = 32
+        self._prune_max_contacts_floor = 512
 
         self._init_static_config()
         self._use_split_narrowphase = (
@@ -172,7 +174,7 @@ class Collider:
             has_non_box_plane_convex_convex,
             has_convex_specialization,
             has_nonconvex_nonterrain,
-            self._n_possible_nonconvex_pairs,
+            self._large_contact_pair_mask,
         ) = self._compute_collision_pair_idx()
 
         # Link-pair pruning can do useful work only when contacts from distinct geom-pairs can accumulate into the same
@@ -271,7 +273,7 @@ class Collider:
         self._init_collision_pair_idx(self._collision_pair_idx)
         self._init_valid_pairs()
         self._init_verts_connectivity(vert_neighbors, vert_neighbor_start, vert_n_neighbors)
-        self._init_max_contact_pairs(self._n_possible_pairs, self._n_possible_nonconvex_pairs)
+        self._init_max_contacts(self._n_possible_pairs, self._large_contact_pair_mask)
         self._init_terrain_state()
 
         # Initialize [state], which stores every data that are may be updated at every single simulation step
@@ -355,7 +357,8 @@ class Collider:
 
         if n_geoms == 0:
             empty_pairs = np.empty((0, 2), dtype=gs.np_int)
-            return 0, np.full((0, 0), fill_value=-1, dtype=gs.np_int), empty_pairs, False, False, False, False, 0
+            empty_mask = np.zeros((0,), dtype=bool)
+            return 0, np.full((0, 0), -1, dtype=gs.np_int), empty_pairs, False, False, False, False, empty_mask
 
         # Links delegated to IPC coupler (skip pair only when BOTH are IPC-handled)
         ipc_delegated_link_idxs = set()
@@ -581,7 +584,6 @@ class Collider:
             large_contact_mask = large_contact_mask | (
                 (valid_type_a == gs.GEOM_TYPE.BOX) & (valid_type_b == gs.GEOM_TYPE.BOX)
             )
-        n_possible_nonconvex_pairs = int(np.count_nonzero(large_contact_mask))
 
         return (
             n_possible_pairs,
@@ -591,7 +593,7 @@ class Collider:
             has_non_box_plane_convex_convex,
             has_convex_specialization,
             has_nonconvex_vs_nonterrain,
-            n_possible_nonconvex_pairs,
+            large_contact_mask,
         )
 
     def _compute_verts_connectivity(self):
@@ -631,7 +633,8 @@ class Collider:
             self._collider_info.vert_neighbor_start.from_numpy(vert_neighbor_start)
             self._collider_info.vert_n_neighbors.from_numpy(vert_n_neighbors)
 
-    def _init_max_contact_pairs(self, n_possible_pairs, n_possible_nonconvex_pairs):
+    def _init_max_contacts(self, n_possible_pairs, large_contact_pair_mask):
+        n_possible_nonconvex_pairs = int(np.count_nonzero(large_contact_pair_mask))
         max_collision_pairs = min(self._solver.max_collision_pairs, n_possible_pairs)
         # Size the contact buffer per regime: nonconvex pairs each emit up to n_contacts_per_nonconvex_pair, convex and
         # terrain pairs up to n_contacts_per_convex_pair. The worst case fills the capped pair budget with as many
@@ -640,13 +643,40 @@ class Collider:
         cap_convex = self._collider_static_config.n_contacts_per_convex_pair
         n_nonconvex = min(n_possible_nonconvex_pairs, max_collision_pairs)
         n_convex = min(n_possible_pairs - n_possible_nonconvex_pairs, max_collision_pairs - n_nonconvex)
-        max_contact_pairs = n_nonconvex * cap_nonconvex + n_convex * cap_convex
-        max_contact_pairs_broad = max_collision_pairs * self._solver._options.multiplier_collision_broad_phase
+        max_candidate_contacts = n_nonconvex * cap_nonconvex + n_convex * cap_convex
+        max_collision_pairs_broad = max_collision_pairs * self._solver._options.multiplier_collision_broad_phase
+
+        # Post-pruning contact budget for sizing the contact constraint buffers. The physical contact buffer must hold
+        # everything the narrowphase can emit (max_candidate_contacts), but the constraint solver only consumes
+        # contacts surviving link-pair pruning, which keeps roughly the 2D support polygon of each (link_a, link_b)
+        # contact patch. Cap each candidate link pair at _prune_max_contacts_per_link_pair points (or the sum of its
+        # geom-pair caps if smaller) instead of the per-geom-pair worst case. This is a heuristic, not a hard
+        # guarantee: conforming (non-coplanar) contact patches are not pruned and can exceed the cap, which clamps
+        # the contact count and halts the simulation with a request to increase 'max_contacts'. Tightening only pays
+        # off when the worst case is large, so the budget never goes below _prune_max_contacts_floor: under it, the
+        # halt risk buys no meaningful memory savings. The constraint solver overrides this budget at build time when
+        # 'max_contacts' is set.
+        max_contacts = max_candidate_contacts
+        if (
+            self._collider_static_config.has_prunable_contacts
+            and not self._solver._requires_grad
+            and self._solver._options.contact_pruning_tolerance is not None
+        ):
+            geoms_link_idx = np.array([geom.link.idx for geom in self._solver.geoms], dtype=np.int64)
+            pairs_link_idx = geoms_link_idx[self._valid_collision_pairs]
+            pairs_key = self._solver.n_links * pairs_link_idx.min(axis=1) + pairs_link_idx.max(axis=1)
+            _, pairs_group_idx = np.unique(pairs_key, return_inverse=True)
+            pairs_n_contacts = np.where(large_contact_pair_mask, cap_nonconvex, cap_convex)
+            link_pairs_n_contacts = np.bincount(pairs_group_idx, weights=pairs_n_contacts)
+            max_contacts_pruned = np.minimum(link_pairs_n_contacts, self._prune_max_contacts_per_link_pair)
+            max_contacts_pruned_total = max(int(max_contacts_pruned.sum()), self._prune_max_contacts_floor)
+            max_contacts = min(max_contacts, max_contacts_pruned_total)
 
         self._collider_info.max_possible_pairs[None] = n_possible_pairs
         self._collider_info.max_collision_pairs[None] = max_collision_pairs
-        self._collider_info.max_collision_pairs_broad[None] = max_contact_pairs_broad
-        self._collider_info.max_contact_pairs[None] = max_contact_pairs
+        self._collider_info.max_collision_pairs_broad[None] = max_collision_pairs_broad
+        self._collider_info.max_candidate_contacts[None] = max_candidate_contacts
+        self._collider_info.max_contacts[None] = max_contacts
 
     def _init_terrain_state(self):
         if self._collider_static_config.has_terrain:
@@ -937,6 +967,7 @@ class Collider:
                 self._solver._rigid_global_info,
                 self._solver._static_rigid_sim_config,
                 self._collider_static_config,
+                self._solver._errno,
             )
         else:
             func_clamp_prune_and_sort_contacts(
@@ -945,6 +976,7 @@ class Collider:
                 self._solver._rigid_global_info,
                 self._solver._static_rigid_sim_config,
                 self._collider_static_config,
+                self._solver._errno,
             )
 
     def get_contacts(self, as_tensor: bool = True, to_torch: bool = True, keep_batch_dim: bool = False):
@@ -991,7 +1023,7 @@ class Collider:
                     else:
                         data = tensor_to_array(data)
                 else:
-                    # data shape is (_B, max_contact_pairs) for scalars or (_B, max_contact_pairs, 3) for vectors.
+                    # data shape is (_B, max_candidate_contacts) for scalars, with a trailing 3 axis for vectors.
                     gidx = gather_idx_vec if data.dim() == 3 else gather_idx_flat
                     data = data.gather(dim=1, index=gidx)
                     if n_envs == 0 and not keep_batch_dim:

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -325,7 +325,7 @@ def func_add_contact(
         i_c = qd.atomic_add(collider_state.n_contacts[i_b], 1)
     else:
         i_c = collider_state.n_contacts[i_b]
-    if i_c < collider_info.max_contact_pairs[None]:
+    if i_c < collider_info.max_candidate_contacts[None]:
         friction_a = geoms_info.friction[i_ga] * geoms_state.friction_ratio[i_ga, i_b]
         friction_b = geoms_info.friction[i_gb] * geoms_state.friction_ratio[i_gb, i_b]
 
@@ -395,7 +395,7 @@ def func_add_diff_contact_input(
     collider_info: array_class.ColliderInfo,
 ):
     i_c = collider_state.n_contacts[i_b]
-    if i_c < collider_info.max_contact_pairs[None]:
+    if i_c < collider_info.max_candidate_contacts[None]:
         collider_state.diff_contact_input.geom_a[i_b, i_c] = i_ga
         collider_state.diff_contact_input.geom_b[i_b, i_c] = i_gb
         collider_state.diff_contact_input.local_pos1_a[i_b, i_c] = gjk_state.diff_contact_input.local_pos1_a[i_b, i_d]
@@ -568,6 +568,7 @@ def func_clamp_prune_and_sort_contacts(
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     collider_static_config: qd.template(),
+    errno: qd.Tensor,
 ):
     """Clamp + (optional) link-pair pruning + (optional) x-position sort, in one per-env loop pass.
 
@@ -576,10 +577,12 @@ def func_clamp_prune_and_sort_contacts(
     ``contact_data.X[contact_sort_idx[i_col, i_b], i_b]``. The physical layout of ``contact_data`` is left intact.
 
     Phases per env (gated at compile time by ``collider_static_config``):
-    - Always: clamp ``n_contacts`` to ``max_contact_pairs``; initialise ``contact_sort_idx`` to the identity.
+    - Always: clamp ``n_contacts`` to ``max_candidate_contacts``; initialise ``contact_sort_idx`` to the identity.
     - If ``has_prunable_contacts and not requires_grad``: prune redundant contacts via 2D convex hull on the
       contact-patch plane (skipped at runtime when ``contact_pruning_tolerance`` is 0). Drops are realised by
       compacting ``contact_sort_idx`` rather than ``contact_data``.
+    - Always: clamp the surviving ``n_contacts`` to ``max_contacts`` (the budget sizing the contact constraint
+      buffers) and flag OVERFLOW_CONTACTS in ``errno``, which halts the simulation at the next errno check.
     - If ``has_non_box_plane_convex_convex and backend != cpu``: spatial sort the index permutation by x-position
       with geom-pair groups treated as units (provides spatial locality for downstream constraint-solver reads), with
       a (geom_a, geom_b) tie-break so groups sharing the same x sort deterministically regardless of physical layout.
@@ -593,7 +596,7 @@ def func_clamp_prune_and_sort_contacts(
     The single ``tol`` parameter controls the depth gate as a dimensionless slop fraction:
       max |out-of-plane offset| / in-plane radius <= tol.
 
-    Phases (per env, scratch sized to max_contact_pairs):
+    Phases (per env, scratch sized to max_candidate_contacts):
     1. Group by canonical link-pair: insertion-sort ``contact_sort_idx`` by (min_link, max_link) key, reading link
        data through the current index permutation.
     2. Per bucket of >= 3 contacts: compute mean normal (folded to a common hemisphere). Check depth coplanarity of
@@ -605,7 +608,8 @@ def func_clamp_prune_and_sort_contacts(
     overwriting it with final keep flags before the bucket exits.
     """
     _B = collider_state.n_contacts.shape[0]
-    max_contact_pairs = collider_info.max_contact_pairs[None]
+    max_candidate_contacts = collider_info.max_candidate_contacts[None]
+    max_contacts = collider_info.max_contacts[None]
     tol = collider_info.contact_pruning_tolerance[None]
     prune_deep_penetration_ratio = collider_info.prune_deep_penetration_ratio[None]
     LP_KEY_STRIDE = gs.qd_float(1.0e7)
@@ -613,7 +617,7 @@ def func_clamp_prune_and_sort_contacts(
 
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
-        n_con = qd.min(collider_state.n_contacts[i_b], max_contact_pairs)
+        n_con = qd.min(collider_state.n_contacts[i_b], max_candidate_contacts)
         collider_state.n_contacts[i_b] = n_con
 
         # Identity permutation. Required so downstream consumers can always indirect through contact_sort_idx,
@@ -924,7 +928,7 @@ def func_clamp_prune_and_sort_contacts(
                                         break
                                 # The closing iteration of the upper hull visits the leftmost point, which already sits
                                 # at stack[i_cb_start] from the lower hull. Skipping that push, plus the n_hull < n_cb
-                                # guard, bounds n_hull to n_cb and keeps the write index within max_contact_pairs even
+                                # guard, bounds n_hull to n_cb and keeps the write index within the candidate buffer even
                                 # for buckets where the lower-hull pass already kept all n_cb points (downward-convex
                                 # layouts: every lex-sorted triple makes a left turn so nothing gets popped, then the
                                 # upper-hull pass tries to push a duplicate of an already-kept lower-hull vertex).
@@ -976,6 +980,13 @@ def func_clamp_prune_and_sort_contacts(
                             collider_state.contact_sort_idx[i_cw, i_b] = collider_state.contact_sort_idx[i_cr, i_b]
                         i_cw += 1
                 collider_state.n_contacts[i_b] = i_cw
+
+        # The contact constraint buffers are sized to 4 * max_contacts, so any surviving contact beyond that budget
+        # would write out of bounds. Clamp and flag the env: check_errno halts the simulation with a request to
+        # increase 'max_contacts'.
+        if collider_state.n_contacts[i_b] > max_contacts:
+            collider_state.n_contacts[i_b] = max_contacts
+            errno[i_b] = errno[i_b] | array_class.ErrorCode.OVERFLOW_CONTACTS
 
         # === Spatial sort by x-position with geom-pair grouping. Gated on collider_static_config.
         # spatial_sort_supported, which combines the narrowphase condition (has_non_box_plane_convex_convex on GPU)
@@ -1037,6 +1048,7 @@ def func_clamp_prune_and_sort_contacts_coop(
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
     collider_static_config: qd.template(),
+    errno: qd.Tensor,
 ):
     """GPU-only cooperative warp-per-env variant of `func_clamp_prune_and_sort_contacts`.
 
@@ -1048,7 +1060,8 @@ def func_clamp_prune_and_sort_contacts_coop(
         the phase-3 compact (with fused spatial sort when `collider_static_config.spatial_sort_supported`).
     """
     _B = collider_state.n_contacts.shape[0]
-    max_contact_pairs = collider_info.max_contact_pairs[None]
+    max_candidate_contacts = collider_info.max_candidate_contacts[None]
+    max_contacts = collider_info.max_contacts[None]
     tol = collider_info.contact_pruning_tolerance[None]
     prune_deep_penetration_ratio = collider_info.prune_deep_penetration_ratio[None]
     LP_KEY_STRIDE = gs.qd_float(1.0e7)
@@ -1061,7 +1074,7 @@ def func_clamp_prune_and_sort_contacts_coop(
         tid = i_flat % _K
         i_b = i_flat // _K
         # All lanes compute n_con (cheap, no memory write on non-lane-0).
-        n_con = qd.min(collider_state.n_contacts[i_b], max_contact_pairs)
+        n_con = qd.min(collider_state.n_contacts[i_b], max_candidate_contacts)
         if tid == 0:
             collider_state.n_contacts[i_b] = n_con
 
@@ -1501,6 +1514,13 @@ def func_clamp_prune_and_sort_contacts_coop(
                         collider_state.contact_sort_idx[i_cw, i_b] = i_c
                         i_cw += 1
                 collider_state.n_contacts[i_b] = i_cw
+
+            # The contact constraint buffers are sized to 4 * max_contacts, so any surviving contact beyond that
+            # budget would write out of bounds. Clamp and flag the env: check_errno halts the simulation with a
+            # request to increase 'max_contacts'.
+            if collider_state.n_contacts[i_b] > max_contacts:
+                collider_state.n_contacts[i_b] = max_contacts
+                errno[i_b] = errno[i_b] | array_class.ErrorCode.OVERFLOW_CONTACTS
 
 
 @qd.kernel

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -2150,12 +2150,12 @@ def _func_multicontact_mpr(
     if n_con > 0:
         # Non-atomic pre-check to avoid reserving slots we cannot fill. A rare race between the read and the
         # atomic_add below may still overshoot; in that case we write only the contacts that fit and set errno.
-        max_contact_pairs = collider_info.max_contact_pairs[None]
-        if collider_state.n_contacts[i_b] + n_con > max_contact_pairs:
+        max_candidate_contacts = collider_info.max_candidate_contacts[None]
+        if collider_state.n_contacts[i_b] + n_con > max_candidate_contacts:
             errno[i_b] = errno[i_b] | array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS
         else:
             start_idx = qd.atomic_add(collider_state.n_contacts[i_b], n_con)
-            n_con = qd.math.clamp(max_contact_pairs - start_idx, 0, n_con)
+            n_con = qd.math.clamp(max_candidate_contacts - start_idx, 0, n_con)
             if n_con == 0:
                 errno[i_b] = errno[i_b] | array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS
             for i in range(n_con):

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -63,12 +63,18 @@ class ConstraintSolver:
         self.sparse_solve = rigid_solver._static_rigid_sim_config.sparse_solve
 
         # Note that it must be over-estimated because friction parameters and joint limits may be updated dynamically.
-        # * 4 constraints per contact
+        # * 4 constraints per contact, bounded by the post-pruning contact budget enforced by the collider
         # * 1 constraint per 1DoF joint limit (upper and lower, if not inf)
         # * 1 constraint per dof frictionloss
         # * up to 6 constraints per equality (weld)
+        # When 'max_contacts' is set, it overrides the post-pruning contact budget enforced by the collider.
+        collider_info = rigid_solver.collider._collider_info
+        if rigid_solver._options.max_contacts is not None:
+            collider_info.max_contacts[None] = min(
+                rigid_solver._options.max_contacts, collider_info.max_candidate_contacts[None]
+            )
         self.len_constraints = int(
-            4 * rigid_solver.collider._collider_info.max_contact_pairs[None]
+            4 * collider_info.max_contacts[None]
             + sum(joint.type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC) for joint in self._solver.joints)
             + self._solver.n_dofs
             + self._solver.n_candidate_equalities_ * 6
@@ -732,12 +738,12 @@ def _add_collision_constraints_per_friction(
     layout (_B, n_dofs, n_constraints), n_con is stride-1, so jac writes coalesce.
     """
     _B = dofs_state.ctrl_mode.shape[1]
-    max_contact_pairs = collider_state.contact_data.link_a.shape[0]
+    max_candidate_contacts = collider_state.contact_data.link_a.shape[0]
 
     qd.loop_config(name="add_collision_constraints", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for flat_idx in range(_B * max_contact_pairs * 4):
-        slot = flat_idx % (max_contact_pairs * 4)
-        i_b = flat_idx // (max_contact_pairs * 4)
+    for flat_idx in range(_B * max_candidate_contacts * 4):
+        slot = flat_idx % (max_candidate_contacts * 4)
+        i_b = flat_idx // (max_candidate_contacts * 4)
         i_col_ = slot // 4
         i_friction = slot % 4
         if i_col_ < collider_state.n_contacts[i_b]:
@@ -769,10 +775,10 @@ def _add_collision_constraints_per_contact(
     EPS = rigid_global_info.EPS[None]
     _B = dofs_state.ctrl_mode.shape[1]
     n_dofs = dofs_state.ctrl_mode.shape[0]
-    max_contact_pairs = collider_state.contact_data.link_a.shape[0]
+    max_candidate_contacts = collider_state.contact_data.link_a.shape[0]
 
     qd.loop_config(name="add_collision_constraints", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for flat_idx in range(max_contact_pairs * _B):
+    for flat_idx in range(max_candidate_contacts * _B):
         i_b = flat_idx % _B
         i_col_ = flat_idx // _B
         if i_col_ < collider_state.n_contacts[i_b]:

--- a/genesis/engine/solvers/rigid/constraint/solver_island.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_island.py
@@ -32,8 +32,14 @@ class ConstraintSolverIsland:
         self.sparse_solve: bool = True
 
         # 4 constraints per contact and 1 constraints per joint limit (upper and lower, if not inf)
+        # When 'max_contacts' is set, it overrides the post-pruning contact budget enforced by the collider.
+        collider_info = self._collider._collider_info
+        if rigid_solver._options.max_contacts is not None:
+            collider_info.max_contacts[None] = min(
+                rigid_solver._options.max_contacts, collider_info.max_candidate_contacts[None]
+            )
         self.len_constraints = int(
-            4 * self._collider._collider_info.max_contact_pairs[None]
+            4 * collider_info.max_contacts[None]
             + np.logical_not(np.isinf(self._solver.dofs_info.limit.to_numpy()[:, 0])).sum()
         )
         self.len_constraints_ = max(1, self.len_constraints)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1101,10 +1101,16 @@ class RigidSolver(KinematicSolver):
                 f"Please increase the value of RigidSolver's option 'multiplier_collision_broad_phase'."
             )
         if errno & array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS:
-            max_contact_pairs = self.collider._collider_info.max_contact_pairs[None]
+            max_candidate_contacts = self.collider._collider_info.max_candidate_contacts[None]
             gs.raise_exception(
-                f"Exceeding max number of contact pairs ({max_contact_pairs}). Please increase the value of "
-                "RigidSolver's option 'max_collision_pairs'."
+                f"Exceeding max number of candidate contact points ({max_candidate_contacts}). Please increase the "
+                "value of RigidSolver's option 'max_collision_pairs'."
+            )
+        if errno & array_class.ErrorCode.OVERFLOW_CONTACTS:
+            max_contacts = self.collider._collider_info.max_contacts[None]
+            gs.raise_exception(
+                f"Exceeding max number of post-pruning contact points ({max_contacts}) supported by the constraint "
+                "solver. Please increase the value of RigidSolver's option 'max_contacts'."
             )
         if errno & array_class.ErrorCode.INVALID_FORCE_NAN:
             gs.raise_exception("Invalid constraint forces causing 'nan'. Please decrease Rigid simulation timestep.")

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -418,6 +418,15 @@ class RigidOptions(Options):
         Whether to disable all constraints. Defaults to False.
     max_collision_pairs : int, optional
         Maximum number of collision pairs. Defaults to 100.
+    max_contacts : int, optional
+        Maximum number of simultaneous contact points per environment that the constraint solver can handle, which
+        determines the size of the contact constraint buffers (4 constraints per contact point). Defaults to None.
+
+        This limit applies to the final contact points after pruning, not to the candidate contact points that
+        collision detection can emit (see 'max_collision_pairs'). Exceeding it at runtime halts the simulation with
+        an error. None resolves it automatically: the pre-pruning worst case or, when contact pruning is enabled
+        (see 'contact_pruning_tolerance'), 32 contact points per candidate link pair but no less than 512, whichever
+        is smaller.
     integrator : gs.integrator, optional
         Integrator type. Current supported integrators are 'gs.integrator.Euler', 'gs.integrator.implicitfast' and
         'gs.integrator.approximate_implicitfast'. 'Euler' and 'implicitfast' are consistent with their Mujoco
@@ -495,6 +504,7 @@ class RigidOptions(Options):
     enable_adjacent_collision: StrictBool = False
     disable_constraint: StrictBool = False
     max_collision_pairs: NonNegativeInt = 150
+    max_contacts: PositiveInt | None = None
     multiplier_collision_broad_phase: PositiveInt = 8
     integrator: gs.integrator = gs.integrator.approximate_implicitfast
     IK_max_targets: PositiveInt = 6

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -86,6 +86,7 @@ class ErrorCode(IntEnum):
     OVERFLOW_HIBERNATION_ISLANDS = 0b00000000000000000000000000000100
     INVALID_FORCE_NAN = 0b00000000000000000000000000001000
     INVALID_ACC_NAN = 0b00000000000000000000000000010000
+    OVERFLOW_CONTACTS = 0b00000000000000000000000000100000
 
 
 # =========================================== RigidGlobalInfo ===========================================
@@ -478,22 +479,22 @@ class ContactData:
     pair_idx: qd.Tensor
 
 
-def get_contact_data(solver, max_contact_pairs, requires_grad):
+def get_contact_data(solver, max_candidate_contacts, requires_grad):
     _B = solver._B
-    max_contact_pairs_ = max(max_contact_pairs, 1)
+    max_candidate_contacts_ = max(max_candidate_contacts, 1)
 
     return ContactData(
-        geom_a=V(dtype=gs.qd_int, shape=(max_contact_pairs_, _B)),
-        geom_b=V(dtype=gs.qd_int, shape=(max_contact_pairs_, _B)),
-        normal=V(dtype=gs.qd_vec3, shape=(max_contact_pairs_, _B), needs_grad=requires_grad),
-        pos=V(dtype=gs.qd_vec3, shape=(max_contact_pairs_, _B), needs_grad=requires_grad),
-        penetration=V(dtype=gs.qd_float, shape=(max_contact_pairs_, _B), needs_grad=requires_grad),
-        friction=V(dtype=gs.qd_float, shape=(max_contact_pairs_, _B)),
-        sol_params=V_VEC(7, dtype=gs.qd_float, shape=(max_contact_pairs_, _B)),
-        force=V(dtype=gs.qd_vec3, shape=(max_contact_pairs_, _B)),
-        link_a=V(dtype=gs.qd_int, shape=(max_contact_pairs_, _B)),
-        link_b=V(dtype=gs.qd_int, shape=(max_contact_pairs_, _B)),
-        pair_idx=V(dtype=gs.qd_int, shape=(max_contact_pairs_, _B)),
+        geom_a=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
+        geom_b=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
+        normal=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
+        pos=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
+        penetration=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
+        friction=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
+        sol_params=V_VEC(7, dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
+        force=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B)),
+        link_a=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
+        link_b=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
+        pair_idx=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
     )
 
 
@@ -612,20 +613,20 @@ class ContactIslandState:
 
 def get_contact_island_state(solver, collider):
     _B = solver._B
-    max_contact_pairs = max(collider._collider_info.max_contact_pairs[None], 1)
+    max_candidate_contacts = max(collider._collider_info.max_candidate_contacts[None], 1)
     n_entities = max(solver.n_entities, 1)
 
     # When hibernation is enabled, the island construction adds edges for hibernated entity chains
     # in addition to contact edges. The chain construction is cyclic (last entity links back to first),
     # so worst case: each entity contributes one hibernation edge, totaling n_entities hibernation edges.
     max_hibernation_edges = n_entities if solver._use_hibernation else 0
-    max_edges = max_contact_pairs + max_hibernation_edges
+    max_edges = max_candidate_contacts + max_hibernation_edges
 
     return ContactIslandState(
         ci_edges=V(dtype=gs.qd_int, shape=(max_edges, 2, _B)),
         edge_id=V(dtype=gs.qd_int, shape=(max_edges * 2, _B)),
-        constraint_list=V(dtype=gs.qd_int, shape=(max_contact_pairs, _B)),
-        constraint_id=V(dtype=gs.qd_int, shape=(max_contact_pairs * 2, _B)),
+        constraint_list=V(dtype=gs.qd_int, shape=(max_candidate_contacts, _B)),
+        constraint_id=V(dtype=gs.qd_int, shape=(max_candidate_contacts * 2, _B)),
         entity_edge=get_agg_list(solver),
         island_col=get_agg_list(solver),
         island_hibernated=V(dtype=gs.qd_int, shape=(n_entities, _B)),
@@ -703,7 +704,7 @@ class ColliderState:
     contact_keep: qd.Tensor
     contact_hull_stack: qd.Tensor
     # Per-bucket lex sort permutation used by the cooperative dedup kernel
-    # (func_clamp_prune_and_sort_contacts_coop) for the phase-3 (u, v) lex sort. Sized to max_contact_pairs because
+    # (func_clamp_prune_and_sort_contacts_coop) for the phase-3 (u, v) lex sort. Sized to max_candidate_contacts because
     # each env writes its own permutation.
     contact_lex_idx: qd.Tensor
 
@@ -720,8 +721,8 @@ def get_collider_state(
     n_geoms = solver.n_geoms_
     max_collision_pairs = min(solver.max_collision_pairs, n_possible_pairs)
     max_collision_pairs_broad = max_collision_pairs * max_collision_pairs_broad_k
-    # Already sized per regime (convex vs nonconvex) by Collider._init_max_contact_pairs, which runs before this.
-    max_contact_pairs = max(collider_info.max_contact_pairs[None], 1)
+    # Already sized per regime (convex vs nonconvex) by Collider._init_max_contacts, which runs before this.
+    max_candidate_contacts = max(collider_info.max_candidate_contacts[None], 1)
     requires_grad = static_rigid_sim_config.requires_grad
 
     box_depth_shape = maybe_shape(
@@ -736,7 +737,7 @@ def get_collider_state(
     box_axi_shape = maybe_shape((3, _B), static_rigid_sim_config.box_box_detection)
     box_ppts2_shape = maybe_shape((4, 2, _B), static_rigid_sim_config.box_box_detection)
     box_pu_shape = maybe_shape((4, _B), static_rigid_sim_config.box_box_detection)
-    prune_shape = maybe_shape((max(max_contact_pairs, 1), _B), collider_static_config.has_prunable_contacts)
+    prune_shape = maybe_shape((max(max_candidate_contacts, 1), _B), collider_static_config.has_prunable_contacts)
 
     return ColliderState(
         sort_buffer=get_sort_buffer(solver),
@@ -759,13 +760,13 @@ def get_collider_state(
         first_time=V(dtype=gs.qd_bool, shape=(_B,)),
         contact_cache=get_contact_cache(solver, n_possible_pairs),
         broad_collision_pairs=V_VEC(2, dtype=gs.qd_int, shape=(max(max_collision_pairs_broad, 1), _B)),
-        contact_data=get_contact_data(solver, max_contact_pairs, requires_grad),
-        diff_contact_input=get_diff_contact_input(_B, max(max_contact_pairs, 1), True, requires_grad),
+        contact_data=get_contact_data(solver, max_candidate_contacts, requires_grad),
+        diff_contact_input=get_diff_contact_input(_B, max(max_candidate_contacts, 1), True, requires_grad),
         narrowphase_work_queues=get_narrowphase_work_queues(
             max(max_collision_pairs_broad * _B, 1) if collider_static_config.has_non_box_plane_convex_convex else 1
         ),
-        contact_sort_key=V(dtype=gs.qd_float, shape=(max(max_contact_pairs, 1), _B)),
-        contact_sort_idx=V(dtype=gs.qd_int, shape=(max(max_contact_pairs, 1), _B)),
+        contact_sort_key=V(dtype=gs.qd_float, shape=(max(max_candidate_contacts, 1), _B)),
+        contact_sort_idx=V(dtype=gs.qd_int, shape=(max(max_candidate_contacts, 1), _B)),
         contact_proj_v=V(dtype=gs.qd_float, shape=prune_shape),
         contact_keep=V(dtype=gs.qd_int, shape=prune_shape),
         contact_hull_stack=V(dtype=gs.qd_int, shape=prune_shape),
@@ -782,8 +783,12 @@ class ColliderInfo:
     collision_pair_idx: qd.Tensor
     max_possible_pairs: qd.Tensor
     max_collision_pairs: qd.Tensor
-    max_contact_pairs: qd.Tensor
+    max_candidate_contacts: qd.Tensor
     max_collision_pairs_broad: qd.Tensor
+    # Post-pruning contact-point budget per environment, which sizes the contact constraint buffers (4 constraints
+    # per contact point). Smaller than max_candidate_contacts when contact pruning is enabled or 'max_contacts'
+    # is set.
+    max_contacts: qd.Tensor
     # Compact list of valid collision pairs. Used by all-vs-all broadphase to dispatch valid pairs to GPU threads.
     n_valid_pairs: qd.Tensor
     valid_collision_pairs: qd.Tensor
@@ -820,8 +825,9 @@ def get_collider_info(solver, n_vert_neighbors, n_valid_pairs, collider_static_c
         collision_pair_idx=V(dtype=gs.qd_int, shape=(solver.n_geoms_, solver.n_geoms_)),
         max_possible_pairs=V(dtype=gs.qd_int, shape=()),
         max_collision_pairs=V(dtype=gs.qd_int, shape=()),
-        max_contact_pairs=V(dtype=gs.qd_int, shape=()),
+        max_candidate_contacts=V(dtype=gs.qd_int, shape=()),
         max_collision_pairs_broad=V(dtype=gs.qd_int, shape=()),
+        max_contacts=V(dtype=gs.qd_int, shape=()),
         n_valid_pairs=V_SCALAR_FROM(dtype=gs.qd_int, value=n_valid_pairs),
         valid_collision_pairs=V(dtype=gs.qd_ivec2, shape=(max(n_valid_pairs, 1),)),
         terrain_hf=V(dtype=gs.qd_float, shape=terrain_hf_shape),

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -3958,28 +3958,29 @@ def test_convexify(euler, show_viewer, gjk_collision):
 
 
 @pytest.mark.slow("gpu")  # gpu ~250s
-@pytest.mark.required
 @pytest.mark.parametrize(
-    "max_collision_pairs, max_contacts, error_pattern",
+    "scene_kind, max_collision_pairs, max_contacts, error_pattern",
     [
-        # Post-pruning contact budget overflow, with the candidate buffer oversized so that it cannot trip first.
-        # The automatic budget resolves to 32 contact points per link pair floored at 512, far below what the
-        # piled-up bowls produce.
-        (5_000, None, "max number of post-pruning contact points"),
-        (5_000, 16, "max number of post-pruning contact points"),
+        # Post-pruning contact budget overflow, with the candidate buffer large enough (2x margin) that it cannot
+        # trip first. The automatic budget resolves to 32 contact points per link pair floored at 512, far below
+        # what the piled-up bowls produce.
+        pytest.param("bowls", 1_000, None, "max number of post-pruning contact points", marks=pytest.mark.required),
         # Candidate contact buffer overflow. The explicit contact budget is clamped down to the buffer size, so only
         # the buffer itself can overflow.
-        (150, 5_000, "max number of candidate contact points"),
-        # Buffers large enough for the whole pile: no overflow at all.
-        (5_000, 5_000, None),
+        ("bowls", 150, 1_000, "max number of candidate contact points"),
+        # Buffers large enough for the whole pile: no overflow at all. Both values keep a 2x margin over the peaks
+        # reached within the stepped window (about 500 colliding geom pairs and 1040 post-pruning contact points).
+        ("bowls", 1_000, 2_000, None),
+        # Two contacts against a budget of one: the clamp must also run when the contact count is below the pruning
+        # gate (n_contacts < 3), in both the serial and the GPU cooperative kernel variants.
+        ("spheres", 150, 1, "max number of post-pruning contact points"),
     ],
 )
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_num_contact_overflow(max_collision_pairs, max_contacts, error_pattern, show_viewer):
+def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, error_pattern, show_viewer):
     from genesis.engine.simulator import RATE_CHECK_ERRNO
 
     N_BOWLS = 4
-    asset_path = get_hf_dataset(pattern="glb/orange_plastic_bowl.glb")
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             max_collision_pairs=max_collision_pairs,
@@ -3989,17 +3990,37 @@ def test_num_contact_overflow(max_collision_pairs, max_contacts, error_pattern, 
         renderer=gs.renderers.Rasterizer(),
     )
     scene.add_entity(morph=gs.morphs.Plane())
-    for _ in range(N_BOWLS):
+    if scene_kind == "bowls":
+        asset_path = get_hf_dataset(pattern="glb/orange_plastic_bowl.glb")
+        for _ in range(N_BOWLS):
+            scene.add_entity(
+                morph=gs.morphs.Mesh(
+                    file=f"{asset_path}/glb/orange_plastic_bowl.glb",
+                    pos=(0, 0, 0.5),
+                    euler=(90, 0, 0),
+                    convexify=True,
+                    file_meshes_are_zup=True,
+                ),
+            )
+    else:
+        # Non-contacting nonconvex mesh: makes the scene prunable so that the GPU cooperative kernel is exercised.
         scene.add_entity(
             morph=gs.morphs.Mesh(
-                file=f"{asset_path}/glb/orange_plastic_bowl.glb",
-                pos=(0, 0, 0.5),
-                euler=(90, 0, 0),
-                convexify=True,
-                file_meshes_are_zup=True,
+                file="meshes/duck.obj",
+                scale=0.04,
+                pos=(5.0, 5.0, 5.0),
+                convexify=False,
             ),
         )
+        for i in range(2):
+            scene.add_entity(
+                morph=gs.morphs.Sphere(
+                    pos=(0.5 * i, 0.0, 0.0999),
+                    radius=0.1,
+                ),
+            )
     scene.build()
+    assert scene.rigid_solver.collider._collider_static_config.has_prunable_contacts
 
     # The resolved contact budget must match the documented resolution: 32 contact points per link pair floored at
     # 512 when automatic (every link pair here has more than 32 candidate contact points), the explicit value clamped
@@ -4016,8 +4037,9 @@ def test_num_contact_overflow(max_collision_pairs, max_contacts, error_pattern, 
     expected_len_constraints = 4 * expected_max_contacts + solver.n_dofs + 6 * solver.n_candidate_equalities_
     assert solver.constraint_solver.len_constraints == expected_len_constraints
 
-    # Both overflows occur on the very first step (the bowls start fully overlapping), but errno is only polled every
-    # RATE_CHECK_ERRNO substeps, so one extra step is required to guarantee that the error gets raised.
+    # All overflows occur on the very first step (the bowls start fully overlapping, the spheres start resting on the
+    # plane), but errno is only polled every RATE_CHECK_ERRNO substeps, so one extra step is required to guarantee
+    # that the error gets raised.
     with nullcontext() if error_pattern is None else pytest.raises(gs.GenesisException, match=error_pattern):
         for _ in range(RATE_CHECK_ERRNO + 1):
             scene.step()

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -3959,12 +3959,37 @@ def test_convexify(euler, show_viewer, gjk_collision):
 
 @pytest.mark.slow("gpu")  # gpu ~250s
 @pytest.mark.required
+@pytest.mark.parametrize(
+    "max_collision_pairs, max_contacts, error_pattern",
+    [
+        # Post-pruning contact budget overflow, with the candidate buffer oversized so that it cannot trip first.
+        # The automatic budget resolves to 32 contact points per link pair floored at 512, far below what the
+        # piled-up bowls produce.
+        (5_000, None, "max number of post-pruning contact points"),
+        (5_000, 16, "max number of post-pruning contact points"),
+        # Candidate contact buffer overflow. The explicit contact budget is clamped down to the buffer size, so only
+        # the buffer itself can overflow.
+        (150, 5_000, "max number of candidate contact points"),
+        # Buffers large enough for the whole pile: no overflow at all.
+        (5_000, 5_000, None),
+    ],
+)
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_num_contact_overflow(show_viewer):
+def test_num_contact_overflow(max_collision_pairs, max_contacts, error_pattern, show_viewer):
+    from genesis.engine.simulator import RATE_CHECK_ERRNO
+
+    N_BOWLS = 4
     asset_path = get_hf_dataset(pattern="glb/orange_plastic_bowl.glb")
-    scene = gs.Scene(show_viewer=show_viewer, renderer=gs.renderers.Rasterizer())
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            max_collision_pairs=max_collision_pairs,
+            max_contacts=max_contacts,
+        ),
+        show_viewer=show_viewer,
+        renderer=gs.renderers.Rasterizer(),
+    )
     scene.add_entity(morph=gs.morphs.Plane())
-    for _ in range(4):
+    for _ in range(N_BOWLS):
         scene.add_entity(
             morph=gs.morphs.Mesh(
                 file=f"{asset_path}/glb/orange_plastic_bowl.glb",
@@ -3975,8 +4000,26 @@ def test_num_contact_overflow(show_viewer):
             ),
         )
     scene.build()
-    with pytest.raises(gs.GenesisException, match="max number of contact pairs"):
-        for _ in range(20):
+
+    # The resolved contact budget must match the documented resolution: 32 contact points per link pair floored at
+    # 512 when automatic (every link pair here has more than 32 candidate contact points), the explicit value clamped
+    # to the candidate buffer size otherwise. The constraint buffers are sized accordingly, with 4 constraint rows
+    # per contact point (all joints are free so there is no joint-limit term).
+    solver = scene.rigid_solver
+    collider_info = solver.collider._collider_info
+    if max_contacts is None:
+        n_link_pairs = (N_BOWLS + 1) * N_BOWLS // 2
+        expected_max_contacts = max(32 * n_link_pairs, 512)
+    else:
+        expected_max_contacts = min(max_contacts, int(collider_info.max_candidate_contacts[None]))
+    assert int(collider_info.max_contacts[None]) == expected_max_contacts
+    expected_len_constraints = 4 * expected_max_contacts + solver.n_dofs + 6 * solver.n_candidate_equalities_
+    assert solver.constraint_solver.len_constraints == expected_len_constraints
+
+    # Both overflows occur on the very first step (the bowls start fully overlapping), but errno is only polled every
+    # RATE_CHECK_ERRNO substeps, so one extra step is required to guarantee that the error gets raised.
+    with nullcontext() if error_pattern is None else pytest.raises(gs.GenesisException, match=error_pattern):
+        for _ in range(RATE_CHECK_ERRNO + 1):
             scene.step()
 
 


### PR DESCRIPTION
## Description

The constraint buffers were sized for the pre-pruning worst case (4 constraints per candidate contact point), which massively over-allocates on scenes with convex-decomposed bodies. This PR sizes them from a post-pruning contact budget instead:

- New `RigidOptions.max_contacts` (default `None`): max simultaneous post-pruning contact points per env. Automatic resolution: the pre-pruning worst case or, when contact pruning is enabled, `sum over candidate link pairs of min(32, link-pair cap)`, floored at 512 so that small scenes keep their exact worst case (zero added risk).
- The budget is enforced at runtime: both clamp/prune kernels clamp `n_contacts` to it and flag a new `OVERFLOW_CONTACTS` errno, which halts with a message pointing at `max_contacts`. This is required because pruning is a heuristic: conforming (non-coplanar) patches are not pruned and can exceed the per-link-pair cap.
- Renamed `collider_info.max_contact_pairs` to `max_candidate_contacts`: it counts contact points the narrowphase can emit (pre-pruning), not pairs, and was ambiguous next to the new budget.

## Motivation and Context

The dense Jacobian (`len_constraints x n_dofs x B`) dominates GPU memory and hits the int32 element-count limit at large batch sizes. On the authored-decomposition tower (`max_collision_pairs=1200`), buffers shrink from 24k to 1.7k constraint rows (~14x); a franka + objects scene at 30k envs drops from int32-infeasible to ~18 GB.

## How Has This Been / Can This Be Tested?

- `test_num_contact_overflow` is generalized (CPU + GPU): budget overflow (automatic and explicit), candidate-buffer overflow, no-overflow with custom thresholds, plus exact assertions on the resolved budget and `len_constraints`.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
