### PR TITLE
[BUG FIX] Fix island support in rigid body solver.

### DIFF
--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -265,9 +265,10 @@ def kernel_wake_up_entities_by_links(
     contact_island_state: array_class.ContactIslandState,
     static_rigid_sim_config: qd.template(),
 ):
-    """Wake up the entities owning the specified links, together with all the other entities of their hibernated
-    islands. Waking up the whole island is necessary to clear its daisy-chain links, which would otherwise keep
-    re-connecting the woken entities to their previous islands at the next contact island construction."""
+    """Wake up the entities owning the specified links, along with the other entities of their hibernated islands.
+
+    Waking up the whole island is necessary to clear its daisy-chain links, which would otherwise keep re-connecting
+    the woken entities to their previous islands at the next contact island construction."""
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
         i_b = envs_idx[i_b_]

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -14,7 +14,11 @@ import quadrants as qd
 import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.array_class as array_class
-from .misc import func_apply_link_external_force, func_apply_link_external_torque
+from .misc import (
+    func_apply_link_external_force,
+    func_apply_link_external_torque,
+    func_wakeup_entity_and_its_temp_island,
+)
 
 
 @qd.kernel(fastcache=True)
@@ -258,9 +262,12 @@ def kernel_wake_up_entities_by_links(
     dofs_state: array_class.DofsState,
     geoms_state: array_class.GeomsState,
     rigid_global_info: array_class.RigidGlobalInfo,
+    contact_island_state: array_class.ContactIslandState,
     static_rigid_sim_config: qd.template(),
 ):
-    """Wake up entities that own the specified links by setting their hibernated flags to False."""
+    """Wake up the entities owning the specified links, together with all the other entities of their hibernated
+    islands. Waking up the whole island is necessary to clear its daisy-chain links, which would otherwise keep
+    re-connecting the woken entities to their previous islands at the next contact island construction."""
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
         i_b = envs_idx[i_b_]
@@ -268,29 +275,18 @@ def kernel_wake_up_entities_by_links(
         I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
         i_e = links_info.entity_idx[I_l]
 
-        # Wake up the entity and all its components
         if entities_state.hibernated[i_e, i_b]:
-            entities_state.hibernated[i_e, i_b] = False
-
-            # Add entity to awake_entities list
-            n_awake = qd.atomic_add(rigid_global_info.n_awake_entities[i_b], 1)
-            rigid_global_info.awake_entities[n_awake, i_b] = i_e
-
-            # Wake up all links of this entity and add to awake_links
-            for i_l2 in range(entities_info.link_start[i_e], entities_info.link_end[i_e]):
-                links_state.hibernated[i_l2, i_b] = False
-                n_awake_links = qd.atomic_add(rigid_global_info.n_awake_links[i_b], 1)
-                rigid_global_info.awake_links[n_awake_links, i_b] = i_l2
-
-            # Wake up all DOFs of this entity and add to awake_dofs
-            for i_d in range(entities_info.dof_start[i_e], entities_info.dof_end[i_e]):
-                dofs_state.hibernated[i_d, i_b] = False
-                n_awake_dofs = qd.atomic_add(rigid_global_info.n_awake_dofs[i_b], 1)
-                rigid_global_info.awake_dofs[n_awake_dofs, i_b] = i_d
-
-            # Wake up all geoms of this entity
-            for i_g in range(entities_info.geom_start[i_e], entities_info.geom_end[i_e]):
-                geoms_state.hibernated[i_g, i_b] = False
+            func_wakeup_entity_and_its_temp_island(
+                i_e,
+                i_b,
+                entities_state,
+                entities_info,
+                dofs_state,
+                links_state,
+                geoms_state,
+                rigid_global_info,
+                contact_island_state,
+            )
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/constraint/solver_island.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_island.py
@@ -119,14 +119,33 @@ class ConstraintSolverIsland:
             self.n_constraints[i_b] = 0
 
     @qd.kernel
-    def resolve(self, entities_info: array_class.EntitiesInfo, rigid_global_info: array_class.RigidGlobalInfo):
+    def resolve(
+        self,
+        entities_state: array_class.EntitiesState,
+        entities_info: array_class.EntitiesInfo,
+        dofs_state: array_class.DofsState,
+        links_state: array_class.LinksState,
+        geoms_state: array_class.GeomsState,
+        rigid_global_info: array_class.RigidGlobalInfo,
+        contact_island_state: array_class.ContactIslandState,
+    ):
         for i_b in range(self._B):
             for i_island in range(self.contact_island.n_islands[i_b]):
                 is_active = True
                 if qd.static(self._solver._use_hibernation):
                     is_active = not self.contact_island.island_hibernated[i_island, i_b]
                 if is_active:
-                    self.add_collision_constraints_and_wakeup_entities(i_island, i_b)
+                    self.add_collision_constraints_and_wakeup_entities(
+                        i_island,
+                        i_b,
+                        entities_state,
+                        entities_info,
+                        dofs_state,
+                        links_state,
+                        geoms_state,
+                        rigid_global_info,
+                        contact_island_state,
+                    )
                     self.add_joint_limit_constraints(i_island, i_b)
                     self._func_init_solver(i_island, i_b, entities_info, rigid_global_info)
                     self._func_solve(i_island, i_b, entities_info, rigid_global_info)
@@ -137,7 +156,18 @@ class ConstraintSolverIsland:
         self.contact_island.construct()
 
     @qd.func
-    def add_collision_constraints_and_wakeup_entities(self, i_island: int, i_b: int):
+    def add_collision_constraints_and_wakeup_entities(
+        self,
+        i_island: int,
+        i_b: int,
+        entities_state: array_class.EntitiesState,
+        entities_info: array_class.EntitiesInfo,
+        dofs_state: array_class.DofsState,
+        links_state: array_class.LinksState,
+        geoms_state: array_class.GeomsState,
+        rigid_global_info: array_class.RigidGlobalInfo,
+        contact_island_state: array_class.ContactIslandState,
+    ):
         self.n_constraints[i_b] = 0
         for i_island_col in range(self.contact_island.island_col.n[i_island, i_b]):
             i_col_ = self.contact_island.island_col.start[i_island, i_b] + i_island_col
@@ -223,8 +253,8 @@ class ConstraintSolverIsland:
                 entity_idx_a = self._solver.links_info.entity_idx[link_a_maybe_batch]
                 entity_idx_b = self._solver.links_info.entity_idx[link_b_maybe_batch]
 
-                is_entity_a_hibernated = self._solver.entities_state.hibernated[entity_idx_a, i_b]
-                is_entity_b_hibernated = self._solver.entities_state.hibernated[entity_idx_b, i_b]
+                is_entity_a_hibernated = entities_state.hibernated[entity_idx_a, i_b]
+                is_entity_b_hibernated = entities_state.hibernated[entity_idx_b, i_b]
                 if is_entity_a_hibernated or is_entity_b_hibernated:
                     # wake up entities
                     any_hibernated_entity_idx = entity_idx_a if is_entity_a_hibernated else entity_idx_b
@@ -232,13 +262,13 @@ class ConstraintSolverIsland:
                     func_wakeup_entity_and_its_temp_island(
                         any_hibernated_entity_idx,
                         i_b,
-                        self._solver.entities_state,
-                        self._solver.entities_info,
-                        self._solver.dofs_state,
-                        self._solver.links_state,
-                        self._solver.geoms_state,
-                        self._solver.data_manager.rigid_global_info,
-                        self.contact_island,
+                        entities_state,
+                        entities_info,
+                        dofs_state,
+                        links_state,
+                        geoms_state,
+                        rigid_global_info,
+                        contact_island_state,
                     )
 
     @qd.func

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1784,7 +1784,7 @@ class RigidSolver(KinematicSolver):
         # Zero-copy fast path: single base link, non-relative. Write the position buffer in place instead of
         # launching a kernel. The kernel path below handles relative or multi-link updates, as well as waking up
         # hibernated entities, which is required whenever hibernation is enabled.
-        if gs.use_zerocopy and not relative and isinstance(links_idx, int) and not self._options.use_hibernation:
+        if gs.use_zerocopy and not relative and isinstance(links_idx, int) and not self._use_hibernation:
             link = self.links[links_idx]
             if link.is_fixed:
                 data = qd_to_torch(self.links_state.pos, transpose=True, copy=False)
@@ -1841,7 +1841,7 @@ class RigidSolver(KinematicSolver):
                 )
 
             # Wake up hibernated entities before setting position (fixed links don't need wake-up)
-            if self._options.use_hibernation and not all(self.links[i_l].is_fixed for i_l in links_idx):
+            if self._use_hibernation and not all(self.links[i_l].is_fixed for i_l in links_idx):
                 kernel_wake_up_entities_by_links(
                     links_idx,
                     envs_idx,
@@ -1852,6 +1852,7 @@ class RigidSolver(KinematicSolver):
                     dofs_state=self.dofs_state,
                     geoms_state=self.geoms_state,
                     rigid_global_info=self._rigid_global_info,
+                    contact_island_state=self.constraint_solver.contact_island.contact_island_state,
                     static_rigid_sim_config=self._static_rigid_sim_config,
                 )
 
@@ -1904,7 +1905,7 @@ class RigidSolver(KinematicSolver):
         # Zero-copy fast path: single base link, non-relative. Write the quaternion buffer in place instead of
         # launching a kernel. The kernel path below handles relative or multi-link updates, as well as waking up
         # hibernated entities, which is required whenever hibernation is enabled.
-        if gs.use_zerocopy and not relative and isinstance(links_idx, int) and not self._options.use_hibernation:
+        if gs.use_zerocopy and not relative and isinstance(links_idx, int) and not self._use_hibernation:
             link = self.links[links_idx]
             if link.is_fixed:
                 data = qd_to_torch(self.links_state.quat, transpose=True, copy=False)
@@ -1955,7 +1956,7 @@ class RigidSolver(KinematicSolver):
                 gs.raise_exception("Impossible to set env-specific quat for fixed links with at least one geometry.")
 
             # Wake up hibernated entities before setting quaternion (fixed links don't need wake-up)
-            if self._options.use_hibernation and not all(self.links[i_l].is_fixed for i_l in links_idx):
+            if self._use_hibernation and not all(self.links[i_l].is_fixed for i_l in links_idx):
                 kernel_wake_up_entities_by_links(
                     links_idx,
                     envs_idx,
@@ -1966,6 +1967,7 @@ class RigidSolver(KinematicSolver):
                     dofs_state=self.dofs_state,
                     geoms_state=self.geoms_state,
                     rigid_global_info=self._rigid_global_info,
+                    contact_island_state=self.constraint_solver.contact_island.contact_island_state,
                     static_rigid_sim_config=self._static_rigid_sim_config,
                 )
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1157,10 +1157,18 @@ class RigidSolver(KinematicSolver):
         if not self._disable_constraint:
             if self._use_contact_island:
                 self.constraint_solver.add_constraints()
+                self.constraint_solver.resolve(
+                    self.entities_state,
+                    self.entities_info,
+                    self.dofs_state,
+                    self.links_state,
+                    self.geoms_state,
+                    self._rigid_global_info,
+                    self.constraint_solver.contact_island.contact_island_state,
+                )
             else:
                 self.constraint_solver.add_inequality_constraints()
-
-            self.constraint_solver.resolve(self.entities_info, self._rigid_global_info)
+                self.constraint_solver.resolve(self.entities_info, self._rigid_global_info)
 
     def _func_forward_dynamics(self):
         kernel_forward_dynamics(
@@ -1774,8 +1782,9 @@ class RigidSolver(KinematicSolver):
             links_idx = self._base_links_idx
 
         # Zero-copy fast path: single base link, non-relative. Write the position buffer in place instead of
-        # launching a kernel. The kernel path below handles relative or multi-link updates.
-        if gs.use_zerocopy and not relative and isinstance(links_idx, int):
+        # launching a kernel. The kernel path below handles relative or multi-link updates, as well as waking up
+        # hibernated entities, which is required whenever hibernation is enabled.
+        if gs.use_zerocopy and not relative and isinstance(links_idx, int) and not self._options.use_hibernation:
             link = self.links[links_idx]
             if link.is_fixed:
                 data = qd_to_torch(self.links_state.pos, transpose=True, copy=False)
@@ -1893,8 +1902,9 @@ class RigidSolver(KinematicSolver):
             links_idx = self._base_links_idx
 
         # Zero-copy fast path: single base link, non-relative. Write the quaternion buffer in place instead of
-        # launching a kernel. The kernel path below handles relative or multi-link updates.
-        if gs.use_zerocopy and not relative and isinstance(links_idx, int):
+        # launching a kernel. The kernel path below handles relative or multi-link updates, as well as waking up
+        # hibernated entities, which is required whenever hibernation is enabled.
+        if gs.use_zerocopy and not relative and isinstance(links_idx, int) and not self._options.use_hibernation:
             link = self.links[links_idx]
             if link.is_fixed:
                 data = qd_to_torch(self.links_state.quat, transpose=True, copy=False)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -7267,7 +7267,6 @@ def test_heterogeneous_articulated_structure_mismatch():
 
 
 @pytest.mark.required
-@pytest.mark.xfail(reason="QuadrantsSyntaxError caused by dataclass argument parsing.")
 @pytest.mark.parametrize("performance_mode", [True])
 def test_hibernation_and_contact_islands(show_viewer):
     """

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -7277,6 +7277,8 @@ def test_hibernation_and_contact_islands(show_viewer):
     2. Move one box above the other using set_pos (wakes it up)
     3. Box falls and collides -> both boxes awake
     4. Stacked boxes settle and hibernate -> 1 contact island (merged)
+    5. Move one box off the hibernated stack using set_pos -> the whole island wakes up
+    6. Boxes settle separately and hibernate -> 2 contact islands (split)
     """
     if gs.use_ndarray:
         pytest.skip("Hibernation does not support dynamic array mode.")
@@ -7343,6 +7345,22 @@ def test_hibernation_and_contact_islands(show_viewer):
 
     # Stacked boxes should form 1 contact island
     assert solver.constraint_solver.contact_island.n_islands[0] == 1
+
+    # Phase 4: Move box1 off the hibernated stack. The whole island must wake up, otherwise the stale hibernated
+    # island daisy-chain would keep re-connecting both boxes at every contact island construction.
+    box1.set_pos(np.array([1.0, 0.0, 0.15]))
+    assert not solver.entities_state.hibernated[box1_idx, 0]
+    assert not solver.entities_state.hibernated[box2_idx, 0]
+
+    # Phase 5: Let both boxes settle far apart and hibernate as 2 distinct contact islands
+    for step in range(500):
+        scene.step()
+        if solver.entities_state.hibernated[box1_idx, 0] and solver.entities_state.hibernated[box2_idx, 0]:
+            break
+
+    assert solver.entities_state.hibernated[box1_idx, 0]
+    assert solver.entities_state.hibernated[box2_idx, 0]
+    assert solver.constraint_solver.contact_island.n_islands[0] == 2
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

The contact island constraint solver was unusable: its main kernel did not even compile (`test_hibernation_and_contact_islands` was marked xfail with `QuadrantsSyntaxError`), and once fixed, several hibernation wake-up bugs surfaced behind it:

- `ConstraintSolverIsland.resolve` passed Python-scope attribute instances (`self._solver.entities_state`, ...) and the `ContactIsland` wrapper to the dataclass-annotated `func_wakeup_entity_and_its_temp_island`. Quadrants only expands dataclass arguments that are kernel/func parameters, so argument fusing failed. The state dataclasses are now threaded as parameters through `resolve`, the same pattern as `kernel_forward_dynamics`.
- `set_pos` / `set_quat` did not wake up hibernated entities because the zero-copy fast path bypasses the wake-up kernel. The fast path is now disabled when hibernation is enabled.
- `kernel_wake_up_entities_by_links` only woke up the touched entity and left the hibernated-island daisy chain stale, so `add_hibernated_edges_to_islands` kept re-connecting the moved body to its old island at every construction: two bodies split from a hibernated stack stayed merged in 1 island forever. It now delegates to `func_wakeup_entity_and_its_temp_island`, which wakes up the whole island and clears the chain.

## How Has This Been / Can This Be Tested?

- Removed the xfail marker from `test_hibernation_and_contact_islands[True]`.
- Extended it with two phases: splitting a hibernated 2-box stack via `set_pos` must wake up the whole island, and the boxes must re-hibernate as 2 distinct islands. Both fail without this fix (the stale chain keeps them merged in 1 island).

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
