### PR TITLE
[MISC] Fix serialized batched simulation on CPU scaling sub-linearly.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -263,7 +263,8 @@ def init(
             enable_fallback=False,
             # Add a (hidden) mechanism to forcible disable Quadrants debug mode as it is still a bit experimental
             debug=qd_debug and backend == _gs_backend.cpu,
-            check_out_of_bound=debug and backend != _gs_backend.metal,
+            # Forcibly disabling out of bound checks on GPU because memory usage is blowing up (x10)
+            check_out_of_bound=debug and backend == gs.cpu,  # backend != _gs_backend.metal,
             # force_scalarize_matrix=True for speeding up kernel compilation
             # FIXME: Turning off 'force_scalarize_matrix' is causing numerical instabilities ('nan') on MacOS
             force_scalarize_matrix=True,

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -25,9 +25,9 @@ from .misc import (
     func_add_safe_backward,
 )
 
-# Block size (warp width) for the cooperative mass_mat_assemble path. Used only when constraint_layout_transposed=True
-# (and not use_hibernation). One warp per (entity, env); lanes stride i_d_ within the entity dof block to coalesce the
-# flipped mass_mat writes.
+# Block size (warp width) for the cooperative mass_mat_assemble path. Used only when
+# enable_cooperative_constraint_kernels=True (and not use_hibernation). One warp per (entity, env); lanes stride i_d_
+# within the entity dof block to coalesce the flipped mass_mat writes.
 _MASS_MAT_BLOCK = 32
 
 
@@ -380,7 +380,9 @@ def func_compute_mass_matrix(
                         dofs_state.cdof_ang[i_d, i_b],
                     )
 
-    if qd.static(static_rigid_sim_config.constraint_layout_transposed and not static_rigid_sim_config.use_hibernation):
+    if qd.static(
+        static_rigid_sim_config.enable_cooperative_constraint_kernels and not static_rigid_sim_config.use_hibernation
+    ):
         # Cooperative warp-per-(entity, env) writer over the lower triangle (inclusive of diagonal). Each cell's
         # symmetric value is computed once via the sqrt-formula compressed pair index and written to both
         # `[i_d, j_d, i_b]` and `[j_d, i_d, i_b]` inline, saving the upper-tri dot products that the previous

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -97,6 +97,7 @@ class Collider:
         self._prune_deep_penetration_ratio = 3.0
         self._prune_max_contacts_per_link_pair = 32
         self._prune_max_contacts_floor = 512
+        self._noslip_max_contacts = 128
 
         self._init_static_config()
         self._use_split_narrowphase = (
@@ -671,6 +672,13 @@ class Collider:
             max_contacts_pruned = np.minimum(link_pairs_n_contacts, self._prune_max_contacts_per_link_pair)
             max_contacts_pruned_total = max(int(max_contacts_pruned.sum()), self._prune_max_contacts_floor)
             max_contacts = min(max_contacts, max_contacts_pruned_total)
+
+        # The noslip dual matrix efc_AR is quadratic in the contact budget, so noslip scenes get a much tighter
+        # default cap: measured noslip workloads (manipulation-style scenes) peak below ~70 simultaneous contact
+        # points, while the worst-case candidate budget is orders of magnitude larger. A denser scene hits the
+        # max_contacts clamp and halts with a request to set 'max_contacts' explicitly, which overrides this cap.
+        if self._solver._options.noslip_iterations > 0 and self._solver._options.max_contacts is None:
+            max_contacts = min(max_contacts, self._noslip_max_contacts)
 
         self._collider_info.max_possible_pairs[None] = n_possible_pairs
         self._collider_info.max_collision_pairs[None] = max_collision_pairs

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -117,79 +117,6 @@ def func_solve_mass_entity_row(
             buf[i_row, i_d, i_b] = curr_out
 
 
-@qd.kernel(fastcache=True)
-def kernel_compute_MinvJT(
-    entities_info: array_class.EntitiesInfo,
-    rigid_global_info: array_class.RigidGlobalInfo,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    """Compute MinvJT[row, :, i_b] = M^{-1} @ J[row, :, i_b] for each constraint row.
-
-    Parallelized over (row, batch) via ndrange — each thread independently
-    copies J[row] into MinvJT[row] and solves M^{-1} in-place using the
-    row-indexed LDL^T substitution. No shared buffers between rows.
-    """
-    len_c = constraint_state.MinvJT.shape[0]
-    _B = constraint_state.jac.shape[2]
-    n_dofs = constraint_state.jac.shape[1]
-
-    for i_row, i_b in qd.ndrange(len_c, _B):
-        if i_row < constraint_state.n_constraints[i_b]:
-            # Copy J[row] into MinvJT[row] (per-row buffer)
-            for i_d in range(n_dofs):
-                constraint_state.MinvJT[i_row, i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
-
-            # In-place solve: MinvJT[row] = M^{-1} @ J[row]
-            for i_0 in (
-                range(rigid_global_info.n_awake_entities[i_b])
-                if qd.static(static_rigid_sim_config.use_hibernation)
-                else range(entities_info.n_links.shape[0])
-            ):
-                i_e = (
-                    rigid_global_info.awake_entities[i_0, i_b]
-                    if qd.static(static_rigid_sim_config.use_hibernation)
-                    else i_0
-                )
-                func_solve_mass_entity_row(i_row, i_e, i_b, constraint_state.MinvJT, entities_info, rigid_global_info)
-
-
-@qd.kernel(fastcache=True)
-def kernel_compute_AR_and_b(
-    dofs_state: array_class.DofsState,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    """Phase 2: Compute AR = J @ MinvJT and efc_b.
-
-    AR[row, col, i_b] = sum_d J[col, d, i_b] * MinvJT[row, d, i_b]
-
-    Uses ndrange for full GPU parallelism across (row, col, batch) - gives nefc^2 * n_envs independent threads (~490K
-    for typical scenes). This kernel is only called when para_level >= PARA_LEVEL.PARTIAL (GPU). On the serialized
-    path, kernel_noslip_fused builds AR/b per env instead.
-    """
-    len_c = constraint_state.efc_AR.shape[0]
-    _B = constraint_state.jac.shape[2]
-    n_dofs = constraint_state.jac.shape[1]
-
-    for i_row, i_col, i_b in qd.ndrange(len_c, len_c, _B):
-        nefc = constraint_state.n_constraints[i_b]
-        if i_row < nefc and i_col < nefc:
-            s = gs.qd_float(0.0)
-            for i_d in range(n_dofs):
-                s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.MinvJT[i_row, i_d, i_b]
-            constraint_state.efc_AR[i_row, i_col, i_b] = s
-        else:
-            constraint_state.efc_AR[i_row, i_col, i_b] = gs.qd_float(0.0)
-
-    for i_c, i_b in qd.ndrange(len_c, _B):
-        if i_c < constraint_state.n_constraints[i_b]:
-            v = -constraint_state.aref[i_c, i_b]
-            for i_d in range(n_dofs):
-                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
-            constraint_state.efc_b[i_c, i_b] = v
-
-
 @qd.func
 def func_noslip_batch(
     i_b,
@@ -302,20 +229,6 @@ def func_noslip_batch(
             break
 
 
-@qd.kernel(fastcache=True)
-def kernel_noslip(
-    collider_state: array_class.ColliderState,
-    constraint_state: array_class.ConstraintState,
-    rigid_global_info: array_class.RigidGlobalInfo,
-    static_rigid_sim_config: qd.template(),
-):
-    _B = constraint_state.jac.shape[2]
-
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
-
-
 @qd.func
 def func_dual_finish_batch(
     i_b,
@@ -357,23 +270,6 @@ def func_dual_finish_batch(
 
 
 @qd.kernel(fastcache=True)
-def kernel_dual_finish(
-    dofs_state: array_class.DofsState,
-    entities_info: array_class.EntitiesInfo,
-    rigid_global_info: array_class.RigidGlobalInfo,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    _B = constraint_state.qfrc_constraint.shape[1]
-
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        func_dual_finish_batch(
-            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
-        )
-
-
-@qd.kernel(fastcache=True)
 def kernel_noslip_fused(
     collider_state: array_class.ColliderState,
     dofs_state: array_class.DofsState,
@@ -395,6 +291,76 @@ def kernel_noslip_fused(
             i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
         )
         func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
+        func_dual_finish_batch(
+            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
+        )
+
+
+@qd.kernel(fastcache=True)
+def kernel_noslip_decomposed(
+    collider_state: array_class.ColliderState,
+    dofs_state: array_class.DofsState,
+    entities_info: array_class.EntitiesInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    constraint_state: array_class.ConstraintState,
+    static_rigid_sim_config: qd.template(),
+):
+    """Decomposed noslip pass: parallel MinvJT solve, parallel AR/b build, force-update sweep, and dual finish.
+
+    Each top-level loop is an independent offloaded task with its own launch shape, with implicit barriers in
+    between. The MinvJT solve runs one thread per (row, env): each thread copies J[row] into its own MinvJT row and
+    solves M^{-1} in place via the row-indexed LDL^T substitution, with no shared buffers between rows. The AR build
+    runs one thread per (row, col, env) - nefc^2 * n_envs independent threads (~490K for typical scenes) - computing
+    AR[row, col, i_b] = sum_d J[col, d, i_b] * MinvJT[row, d, i_b]. On the serialized path, kernel_noslip_fused is
+    used instead.
+    """
+    len_c = constraint_state.MinvJT.shape[0]
+    _B = constraint_state.jac.shape[2]
+    n_dofs = constraint_state.jac.shape[1]
+
+    for i_row, i_b in qd.ndrange(len_c, _B):
+        if i_row < constraint_state.n_constraints[i_b]:
+            # Copy J[row] into MinvJT[row] (per-row buffer)
+            for i_d in range(n_dofs):
+                constraint_state.MinvJT[i_row, i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
+
+            # In-place solve: MinvJT[row] = M^{-1} @ J[row]
+            for i_0 in (
+                range(rigid_global_info.n_awake_entities[i_b])
+                if qd.static(static_rigid_sim_config.use_hibernation)
+                else range(entities_info.n_links.shape[0])
+            ):
+                i_e = (
+                    rigid_global_info.awake_entities[i_0, i_b]
+                    if qd.static(static_rigid_sim_config.use_hibernation)
+                    else i_0
+                )
+                func_solve_mass_entity_row(i_row, i_e, i_b, constraint_state.MinvJT, entities_info, rigid_global_info)
+
+    for i_row, i_col, i_b in qd.ndrange(len_c, len_c, _B):
+        nefc = constraint_state.n_constraints[i_b]
+        if i_row < nefc and i_col < nefc:
+            s = gs.qd_float(0.0)
+            for i_d in range(n_dofs):
+                s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.MinvJT[i_row, i_d, i_b]
+            constraint_state.efc_AR[i_row, i_col, i_b] = s
+        else:
+            constraint_state.efc_AR[i_row, i_col, i_b] = gs.qd_float(0.0)
+
+    # Build efc_b
+    for i_c, i_b in qd.ndrange(len_c, _B):
+        if i_c < constraint_state.n_constraints[i_b]:
+            v = -constraint_state.aref[i_c, i_b]
+            for i_d in range(n_dofs):
+                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
+            constraint_state.efc_b[i_c, i_b] = v
+
+    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_b in range(_B):
+        func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
+
+    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_b in range(_B):
         func_dual_finish_batch(
             i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
         )

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -6,77 +6,74 @@ import genesis.utils.array_class as array_class
 import genesis.engine.solvers.rigid.rigid_solver as rigid_solver
 
 
-@qd.kernel(fastcache=True)
-def kernel_build_efc_AR_b(
+@qd.func
+def func_build_efc_AR_b_batch(
+    i_b,
     dofs_state: array_class.DofsState,
     entities_info: array_class.EntitiesInfo,
     rigid_global_info: array_class.RigidGlobalInfo,
     constraint_state: array_class.ConstraintState,
     static_rigid_sim_config: qd.template(),
 ):
-    _B = constraint_state.jac.shape[2]
     n_dofs = constraint_state.jac.shape[1]
+    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
+    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
+    nefc = constraint_state.n_constraints[i_b]
 
-    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL))
-    for i_b in range(_B):
-        nefc = constraint_state.n_constraints[i_b]
-        # zero AR
-        for i_row in range(nefc):
-            for i_col in range(nefc):
-                constraint_state.efc_AR[i_row, i_col, i_b] = gs.qd_float(0.0)
+    # build AR = J * inv(M) * J^T
+    # do it row-by-row: for each row r, tmp = inv(M) * J[r]^T, then AR[r,:] = J * tmp.
+    # No zeroing pass is needed: the symmetric lower-triangle fill writes every entry of [0, nefc)^2 and
+    # consumers never read beyond nefc.
+    for i_row in range(nefc):
+        # tmp = M^{-1} * Jr^T
+        if qd.static(static_rigid_sim_config.sparse_solve):
+            # Sparse: zero buffer, copy only relevant DOFs
+            for i_d in range(n_dofs):
+                constraint_state.Mgrad[i_d, i_b] = gs.qd_float(0.0)
+            for i_d_ in range(constraint_state.jac_n_dofs[i_row, i_b]):
+                i_d = constraint_state.jac_dofs_idx[i_row, i_d_, i_b]
+                constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
+        else:
+            for i_d in range(n_dofs):
+                constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
 
-        # build AR = J * inv(M) * J^T
-        # do it row-by-row: for each row r, tmp = inv(M) * J[r]^T, then AR[r,:] = J * tmp
-        for i_row in range(nefc):
-            # tmp = M^{-1} * Jr^T
+        rigid_solver.func_solve_mass_batch(
+            i_b,
+            constraint_state.Mgrad,
+            constraint_state.Mgrad,
+            None,
+            entities_info=entities_info,
+            rigid_global_info=rigid_global_info,
+            static_rigid_sim_config=static_rigid_sim_config,
+            is_backward=False,
+        )
+
+        # TODO: For consistency with other usages, migrate to either the lower or upper variant
+        # and update all remaining use cases that still read both.
+        # AR[r, c] = J[c, :] * Mgrad, only compute lower triangle
+        for i_col in range(i_row + 1):
+            s = gs.qd_float(0.0)
             if qd.static(static_rigid_sim_config.sparse_solve):
-                # Sparse: zero buffer, copy only relevant DOFs
-                for i_d in range(n_dofs):
-                    constraint_state.Mgrad[i_d, i_b] = gs.qd_float(0.0)
-                for i_d_ in range(constraint_state.jac_n_dofs[i_row, i_b]):
-                    i_d = constraint_state.jac_dofs_idx[i_row, i_d_, i_b]
-                    constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
+                for i_d_ in range(constraint_state.jac_n_dofs[i_col, i_b]):
+                    i_d = constraint_state.jac_dofs_idx[i_col, i_d_, i_b]
+                    s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
             else:
                 for i_d in range(n_dofs):
-                    constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
+                    s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
+            constraint_state.efc_AR[i_row, i_col, i_b_AR] = s
+            constraint_state.efc_AR[i_col, i_row, i_b_AR] = s
 
-            rigid_solver.func_solve_mass_batch(
-                i_b,
-                constraint_state.Mgrad,
-                constraint_state.Mgrad,
-                None,
-                entities_info=entities_info,
-                rigid_global_info=rigid_global_info,
-                static_rigid_sim_config=static_rigid_sim_config,
-                is_backward=False,
-            )
-
-            # TODO: For consistency with other usages, migrate to either the lower or upper variant
-            # and update all remaining use cases that still read both.
-            # AR[r, c] = J[c, :] * Mgrad, only compute lower triangle
-            for i_col in range(i_row + 1):
-                s = gs.qd_float(0.0)
-                if qd.static(static_rigid_sim_config.sparse_solve):
-                    for i_d_ in range(constraint_state.jac_n_dofs[i_col, i_b]):
-                        i_d = constraint_state.jac_dofs_idx[i_col, i_d_, i_b]
-                        s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
-                else:
-                    for i_d in range(n_dofs):
-                        s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
-                constraint_state.efc_AR[i_row, i_col, i_b] = s
-                constraint_state.efc_AR[i_col, i_row, i_b] = s
-
-        # Build efc_b
-        for i_c in range(constraint_state.n_constraints[i_b]):
-            v = -constraint_state.aref[i_c, i_b]
-            if qd.static(static_rigid_sim_config.sparse_solve):
-                for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
-                    i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
-                    v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
-            else:
-                for i_d in range(n_dofs):
-                    v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
-            constraint_state.efc_b[i_c, i_b] = v
+    # Build efc_b
+    for i_c in range(nefc):
+        v = -constraint_state.aref[i_c, i_b]
+        if qd.static(static_rigid_sim_config.sparse_solve):
+            for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
+                i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
+                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
+        else:
+            for i_d in range(n_dofs):
+                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
+        constraint_state.efc_b[i_c, i_b_AR] = v
 
 
 @qd.func
@@ -163,15 +160,13 @@ def kernel_compute_AR_and_b(
     constraint_state: array_class.ConstraintState,
     static_rigid_sim_config: qd.template(),
 ):
-    """Phase 2: Compute AR = J @ MinvJT and efc_b (GPU multi-env only).
+    """Phase 2: Compute AR = J @ MinvJT and efc_b.
 
     AR[row, col, i_b] = sum_d J[col, d, i_b] * MinvJT[row, d, i_b]
 
-    Uses ndrange for full GPU parallelism across (row, col, batch) — gives
-    nefc^2 * n_envs independent threads (~490K for typical scenes).
-
-    This kernel is only called when para_level >= PARA_LEVEL.ALL (GPU multi-env).
-    For CPU and GPU single-env, the fused kernel_build_efc_AR_b is used instead.
+    Uses ndrange for full GPU parallelism across (row, col, batch) - gives nefc^2 * n_envs independent threads (~490K
+    for typical scenes). This kernel is only called when para_level >= PARA_LEVEL.PARTIAL (GPU). On the serialized
+    path, kernel_noslip_fused builds AR/b per env instead.
     """
     len_c = constraint_state.efc_AR.shape[0]
     _B = constraint_state.jac.shape[2]
@@ -195,6 +190,118 @@ def kernel_compute_AR_and_b(
             constraint_state.efc_b[i_c, i_b] = v
 
 
+@qd.func
+def func_noslip_batch(
+    i_b,
+    collider_state: array_class.ColliderState,
+    constraint_state: array_class.ConstraintState,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    EPS = rigid_global_info.EPS[None]
+    n_dofs = constraint_state.jac.shape[1]
+    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
+    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
+
+    # temp variables
+    res = qd.Vector.zero(gs.qd_float, 5)
+    old_force = qd.Vector.zero(gs.qd_float, 5)
+    bc = qd.Vector.zero(gs.qd_float, 5)
+    Ac = qd.Vector.zero(gs.qd_float, 9)
+
+    n_con = collider_state.n_contacts[i_b]
+    ne = constraint_state.n_constraints_equality[i_b]
+    nf = constraint_state.n_constraints_frictionloss[i_b]
+    const_start = ne + nf
+
+    scale = 1.0 / (rigid_global_info.meaninertia[i_b] * qd.max(1.0, n_dofs))
+
+    for i_iter in range(rigid_global_info.noslip_iterations[None]):
+        improvement = gs.qd_float(0.0)
+        if i_iter == 0:
+            for i_c in range(constraint_state.n_constraints[i_b]):
+                improvement += 0.5 * constraint_state.efc_force[i_c, i_b] ** 2 * constraint_state.diag[i_c, i_b]
+
+        for i_c in range(ne, ne + nf):
+            res = func_residual_constraint_force(
+                res=res,
+                i_b=i_b,
+                i_efc=i_c,
+                dim=1,
+                constraint_state=constraint_state,
+                static_rigid_sim_config=static_rigid_sim_config,
+            )
+            old_force[0] = constraint_state.efc_force[i_c, i_b]
+            constraint_state.efc_force[i_c, i_b] -= res[0] / constraint_state.efc_AR[i_c, i_c, i_b_AR]
+            if constraint_state.efc_force[i_c, i_b] < -constraint_state.efc_frictionloss[i_c, i_b]:
+                constraint_state.efc_force[i_c, i_b] = -constraint_state.efc_frictionloss[i_c, i_b]
+            elif constraint_state.efc_force[i_c, i_b] > constraint_state.efc_frictionloss[i_c, i_b]:
+                constraint_state.efc_force[i_c, i_b] = constraint_state.efc_frictionloss[i_c, i_b]
+            delta = constraint_state.efc_force[i_c, i_b] - old_force[0]
+            improvement -= 0.5 * delta**2 / constraint_state.efc_AR[i_c, i_c, i_b_AR] + delta * res[0]
+
+        # Project contact friction (pyramidal 4-edge) with normal fixed
+        for i_col in range(n_con):
+            base = const_start + i_col * 4
+            for j2 in qd.static(range(2)):
+                j_efc = base + j2 * 2
+                res = func_residual_constraint_force(
+                    res=res,
+                    i_b=i_b,
+                    i_efc=j_efc,
+                    dim=2,
+                    constraint_state=constraint_state,
+                    static_rigid_sim_config=static_rigid_sim_config,
+                )
+                for i2 in qd.static(range(2)):
+                    old_force[i2] = constraint_state.efc_force[j_efc + i2, i_b]
+                Ac = func_extract_block_matrix_from_AR(
+                    Ac=Ac,
+                    i_b=i_b,
+                    start=j_efc,
+                    n=2,
+                    constraint_state=constraint_state,
+                    static_rigid_sim_config=static_rigid_sim_config,
+                )
+                for j in qd.static(range(2)):
+                    bc[j] = res[j]
+                    for k in qd.static(range(2)):
+                        bc[j] -= Ac[j * 2 + k] * old_force[k]
+                mid = 0.5 * (constraint_state.efc_force[j_efc, i_b] + constraint_state.efc_force[j_efc + 1, i_b])
+                y = 0.5 * (constraint_state.efc_force[j_efc, i_b] - constraint_state.efc_force[j_efc + 1, i_b])
+                K1 = Ac[0] + Ac[3] - Ac[1] - Ac[2]
+                K0 = mid * (Ac[0] - Ac[3]) + bc[0] - bc[1]
+                if K1 < EPS:
+                    constraint_state.efc_force[j_efc, i_b] = constraint_state.efc_force[j_efc + 1, i_b] = mid
+                else:
+                    y = -K0 / K1
+                    if y < -mid:
+                        constraint_state.efc_force[j_efc, i_b] = 0
+                        constraint_state.efc_force[j_efc + 1, i_b] = 2 * mid
+                    elif y > mid:
+                        constraint_state.efc_force[j_efc, i_b] = 2 * mid
+                        constraint_state.efc_force[j_efc + 1, i_b] = 0
+                    else:
+                        constraint_state.efc_force[j_efc, i_b] = mid + y
+                        constraint_state.efc_force[j_efc + 1, i_b] = mid - y
+                cost_change = func_cost_change(
+                    i_b=i_b,
+                    Ac=Ac,
+                    force=constraint_state.efc_force,
+                    force_start=j_efc,
+                    old_force=old_force,
+                    res=res,
+                    dim=2,
+                    eps=EPS,
+                )
+
+                improvement -= cost_change
+        improvement *= scale
+
+        if improvement < rigid_global_info.noslip_tolerance[None]:
+            break
+
+
 @qd.kernel(fastcache=True)
 def kernel_noslip(
     collider_state: array_class.ColliderState,
@@ -202,106 +309,51 @@ def kernel_noslip(
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
 ):
-    EPS = rigid_global_info.EPS[None]
     _B = constraint_state.jac.shape[2]
-    n_dofs = constraint_state.jac.shape[1]
 
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
-        # temp variables
-        res = qd.Vector.zero(gs.qd_float, 5)
-        old_force = qd.Vector.zero(gs.qd_float, 5)
-        bc = qd.Vector.zero(gs.qd_float, 5)
-        Ac = qd.Vector.zero(gs.qd_float, 9)
+        func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
 
-        n_con = collider_state.n_contacts[i_b]
-        ne = constraint_state.n_constraints_equality[i_b]
-        nf = constraint_state.n_constraints_frictionloss[i_b]
-        const_start = ne + nf
 
-        scale = 1.0 / (rigid_global_info.meaninertia[i_b] * qd.max(1.0, n_dofs))
+@qd.func
+def func_dual_finish_batch(
+    i_b,
+    dofs_state: array_class.DofsState,
+    entities_info: array_class.EntitiesInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    constraint_state: array_class.ConstraintState,
+    static_rigid_sim_config: qd.template(),
+):
+    n_dofs = constraint_state.qfrc_constraint.shape[0]
 
-        for i_iter in range(rigid_global_info.noslip_iterations[None]):
-            improvement = gs.qd_float(0.0)
-            if i_iter == 0:
-                for i_c in range(constraint_state.n_constraints[i_b]):
-                    improvement += 0.5 * constraint_state.efc_force[i_c, i_b] ** 2 * constraint_state.diag[i_c, i_b]
+    # zero
+    for i_d in range(n_dofs):
+        constraint_state.qfrc_constraint[i_d, i_b] = gs.qd_float(0.0)
 
-            for i_c in range(ne, ne + nf):
-                res = func_residual_constraint_force(
-                    res=res,
-                    i_b=i_b,
-                    i_efc=i_c,
-                    dim=1,
-                    constraint_state=constraint_state,
-                )
-                old_force[0] = constraint_state.efc_force[i_c, i_b]
-                constraint_state.efc_force[i_c, i_b] -= res[0] / constraint_state.efc_AR[i_c, i_c, i_b]
-                if constraint_state.efc_force[i_c, i_b] < -constraint_state.efc_frictionloss[i_c, i_b]:
-                    constraint_state.efc_force[i_c, i_b] = -constraint_state.efc_frictionloss[i_c, i_b]
-                elif constraint_state.efc_force[i_c, i_b] > constraint_state.efc_frictionloss[i_c, i_b]:
-                    constraint_state.efc_force[i_c, i_b] = constraint_state.efc_frictionloss[i_c, i_b]
-                delta = constraint_state.efc_force[i_c, i_b] - old_force[0]
-                improvement -= 0.5 * delta**2 / constraint_state.efc_AR[i_c, i_c, i_b] + delta * res[0]
+        for i_c in range(constraint_state.n_constraints[i_b]):
+            constraint_state.qfrc_constraint[i_d, i_b] = (
+                constraint_state.qfrc_constraint[i_d, i_b]
+                + constraint_state.jac[i_c, i_d, i_b] * constraint_state.efc_force[i_c, i_b]
+            )
 
-            # Project contact friction (pyramidal 4-edge) with normal fixed
-            for i_col in range(n_con):
-                base = const_start + i_col * 4
-                for j2 in qd.static(range(2)):
-                    j_efc = base + j2 * 2
-                    res = func_residual_constraint_force(
-                        res=res,
-                        i_b=i_b,
-                        i_efc=j_efc,
-                        dim=2,
-                        constraint_state=constraint_state,
-                    )
-                    for i2 in qd.static(range(2)):
-                        old_force[i2] = constraint_state.efc_force[j_efc + i2, i_b]
-                    Ac = func_extract_block_matrix_from_AR(
-                        Ac=Ac,
-                        i_b=i_b,
-                        start=j_efc,
-                        n=2,
-                        constraint_state=constraint_state,
-                    )
-                    for j in qd.static(range(2)):
-                        bc[j] = res[j]
-                        for k in qd.static(range(2)):
-                            bc[j] -= Ac[j * 2 + k] * old_force[k]
-                    mid = 0.5 * (constraint_state.efc_force[j_efc, i_b] + constraint_state.efc_force[j_efc + 1, i_b])
-                    y = 0.5 * (constraint_state.efc_force[j_efc, i_b] - constraint_state.efc_force[j_efc + 1, i_b])
-                    K1 = Ac[0] + Ac[3] - Ac[1] - Ac[2]
-                    K0 = mid * (Ac[0] - Ac[3]) + bc[0] - bc[1]
-                    if K1 < EPS:
-                        constraint_state.efc_force[j_efc, i_b] = constraint_state.efc_force[j_efc + 1, i_b] = mid
-                    else:
-                        y = -K0 / K1
-                        if y < -mid:
-                            constraint_state.efc_force[j_efc, i_b] = 0
-                            constraint_state.efc_force[j_efc + 1, i_b] = 2 * mid
-                        elif y > mid:
-                            constraint_state.efc_force[j_efc, i_b] = 2 * mid
-                            constraint_state.efc_force[j_efc + 1, i_b] = 0
-                        else:
-                            constraint_state.efc_force[j_efc, i_b] = mid + y
-                            constraint_state.efc_force[j_efc + 1, i_b] = mid - y
-                    cost_change = func_cost_change(
-                        i_b=i_b,
-                        Ac=Ac,
-                        force=constraint_state.efc_force,
-                        force_start=j_efc,
-                        old_force=old_force,
-                        res=res,
-                        dim=2,
-                        eps=EPS,
-                    )
+    rigid_solver.func_solve_mass_batch(
+        i_b=i_b,
+        vec=constraint_state.qfrc_constraint,
+        out=constraint_state.qacc,
+        out_bw=None,
+        entities_info=entities_info,
+        rigid_global_info=rigid_global_info,
+        static_rigid_sim_config=static_rigid_sim_config,
+        is_backward=False,
+    )
 
-                    improvement -= cost_change
-            improvement *= scale
+    for i_d in range(n_dofs):
+        constraint_state.qacc[i_d, i_b] = constraint_state.qacc[i_d, i_b] + dofs_state.acc_smooth[i_d, i_b]
+        dofs_state.acc[i_d, i_b] = constraint_state.qacc[i_d, i_b]
 
-            if improvement < rigid_global_info.noslip_tolerance[None]:
-                break
+        dofs_state.qf_constraint[i_d, i_b] = constraint_state.qfrc_constraint[i_d, i_b]
+        dofs_state.force[i_d, i_b] = dofs_state.qf_smooth[i_d, i_b] + constraint_state.qfrc_constraint[i_d, i_b]
 
 
 @qd.kernel(fastcache=True)
@@ -312,38 +364,40 @@ def kernel_dual_finish(
     constraint_state: array_class.ConstraintState,
     static_rigid_sim_config: qd.template(),
 ):
-    n_dofs = constraint_state.qfrc_constraint.shape[0]
     _B = constraint_state.qfrc_constraint.shape[1]
 
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
-        # zero
-        for i_d in range(n_dofs):
-            constraint_state.qfrc_constraint[i_d, i_b] = gs.qd_float(0.0)
-
-            for i_c in range(constraint_state.n_constraints[i_b]):
-                constraint_state.qfrc_constraint[i_d, i_b] = (
-                    constraint_state.qfrc_constraint[i_d, i_b]
-                    + constraint_state.jac[i_c, i_d, i_b] * constraint_state.efc_force[i_c, i_b]
-                )
-
-        rigid_solver.func_solve_mass_batch(
-            i_b=i_b,
-            vec=constraint_state.qfrc_constraint,
-            out=constraint_state.qacc,
-            out_bw=None,
-            entities_info=entities_info,
-            rigid_global_info=rigid_global_info,
-            static_rigid_sim_config=static_rigid_sim_config,
-            is_backward=False,
+        func_dual_finish_batch(
+            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
         )
 
-        for i_d in range(n_dofs):
-            constraint_state.qacc[i_d, i_b] = constraint_state.qacc[i_d, i_b] + dofs_state.acc_smooth[i_d, i_b]
-            dofs_state.acc[i_d, i_b] = constraint_state.qacc[i_d, i_b]
 
-            dofs_state.qf_constraint[i_d, i_b] = constraint_state.qfrc_constraint[i_d, i_b]
-            dofs_state.force[i_d, i_b] = dofs_state.qf_smooth[i_d, i_b] + constraint_state.qfrc_constraint[i_d, i_b]
+@qd.kernel(fastcache=True)
+def kernel_noslip_fused(
+    collider_state: array_class.ColliderState,
+    dofs_state: array_class.DofsState,
+    entities_info: array_class.EntitiesInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    constraint_state: array_class.ConstraintState,
+    static_rigid_sim_config: qd.template(),
+):
+    """Serialized noslip pass: build AR/b, run the force-update sweep, and finish, one env at a time.
+
+    Processing each env end-to-end keeps its efc_AR block (written by the build, consumed by the sweep) cache-hot, and
+    allows efc_AR/efc_b to be allocated with a single batch slot shared by all envs.
+    """
+    _B = constraint_state.jac.shape[2]
+
+    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_b in range(_B):
+        func_build_efc_AR_b_batch(
+            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
+        )
+        func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
+        func_dual_finish_batch(
+            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
+        )
 
 
 @qd.func
@@ -353,10 +407,13 @@ def func_extract_block_matrix_from_AR(
     start: int,
     n: int,
     constraint_state: array_class.ConstraintState,
+    static_rigid_sim_config: qd.template(),
 ):
+    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
+    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
     for j in range(n):
         for k in range(n):
-            Ac[j * n + k] = constraint_state.efc_AR[start + j, start + k, i_b]
+            Ac[j * n + k] = constraint_state.efc_AR[start + j, start + k, i_b_AR]
     return Ac
 
 
@@ -367,11 +424,14 @@ def func_residual_constraint_force(
     i_efc: int,
     dim: int,
     constraint_state: array_class.ConstraintState,
+    static_rigid_sim_config: qd.template(),
 ):
+    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
+    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
     for j in range(dim):
-        res[j] = constraint_state.efc_b[i_efc + j, i_b]
+        res[j] = constraint_state.efc_b[i_efc + j, i_b_AR]
         for k in range(constraint_state.n_constraints[i_b]):
-            res[j] += constraint_state.efc_AR[i_efc + j, k, i_b] * constraint_state.efc_force[k, i_b]
+            res[j] += constraint_state.efc_AR[i_efc + j, k, i_b_AR] * constraint_state.efc_force[k, i_b]
     return res
 
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -291,27 +291,10 @@ class ConstraintSolver:
 
     def noslip(self):
         if self._solver._para_level >= gs.PARA_LEVEL.PARTIAL:
-            # GPU (any n_envs): split into Phase 1 (parallel M^{-1} solve) + Phase 2 (parallel AR build)
-            constraint_noslip.kernel_compute_MinvJT(
-                self._solver.entities_info,
-                self._solver._rigid_global_info,
-                self.constraint_state,
-                self._solver._static_rigid_sim_config,
-            )
-            constraint_noslip.kernel_compute_AR_and_b(
-                self._solver.dofs_state,
-                self.constraint_state,
-                self._solver._static_rigid_sim_config,
-            )
-
-            constraint_noslip.kernel_noslip(
+            # GPU (any n_envs): one kernel decomposed into per-phase offloaded tasks, so that each phase keeps its
+            # own parallel launch shape.
+            constraint_noslip.kernel_noslip_decomposed(
                 self._collider._collider_state,
-                self.constraint_state,
-                self._solver._rigid_global_info,
-                self._solver._static_rigid_sim_config,
-            )
-
-            constraint_noslip.kernel_dual_finish(
                 self._solver.dofs_state,
                 self._solver.entities_info,
                 self._solver._rigid_global_info,

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -303,30 +303,32 @@ class ConstraintSolver:
                 self.constraint_state,
                 self._solver._static_rigid_sim_config,
             )
-        else:
-            # CPU: use original fused kernel (no overhead)
-            constraint_noslip.kernel_build_efc_AR_b(
+
+            constraint_noslip.kernel_noslip(
+                self._collider._collider_state,
+                self.constraint_state,
+                self._solver._rigid_global_info,
+                self._solver._static_rigid_sim_config,
+            )
+
+            constraint_noslip.kernel_dual_finish(
                 self._solver.dofs_state,
                 self._solver.entities_info,
                 self._solver._rigid_global_info,
                 self.constraint_state,
                 self._solver._static_rigid_sim_config,
             )
-
-        constraint_noslip.kernel_noslip(
-            self._collider._collider_state,
-            self.constraint_state,
-            self._solver._rigid_global_info,
-            self._solver._static_rigid_sim_config,
-        )
-
-        constraint_noslip.kernel_dual_finish(
-            self._solver.dofs_state,
-            self._solver.entities_info,
-            self._solver._rigid_global_info,
-            self.constraint_state,
-            self._solver._static_rigid_sim_config,
-        )
+        else:
+            # Serialized (CPU): single fused kernel processing each env end-to-end, so that the per-env AR scratch stays
+            # cache-hot between the AR build and the force-update sweep (func_noslip_batch).
+            constraint_noslip.kernel_noslip_fused(
+                self._collider._collider_state,
+                self._solver.dofs_state,
+                self._solver.entities_info,
+                self._solver._rigid_global_info,
+                self.constraint_state,
+                self._solver._static_rigid_sim_config,
+            )
 
     def get_equality_constraints(self, as_tensor: bool = True, to_torch: bool = True):
         # Early return if already pre-computed
@@ -777,10 +779,14 @@ def _add_collision_constraints_per_contact(
     n_dofs = dofs_state.ctrl_mode.shape[0]
     max_candidate_contacts = collider_state.contact_data.link_a.shape[0]
 
+    # Iteration order follows the jac layout: batch-outer keeps every write within one env's batch-first block, while
+    # the batch-inner order keeps consecutive GPU threads on consecutive envs (coalesced batch-last).
     qd.loop_config(name="add_collision_constraints", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for flat_idx in range(max_candidate_contacts * _B):
-        i_b = flat_idx % _B
-        i_col_ = flat_idx // _B
+    for i_col_, i_b in qd.ndrange(
+        max_candidate_contacts,
+        _B,
+        axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None),
+    ):
         if i_col_ < collider_state.n_contacts[i_b]:
             collision_con_start = constraint_state.n_constraints[i_b]
 
@@ -880,7 +886,7 @@ def add_collision_constraints(
 ):
     _B = dofs_state.ctrl_mode.shape[1]
 
-    if qd.static(static_rigid_sim_config.constraint_layout_transposed):
+    if qd.static(static_rigid_sim_config.enable_cooperative_constraint_kernels):
         _add_collision_constraints_per_friction(
             links_info=links_info,
             links_state=links_state,
@@ -3515,7 +3521,7 @@ def _func_update_efc_force(
 
     qd.loop_config(name="update_constraint_forces", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_c, i_b in qd.ndrange(
-        len_constraints, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        len_constraints, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
     ):
         if i_c < constraint_state.n_constraints[i_b]:
             _func_update_efc_force_body(i_c, i_b, constraint_state, static_rigid_sim_config)
@@ -3647,13 +3653,13 @@ def func_update_constraint(
 ):
     """Compute active / efc_force / qfrc_constraint / gauss / cost.
 
-    Under ``constraint_layout_transposed=True`` we run three sub-kernels (``_func_update_efc_force``,
+    Under ``enable_cooperative_constraint_kernels=True`` we run three sub-kernels (``_func_update_efc_force``,
     ``_func_update_qfrc_constraint_coop``, ``_func_update_cost_coop``) so per-constraint reads/writes coalesce against
     the flipped jac and Tier-1 constraint-state tensors. Under canonical we keep the original 1-thread-per-env loop
     (bit-identical to the previous code path). The transpose heuristic disables the flip entirely under sparse_solve,
     so sparse runs always take the canonical path here.
     """
-    if qd.static(static_rigid_sim_config.constraint_layout_transposed):
+    if qd.static(static_rigid_sim_config.enable_cooperative_constraint_kernels):
         _func_update_efc_force(constraint_state, static_rigid_sim_config)
         _func_update_qfrc_constraint_coop(constraint_state, static_rigid_sim_config)
         _func_update_cost_coop(
@@ -3729,7 +3735,7 @@ def func_update_gradient_tiled(
     # is canonical — swap the ndrange so adjacent lanes vary i_d.
     qd.loop_config(name="update_gradient_tiled", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_d, i_b in qd.ndrange(
-        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
     ):
         constraint_state.grad[i_d, i_b] = (
             constraint_state.Ma[i_d, i_b] - dofs_state.force[i_d, i_b] - constraint_state.qfrc_constraint[i_d, i_b]
@@ -3930,7 +3936,7 @@ def _initialize_Jaref_parallel(
     # layout, i_b-innermost under canonical.
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_c, i_b in qd.ndrange(
-        len_constraints, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        len_constraints, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
     ):
         if i_c < constraint_state.n_constraints[i_b]:
             _initialize_Jaref_body(i_c, i_b, n_dofs, qacc, constraint_state, static_rigid_sim_config)
@@ -3953,7 +3959,7 @@ def initialize_Ma(
     # constant within the warp -> broadcast load.
     qd.loop_config(name="init_ma", serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
     for i_d1, i_b in qd.ndrange(
-        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
     ):
         I_d1 = [i_d1, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d1
         i_e = dofs_info.entity_idx[I_d1]
@@ -4049,7 +4055,7 @@ def func_solve_init(
         # set, dominated by the qacc write).
         qd.loop_config(name="from_warmstart", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
         for i_d, i_b in qd.ndrange(
-            n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+            n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
         ):
             if constraint_state.n_constraints[i_b] > 0 and constraint_state.is_warmstart[i_b]:
                 constraint_state.qacc[i_d, i_b] = constraint_state.qacc_ws[i_d, i_b]
@@ -4104,7 +4110,7 @@ def func_solve_init(
 
     qd.loop_config(name="assign_search", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_d, i_b in qd.ndrange(
-        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
     ):
         constraint_state.search[i_d, i_b] = -constraint_state.Mgrad[i_d, i_b]
 

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -405,14 +405,15 @@ def _func_decomp_linesearch_refine(
     rigid_global_info: array_class.RigidGlobalInfo,
     static_rigid_sim_config: qd.template(),
 ):
-    """Linesearch refinement body, called per-env from ``_func_decomp_linesearch_refine_and_apply``. Dispatches at compile time
-    on ``constraint_layout_transposed`` to ``_func_decomp_linesearch_refine_coop`` (warp-cooperative, all 32 lanes)
-    or ``_func_decomp_linesearch_refine_serial`` (1-thread-per-env, bit-identical baseline).
+    """Linesearch refinement body, called per-env from ``_func_decomp_linesearch_refine_and_apply``. Dispatches at
+    compile time on ``enable_cooperative_constraint_kernels`` to ``_func_decomp_linesearch_refine_coop``
+    (warp-cooperative, all 32 lanes) or ``_func_decomp_linesearch_refine_serial`` (1-thread-per-env, bit-identical
+    baseline).
 
     Each branch passes the literal Python ``True`` / ``False`` for the ``coop`` template arg of the unified
     ``_func_linesearch_eval_at_alpha`` / ``func_linesearch_refine``: Quadrants' ``qd.template()`` machinery does not
     auto-promote a struct member access to a compile-time value, so we cannot share a single call site here."""
-    if qd.static(static_rigid_sim_config.constraint_layout_transposed):
+    if qd.static(static_rigid_sim_config.enable_cooperative_constraint_kernels):
         _func_decomp_linesearch_refine_coop(
             i_b, tid, alpha_newton, p0_cost, gtol, constraint_state, rigid_global_info, static_rigid_sim_config
         )
@@ -432,8 +433,8 @@ def _func_decomp_linesearch_refine_and_apply(
 
     The P0 kernel precomputes a Newton step (ls_alpha_newton). This kernel refines it via the unified
     ``func_linesearch_refine`` (templated on ``coop``: serial-on-tid-0 when False, cooperative across the 32-lane
-    warp when True), gated on ``constraint_layout_transposed``. It then cooperatively applies the chosen alpha to
-    qacc, Ma, and Jaref.
+    warp when True), gated on ``enable_cooperative_constraint_kernels``. It then cooperatively applies the chosen alpha
+    to qacc, Ma, and Jaref.
 
     The cooperative path is only safe when the layout-flippable constraint-state tensors are stored with
     ``layout=(1, 0)`` (so per-lane strided reads of ``Jaref[i_c, i_b]`` etc. are coalesced across constraints for a
@@ -563,7 +564,9 @@ def _func_update_constraint_forces(
 
     qd.loop_config(name="update_constraint_forces")
     for i_c, i_b in qd.ndrange(
-        len_constraints, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        len_constraints,
+        _B,
+        axes=qd.static((1, 0) if static_rigid_sim_config.enable_cooperative_constraint_kernels else None),
     ):
         if i_c < constraint_state.n_constraints[i_b] and constraint_state.improved[i_b]:
             _func_update_constraint_forces_body(i_c, i_b, constraint_state, static_rigid_sim_config)
@@ -576,16 +579,16 @@ def _func_update_qfrc_constraint_per_dof(
 ):
     """Compute qfrc_constraint = J^T @ efc_force with one thread per (dof, env), each summing serially over i_c.
 
-    Under ``constraint_layout_transposed`` the outer ndrange is swapped so adjacent lanes vary i_d: the qfrc_constraint
-    write coalesces under the flipped DOF-vec layout. (jac and efc_force are both in the Tier-1 / jac-flip set, so the
-    inner serial reads see the same stride pattern either way.)
+    Under ``enable_cooperative_constraint_kernels`` the outer ndrange is swapped so adjacent lanes vary i_d: the
+    qfrc_constraint write coalesces under the flipped DOF-vec layout. (jac and efc_force are both in the Tier-1 /
+    jac-flip set, so the inner serial reads see the same stride pattern either way.)
     """
     n_dofs = constraint_state.qfrc_constraint.shape[0]
     _B = constraint_state.grad.shape[1]
 
     qd.loop_config(name="update_constraint_qfrc")
     for i_d, i_b in qd.ndrange(
-        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.enable_cooperative_constraint_kernels else None)
     ):
         if constraint_state.n_constraints[i_b] > 0 and constraint_state.improved[i_b]:
             n_con = constraint_state.n_constraints[i_b]
@@ -721,9 +724,9 @@ def _func_update_constraint_cost(
     static_rigid_sim_config: qd.template(),
 ):
     """Compute gauss and cost (reductions over dofs and constraints). Dispatches at compile time on
-    ``constraint_layout_transposed`` to ``_func_update_constraint_cost_coop`` (warp-per-env) or
+    ``enable_cooperative_constraint_kernels`` to ``_func_update_constraint_cost_coop`` (warp-per-env) or
     ``_func_update_constraint_cost_serial`` (1-thread-per-env, bit-identical baseline)."""
-    if qd.static(static_rigid_sim_config.constraint_layout_transposed):
+    if qd.static(static_rigid_sim_config.enable_cooperative_constraint_kernels):
         _func_update_constraint_cost_coop(dofs_state, constraint_state, static_rigid_sim_config)
     else:
         _func_update_constraint_cost_serial(dofs_state, constraint_state, static_rigid_sim_config)
@@ -898,14 +901,14 @@ def _func_update_gradient_no_solve(
 ):
     """Compute gradient only (no Cholesky solve) — used with fused Cholesky+Solve.
 
-    Under ``constraint_layout_transposed`` the ndrange is swapped so adjacent lanes vary i_d — 3 of 4 in-loop accesses
-    (grad, Ma, qfrc_constraint) are flipped DOF-vec; only dofs_state.force stays canonical.
+    Under ``enable_cooperative_constraint_kernels`` the ndrange is swapped so adjacent lanes vary i_d - 3 of 4 in-loop
+    accesses (grad, Ma, qfrc_constraint) are flipped DOF-vec; only dofs_state.force stays canonical.
     """
     _B = constraint_state.grad.shape[1]
     n_dofs = constraint_state.grad.shape[0]
     qd.loop_config(name="update_gradient_no_solve", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_d, i_b in qd.ndrange(
-        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_transposed else None)
+        n_dofs, _B, axes=qd.static((1, 0) if static_rigid_sim_config.enable_cooperative_constraint_kernels else None)
     ):
         if constraint_state.n_constraints[i_b] > 0 and constraint_state.improved[i_b]:
             constraint_state.grad[i_d, i_b] = (

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -381,10 +381,10 @@ class RigidSolver(KinematicSolver):
             return gs.broadphase_traversal.SAP
         return gs.broadphase_traversal.ALL_VS_ALL
 
-    def _should_transpose_constraint_layout(self) -> bool:
-        """Decide whether to allocate the layout-flippable constraint-state with layout=(1, 0).
+    def _should_enable_cooperative_constraint_kernels(self) -> bool:
+        """Decide whether to use the subgroup-cooperative constraint kernels and their batch-first layouts.
 
-        The transposed layout (plus its companion cooperative kernels) wins on workloads with enough per-env compute
+        The cooperative kernels (plus the batch-first layouts they expect) win on workloads with enough per-env compute
         density to amortize the warp-per-env overhead, and loses when envs are sparse and many: in those cases the
         legacy 1-thread-per-env path is already coalesced under (len_constraints_, _B) and warp scheduling dominates.
 
@@ -435,6 +435,15 @@ class RigidSolver(KinematicSolver):
         # sparsity applies, matching the pre-existing behaviour.
         sparse_envelope = sparse_solve and gs.backend == gs.cpu and not self.sim.options.requires_grad
 
+        # The layout-flippable constraint-state tensors are stored batch-first either for the GPU cooperative kernels or
+        # under serialized execution, where the env loop is outermost and per-env rows must be contiguous to avoid
+        # stride-n_envs access. Batched sweeps key their iteration-axis order on the same flag, so that iteration order
+        # always follows the physical layout.
+        enable_cooperative_constraint_kernels = self._should_enable_cooperative_constraint_kernels()
+        constraint_layout_batch_first = (
+            enable_cooperative_constraint_kernels or self.sim._para_level < gs.PARA_LEVEL.ALL
+        )
+
         static_rigid_sim_config = dict(
             backend=gs.backend,
             para_level=self.sim._para_level,
@@ -458,7 +467,8 @@ class RigidSolver(KinematicSolver):
             parallel_init=(
                 gs.backend != gs.cpu and not self.sim.options.requires_grad and self.n_envs <= get_gpu_core_count()
             ),
-            constraint_layout_transposed=self._should_transpose_constraint_layout(),
+            enable_cooperative_constraint_kernels=enable_cooperative_constraint_kernels,
+            constraint_layout_batch_first=constraint_layout_batch_first,
         )
 
         # Prefer the monolith solver on CPU (always faster there, perf dispatch is a waste of effort)

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -368,14 +368,14 @@ def get_constraint_state(constraint_solver, solver):
     dof_vec_layout = (1, 0) if batch_first else None
 
     jac_shape = (len_constraints_, solver.n_dofs_, _B)
-    # The split (parallel) noslip build computes MinvJT and efc_AR/efc_b for all envs before the force-update sweep.
+    # The decomposed (parallel) noslip build computes MinvJT and efc_AR/efc_b for all envs before the force-update sweep.
     # The serialized path instead fuses build, sweep, and finish per env (kernel_noslip_fused): each env consumes its
     # AR block right after writing it, so a single batch slot shared by all envs suffices. This keeps the scratch
     # cache-hot across the fused phases and shrinks its memory footprint by n_envs, and MinvJT is never needed.
     noslip = solver._options.noslip_iterations > 0
-    noslip_split = noslip and solver._static_rigid_sim_config.para_level >= gs.PARA_LEVEL.PARTIAL
-    efc_AR_shape = maybe_shape((len_constraints_, len_constraints_, _B if noslip_split else 1), noslip)
-    efc_b_shape = maybe_shape((len_constraints_, _B if noslip_split else 1), noslip)
+    noslip_decomposed = noslip and solver._static_rigid_sim_config.para_level >= gs.PARA_LEVEL.PARTIAL
+    efc_AR_shape = maybe_shape((len_constraints_, len_constraints_, _B if noslip_decomposed else 1), noslip)
+    efc_b_shape = maybe_shape((len_constraints_, _B if noslip_decomposed else 1), noslip)
     jac_dofs_idx_shape = maybe_shape(jac_shape, constraint_solver.sparse_solve)
     jac_n_dofs_shape = maybe_shape((len_constraints_, _B), constraint_solver.sparse_solve)
     sparse_dof_shape = maybe_shape((_B, solver.n_dofs_), constraint_solver.sparse_solve)
@@ -418,7 +418,7 @@ def get_constraint_state(constraint_solver, solver):
         Ma_ws=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         grad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         Mgrad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
-        MinvJT=V(dtype=gs.qd_float, shape=maybe_shape(jac_shape, noslip_split)),
+        MinvJT=V(dtype=gs.qd_float, shape=maybe_shape(jac_shape, noslip_decomposed)),
         search=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         qfrc_constraint=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         qacc=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -385,10 +385,10 @@ def get_constraint_state(constraint_solver, solver):
             f"Jacobian shape (n_constraints={len_constraints_}, n_dofs={solver.n_dofs_}, n_envs={_B}) is too large."
         )
     if math.prod(efc_AR_shape) > np.iinfo(np.int32).max:
-        gs.logger.warning(
-            f"efc_AR shape (n_constraints={len_constraints_}, n_constraints={solver.n_dofs_}, n_envs={_B}) is too "
-            "large. Consider manually setting a smaller 'max_collision_pairs' in RigidOptions to reduce the size of "
-            "reserved memory. "
+        gs.raise_exception(
+            f"efc_AR shape (n_constraints={len_constraints_}, n_constraints={len_constraints_}, "
+            f"n_envs={efc_AR_shape[2]}) is too large. Consider setting a smaller 'max_contacts' in RigidOptions "
+            "to reduce the size of reserved memory."
         )
 
     # /!\ Changing allocation order of these tensors may reduce runtime speed by >10%  /!\

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -148,13 +148,15 @@ def get_rigid_global_info(solver, kinematic_only):
     # Flip mass_mat from canonical (n_dofs(i_d1), n_dofs(i_d2), _B) -> physical (_B, n_dofs(i_d2), n_dofs(i_d1)) via
     # layout=(2, 1, 0): i_d1 becomes innermost / stride-1, which coalesces consumer kernels whose lanes stride i_d1
     # with a serial inner i_d2 loop. The trade-off is regression on writer-side kernels that pair with cooperative
-    # rewrites to recover under the same constraint_layout_transposed flag.
+    # rewrites to recover under the same enable_cooperative_constraint_kernels flag.
     #
     # mass_mat_L stays canonical. Its dominant consumer is a serial Cholesky-style back-substitution that is already
     # coalesced under (n_dofs, n_dofs, _B) with lanes varying i_b, so flipping L would regress that path more than
     # the corresponding writer-side win on the tiled factor_mass.
     mass_mat_layout = (
-        (2, 1, 0) if not kinematic_only and solver._static_rigid_sim_config.constraint_layout_transposed else None
+        (2, 1, 0)
+        if not kinematic_only and solver._static_rigid_sim_config.enable_cooperative_constraint_kernels
+        else None
     )
 
     # FIXME: Add a better split between kinematic and Genesis
@@ -338,26 +340,42 @@ def get_constraint_state(constraint_solver, solver):
     _B = solver._B
     len_constraints_ = constraint_solver.len_constraints_
 
-    # All three constraint-state layout flips (con / jac / dof_vec) gate on the same `constraint_layout_transposed`
-    # static-config flag. See `_should_transpose_constraint_layout` in rigid_solver.py for the heuristic, and the
-    # per-flip docs below.
-    transposed = solver._static_rigid_sim_config.constraint_layout_transposed
+    # The constraint-state layout flips (con / jac / dof_vec) gate on constraint_layout_batch_first; jac additionally
+    # picks its batch-first permutation from enable_cooperative_constraint_kernels. See the per-flip docs below.
+    cooperative = solver._static_rigid_sim_config.enable_cooperative_constraint_kernels
+    batch_first = solver._static_rigid_sim_config.constraint_layout_batch_first
+    # Serialized execution visits envs in the outermost loop of every constraint kernel, so the hot per-env rows of the
+    # constraint tensors must be contiguous in memory: batch-first physical layout. With the canonical batch-last layout
+    # every scalar access strides by n_envs, wasting a full cache line per element, which makes the constraint solver
+    # DRAM-bound once the combined per-env working sets exceed the CPU caches and batched stepping scales super-linearly
+    # with n_envs.
+    serialized = solver._static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL
     # Layout-flippable constraint-state tensors (Jaref, jv, efc_D, efc_frictionloss, diag, active) keep their
     # canonical (len_constraints_, _B) shape; the static config flag picks the physical layout via ``layout=(1, 0)``.
     # Cooperative kernels read the same flag at compile time to switch between serial and warp-cooperative reductions.
-    con_layout = (1, 0) if transposed else None
+    # The remaining (len_constraints_,) tensors outside the GPU cooperative flip set follow only the serialized flip.
+    con_layout = (1, 0) if batch_first else None
+    serial_layout = (1, 0) if serialized else None
     # The 3D Jacobian and its sparse-column-index sibling extend the flip: canonical (len_constraints_, n_dofs_, _B) ->
     # physical (_B, n_dofs_, len_constraints_) via layout=(2, 1, 0). This makes cooperative-warp-per-env access (lanes
     # stride i_c) coalesced for the hot p0 J@search, hessian_direct_tiled, and patch_hessian_delta kernels.
-    jac_layout = (2, 1, 0) if transposed else None
+    # Serialized execution instead wants physical (_B, len_constraints_, n_dofs_) via layout=(2, 0, 1): constraint rows
+    # are read and written dof-by-dof for a fixed env.
+    jac_layout = (2, 1, 0) if cooperative else (2, 0, 1) if serialized else None
     # DOF-vec family flip: canonical (n_dofs_, _B) -> physical (_B, n_dofs_) via layout=(1, 0). Adjacent-lane reads
     # striding i_d in cooperative kernels become stride-1; the regression on 1T-per-(i_d, i_b) writers is patched on
-    # a per-consumer basis under the same constraint_layout_transposed flag.
-    dof_vec_layout = (1, 0) if transposed else None
+    # a per-consumer basis under the same enable_cooperative_constraint_kernels flag.
+    dof_vec_layout = (1, 0) if batch_first else None
 
     jac_shape = (len_constraints_, solver.n_dofs_, _B)
-    efc_AR_shape = maybe_shape((len_constraints_, len_constraints_, _B), solver._options.noslip_iterations > 0)
-    efc_b_shape = maybe_shape((len_constraints_, _B), solver._options.noslip_iterations > 0)
+    # The split (parallel) noslip build computes MinvJT and efc_AR/efc_b for all envs before the force-update sweep.
+    # The serialized path instead fuses build, sweep, and finish per env (kernel_noslip_fused): each env consumes its
+    # AR block right after writing it, so a single batch slot shared by all envs suffices. This keeps the scratch
+    # cache-hot across the fused phases and shrinks its memory footprint by n_envs, and MinvJT is never needed.
+    noslip = solver._options.noslip_iterations > 0
+    noslip_split = noslip and solver._static_rigid_sim_config.para_level >= gs.PARA_LEVEL.PARTIAL
+    efc_AR_shape = maybe_shape((len_constraints_, len_constraints_, _B if noslip_split else 1), noslip)
+    efc_b_shape = maybe_shape((len_constraints_, _B if noslip_split else 1), noslip)
     jac_dofs_idx_shape = maybe_shape(jac_shape, constraint_solver.sparse_solve)
     jac_n_dofs_shape = maybe_shape((len_constraints_, _B), constraint_solver.sparse_solve)
     sparse_dof_shape = maybe_shape((_B, solver.n_dofs_), constraint_solver.sparse_solve)
@@ -400,7 +418,7 @@ def get_constraint_state(constraint_solver, solver):
         Ma_ws=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         grad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         Mgrad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
-        MinvJT=V(dtype=gs.qd_float, shape=maybe_shape(jac_shape, solver._options.noslip_iterations > 0)),
+        MinvJT=V(dtype=gs.qd_float, shape=maybe_shape(jac_shape, noslip_split)),
         search=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         qfrc_constraint=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         qacc=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
@@ -415,7 +433,7 @@ def get_constraint_state(constraint_solver, solver):
         dof_perm=V(dtype=gs.qd_int, shape=sparse_dof_shape),
         dof_iperm=V(dtype=gs.qd_int, shape=sparse_dof_shape),
         dof_sort_key=V(dtype=gs.qd_float, shape=sparse_dof_shape),
-        incr_changed_idx=V(dtype=gs.qd_int, shape=(len_constraints_, _B)),
+        incr_changed_idx=V(dtype=gs.qd_int, shape=(len_constraints_, _B), layout=serial_layout),
         incr_n_changed=V(dtype=gs.qd_int, shape=(_B,)),
         efc_b=V(dtype=gs.qd_float, shape=efc_b_shape),
         efc_AR=V(dtype=gs.qd_float, shape=efc_AR_shape),
@@ -423,12 +441,12 @@ def get_constraint_state(constraint_solver, solver):
         # ``layout=(1, 0)`` to physically store as (_B, len_constraints_). Canonical shape stays (len_constraints_, _B);
         # kernel-body indexing ``Jaref[i_c, i_b]`` is rewritten by the AST when ``layout != None``.
         active=V(dtype=gs.qd_bool, shape=(len_constraints_, _B), layout=con_layout),
-        prev_active=V(dtype=gs.qd_bool, shape=(len_constraints_, _B)),
+        prev_active=V(dtype=gs.qd_bool, shape=(len_constraints_, _B), layout=serial_layout),
         diag=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=con_layout),
-        aref=V(dtype=gs.qd_float, shape=(len_constraints_, _B)),
+        aref=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=serial_layout),
         Jaref=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=con_layout),
         efc_frictionloss=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=con_layout),
-        efc_force=V(dtype=gs.qd_float, shape=(len_constraints_, _B)),
+        efc_force=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=serial_layout),
         efc_D=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=con_layout),
         jv=V(dtype=gs.qd_float, shape=(len_constraints_, _B), layout=con_layout),
         jac=V(dtype=gs.qd_float, shape=jac_shape, layout=jac_layout),
@@ -437,7 +455,7 @@ def get_constraint_state(constraint_solver, solver):
             shape=jac_dofs_idx_shape,
             layout=jac_layout if constraint_solver.sparse_solve else None,
         ),
-        jac_n_dofs=V(dtype=gs.qd_int, shape=jac_n_dofs_shape),
+        jac_n_dofs=V(dtype=gs.qd_int, shape=jac_n_dofs_shape, layout=serial_layout if jac_n_dofs_shape else None),
         # Backward gradients
         dL_dqacc=V(dtype=gs.qd_float, shape=maybe_shape((solver.n_dofs_, _B), solver._requires_grad)),
         dL_dM=V(dtype=gs.qd_float, shape=maybe_shape((solver.n_dofs_, solver.n_dofs_, _B), solver._requires_grad)),
@@ -2165,10 +2183,17 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # ``func_cholesky_factor_direct_tiled`` + ``func_cholesky_solve_tiled`` pair. Requires
     # ``enable_tiled_cholesky_hessian`` for the fused kernel to be available.
     enable_fused_factor_solve_init: bool = False
-    # When True, some constraint-state tensors (eg Jaref, efc_D, ...) are allocated with ``layout=(1, 0)``,
-    # i.e. (_B, len_constraints_) physical storage. This unlocks coalesced cross-lane reads for the
-    # subgroup-cooperative refinement in the linesearch and contiguous per-thread access.
-    constraint_layout_transposed: bool = False
+    # When True, the constraint solver uses the GPU subgroup-cooperative kernel variants (warp-cooperative linesearch
+    # refinement, per-friction constraint builder, cooperative mass-matrix assembly), together with the batch-first
+    # tensor layouts they expect, eg (_B, len_constraints_) for Jaref / efc_D / ... which unlocks coalesced cross-lane
+    # reads.
+    enable_cooperative_constraint_kernels: bool = False
+    # Purely descriptive layout flag: True whenever the layout-flippable constraint-state tensors are physically
+    # batch-first, i.e. enable_cooperative_constraint_kernels or serialized execution (env loop outermost, so per-env
+    # rows must be contiguous). Consumers that only need iteration order to follow the physical layout (ndrange axes,
+    # flattened index decompositions) key on this flag, while algorithm selection (warp-cooperative vs serial
+    # reductions) keys on enable_cooperative_constraint_kernels alone.
+    constraint_layout_batch_first: bool = False
     tiled_n_dofs_per_entity: int = -1
     tiled_n_dofs: int = -1
     max_n_links_per_entity: int = -1

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -3934,12 +3934,14 @@ def test_convexify(euler, show_viewer, gjk_collision):
     assert all(geom.metadata["decomposed"] for geom in box.geoms) and 5 <= len(box.geoms) <= 20
 
     # Check resting conditions repeateadly rather not just once, for numerical robustness
+    # FIXME: The cup is falling on Windows OS because the convex decomposition provided by CoACD is different than
+    # other platform, and much worst in practice, with the bottom of the tank that is not planar (even discontinuous).
     # cam.start_recording()
     for i in range(1000):
         scene.step()
         # cam.render()
         if i > 900:
-            assert_allclose(gs_sim.rigid_solver.get_dofs_velocity(), 0.0, atol=0.5)
+            assert_allclose(gs_sim.rigid_solver.get_dofs_velocity(), 0.0, atol=1.0 if sys.platform == "win32" else 0.5)
     # cam.stop_recording(save_to_filename="video.mp4", fps=60)
 
     for obj in objs:
@@ -3949,8 +3951,6 @@ def test_convexify(euler, show_viewer, gjk_collision):
         np.testing.assert_array_less(np.linalg.norm(obj_pos[:2]), 0.5)
 
     # Check that the mug, donut and cup are landing straight if the tank is horizontal
-    # Note that the cup is falling on Windows OS because the convex decomposition provided by CoACD is different than
-    # other platform, and much worst in practice, with the bottom of the tank that is not planar (even discontinuous).
     if euler == (90, 0, 90):
         for i, obj in enumerate((mug, donut, *(() if sys.platform == "win32" else (cup,)))):
             obj_pos = obj.get_pos()


### PR DESCRIPTION
* Fix serialized batched simulation on CPU scaling sub-linearly.
* Unify noslip GPU code path as a single decomposed kernel.
* Reduce reserved contact constraint memory.
* Reduce unit test flakiness on Windows.
* Disable Quadrants' bound check on GPU for now because memory usage is blowing up (x10).