### PR TITLE
[BREAKING][FEATURE] Add morph pose offset and relative-frame pose accessors for rigid bodies.

### DIFF
--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -369,8 +369,11 @@ class FEMEntity(Entity):
         verts = verts.astype(gs.np_float, copy=False)
         elems = elems.astype(gs.np_int, copy=False)
 
-        # rotate
-        R = gu.quat_to_R(np.array(self.morph.quat, dtype=gs.np_float))
+        # rotate (composing the morph pose offset, e.g. an up-axis conversion, onto the morph orientation)
+        init_quat = gu.transform_quat_by_quat(
+            np.array(self._morph.offset_quat, dtype=gs.np_float), np.array(self._morph.quat, dtype=gs.np_float)
+        )
+        R = gu.quat_to_R(init_quat)
         verts_COM = verts.mean(axis=0)
         init_positions = (verts - verts_COM) @ R.T + verts_COM
 
@@ -919,8 +922,8 @@ class FEMEntity(Entity):
         else:
             assert isinstance(link, RigidLink), "Only RigidLink is supported for vertex constraints."
             link_idx = link.idx
-            link_init_pos = link.get_pos()
-            link_init_quat = link.get_quat()
+            link_init_pos = link.get_pos(relative=False)
+            link_init_quat = link.get_quat(relative=False)
             if self._scene.n_envs == 0:
                 link_init_pos = link_init_pos[None]
                 link_init_quat = link_init_quat[None]

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -370,7 +370,9 @@ class FEMEntity(Entity):
         elems = elems.astype(gs.np_int, copy=False)
 
         # Compose the morph pose offset (e.g. an up-axis conversion) onto the morph orientation, rotating the verts
-        # about their COM, then translate by the body-frame offset position R(morph.quat) @ offset_pos.
+        # about their COM (the pre-existing morph.quat convention), then translate by the body-frame offset position
+        # R(morph.quat) @ offset_pos. NB: pivoting the orientation about the vertex COM differs from the rigid
+        # parent-child composition when the mesh COM is not at the morph origin.
         morph_quat = np.array(self._morph.quat, dtype=gs.np_float)
         init_quat = gu.transform_quat_by_quat(np.array(self._morph.offset_quat, dtype=gs.np_float), morph_quat)
         R = gu.quat_to_R(init_quat)

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -369,19 +369,21 @@ class FEMEntity(Entity):
         verts = verts.astype(gs.np_float, copy=False)
         elems = elems.astype(gs.np_int, copy=False)
 
-        # rotate (composing the morph pose offset, e.g. an up-axis conversion, onto the morph orientation)
-        init_quat = gu.transform_quat_by_quat(
-            np.array(self._morph.offset_quat, dtype=gs.np_float), np.array(self._morph.quat, dtype=gs.np_float)
-        )
+        # Compose the morph pose offset (e.g. an up-axis conversion) onto the morph orientation, rotating the verts
+        # about their COM, then translate by the body-frame offset position R(morph.quat) @ offset_pos.
+        morph_quat = np.array(self._morph.quat, dtype=gs.np_float)
+        init_quat = gu.transform_quat_by_quat(np.array(self._morph.offset_quat, dtype=gs.np_float), morph_quat)
         R = gu.quat_to_R(init_quat)
         verts_COM = verts.mean(axis=0)
         init_positions = (verts - verts_COM) @ R.T + verts_COM
+        offset_shift = gu.transform_by_quat(np.array(self._morph.offset_pos, dtype=gs.np_float), morph_quat)
+        init_positions = init_positions + offset_shift
 
         if not init_positions.shape[0] > 0:
             gs.raise_exception("Entity has zero vertices.")
 
         self.init_positions = gs.tensor(init_positions)
-        self.init_positions_COM_offset = self.init_positions - gs.tensor(verts_COM)
+        self.init_positions_COM_offset = self.init_positions - gs.tensor(verts_COM + offset_shift)
 
         self.elems = elems
 

--- a/genesis/engine/entities/particle_entity.py
+++ b/genesis/engine/entities/particle_entity.py
@@ -322,16 +322,16 @@ class ParticleEntity(Entity):
                 self._vfaces = np.zeros((0, 3), dtype=gs.np_int)
             origin = np.mean(self._morph.poss, dtype=gs.np_float)
         else:
-            # transform vmesh
-            pos = np.asarray(self._morph.pos, dtype=gs.np_float)
-            quat = np.asarray(self._morph.quat, dtype=gs.np_float)
+            # transform vmesh (the morph pose offset, e.g. an up-axis conversion, is composed onto the morph pose)
+            pos, quat = gu.transform_pos_quat_by_trans_quat(
+                np.array(self._morph.offset_pos, dtype=gs.np_float),
+                np.array(self._morph.offset_quat, dtype=gs.np_float),
+                np.array(self._morph.pos, dtype=gs.np_float),
+                np.array(self._morph.quat, dtype=gs.np_float),
+            )
             self._vmesh.apply_transform(gu.trans_quat_to_T(pos, quat))
             # transform particles
-            particles = gu.transform_by_trans_quat(
-                particles,
-                np.asarray(self._morph.pos, dtype=gs.np_float),
-                np.asarray(self._morph.quat, dtype=gs.np_float),
-            )
+            particles = gu.transform_by_trans_quat(particles, pos, quat)
 
             if not self._solver.boundary.is_inside(particles):
                 gs.raise_exception(
@@ -347,7 +347,7 @@ class ParticleEntity(Entity):
             else:
                 self._vverts = np.zeros((0, 3), dtype=gs.np_float)
                 self._vfaces = np.zeros((0, 3), dtype=gs.np_int)
-            origin = np.asarray(self._morph.pos, dtype=gs.np_float)
+            origin = pos
 
         self._particles = np.asarray(particles, dtype=gs.np_float, order="C")
         self._init_particles_offset = gs.tensor(self._particles) - gs.tensor(origin)

--- a/genesis/engine/entities/pbd_entity.py
+++ b/genesis/engine/entities/pbd_entity.py
@@ -274,6 +274,8 @@ class PBDTetEntity(PBDBaseEntity):
             np.array(self._morph.pos, dtype=gs.np_float),
             np.array(self._morph.quat, dtype=gs.np_float),
         )
+        # Composed world placement, used as the origin for the particle offsets in the subclasses' 'sample'.
+        self._sampled_pos = pos
         self._vmesh.apply_transform(gu.trans_quat_to_T(pos, quat))
         self._vverts = np.asarray(self._vmesh.verts, dtype=gs.np_float)
         self._vfaces = np.asarray(self._vmesh.faces, dtype=gs.np_int)
@@ -383,7 +385,7 @@ class PBD2DEntity(PBDTetEntity):
         self._mass = self._vmesh.area * self.material.rho
 
         self._particles = np.asarray(self._mesh.verts, dtype=gs.np_float)
-        self._init_particles_offset = gs.tensor(self._particles) - gs.tensor(self._morph.pos)
+        self._init_particles_offset = gs.tensor(self._particles) - gs.tensor(self._sampled_pos)
 
         self._edges = np.asarray(self._mesh.get_unique_edges(), dtype=gs.np_int)
 
@@ -523,7 +525,7 @@ class PBD3DEntity(PBDTetEntity):
         tet_cfg = mu.generate_tetgen_config_from_morph(self.morph)
         particles, elems, *_ = self._mesh.tetrahedralize(tet_cfg)
         self._particles = particles.astype(gs.np_float, copy=False)
-        self._init_particles_offset = gs.tensor(self._particles) - gs.tensor(self._morph.pos)
+        self._init_particles_offset = gs.tensor(self._particles) - gs.tensor(self._sampled_pos)
 
         self._elems = elems.astype(gs.np_int, copy=False)
         self._edges = np.array(

--- a/genesis/engine/entities/pbd_entity.py
+++ b/genesis/engine/entities/pbd_entity.py
@@ -266,9 +266,14 @@ class PBDTetEntity(PBDBaseEntity):
         Applies transformation from the morph, stores mesh vertices and faces, and performs remeshing based on the
         particle size.
         """
-        # We don't use ParticleEntity.sample() because we need to maintain the remeshed self._mesh as well
-        pos = np.asarray(self._morph.pos, dtype=gs.np_float)
-        quat = np.asarray(self._morph.quat, dtype=gs.np_float)
+        # We don't use ParticleEntity.sample() because we need to maintain the remeshed self._mesh as well. The morph
+        # pose offset (e.g. an up-axis conversion) is composed onto the morph pose.
+        pos, quat = gu.transform_pos_quat_by_trans_quat(
+            np.array(self._morph.offset_pos, dtype=gs.np_float),
+            np.array(self._morph.offset_quat, dtype=gs.np_float),
+            np.array(self._morph.pos, dtype=gs.np_float),
+            np.array(self._morph.quat, dtype=gs.np_float),
+        )
         self._vmesh.apply_transform(gu.trans_quat_to_T(pos, quat))
         self._vverts = np.asarray(self._vmesh.verts, dtype=gs.np_float)
         self._vfaces = np.asarray(self._vmesh.faces, dtype=gs.np_int)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -52,7 +52,7 @@ def tracked(fun):
     return wrapper
 
 
-def _file_inertial(l_info, recompute_inertia):
+def _declared_inertial(l_info, recompute_inertia):
     """Return a link's file-specified '(inertia, pos, quat)' for alignment, or None to recompute it from geometry.
 
     None is returned when the link has no valid file inertia or 'recompute_inertia' is set.
@@ -180,12 +180,10 @@ class KinematicEntity(Entity):
         self._is_attached: bool = False
         self._variant_init_qpos: list[np.ndarray] | None = None
 
-        # Per-link pose offset between the world frame (used by the solver) and the user frame (reported by relative
-        # getters), keyed by link index local to the entity. Only root links carry an offset (children stay identity);
-        # each is the morph 'offset_pos'/'offset_quat' (e.g. up-axis conversions) composed with that link's inertial
-        # alignment, filled in '_add_by_info'. Independent per root, so multi-root entities keep a distinct offset per
-        # root. The base link's offset is mirrored into '_offset_pos'/'_offset_quat' for the heterogeneous-variant seed.
-        # The solver gathers all of these into per-link tensors at build time.
+        # Per-link world<-user pose offset (morph 'offset_pos'/'offset_quat' composed with the link's inertial
+        # alignment), keyed by local link index; only root links carry one (children stay identity), so a multi-root
+        # entity keeps a distinct offset per root. The base link's is mirrored into '_offset_pos'/'_offset_quat' for the
+        # heterogeneous-variant seed; the solver gathers them into per-link tensors at build.
         self._links_offset_pos: dict[int, np.ndarray] = {}
         self._links_offset_quat: dict[int, np.ndarray] = {}
         self._offset_pos = np.array(self._morph.offset_pos, dtype=gs.np_float)
@@ -311,7 +309,7 @@ class KinematicEntity(Entity):
                         )
                     if align and is_root and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in v_j_infos):
                         global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
-                            cg_infos, vg_infos, _file_inertial(v_l_info, morph.recompute_inertia)
+                            cg_infos, vg_infos, _declared_inertial(v_l_info, morph.recompute_inertia)
                         )
                         if diagonal_inertial is not None:
                             v_l_info["inertial_pos"] = diagonal_inertial[0]
@@ -1165,7 +1163,7 @@ class KinematicEntity(Entity):
         global_com = principal_quat = None
         if do_align:
             global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
-                cg_infos, vg_infos, _file_inertial(l_info, morph.recompute_inertia)
+                cg_infos, vg_infos, _declared_inertial(l_info, morph.recompute_inertia)
             )
             if diagonal_inertial is not None:
                 l_info["inertial_pos"], l_info["inertial_quat"], l_info["inertial_i"] = diagonal_inertial

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -52,10 +52,10 @@ def tracked(fun):
     return wrapper
 
 
-def _declared_inertial(l_info, recompute_inertia):
-    """Return a link's file-specified '(inertia, pos, quat)' for alignment, or None to recompute it from geometry.
+def _get_original_inertial_properties(l_info, recompute_inertia):
+    """Return a link's original '(inertia, pos, quat)' for alignment, or None to recompute it from geometry.
 
-    None is returned when the link has no valid file inertia or 'recompute_inertia' is set.
+    None is returned when the link has no valid declared inertia or 'recompute_inertia' is set.
     """
     inertia_valid = (
         (l_info.get("inertial_mass") or 0.0) > gs.EPS
@@ -309,7 +309,7 @@ class KinematicEntity(Entity):
                         )
                     if align and is_root and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in v_j_infos):
                         global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
-                            cg_infos, vg_infos, _declared_inertial(v_l_info, morph.recompute_inertia)
+                            cg_infos, vg_infos, _get_original_inertial_properties(v_l_info, morph.recompute_inertia)
                         )
                         if diagonal_inertial is not None:
                             v_l_info["inertial_pos"] = diagonal_inertial[0]
@@ -1163,7 +1163,7 @@ class KinematicEntity(Entity):
         global_com = principal_quat = None
         if do_align:
             global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
-                cg_infos, vg_infos, _declared_inertial(l_info, morph.recompute_inertia)
+                cg_infos, vg_infos, _get_original_inertial_properties(l_info, morph.recompute_inertia)
             )
             if diagonal_inertial is not None:
                 l_info["inertial_pos"], l_info["inertial_quat"], l_info["inertial_i"] = diagonal_inertial

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -52,6 +52,80 @@ def tracked(fun):
     return wrapper
 
 
+def _file_inertial(l_info, recompute_inertia):
+    """Return a link's file-specified '(inertia, pos, quat)' for alignment, or None to recompute it from geometry.
+
+    None is returned when the link has no valid file inertia or 'recompute_inertia' is set.
+    """
+    inertia_valid = (
+        (l_info.get("inertial_mass") or 0.0) > gs.EPS
+        and l_info.get("inertial_i") is not None
+        and (np.diag(l_info["inertial_i"]) > 0.0).all()
+        and l_info.get("inertial_pos") is not None
+    )
+    if not inertia_valid or recompute_inertia:
+        return None
+    return (
+        l_info["inertial_i"],
+        np.array(l_info["inertial_pos"]),
+        np.array(l_info["inertial_quat"]) if l_info.get("inertial_quat") is not None else gu.identity_quat(),
+    )
+
+
+def _align_geoms_to_inertia(cg_infos, vg_infos, file_inertial):
+    """Compute a root link's COM and principal-inertia axes, then re-express its geoms into that aligned frame.
+
+    The frame is derived from 'file_inertial' when provided, otherwise recomputed from the (convexified) collision
+    geometry. The collision and visual geom poses in 'cg_infos' / 'vg_infos' are re-expressed in place so the link
+    origin sits at the COM with the principal axes aligned. Returns '(global_com, principal_quat, diagonal_inertial)',
+    where 'diagonal_inertial' is the diagonalized '(pos, quat, inertia)' for the file path and None when recomputed
+    from geometry (the geom-based inertia is rebuilt from the re-expressed geoms at build time).
+    """
+    if file_inertial is not None:
+        # Derive COM and principal axes from file-specified inertia, returning the diagonalized inertia in the new
+        # (aligned) link frame.
+        inertia, inertia_pos, inertia_quat = file_inertial
+        inertia_R = gu.quat_to_R(inertia_quat)
+        inertia_in_link = inertia_R @ inertia @ inertia_R.T
+        R_principal = uu.principal_axes_rot(inertia_in_link)
+        principal_quat = gu.R_to_quat(R_principal)
+        global_com = inertia_pos
+        diagonal_inertial = (gu.zero_pos(), gu.identity_quat(), R_principal.T @ inertia_in_link @ R_principal)
+    else:
+        # Compute COM and principal axes from (convexified) collision geometry
+        geoms_inertial_info = []
+        for cg_info in cg_infos:
+            if not (cg_info.get("contype", 0) or cg_info.get("conaffinity", 0)):
+                continue
+            tmesh = cg_info["mesh"].trimesh
+            if not tmesh.is_watertight:
+                tmesh = tmesh.convex_hull
+            if tmesh.volume > 0:
+                geoms_inertial_info.append(
+                    (
+                        tmesh.mass,
+                        tmesh.center_mass,
+                        tmesh.moment_inertia,
+                        np.array(cg_info.get("pos", gu.zero_pos())),
+                        np.array(cg_info.get("quat", gu.identity_quat())),
+                    )
+                )
+        _global_mass, global_com, global_inertia = compose_inertial_properties(geoms_inertial_info)
+        R_principal = uu.principal_axes_rot(global_inertia)
+        principal_quat = gu.R_to_quat(R_principal)
+        diagonal_inertial = None
+
+    # Re-express all geoms in the new link frame
+    for g_info in chain(cg_infos, vg_infos):
+        g_info["pos"], g_info["quat"] = gu.inv_transform_pos_quat_by_trans_quat(
+            np.array(g_info.get("pos", gu.zero_pos())),
+            np.array(g_info.get("quat", gu.identity_quat())),
+            global_com,
+            principal_quat,
+        )
+    return global_com, principal_quat, diagonal_inertial
+
+
 @qd.data_oriented
 class KinematicEntity(Entity):
     """
@@ -106,6 +180,18 @@ class KinematicEntity(Entity):
         self._is_attached: bool = False
         self._variant_init_qpos: list[np.ndarray] | None = None
 
+        # Pose offset between the world frame (used by the solver) and the user frame (reported by relative getters).
+        # Seeded from the morph's 'offset_pos'/'offset_quat' (e.g. up-axis conversions) and further accumulated with the
+        # inertial-alignment transform of the base link in '_align_link'. Converted to tensors at build time.
+        self._offset_pos = np.array(self._morph.offset_pos, dtype=gs.np_float)
+        self._offset_quat = np.array(self._morph.offset_quat, dtype=gs.np_float)
+
+        # Per-variant base-link offset for heterogeneous entities (None when homogeneous), primary first and aligned
+        # with '_variant_init_qpos'. The primary carries the inertial alignment; the geometry-only variants carry their
+        # morph offset alone, matching how their initial pose is built.
+        self._variant_offset_pos: list[np.ndarray] | None = None
+        self._variant_offset_quat: list[np.ndarray] | None = None
+
         self._load_model()
 
         # Initialize target variables and checkpoint
@@ -154,8 +240,12 @@ class KinematicEntity(Entity):
         for link in self._links:
             link._init_variant_tracking()
 
-        # Track per-variant init_qpos for per-environment dispatch (primary first)
-        self._variant_init_qpos = [self.init_qpos.copy()]
+        # Track per-variant init_qpos and base-link offset for per-environment dispatch (primary first). The primary
+        # already carries its morph offset and inertial alignment in '_offset_*'; each variant accumulates its own
+        # below so an asymmetric variant is aligned exactly like its homogeneous equivalent.
+        self._variant_init_qpos = [self.init_qpos]
+        self._variant_offset_pos = [self._offset_pos]
+        self._variant_offset_quat = [self._offset_quat]
 
         n_links = len(self._links)
 
@@ -196,20 +286,64 @@ class KinematicEntity(Entity):
                                 f"variant has {v_j_info['n_dofs']}."
                             )
 
-                # Extract variant's init_qpos from parsed joint infos
+                # Post-process each link's geoms and align the floating base by its own geometry (mirrors '_align_link'
+                # for the primary), so an asymmetric variant behaves like its homogeneous equivalent. Diagonalized
+                # inertia from a file-specified base is written back so the per-variant inertial uses the aligned frame.
+                offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
+                offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
+                global_com = principal_quat = None
+                cg_vg_infos = []
+                for v_l_info, v_j_infos, v_g_infos in zip(v_l_infos, v_links_j_infos, v_links_g_infos):
+                    is_robot = v_l_info.get("is_robot", np.array(False, dtype=np.bool_))
+                    cg_infos, vg_infos = self._postprocess_geoms_info(morph, v_g_infos, is_robot)
+                    is_root = v_l_info["parent_idx"] == -1
+                    align = morph.align
+                    if align is None:
+                        align = (
+                            is_root
+                            and not bool(is_robot)
+                            and all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in v_j_infos)
+                        )
+                    if align and is_root and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in v_j_infos):
+                        global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
+                            cg_infos, vg_infos, _file_inertial(v_l_info, morph.recompute_inertia)
+                        )
+                        if diagonal_inertial is not None:
+                            v_l_info["inertial_pos"] = diagonal_inertial[0]
+                            v_l_info["inertial_quat"] = diagonal_inertial[1]
+                            v_l_info["inertial_i"] = diagonal_inertial[2]
+                        offset_pos = gu.transform_by_trans_quat(global_com, offset_pos, offset_quat)
+                        offset_quat = gu.transform_quat_by_quat(principal_quat, offset_quat)
+                    cg_vg_infos.append((cg_infos, vg_infos))
+
+                # Extract variant's init_qpos from parsed joint infos, composing the morph offset and the floating
+                # base's alignment into the free joint so relative getters report the variant's user frame.
                 variant_init_qpos_parts = []
-                for v_j_infos in v_links_j_infos:
+                for v_l_info, v_j_infos in zip(v_l_infos, v_links_j_infos):
+                    is_root = v_l_info["parent_idx"] == -1
                     for j_info in v_j_infos:
-                        variant_init_qpos_parts.append(j_info["init_qpos"])
+                        qpos = j_info["init_qpos"]
+                        if is_root and j_info["type"] == gs.JOINT_TYPE.FREE:
+                            init_pos, init_quat = gu.transform_pos_quat_by_trans_quat(
+                                np.array(morph.offset_pos, dtype=gs.np_float),
+                                np.array(morph.offset_quat, dtype=gs.np_float),
+                                qpos[:3],
+                                qpos[3:7],
+                            )
+                            if global_com is not None:
+                                init_pos = gu.transform_by_trans_quat(global_com, init_pos, init_quat)
+                                init_quat = gu.transform_quat_by_quat(principal_quat, init_quat)
+                            qpos = np.concatenate([init_pos, init_quat])
+                        variant_init_qpos_parts.append(qpos)
                 if variant_init_qpos_parts:
                     self._variant_init_qpos.append(np.concatenate(variant_init_qpos_parts))
                 else:
                     self._variant_init_qpos.append(np.array([]))
+                self._variant_offset_pos.append(offset_pos)
+                self._variant_offset_quat.append(offset_quat)
 
                 # Add geoms per link
-                for link, v_l_info, v_g_infos in zip(self._links, v_l_infos, v_links_g_infos):
-                    is_robot = v_l_info.get("is_robot", np.array(False, dtype=np.bool_))
-                    cg_infos, vg_infos = self._postprocess_geoms_info(morph, v_g_infos, is_robot)
+                for link, v_l_info, (cg_infos, vg_infos) in zip(self._links, v_l_infos, cg_vg_infos):
                     self._add_heterogeneous_variant(link, cg_infos, vg_infos)
                     self._on_heterogeneous_scene_variant_loaded(link, morph, v_l_info)
 
@@ -221,9 +355,38 @@ class KinematicEntity(Entity):
                 if morph.fixed != self._morph.fixed:
                     gs.raise_exception("Mixing fixed and non-fixed morphs in heterogeneous entities is not supported.")
                 cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, is_robot=False)
+
+                # Align this variant by its own geometry (mirrors '_align_link' for the primary), so an asymmetric
+                # variant behaves like its homogeneous equivalent. Primitives are never aligned, matching '_align_link'.
+                offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
+                offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
+                align = morph.align if isinstance(morph, gs.options.morphs.FileMorph) else False
+                if align is None:
+                    align = not morph.fixed
+                global_com = principal_quat = None
+                if align and not morph.fixed:
+                    global_com, principal_quat, _ = _align_geoms_to_inertia(cg_infos, vg_infos, None)
+                    offset_pos = gu.transform_by_trans_quat(global_com, offset_pos, offset_quat)
+                    offset_quat = gu.transform_quat_by_quat(principal_quat, offset_quat)
+
                 self._add_heterogeneous_variant(self._links[0], cg_infos, vg_infos)
-                init_qpos = np.array((*morph.pos, *morph.quat) if not morph.fixed else (), dtype=gs.np_float)
+
+                if morph.fixed:
+                    init_qpos = np.array((), dtype=gs.np_float)
+                else:
+                    init_pos, init_quat = gu.transform_pos_quat_by_trans_quat(
+                        np.array(morph.offset_pos, dtype=gs.np_float),
+                        np.array(morph.offset_quat, dtype=gs.np_float),
+                        np.array(morph.pos, dtype=gs.np_float),
+                        np.array(morph.quat, dtype=gs.np_float),
+                    )
+                    if global_com is not None:
+                        init_pos = gu.transform_by_trans_quat(global_com, init_pos, init_quat)
+                        init_quat = gu.transform_quat_by_quat(principal_quat, init_quat)
+                    init_qpos = np.concatenate([init_pos, init_quat])
                 self._variant_init_qpos.append(init_qpos)
+                self._variant_offset_pos.append(offset_pos)
+                self._variant_offset_quat.append(offset_quat)
             else:
                 gs.raise_exception(
                     f"Heterogeneous morphs only support URDF, MJCF, Primitive, and Mesh, got: {type(morph).__name__}."
@@ -875,6 +1038,20 @@ class KinematicEntity(Entity):
         link_idx = self.n_links + self._link_start
         joint_start = self.n_joints + self._joint_start
 
+        # Carry the morph pose offset into the base link's world pose (composed in the base body frame). The solver
+        # strips the matching offset in relative getters, so the user frame is unchanged. The inertial alignment
+        # accumulates further into the offset in '_align_link', and the solver gathers the total at build.
+        if l_info["parent_idx"] < 0:
+            l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
+                np.array(morph.offset_pos, dtype=gs.np_float),
+                np.array(morph.offset_quat, dtype=gs.np_float),
+                l_info["pos"],
+                l_info["quat"],
+            )
+            for j_info in j_infos:
+                if j_info["type"] == gs.JOINT_TYPE.FREE:
+                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+
         cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
         self._align_link(l_info, j_infos, cg_infos, vg_infos, morph)
 
@@ -980,49 +1157,17 @@ class KinematicEntity(Entity):
         ):
             return
 
-        global_com = None
-        inertia_valid = (
-            (l_info.get("inertial_mass") or 0.0) > gs.EPS
-            and (l_info.get("inertial_i") is not None and (np.diag(l_info["inertial_i"]) > 0.0).all())
-            and l_info.get("inertial_pos") is not None
+        global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
+            cg_infos, vg_infos, _file_inertial(l_info, morph.recompute_inertia)
         )
-        if inertia_valid and not morph.recompute_inertia:
-            # Derive COM and principal axes from file-specified inertia
-            inertia_pos = np.array(l_info["inertial_pos"]) if l_info.get("inertial_pos") is not None else gu.zero_pos()
-            inertia_quat = (
-                np.array(l_info["inertial_quat"]) if l_info.get("inertial_quat") is not None else gu.identity_quat()
-            )
-            inertia_R = gu.quat_to_R(inertia_quat)
-            inertia_in_link = inertia_R @ l_info["inertial_i"] @ inertia_R.T
-            R_principal = uu.principal_axes_rot(inertia_in_link)
-            principal_quat = gu.R_to_quat(R_principal)
-            global_com = inertia_pos
-            # Update inertia to diagonalized form in the new (aligned) link frame
-            l_info["inertial_pos"] = gu.zero_pos()
-            l_info["inertial_quat"] = gu.identity_quat()
-            l_info["inertial_i"] = R_principal.T @ inertia_in_link @ R_principal
-        else:
-            # Compute COM and principal axes from (convexified) collision geometry
-            geoms_inertial_info = []
-            for cg_info in cg_infos:
-                if not (cg_info.get("contype", 0) or cg_info.get("conaffinity", 0)):
-                    continue
-                tmesh = cg_info["mesh"].trimesh
-                if not tmesh.is_watertight:
-                    tmesh = tmesh.convex_hull
-                if tmesh.volume > 0:
-                    geoms_inertial_info.append(
-                        (
-                            tmesh.mass,
-                            tmesh.center_mass,
-                            tmesh.moment_inertia,
-                            np.array(cg_info.get("pos", gu.zero_pos())),
-                            np.array(cg_info.get("quat", gu.identity_quat())),
-                        )
-                    )
-            _global_mass, global_com, global_inertia = compose_inertial_properties(geoms_inertial_info)
-            R_principal = uu.principal_axes_rot(global_inertia)
-            principal_quat = gu.R_to_quat(R_principal)
+        if diagonal_inertial is not None:
+            l_info["inertial_pos"], l_info["inertial_quat"], l_info["inertial_i"] = diagonal_inertial
+
+        # Record the alignment as a body-frame pose offset so relative getters report the user's original (unaligned)
+        # base pose while the solver uses the COM-centered, principal-axis frame. Composed in the body frame: the COM
+        # is rotated by the current offset orientation, and the principal-axis rotation post-multiplies the offset.
+        self._offset_pos = gu.transform_by_trans_quat(global_com, self._offset_pos, self._offset_quat)
+        self._offset_quat = gu.transform_quat_by_quat(principal_quat, self._offset_quat)
 
         # Shift link frame to COM and rotate to principal axes
         l_info["pos"] = gu.transform_by_trans_quat(global_com, l_info["pos"], l_info["quat"])
@@ -1032,22 +1177,6 @@ class KinematicEntity(Entity):
         for j_info in j_infos:
             if j_info["type"] == gs.JOINT_TYPE.FREE:
                 j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
-
-        # Re-express all geoms in the new link frame
-        for cg_info in cg_infos:
-            cg_info["pos"], cg_info["quat"] = gu.inv_transform_pos_quat_by_trans_quat(
-                np.array(cg_info.get("pos", gu.zero_pos())),
-                np.array(cg_info.get("quat", gu.identity_quat())),
-                global_com,
-                principal_quat,
-            )
-        for vg_info in vg_infos:
-            vg_info["pos"], vg_info["quat"] = gu.inv_transform_pos_quat_by_trans_quat(
-                np.array(vg_info.get("pos", gu.zero_pos())),
-                np.array(vg_info.get("quat", gu.identity_quat())),
-                global_com,
-                principal_quat,
-            )
 
     @gs.assert_unbuilt
     def attach(self, parent_entity, parent_link_name: str | None = None):
@@ -1334,7 +1463,7 @@ class KinematicEntity(Entity):
             gs.raise_exception("Neither `name` nor `uid` is provided.")
 
     @gs.assert_built
-    def get_pos(self, envs_idx=None):
+    def get_pos(self, envs_idx=None, *, relative=True):
         """
         Returns position of the entity's base link.
 
@@ -1342,16 +1471,19 @@ class KinematicEntity(Entity):
         ----------
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            Whether to report the position in the user frame, with the morph pose offset and inertial alignment
+            stripped, rather than the world frame used by the solver. Defaults to True.
 
         Returns
         -------
         pos : torch.Tensor, shape (3,) or (n_envs, 3)
             The position of the entity's base link.
         """
-        return self._solver.get_links_pos(self.base_link_idx, envs_idx)[..., 0, :]
+        return self._solver.get_links_pos(self.base_link_idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
-    def get_quat(self, envs_idx=None):
+    def get_quat(self, envs_idx=None, *, relative=True):
         """
         Returns quaternion of the entity's base link.
 
@@ -1359,13 +1491,16 @@ class KinematicEntity(Entity):
         ----------
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            Whether to report the orientation in the user frame, with the morph pose offset and inertial alignment
+            stripped, rather than the world frame used by the solver. Defaults to True.
 
         Returns
         -------
         quat : torch.Tensor, shape (4,) or (n_envs, 4)
             The quaternion of the entity's base link.
         """
-        return self._solver.get_links_quat(self.base_link_idx, envs_idx)[..., 0, :]
+        return self._solver.get_links_quat(self.base_link_idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
     def get_vel(self, envs_idx=None):
@@ -1519,7 +1654,7 @@ class KinematicEntity(Entity):
 
     @gs.assert_built
     @tracked
-    def set_pos(self, pos, envs_idx=None, *, zero_velocity=False, relative=False, skip_forward=False):
+    def set_pos(self, pos, envs_idx=None, *, zero_velocity=False, relative=True, skip_forward=False):
         """
         Set position of the entity's base link.
 
@@ -1532,8 +1667,8 @@ class KinematicEntity(Entity):
         zero_velocity : bool, optional
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
-            Whether the position to set is absolute or relative to the initial (not current!) position. Defaults to
-            False.
+            Whether 'pos' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
+            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -1563,8 +1698,8 @@ class KinematicEntity(Entity):
         zero_velocity : bool, optional
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
-            True the quaternion to set is absolute or relative to the initial (not current!) quaternion. Defaults to
-            False.
+            Whether 'quat' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
+            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """
@@ -2269,6 +2404,20 @@ class RigidEntity(KinematicEntity):
                 fixed_verts_start += link.n_verts
             else:
                 free_verts_start += link.n_verts
+
+        # Carry the morph pose offset into the base link's world pose (composed in the base body frame). The solver
+        # strips the matching offset in relative getters, so the user frame is unchanged. The inertial alignment
+        # accumulates further into the offset in '_align_link', and the solver gathers the total at build.
+        if l_info["parent_idx"] < 0:
+            l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
+                np.array(morph.offset_pos, dtype=gs.np_float),
+                np.array(morph.offset_quat, dtype=gs.np_float),
+                l_info["pos"],
+                l_info["quat"],
+            )
+            for j_info in j_infos:
+                if j_info["type"] == gs.JOINT_TYPE.FREE:
+                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
 
         # Split and convexify collision geometry. Must be done before alignment so that
         # convexified geoms are used to compute the inertia frame.
@@ -3316,7 +3465,7 @@ class RigidEntity(KinematicEntity):
 
     @gs.assert_built
     @tracked
-    def set_pos(self, pos, envs_idx=None, *, zero_velocity=True, relative=False, skip_forward=False):
+    def set_pos(self, pos, envs_idx=None, *, zero_velocity=True, relative=True, skip_forward=False):
         """
         Set position of the entity's base link.
 
@@ -3330,8 +3479,8 @@ class RigidEntity(KinematicEntity):
             Whether to zero the velocity of all the entity's dofs. Defaults to True. This is a safety measure after a
             sudden change in entity pose.
         relative : bool, optional
-            Whether the position to set is absolute or relative to the initial (not current!) position. Defaults to
-            False.
+            Whether 'pos' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
+            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -3349,7 +3498,7 @@ class RigidEntity(KinematicEntity):
 
     @gs.assert_built
     @tracked
-    def set_quat(self, quat, envs_idx=None, *, zero_velocity=True, relative=False, skip_forward=False):
+    def set_quat(self, quat, envs_idx=None, *, zero_velocity=True, relative=True, skip_forward=False):
         """
         Set quaternion of the entity's base link.
 
@@ -3363,8 +3512,8 @@ class RigidEntity(KinematicEntity):
             Whether to zero the velocity of all the entity's dofs. Defaults to True. This is a safety measure after a
             sudden change in entity pose.
         relative : bool, optional
-            Whether the quaternion to set is absolute or relative to the initial (not current!) quaternion. Defaults to
-            False.
+            Whether 'quat' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
+            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -3,7 +3,7 @@ import os
 import xml.etree.ElementTree as ET
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Any, Sequence
+from typing import TYPE_CHECKING, Literal, Any, NamedTuple, Sequence
 from functools import wraps
 
 import quadrants as qd
@@ -52,8 +52,16 @@ def tracked(fun):
     return wrapper
 
 
+class InertialProperties(NamedTuple):
+    """A link's inertial properties: the 3x3 inertia matrix 'i' and the inertial frame pose 'pos'/'quat'."""
+
+    i: np.ndarray
+    pos: np.ndarray
+    quat: np.ndarray
+
+
 def _get_original_inertial_properties(l_info, recompute_inertia):
-    """Return a link's original '(inertia, pos, quat)' for alignment, or None to recompute it from geometry.
+    """Return a link's original inertial properties for alignment, or None to recompute them from geometry.
 
     None is returned when the link has no valid declared inertia or 'recompute_inertia' is set.
     """
@@ -65,32 +73,33 @@ def _get_original_inertial_properties(l_info, recompute_inertia):
     )
     if not inertia_valid or recompute_inertia:
         return None
-    return (
-        l_info["inertial_i"],
-        np.array(l_info["inertial_pos"]),
-        np.array(l_info["inertial_quat"]) if l_info.get("inertial_quat") is not None else gu.identity_quat(),
+    return InertialProperties(
+        i=l_info["inertial_i"],
+        pos=np.array(l_info["inertial_pos"]),
+        quat=np.array(l_info["inertial_quat"]) if l_info.get("inertial_quat") is not None else gu.identity_quat(),
     )
 
 
 def _align_geoms_to_inertia(cg_infos, vg_infos, file_inertial):
     """Compute a root link's COM and principal-inertia axes, then re-express its geoms into that aligned frame.
 
-    The frame is derived from 'file_inertial' when provided, otherwise recomputed from the (convexified) collision
-    geometry. The collision and visual geom poses in 'cg_infos' / 'vg_infos' are re-expressed in place so the link
-    origin sits at the COM with the principal axes aligned. Returns '(global_com, principal_quat, diagonal_inertial)',
-    where 'diagonal_inertial' is the diagonalized '(pos, quat, inertia)' for the file path and None when recomputed
-    from geometry (the geom-based inertia is rebuilt from the re-expressed geoms at build time).
+    The frame is derived from 'file_inertial' (an 'InertialProperties') when provided, otherwise recomputed from the
+    (convexified) collision geometry. The collision and visual geom poses in 'cg_infos' / 'vg_infos' are re-expressed
+    in place so the link origin sits at the COM with the principal axes aligned. Returns '(global_com, principal_quat,
+    diagonal_inertial)', where 'diagonal_inertial' is the diagonalized 'InertialProperties' for the file path and None
+    when recomputed from geometry (the geom-based inertia is rebuilt from the re-expressed geoms at build time).
     """
     if file_inertial is not None:
         # Derive COM and principal axes from file-specified inertia, returning the diagonalized inertia in the new
         # (aligned) link frame.
-        inertia, inertia_pos, inertia_quat = file_inertial
-        inertia_R = gu.quat_to_R(inertia_quat)
-        inertia_in_link = inertia_R @ inertia @ inertia_R.T
+        inertia_R = gu.quat_to_R(file_inertial.quat)
+        inertia_in_link = inertia_R @ file_inertial.i @ inertia_R.T
         R_principal = uu.principal_axes_rot(inertia_in_link)
         principal_quat = gu.R_to_quat(R_principal)
-        global_com = inertia_pos
-        diagonal_inertial = (gu.zero_pos(), gu.identity_quat(), R_principal.T @ inertia_in_link @ R_principal)
+        global_com = file_inertial.pos
+        diagonal_inertial = InertialProperties(
+            i=R_principal.T @ inertia_in_link @ R_principal, pos=gu.zero_pos(), quat=gu.identity_quat()
+        )
     else:
         # Compute COM and principal axes from (convexified) collision geometry
         geoms_inertial_info = []
@@ -239,6 +248,11 @@ class KinematicEntity(Entity):
         if not self._enable_heterogeneous:
             return
 
+        # The per-variant offset and inertial alignment are tracked for a single root only; a multi-root entity (one
+        # MJCF/URDF with several free root bodies) would cross-contaminate the roots' offsets and init poses.
+        if sum(link.parent_idx == -1 for link in self._links) > 1:
+            gs.raise_exception("Heterogeneous morphs are not supported on multi-root entities.")
+
         # Init variant tracking on ALL links
         for link in self._links:
             link._init_variant_tracking()
@@ -312,9 +326,9 @@ class KinematicEntity(Entity):
                             cg_infos, vg_infos, _get_original_inertial_properties(v_l_info, morph.recompute_inertia)
                         )
                         if diagonal_inertial is not None:
-                            v_l_info["inertial_pos"] = diagonal_inertial[0]
-                            v_l_info["inertial_quat"] = diagonal_inertial[1]
-                            v_l_info["inertial_i"] = diagonal_inertial[2]
+                            v_l_info["inertial_pos"] = diagonal_inertial.pos
+                            v_l_info["inertial_quat"] = diagonal_inertial.quat
+                            v_l_info["inertial_i"] = diagonal_inertial.i
                         offset_pos = gu.transform_by_trans_quat(global_com, offset_pos, offset_quat)
                         offset_quat = gu.transform_quat_by_quat(principal_quat, offset_quat)
                     cg_vg_infos.append((cg_infos, vg_infos))
@@ -1041,20 +1055,6 @@ class KinematicEntity(Entity):
         link_idx = self.n_links + self._link_start
         joint_start = self.n_joints + self._joint_start
 
-        # Carry the morph pose offset into each root link's world pose (composed in the body frame). The solver strips
-        # the matching offset in relative getters, so the user frame is unchanged. The inertial alignment is folded
-        # into the same per-link offset in '_align_link', which the solver gathers at build.
-        if l_info["parent_idx"] < 0:
-            l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
-                np.array(morph.offset_pos, dtype=gs.np_float),
-                np.array(morph.offset_quat, dtype=gs.np_float),
-                l_info["pos"],
-                l_info["quat"],
-            )
-            for j_info in j_infos:
-                if j_info["type"] == gs.JOINT_TYPE.FREE:
-                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
-
         cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
         self._align_link(l_info, j_infos, cg_infos, vg_infos, morph, link_idx)
 
@@ -1141,49 +1141,53 @@ class KinematicEntity(Entity):
         return cg_infos, vg_infos
 
     def _align_link(self, l_info, j_infos, cg_infos, vg_infos, morph, link_idx):
-        """Align a root link frame to its collision geometry COM and principal inertia axes, and record its offset.
+        """Carry the morph pose offset into a root link, align it to its COM/principal axes, and record its offset.
 
-        Alignment only applies to root (floating-base) links with a free joint, and mutates l_info, j_infos, cg_infos,
-        and vg_infos in-place so kinematic and rigid entities share the same aligned qpos and link frame. Every root
-        link's pose offset (its morph 'offset_pos'/'offset_quat' composed with the inertial alignment, both in the body
-        frame) is stored in '_links_offset_*' so the relative getters report the user's original (unaligned) pose;
-        children carry no offset. Each root is independent, so multi-root entities keep a distinct offset per root.
+        Only root (floating-base) links are affected. The morph 'offset_pos'/'offset_quat' is composed into the link
+        world pose, then (for a free root that opts into alignment) the COM/principal-axis transform is applied on top;
+        l_info, j_infos, cg_infos and vg_infos are mutated in-place so kinematic and rigid entities share the same
+        aligned qpos and link frame. The resulting body-frame offset (morph offset then alignment) is stored in
+        '_links_offset_*' so the relative getters report the user's original pose; children carry no offset, and each
+        root is independent (multi-root entities keep a distinct offset per root).
         """
-        is_root = l_info["parent_idx"] == -1
+        if l_info["parent_idx"] != -1:
+            return
+
+        # Compose the morph pose offset into the root link's world pose. The solver strips the matching offset in
+        # relative getters, so the user frame is unchanged.
+        offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
+        offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
+        l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
+            offset_pos, offset_quat, l_info["pos"], l_info["quat"]
+        )
+
         align = morph.align if isinstance(morph, gs.options.morphs.FileMorph) else False
         if align is None:
             # Auto: True for basic rigid objects (root with free joint only, no articulated descendants)
-            align = (
-                is_root
-                and not bool(l_info.get("is_robot", False))
-                and all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
+            align = not bool(l_info.get("is_robot", False)) and all(
+                j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos
             )
-        do_align = align and is_root and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
-
-        global_com = principal_quat = None
-        if do_align:
+        if align and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos):
             global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
                 cg_infos, vg_infos, _get_original_inertial_properties(l_info, morph.recompute_inertia)
             )
             if diagonal_inertial is not None:
-                l_info["inertial_pos"], l_info["inertial_quat"], l_info["inertial_i"] = diagonal_inertial
+                l_info["inertial_pos"] = diagonal_inertial.pos
+                l_info["inertial_quat"] = diagonal_inertial.quat
+                l_info["inertial_i"] = diagonal_inertial.i
 
-            # Shift link frame to COM and rotate to principal axes
+            # Shift the link frame to the COM and rotate to the principal axes, folding the alignment into the offset.
             l_info["pos"] = gu.transform_by_trans_quat(global_com, l_info["pos"], l_info["quat"])
             l_info["quat"] = gu.transform_quat_by_quat(principal_quat, l_info["quat"])
-
-            # Update free joint init_qpos to reflect the new link pose
-            for j_info in j_infos:
-                if j_info["type"] == gs.JOINT_TYPE.FREE:
-                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
-
-        if not is_root:
-            return
-        offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
-        offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
-        if do_align:
             offset_pos = gu.transform_by_trans_quat(global_com, offset_pos, offset_quat)
             offset_quat = gu.transform_quat_by_quat(principal_quat, offset_quat)
+
+        # Refresh the free joint init_qpos to reflect the composed world pose.
+        for j_info in j_infos:
+            if j_info["type"] == gs.JOINT_TYPE.FREE:
+                j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+
+        # Record the body-frame offset; the base link's also seeds the heterogeneous-variant offset.
         if not self._links_offset_quat:
             self._offset_pos, self._offset_quat = offset_pos, offset_quat
         self._links_offset_pos[link_idx - self._link_start] = offset_pos
@@ -2425,25 +2429,11 @@ class RigidEntity(KinematicEntity):
             else:
                 free_verts_start += link.n_verts
 
-        # Carry the morph pose offset into each root link's world pose (composed in the body frame). The solver strips
-        # the matching offset in relative getters, so the user frame is unchanged. The inertial alignment is folded
-        # into the same per-link offset in '_align_link', which the solver gathers at build.
-        if l_info["parent_idx"] < 0:
-            l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
-                np.array(morph.offset_pos, dtype=gs.np_float),
-                np.array(morph.offset_quat, dtype=gs.np_float),
-                l_info["pos"],
-                l_info["quat"],
-            )
-            for j_info in j_infos:
-                if j_info["type"] == gs.JOINT_TYPE.FREE:
-                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
-
         # Split and convexify collision geometry. Must be done before alignment so that
         # convexified geoms are used to compute the inertia frame.
         cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
 
-        # Align root links' frames to their collision geometry COM and principal inertia axes.
+        # Carry the morph pose offset into root links and align them to their collision-geometry COM/principal axes.
         self._align_link(l_info, j_infos, cg_infos, vg_infos, morph, link_idx)
 
         joints = self._create_joints(j_infos, link_idx, joint_start)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -180,9 +180,14 @@ class KinematicEntity(Entity):
         self._is_attached: bool = False
         self._variant_init_qpos: list[np.ndarray] | None = None
 
-        # Pose offset between the world frame (used by the solver) and the user frame (reported by relative getters).
-        # Seeded from the morph's 'offset_pos'/'offset_quat' (e.g. up-axis conversions) and further accumulated with the
-        # inertial-alignment transform of the base link in '_align_link'. Converted to tensors at build time.
+        # Per-link pose offset between the world frame (used by the solver) and the user frame (reported by relative
+        # getters), keyed by link index local to the entity. Only root links carry an offset (children stay identity);
+        # each is the morph 'offset_pos'/'offset_quat' (e.g. up-axis conversions) composed with that link's inertial
+        # alignment, filled in '_add_by_info'. Independent per root, so multi-root entities keep a distinct offset per
+        # root. The base link's offset is mirrored into '_offset_pos'/'_offset_quat' for the heterogeneous-variant seed.
+        # The solver gathers all of these into per-link tensors at build time.
+        self._links_offset_pos: dict[int, np.ndarray] = {}
+        self._links_offset_quat: dict[int, np.ndarray] = {}
         self._offset_pos = np.array(self._morph.offset_pos, dtype=gs.np_float)
         self._offset_quat = np.array(self._morph.offset_quat, dtype=gs.np_float)
 
@@ -1038,9 +1043,9 @@ class KinematicEntity(Entity):
         link_idx = self.n_links + self._link_start
         joint_start = self.n_joints + self._joint_start
 
-        # Carry the morph pose offset into the base link's world pose (composed in the base body frame). The solver
-        # strips the matching offset in relative getters, so the user frame is unchanged. The inertial alignment
-        # accumulates further into the offset in '_align_link', and the solver gathers the total at build.
+        # Carry the morph pose offset into each root link's world pose (composed in the body frame). The solver strips
+        # the matching offset in relative getters, so the user frame is unchanged. The inertial alignment is folded
+        # into the same per-link offset in '_align_link', which the solver gathers at build.
         if l_info["parent_idx"] < 0:
             l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
                 np.array(morph.offset_pos, dtype=gs.np_float),
@@ -1053,7 +1058,7 @@ class KinematicEntity(Entity):
                     j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
 
         cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
-        self._align_link(l_info, j_infos, cg_infos, vg_infos, morph)
+        self._align_link(l_info, j_infos, cg_infos, vg_infos, morph, link_idx)
 
         joints = self._create_joints(j_infos, link_idx, joint_start)
 
@@ -1137,46 +1142,54 @@ class KinematicEntity(Entity):
 
         return cg_infos, vg_infos
 
-    def _align_link(self, l_info, j_infos, cg_infos, vg_infos, morph):
-        """Align root link frame to collision geometry COM and principal inertia axes.
+    def _align_link(self, l_info, j_infos, cg_infos, vg_infos, morph, link_idx):
+        """Align a root link frame to its collision geometry COM and principal inertia axes, and record its offset.
 
-        Only applies to root (floating-base) links with a free joint. Mutates l_info,
-        j_infos, cg_infos, and vg_infos in-place so that kinematic and rigid entities
-        share the same aligned qpos and link frame definition.
+        Alignment only applies to root (floating-base) links with a free joint, and mutates l_info, j_infos, cg_infos,
+        and vg_infos in-place so kinematic and rigid entities share the same aligned qpos and link frame. Every root
+        link's pose offset (its morph 'offset_pos'/'offset_quat' composed with the inertial alignment, both in the body
+        frame) is stored in '_links_offset_*' so the relative getters report the user's original (unaligned) pose;
+        children carry no offset. Each root is independent, so multi-root entities keep a distinct offset per root.
         """
+        is_root = l_info["parent_idx"] == -1
         align = morph.align if isinstance(morph, gs.options.morphs.FileMorph) else False
         if align is None:
             # Auto: True for basic rigid objects (root with free joint only, no articulated descendants)
             align = (
-                l_info["parent_idx"] == -1
+                is_root
                 and not bool(l_info.get("is_robot", False))
                 and all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
             )
-        if not (
-            align and l_info["parent_idx"] == -1 and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
-        ):
+        do_align = align and is_root and any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
+
+        global_com = principal_quat = None
+        if do_align:
+            global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
+                cg_infos, vg_infos, _file_inertial(l_info, morph.recompute_inertia)
+            )
+            if diagonal_inertial is not None:
+                l_info["inertial_pos"], l_info["inertial_quat"], l_info["inertial_i"] = diagonal_inertial
+
+            # Shift link frame to COM and rotate to principal axes
+            l_info["pos"] = gu.transform_by_trans_quat(global_com, l_info["pos"], l_info["quat"])
+            l_info["quat"] = gu.transform_quat_by_quat(principal_quat, l_info["quat"])
+
+            # Update free joint init_qpos to reflect the new link pose
+            for j_info in j_infos:
+                if j_info["type"] == gs.JOINT_TYPE.FREE:
+                    j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+
+        if not is_root:
             return
-
-        global_com, principal_quat, diagonal_inertial = _align_geoms_to_inertia(
-            cg_infos, vg_infos, _file_inertial(l_info, morph.recompute_inertia)
-        )
-        if diagonal_inertial is not None:
-            l_info["inertial_pos"], l_info["inertial_quat"], l_info["inertial_i"] = diagonal_inertial
-
-        # Record the alignment as a body-frame pose offset so relative getters report the user's original (unaligned)
-        # base pose while the solver uses the COM-centered, principal-axis frame. Composed in the body frame: the COM
-        # is rotated by the current offset orientation, and the principal-axis rotation post-multiplies the offset.
-        self._offset_pos = gu.transform_by_trans_quat(global_com, self._offset_pos, self._offset_quat)
-        self._offset_quat = gu.transform_quat_by_quat(principal_quat, self._offset_quat)
-
-        # Shift link frame to COM and rotate to principal axes
-        l_info["pos"] = gu.transform_by_trans_quat(global_com, l_info["pos"], l_info["quat"])
-        l_info["quat"] = gu.transform_quat_by_quat(principal_quat, l_info["quat"])
-
-        # Update free joint init_qpos to reflect the new link pose
-        for j_info in j_infos:
-            if j_info["type"] == gs.JOINT_TYPE.FREE:
-                j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+        offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
+        offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
+        if do_align:
+            offset_pos = gu.transform_by_trans_quat(global_com, offset_pos, offset_quat)
+            offset_quat = gu.transform_quat_by_quat(principal_quat, offset_quat)
+        if not self._links_offset_quat:
+            self._offset_pos, self._offset_quat = offset_pos, offset_quat
+        self._links_offset_pos[link_idx - self._link_start] = offset_pos
+        self._links_offset_quat[link_idx - self._link_start] = offset_quat
 
     @gs.assert_unbuilt
     def attach(self, parent_entity, parent_link_name: str | None = None):
@@ -1537,7 +1550,7 @@ class KinematicEntity(Entity):
         return self._solver.get_links_ang(self.base_link_idx, envs_idx)[..., 0, :]
 
     @gs.assert_built
-    def get_links_pos(self, links_idx_local=None, envs_idx=None):
+    def get_links_pos(self, links_idx_local=None, envs_idx=None, *, relative=True):
         """
         Returns the position of a given reference point for all the entity's links.
 
@@ -1547,6 +1560,9 @@ class KinematicEntity(Entity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            If True, return the user-frame position with the morph pose offset stripped (matching the morph 'pos'); if
+            False, return the world-frame position used by the solver. Defaults to True.
 
         Returns
         -------
@@ -1554,10 +1570,10 @@ class KinematicEntity(Entity):
             The position of all the entity's links.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_pos(links_idx, envs_idx)
+        return self._solver.get_links_pos(links_idx, envs_idx, relative=relative)
 
     @gs.assert_built
-    def get_links_quat(self, links_idx_local=None, envs_idx=None):
+    def get_links_quat(self, links_idx_local=None, envs_idx=None, *, relative=True):
         """
         Returns quaternion of all the entity's links.
 
@@ -1567,6 +1583,9 @@ class KinematicEntity(Entity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            If True, return the user-frame orientation with the morph pose offset stripped (matching the morph
+            'quat'/'euler'); if False, return the world-frame orientation used by the solver. Defaults to True.
 
         Returns
         -------
@@ -1574,7 +1593,7 @@ class KinematicEntity(Entity):
             The quaternion of all the entity's links.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_quat(links_idx, envs_idx)
+        return self._solver.get_links_quat(links_idx, envs_idx, relative=relative)
 
     @gs.assert_built
     def get_vAABB(self, envs_idx=None):
@@ -1781,6 +1800,9 @@ class KinematicEntity(Entity):
     def get_qpos(self, qs_idx_local=None, envs_idx=None):
         """
         Get the entity's qpos.
+
+        For a free joint, the qpos holds the world-frame pose of the (solver) link origin: it is the raw generalized
+        coordinate and is never expressed in the user/offset frame, unlike the relative `get_pos`/`get_quat`.
 
         Parameters
         ----------
@@ -2405,9 +2427,9 @@ class RigidEntity(KinematicEntity):
             else:
                 free_verts_start += link.n_verts
 
-        # Carry the morph pose offset into the base link's world pose (composed in the base body frame). The solver
-        # strips the matching offset in relative getters, so the user frame is unchanged. The inertial alignment
-        # accumulates further into the offset in '_align_link', and the solver gathers the total at build.
+        # Carry the morph pose offset into each root link's world pose (composed in the body frame). The solver strips
+        # the matching offset in relative getters, so the user frame is unchanged. The inertial alignment is folded
+        # into the same per-link offset in '_align_link', which the solver gathers at build.
         if l_info["parent_idx"] < 0:
             l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
                 np.array(morph.offset_pos, dtype=gs.np_float),
@@ -2424,7 +2446,7 @@ class RigidEntity(KinematicEntity):
         cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
 
         # Align root links' frames to their collision geometry COM and principal inertia axes.
-        self._align_link(l_info, j_infos, cg_infos, vg_infos, morph)
+        self._align_link(l_info, j_infos, cg_infos, vg_infos, morph, link_idx)
 
         joints = self._create_joints(j_infos, link_idx, joint_start)
 
@@ -2755,6 +2777,9 @@ class RigidEntity(KinematicEntity):
         """
         Compute inverse kinematics for a single target link.
 
+        The target `pos`/`quat` are interpreted in the world frame (the morph pose offset is not applied), matching
+        the world-frame link poses returned by `forward_kinematics`.
+
         Parameters
         ----------
         link : RigidLink
@@ -3050,6 +3075,9 @@ class RigidEntity(KinematicEntity):
     def forward_kinematics(self, qpos, qs_idx_local=None, links_idx_local=None, envs_idx=None):
         """
         Compute forward kinematics for a single target link.
+
+        The returned link poses are in the world frame (the morph pose offset is not stripped), consistent with the
+        world-frame `qpos` input.
 
         Parameters
         ----------
@@ -3387,6 +3415,7 @@ class RigidEntity(KinematicEntity):
         envs_idx=None,
         *,
         ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        relative=True,
     ):
         """
         Returns the position of a given reference point for all the entity's links.
@@ -3402,6 +3431,10 @@ class RigidEntity(KinematicEntity):
             * "root_com": center of mass of the sub-entities to which the link belongs. As a reminder, a single
               kinematic tree (aka. 'RigidEntity') may compromise multiple "physical" entities, i.e. a kinematic tree
               that may have at most one free joint, at its root.
+        relative : bool, optional
+            If True, strip the morph pose offset to return the user-frame position; this only affects
+            ref="link_origin", since the offset is defined on the link origin. If False, return the world frame.
+            Defaults to True.
 
         Returns
         -------
@@ -3409,7 +3442,7 @@ class RigidEntity(KinematicEntity):
             The position of all the entity's links.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_pos(links_idx, envs_idx, ref=ref)
+        return self._solver.get_links_pos(links_idx, envs_idx, ref=ref, relative=relative)
 
     @gs.assert_built
     def get_links_vel(

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -307,7 +307,7 @@ class RigidGeom(RBC):
         if T is None:
             if pos is None:
                 T = gu.trans_quat_to_T(
-                    tensor_to_array(self.get_pos(relative=False)), tensor_to_array(self.get_quat(relative=False))
+                    *map(tensor_to_array, (self.get_pos(relative=False), self.get_quat(relative=False)))
                 )
             else:
                 T = gu.trans_to_T(np.array(pos))

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -306,7 +306,9 @@ class RigidGeom(RBC):
         sdf_mesh = self.get_sdf_trimesh(color)
         if T is None:
             if pos is None:
-                T = gu.trans_quat_to_T(tensor_to_array(self.get_pos()), tensor_to_array(self.get_quat()))
+                T = gu.trans_quat_to_T(
+                    tensor_to_array(self.get_pos(relative=False)), tensor_to_array(self.get_quat(relative=False))
+                )
             else:
                 T = gu.trans_to_T(np.array(pos))
         else:
@@ -346,20 +348,24 @@ class RigidGeom(RBC):
     # ------------------------------------------------------------------------------------
 
     @gs.assert_built
-    def get_pos(self, envs_idx=None):
+    def get_pos(self, envs_idx=None, *, relative=True):
         """
-        Get the position of the geom in world frame.
+        Get the position of the geom.
+
+        When 'relative' is True (default), the position is reported in the user frame, with the entity's morph pose
+        offset stripped, rather than the world frame used by the solver.
         """
-        tensor = qd_to_torch(self._solver.geoms_state.pos, envs_idx, self._idx, transpose=True, copy=True)[..., 0, :]
-        return tensor[0] if self._solver.n_envs == 0 else tensor
+        return self._solver.get_geoms_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
-    def get_quat(self, envs_idx=None):
+    def get_quat(self, envs_idx=None, *, relative=True):
         """
-        Get the quaternion of the geom in world frame.
+        Get the quaternion of the geom.
+
+        When 'relative' is True (default), the orientation is reported in the user frame, with the entity's morph pose
+        offset stripped, rather than the world frame used by the solver.
         """
-        tensor = qd_to_torch(self._solver.geoms_state.quat, envs_idx, self._idx, transpose=True, copy=True)[..., 0, :]
-        return tensor[0] if self._solver.n_envs == 0 else tensor
+        return self._solver.get_geoms_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
     def get_verts(self):
@@ -872,20 +878,24 @@ class RigidVisGeom(RBC):
     # ------------------------------------------------------------------------------------
 
     @gs.assert_built
-    def get_pos(self, envs_idx=None):
+    def get_pos(self, envs_idx=None, *, relative=True):
         """
-        Get the position of the geom in world frame.
+        Get the position of the visual geom.
+
+        When 'relative' is True (default), the position is reported in the user frame, with the entity's morph pose
+        offset stripped, rather than the world frame used by the solver.
         """
-        tensor = qd_to_torch(self._solver.vgeoms_state.pos, envs_idx, self._idx, transpose=True, copy=True)[..., 0, :]
-        return tensor[0] if self._solver.n_envs == 0 else tensor
+        return self._solver.get_vgeoms_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
-    def get_quat(self, envs_idx=None):
+    def get_quat(self, envs_idx=None, *, relative=True):
         """
-        Get the quaternion of the geom in world frame.
+        Get the quaternion of the visual geom.
+
+        When 'relative' is True (default), the orientation is reported in the user frame, with the entity's morph pose
+        offset stripped, rather than the world frame used by the solver.
         """
-        tensor = qd_to_torch(self._solver.vgeoms_state.quat, envs_idx, self._idx, transpose=True, copy=True)[..., 0, :]
-        return tensor[0] if self._solver.n_envs == 0 else tensor
+        return self._solver.get_vgeoms_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
     def get_vAABB(self, envs_idx=None):
@@ -903,7 +913,10 @@ class RigidVisGeom(RBC):
             self._aabb_verts = torch.from_numpy(aabb_mesh.verts).to(dtype=gs.tc_float, device=gs.device)
 
         pos, quat = gu.transform_pos_quat_by_trans_quat(
-            self._init_pos_tc, self._init_quat_tc, self.link.get_pos(envs_idx), self.link.get_quat(envs_idx)
+            self._init_pos_tc,
+            self._init_quat_tc,
+            self.link.get_pos(envs_idx, relative=False),
+            self.link.get_quat(envs_idx, relative=False),
         )
         vverts_pos = pos[..., None, :] + gu.transform_by_quat(self._aabb_verts, quat[..., None, :])
         return torch.stack((vverts_pos.min(dim=-2).values, vverts_pos.max(dim=-2).values), dim=-2)

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -251,28 +251,34 @@ class KinematicLink(RBC):
     # ------------------------------------------------------------------------------------
 
     @gs.assert_built
-    def get_pos(self, envs_idx=None):
+    def get_pos(self, envs_idx=None, *, relative=True):
         """
-        Get the position of the link in the world frame.
+        Get the position of the link.
 
         Parameters
         ----------
         envs_idx : int or array of int, optional
             The indices of the environments to get the position. If None, get the position of all environments. Default is None.
+        relative : bool, optional
+            Whether to report the position in the user frame, with the entity's morph pose offset and inertial
+            alignment stripped, rather than the world frame used by the solver. Defaults to True.
         """
-        return self._solver.get_links_pos(self._idx, envs_idx)[..., 0, :]
+        return self._solver.get_links_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
-    def get_quat(self, envs_idx=None):
+    def get_quat(self, envs_idx=None, *, relative=True):
         """
-        Get the quaternion of the link in the world frame.
+        Get the quaternion of the link.
 
         Parameters
         ----------
         envs_idx : int or array of int, optional
             The indices of the environments to get the quaternion. If None, get the quaternion of all environments. Default is None.
+        relative : bool, optional
+            Whether to report the orientation in the user frame, with the entity's morph pose offset and inertial
+            alignment stripped, rather than the world frame used by the solver. Defaults to True.
         """
-        return self._solver.get_links_quat(self._idx, envs_idx)[..., 0, :]
+        return self._solver.get_links_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
     def get_vel(self, envs_idx=None) -> torch.Tensor:

--- a/genesis/engine/entities/tool_entity/tool_entity.py
+++ b/genesis/engine/entities/tool_entity/tool_entity.py
@@ -34,14 +34,12 @@ class ToolEntity(Entity):
         super().__init__(idx, scene, morph, solver, material, surface, name=name)
 
         # The morph pose offset (e.g. an up-axis conversion) is composed onto the morph pose.
-        init_pos, init_quat = transform_pos_quat_by_trans_quat(
+        self._init_pos, self._init_quat = transform_pos_quat_by_trans_quat(
             np.array(morph.offset_pos, dtype=gs.np_float),
             np.array(morph.offset_quat, dtype=gs.np_float),
             np.array(morph.pos, dtype=gs.np_float),
             np.array(morph.quat, dtype=gs.np_float),
         )
-        self._init_pos = np.array(init_pos, dtype=gs.np_float)
-        self._init_quat = np.array(init_quat, dtype=gs.np_float)
 
         self.mesh = Mesh(
             entity=self,

--- a/genesis/engine/entities/tool_entity/tool_entity.py
+++ b/genesis/engine/entities/tool_entity/tool_entity.py
@@ -10,6 +10,7 @@ from genesis.engine.states.entities import ToolEntityState
 from genesis.utils.geom import (
     qd_rotvec_to_quat,
     qd_transform_quat_by_quat,
+    transform_pos_quat_by_trans_quat,
 )
 from genesis.utils.misc import to_gs_tensor
 
@@ -32,8 +33,15 @@ class ToolEntity(Entity):
     ):
         super().__init__(idx, scene, morph, solver, material, surface, name=name)
 
-        self._init_pos = np.array(morph.pos, dtype=gs.np_float)
-        self._init_quat = np.array(morph.quat, dtype=gs.np_float)
+        # The morph pose offset (e.g. an up-axis conversion) is composed onto the morph pose.
+        init_pos, init_quat = transform_pos_quat_by_trans_quat(
+            np.array(morph.offset_pos, dtype=gs.np_float),
+            np.array(morph.offset_quat, dtype=gs.np_float),
+            np.array(morph.pos, dtype=gs.np_float),
+            np.array(morph.quat, dtype=gs.np_float),
+        )
+        self._init_pos = np.array(init_pos, dtype=gs.np_float)
+        self._init_quat = np.array(init_quat, dtype=gs.np_float)
 
         self.mesh = Mesh(
             entity=self,

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -287,8 +287,8 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
             up = torch.tensor(self._options.up, dtype=gs.tc_float, device=gs.device)
             offset_T = pos_lookat_up_to_T(pos, lookat, up)
 
-        link_pos = self._link.get_pos()
-        link_quat = self._link.get_quat()
+        link_pos = self._link.get_pos(relative=False)
+        link_quat = self._link.get_quat(relative=False)
 
         link_T = trans_quat_to_T(link_pos, link_quat)
         camera_T = torch.matmul(link_T, offset_T)
@@ -514,8 +514,8 @@ class RasterizerCameraSensor(
         # If attached to a link and the link is built, pos is relative to link frame
         if self._link is not None and self._link.is_built:
             # Convert pos from link-relative to world coordinates
-            link_pos = self._link.get_pos()
-            link_quat = self._link.get_quat()
+            link_pos = self._link.get_pos(relative=False)
+            link_quat = self._link.get_quat(relative=False)
 
             # Apply pos directly as offset from link
             pos_world = transform_by_quat(pos, link_quat) + link_pos
@@ -646,8 +646,8 @@ class RaytracerCameraSensor(
 
         # If attached to a link and the link is built, transform pos to world coordinates
         if self._link is not None and self._link.is_built:
-            link_pos = self._link.get_pos().squeeze(0)
-            link_quat = self._link.get_quat().squeeze(0)
+            link_pos = self._link.get_pos(relative=False).squeeze(0)
+            link_quat = self._link.get_quat(relative=False).squeeze(0)
 
             # Apply pos directly as offset from link
             pos = transform_by_trans_quat(pos, link_pos, link_quat)

--- a/genesis/engine/sensors/contact_force.py
+++ b/genesis/engine/sensors/contact_force.py
@@ -179,7 +179,7 @@ class ContactSensor(SimpleSensor[ContactSensorOptions, None, ContactSensorMetada
         """
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None
 
-        pos = self._link.get_pos(env_idx).reshape((3,))
+        pos = self._link.get_pos(env_idx, relative=False).reshape((3,))
         is_contact = self.read(env_idx)
 
         if self.debug_object is not None:
@@ -313,8 +313,8 @@ class ContactForceSensor(
         """
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None
 
-        pos = self._link.get_pos(env_idx).reshape((3,))
-        quat = self._link.get_quat(env_idx).reshape((4,))
+        pos = self._link.get_pos(env_idx, relative=False).reshape((3,))
+        quat = self._link.get_quat(env_idx, relative=False).reshape((4,))
 
         force = self.read(env_idx).reshape((3,))
         vec = tensor_to_array(transform_by_quat(force * self._options.debug_scale, quat))

--- a/genesis/engine/sensors/imu.py
+++ b/genesis/engine/sensors/imu.py
@@ -204,8 +204,8 @@ class IMUSensor(RigidSensorMixin[IMUSharedMetadata], SimpleSensor[IMUOptions, No
         """
         env_idx = context.rendered_envs_idx[0] if self._manager._sim.n_envs > 0 else None
 
-        quat = self._link.get_quat(env_idx).reshape((4,))
-        pos = self._link.get_pos(env_idx).reshape((3,)) + transform_by_quat(self.pos_offset, quat)
+        quat = self._link.get_quat(env_idx, relative=False).reshape((4,))
+        pos = self._link.get_pos(env_idx, relative=False).reshape((3,)) + transform_by_quat(self.pos_offset, quat)
 
         # cannot specify envs_idx for read() when n_envs=0
         data = self.read(env_idx)

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -700,8 +700,8 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
                 active_mask = tensor_to_array(active_envs_mask[:, envs_idx].T).astype(bool)
                 if not active_mask.any():
                     continue
-                trk_pos = trk_link.get_pos(envs_idx)[:, None, :]
-                trk_quat = trk_link.get_quat(envs_idx)[:, None, :]
+                trk_pos = trk_link.get_pos(envs_idx, relative=False)[:, None, :]
+                trk_quat = trk_link.get_quat(envs_idx, relative=False)[:, None, :]
                 pc_world = gu.transform_by_trans_quat(pos_local[None, :, :], trk_pos, trk_quat)
                 pc_world = tensor_to_array(pc_world) + env_offsets[:, None, :]
                 world_chunks.append(pc_world[active_mask])
@@ -710,8 +710,8 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
                 pos_active = pos_local[active_mask]
                 if pos_active.numel() == 0:
                     continue
-                trk_pos = trk_link.get_pos(envs_idx).reshape(3)
-                trk_quat = trk_link.get_quat(envs_idx).reshape(4)
+                trk_pos = trk_link.get_pos(envs_idx, relative=False).reshape(3)
+                trk_quat = trk_link.get_quat(envs_idx, relative=False).reshape(4)
                 world_chunks.append(tensor_to_array(gu.transform_by_trans_quat(pos_active, trk_pos, trk_quat)))
         if not world_chunks:
             return

--- a/genesis/engine/sensors/probe.py
+++ b/genesis/engine/sensors/probe.py
@@ -118,8 +118,8 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
             envs_idx = list(context.rendered_envs_idx)
             n_debug_envs = len(envs_idx)
             env_offsets = context.scene.envs_offset[np.asarray(envs_idx, dtype=gs.np_int)]
-            link_pos = self._link.get_pos(envs_idx)[:, None, :]
-            link_quat = self._link.get_quat(envs_idx)[:, None, :]
+            link_pos = self._link.get_pos(envs_idx, relative=False)[:, None, :]
+            link_quat = self._link.get_quat(envs_idx, relative=False)[:, None, :]
             probe_world = gu.transform_by_trans_quat(
                 self._probe_local_pos.reshape(-1, 3)[None, :, :], link_pos, link_quat
             )
@@ -128,8 +128,8 @@ class ProbeSensorMixin(Generic[ProbeSensorSharedMetadataT]):
             envs_idx = None
             n_debug_envs = 1
             env_offsets = None
-            link_pos = self._link.get_pos(envs_idx).reshape(3)
-            link_quat = self._link.get_quat(envs_idx).reshape(4)
+            link_pos = self._link.get_pos(envs_idx, relative=False).reshape(3)
+            link_quat = self._link.get_quat(envs_idx, relative=False).reshape(4)
             probe_world = tensor_to_array(
                 gu.transform_by_trans_quat(self._probe_local_pos.reshape(-1, 3), link_pos, link_quat)
             )

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -419,8 +419,8 @@ class RaycasterSensor(
         data = self.read(env_idx)
         points = data.points.reshape((-1, 3))
 
-        pos = self._link.get_pos(env_idx)
-        quat = self._link.get_quat(env_idx)
+        pos = self._link.get_pos(env_idx, relative=False)
+        quat = self._link.get_quat(env_idx, relative=False)
         if pos.ndim == 2:
             pos, quat = pos[0], quat[0]
 

--- a/genesis/engine/sensors/surface_distance_probe.py
+++ b/genesis/engine/sensors/surface_distance_probe.py
@@ -322,8 +322,8 @@ class SurfaceDistanceProbeSensor(
             context.clear_debug_object(obj)
         self._debug_objects.clear()
 
-        link_pos = self._link.get_pos(env_idx).squeeze()
-        link_quat = self._link.get_quat(env_idx).squeeze()
+        link_pos = self._link.get_pos(env_idx, relative=False).squeeze()
+        link_quat = self._link.get_quat(env_idx, relative=False).squeeze()
         probe_world = tensor_to_array(gu.transform_by_trans_quat(self._probe_local_pos, link_pos, link_quat))
         points = tensor_to_array(self.nearest_points[env_idx]).reshape(-1, 3)
 

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -600,7 +600,7 @@ class TemperatureGridSensor(
             aabb_world = aabb_world.unsqueeze(0)  # (1, 2, 3)
         aabb_min_w = aabb_world[0, 0]  # (3,)
         aabb_max_w = aabb_world[0, 1]  # (3,)
-        link_pos, link_quat = self._link.get_pos(), self._link.get_quat()
+        link_pos, link_quat = self._link.get_pos(relative=False), self._link.get_quat(relative=False)
         if link_pos.ndim == 2:
             link_pos, link_quat = link_pos[0], link_quat[0]
         aabb_min_local = gu.inv_transform_by_trans_quat(aabb_min_w, link_pos, link_quat)
@@ -816,8 +816,8 @@ class TemperatureGridSensor(
                 context.clear_debug_object(obj)
         self._debug_objects = []
 
-        link_pos = self._link.get_pos(env_idx)
-        link_quat = self._link.get_quat(env_idx)
+        link_pos = self._link.get_pos(env_idx, relative=False)
+        link_quat = self._link.get_quat(env_idx, relative=False)
         link_pos = tensor_to_array(link_pos).reshape(3)
         link_quat = tensor_to_array(link_quat).reshape(4)
         link_T = gu.trans_quat_to_T(link_pos, link_quat)

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -869,6 +869,15 @@ class KinematicSolver(Solver):
         )
         if self.n_envs == 0:
             pos_grad_ = pos_grad_.unsqueeze(0)
+        # A relative 'set_pos' adds 'R(user_quat) @ offset_pos', which reads the current orientation; that dependency
+        # is not propagated, so with a non-zero offset position the backward pass is only supported on links without
+        # one. 'relative=False' sets the world position directly and is a plain passthrough.
+        if relative and not self._links_offset_pos_is_identity[links_idx].all():
+            gs.raise_exception(
+                "Backward pass for 'set_pos' with 'relative=True' is only supported on links without an offset "
+                "position (no inertial alignment shifting the link origin). Use 'relative=False' to set the world "
+                "position."
+            )
         kernel_set_links_pos_grad(
             pos_grad_,
             links_idx,

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -84,6 +84,16 @@ def _select_links_offset(offset, links_idx, envs_idx):
     return offset[indices_to_mask(row_mask, links_idx)]
 
 
+def _offset_world_shift(offset_pos, offset_quat, world_quat):
+    """World-frame displacement contributed by a body-frame offset position at a given world orientation.
+
+    The user orientation is 'world_quat' with the offset stripped, and 'offset_pos' rotates with it. Relative getters
+    subtract this from the world position to recover the user position; relative setters add it to do the reverse.
+    """
+    user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), world_quat)
+    return gu.transform_by_quat(offset_pos, user_quat)
+
+
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
     """Fill the per-geom forward offset for an entity's collision or visual geoms.
 
@@ -268,8 +278,10 @@ class KinematicSolver(Solver):
             _fill_base_link_geom_offsets(vgeoms_offset_pos, vgeoms_offset_quat, entity, entity.vgeoms, vgeoms_ranges)
         # Per-link identity flags gate the relative backward passes: a relative set on a link whose offset is identity
         # is a plain passthrough and stays differentiable, while a non-identity offset drops the composition jacobian.
-        links_offset_quat_is_identity = np.all(np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0), axis=2).all(axis=0)
-        links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0), axis=2).all(axis=0)
+        links_offset_quat_is_identity = np.all(
+            np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0, atol=gs.EPS), axis=2
+        ).all(axis=0)
+        links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=2).all(axis=0)
         self._links_offset_quat_is_identity = torch.from_numpy(links_offset_quat_is_identity).to(device=gs.device)
         self._links_offset_pos_is_identity = torch.from_numpy(links_offset_pos_is_identity).to(device=gs.device)
         self._links_offset_pos = self._links_offset_quat = None
@@ -277,7 +289,10 @@ class KinematicSolver(Solver):
             self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
             self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
         self._vgeoms_offset_pos = self._vgeoms_offset_quat = None
-        if not (np.allclose(vgeoms_offset_pos, 0.0) and np.allclose(gu.quat_to_xyz(vgeoms_offset_quat), 0.0)):
+        if not (
+            np.allclose(vgeoms_offset_pos, 0.0, atol=gs.EPS)
+            and np.allclose(gu.quat_to_xyz(vgeoms_offset_quat), 0.0, atol=gs.EPS)
+        ):
             self._vgeoms_offset_pos = torch.from_numpy(vgeoms_offset_pos).to(device=gs.device, dtype=gs.tc_float)
             self._vgeoms_offset_quat = torch.from_numpy(vgeoms_offset_quat).to(device=gs.device, dtype=gs.tc_float)
 
@@ -828,8 +843,7 @@ class KinematicSolver(Solver):
             cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
-            pos = pos + gu.transform_by_quat(offset_pos, user_quat)
+            pos = pos + _offset_world_shift(offset_pos, offset_quat, cur_quat)
             relative = False
 
         kernel_set_links_pos(
@@ -909,8 +923,7 @@ class KinematicSolver(Solver):
                 cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
                 cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
                 offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-                cur_user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
-                user_pos = cur_pos - gu.transform_by_quat(offset_pos, cur_user_quat)
+                user_pos = cur_pos - _offset_world_shift(offset_pos, offset_quat, cur_quat)
                 world_pos = user_pos + gu.transform_by_quat(offset_pos, quat)
                 kernel_set_links_pos(
                     world_pos,
@@ -1163,8 +1176,7 @@ class KinematicSolver(Solver):
             quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
-            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
+            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_quat(self, links_idx=None, envs_idx=None, *, relative=False):
@@ -1180,8 +1192,7 @@ class KinematicSolver(Solver):
             quat = qd_to_torch(self.vgeoms_state.quat, envs_idx, vgeoms_idx, transpose=True, copy=True)
             offset_pos = self._vgeoms_offset_pos if vgeoms_idx is None else self._vgeoms_offset_pos[vgeoms_idx]
             offset_quat = self._vgeoms_offset_quat if vgeoms_idx is None else self._vgeoms_offset_quat[vgeoms_idx]
-            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
-            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
+            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_vgeoms_quat(self, vgeoms_idx=None, envs_idx=None, *, relative=False):

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -85,34 +85,43 @@ def _select_links_offset(offset, links_idx, envs_idx):
 
 
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
-    """Fill the per-geom forward offset for a base link's collision or visual geoms.
+    """Fill the per-geom forward offset for an entity's collision or visual geoms.
 
-    Each geom's stored offset is the (per-variant) morph offset conjugated into the geom's own frame, so the
-    body-frame strip in the relative getters reverts it even for geoms rotated/translated relative to the link. A
-    geom's world pose is 'link_pose . G' with 'link_pose' carrying 'link_offset = morph_offset . alignment' (G is the
-    geom pose relative to the link); reverting only the morph offset from the geom's own frame needs '(link_offset .
-    G)^-1 . morph_offset . (link_offset . G)'. This equals the morph offset itself when the geom is aligned with the
-    link or the offset is a pure translation. 'ranges' are the per-variant geom index ranges, or None when uniform.
+    Each geom's stored offset is the morph offset (per-variant for a heterogeneous base link, else its own root link's
+    offset) conjugated into the geom's own frame, so the body-frame strip in the relative getters reverts it even for
+    geoms rotated/translated relative to the link. A geom's world pose is 'link_pose . G' with 'link_pose' carrying
+    'link_offset = morph_offset . alignment' (G is the geom pose relative to the link); reverting only the morph offset
+    from the geom's own frame needs '(link_offset . G)^-1 . morph_offset . (link_offset . G)'. This equals the morph
+    offset itself when the geom is aligned with the link or the offset is a pure translation. 'ranges' are the
+    per-variant geom index ranges for a heterogeneous base link, or None to use each geom's own root link offset.
     """
     for geom in geoms:
-        i_variant = 0 if ranges is None else next(i for i, (start, end) in enumerate(ranges) if start <= geom.idx < end)
-        morph = entity._morph if i_variant == 0 else entity._morph_heterogeneous[i_variant - 1]
-        link_off_pos, link_off_quat = (
-            (entity._variant_offset_pos[i_variant], entity._variant_offset_quat[i_variant])
-            if entity._variant_offset_pos is not None
-            else (entity._offset_pos, entity._offset_quat)
-        )
+        if ranges is None:
+            link_off_pos = entity._links_offset_pos.get(geom.link.idx - entity._link_start)
+            if link_off_pos is None:
+                continue
+            link_off_quat = entity._links_offset_quat[geom.link.idx - entity._link_start]
+            morph = entity._morph
+        else:
+            # 'ranges' only cover the heterogeneous base link's variant geoms; geoms on other (child) links carry no
+            # offset, so skip them.
+            i_variant = next((i for i, (start, end) in enumerate(ranges) if start <= geom.idx < end), None)
+            if i_variant is None:
+                continue
+            link_off_pos = entity._variant_offset_pos[i_variant]
+            link_off_quat = entity._variant_offset_quat[i_variant]
+            morph = entity._morph if i_variant == 0 else entity._morph_heterogeneous[i_variant - 1]
         frame_pos, frame_quat = gu.transform_pos_quat_by_trans_quat(
             geom.init_pos, geom.init_quat, link_off_pos, link_off_quat
         )
-        t_pos, t_quat = gu.transform_pos_quat_by_trans_quat(
+        offset_frame_pos, offset_frame_quat = gu.transform_pos_quat_by_trans_quat(
             frame_pos,
             frame_quat,
             np.array(morph.offset_pos, dtype=gs.np_float),
             np.array(morph.offset_quat, dtype=gs.np_float),
         )
         offset_pos[geom.idx], offset_quat[geom.idx] = gu.inv_transform_pos_quat_by_trans_quat(
-            t_pos, t_quat, frame_pos, frame_quat
+            offset_frame_pos, offset_frame_quat, frame_pos, frame_quat
         )
 
 
@@ -248,20 +257,23 @@ class KinematicSolver(Solver):
                 links_offset_quat[np.arange(self._B), entity.base_link_idx] = np.stack(
                     [entity._variant_offset_quat[v] for v in variant_idx]
                 )
+                vgeoms_ranges = entity.base_link._variant_vgeom_ranges
             else:
-                links_offset_pos[:, entity.base_link_idx] = entity._offset_pos
-                links_offset_quat[:, entity.base_link_idx] = entity._offset_quat
-            # Only the base link carries the offset; its visual geoms get the morph offset conjugated into their own
-            # frame (child-link geoms inherit the offset through the kinematic chain and keep an identity offset).
-            base_link = entity.links[0]
-            _fill_base_link_geom_offsets(
-                vgeoms_offset_pos, vgeoms_offset_quat, entity, base_link.vgeoms, base_link._variant_vgeom_ranges
-            )
-        # Whether the orientation offset is identity everywhere, used to gate the 'set_quat' backward pass at build
-        # time rather than per call (the offset is fixed once the scene is built).
-        self._links_offset_quat_is_identity = bool(np.allclose(gu.quat_to_xyz(links_offset_quat), 0.0))
+                # Each root link carries its own offset; children inherit it through the kinematic chain and stay
+                # identity. Visual geoms get the morph offset conjugated into their own frame.
+                for local_idx, link_offset_pos in entity._links_offset_pos.items():
+                    links_offset_pos[:, entity._link_start + local_idx] = link_offset_pos
+                    links_offset_quat[:, entity._link_start + local_idx] = entity._links_offset_quat[local_idx]
+                vgeoms_ranges = None
+            _fill_base_link_geom_offsets(vgeoms_offset_pos, vgeoms_offset_quat, entity, entity.vgeoms, vgeoms_ranges)
+        # Per-link identity flags gate the relative backward passes: a relative set on a link whose offset is identity
+        # is a plain passthrough and stays differentiable, while a non-identity offset drops the composition jacobian.
+        links_offset_quat_is_identity = np.all(np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0), axis=2).all(axis=0)
+        links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0), axis=2).all(axis=0)
+        self._links_offset_quat_is_identity = torch.from_numpy(links_offset_quat_is_identity).to(device=gs.device)
+        self._links_offset_pos_is_identity = torch.from_numpy(links_offset_pos_is_identity).to(device=gs.device)
         self._links_offset_pos = self._links_offset_quat = None
-        if not (np.allclose(links_offset_pos, 0.0) and self._links_offset_quat_is_identity):
+        if not (links_offset_pos_is_identity.all() and links_offset_quat_is_identity.all()):
             self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
             self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
         self._vgeoms_offset_pos = self._vgeoms_offset_quat = None
@@ -810,7 +822,7 @@ class KinematicSolver(Solver):
         if self.n_envs == 0:
             pos = pos[None]
 
-        if relative and self._links_offset_pos is not None:
+        if relative:
             # Compose the body-frame offset onto the user position while keeping the current orientation, then set the
             # resulting world position.
             cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
@@ -821,7 +833,6 @@ class KinematicSolver(Solver):
             relative = False
 
         kernel_set_links_pos(
-            relative,
             pos,
             links_idx,
             envs_idx,
@@ -859,7 +870,6 @@ class KinematicSolver(Solver):
         if self.n_envs == 0:
             pos_grad_ = pos_grad_.unsqueeze(0)
         kernel_set_links_pos_grad(
-            relative,
             pos_grad_,
             links_idx,
             envs_idx,
@@ -882,13 +892,31 @@ class KinematicSolver(Solver):
         if self.n_envs == 0:
             quat = quat[None]
 
-        if relative and self._links_offset_quat is not None:
+        if relative:
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            if not self._links_offset_pos_is_identity[links_idx].all():
+                # The offset position rotates with the orientation, so keep the user-frame position fixed by rewriting
+                # the world position from the current user position and the new user orientation.
+                cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
+                cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+                offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+                cur_user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
+                user_pos = cur_pos - gu.transform_by_quat(offset_pos, cur_user_quat)
+                world_pos = user_pos + gu.transform_by_quat(offset_pos, quat)
+                kernel_set_links_pos(
+                    world_pos,
+                    links_idx,
+                    envs_idx,
+                    links_info=self.links_info,
+                    links_state=self.links_state,
+                    rigid_global_info=self._rigid_global_info,
+                    static_rigid_sim_config=self._static_rigid_sim_config,
+                )
             # Compose the offset onto the user orientation, then set the resulting world orientation.
-            quat = gu.transform_quat_by_quat(_select_links_offset(self._links_offset_quat, links_idx, envs_idx), quat)
+            quat = gu.transform_quat_by_quat(offset_quat, quat)
             relative = False
 
         kernel_set_links_quat(
-            relative,
             quat,
             links_idx,
             envs_idx,
@@ -925,16 +953,18 @@ class KinematicSolver(Solver):
         )
         if self.n_envs == 0:
             quat_grad_ = quat_grad_.unsqueeze(0)
-        # The offset orientation enters 'set_quat' as a constant right-multiplication that is not propagated through
-        # the quaternion gradient, so differentiation is only supported in the world frame without an orientation
-        # offset (the offset position does not affect the orientation gradient).
-        if relative or not self._links_offset_quat_is_identity:
+        # A relative 'set_quat' composes the orientation offset (a constant right-multiplication) and, when the offset
+        # position is non-zero, also rewrites the world position from the input orientation. Neither jacobian is
+        # propagated, so the backward pass is only supported when the targeted links carry no pose offset. With
+        # 'relative=False' the world orientation is set directly, which is a plain passthrough and always differentiable.
+        if relative and not (
+            self._links_offset_quat_is_identity[links_idx].all() and self._links_offset_pos_is_identity[links_idx].all()
+        ):
             gs.raise_exception(
-                "Backward pass for 'set_quat' is only supported with 'relative=False' on entities without an "
-                "orientation offset (no up-axis conversion or inertial alignment)."
+                "Backward pass for 'set_quat' with 'relative=True' is only supported on links without a pose offset "
+                "(no up-axis conversion or inertial alignment). Use 'relative=False' to set the world orientation."
             )
         kernel_set_links_quat_grad(
-            relative,
             quat_grad_,
             links_idx,
             envs_idx,

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -5,6 +5,7 @@ import torch
 
 import genesis as gs
 import genesis.utils.array_class as array_class
+import genesis.utils.geom as gu
 from genesis.engine.entities.rigid_entity import KinematicEntity
 from genesis.engine.states.solvers import KinematicSolverState
 from genesis.options.solvers import RigidOptions, KinematicOptions
@@ -68,6 +69,51 @@ def _balanced_variant_mapping(n_variants, B):
         return np.repeat(np.arange(n_variants), sizes)
     else:
         return np.arange(B)
+
+
+def _select_links_offset(offset, links_idx, envs_idx):
+    """Index a base-link forward offset for a transposed state query.
+
+    'offset' has shape '[n_offset_envs, n_links, dim]', where 'n_offset_envs' is 1 for an environment-uniform offset
+    (broadcast over the batch) or 'n_envs' when heterogeneous variants make it environment-specific. It is indexed
+    with the same combined mask as 'qd_to_torch' so the result broadcasts against the '[n_envs, n_sel, dim]' state
+    tensor, keeping the link dimension for integer indices. The environment axis is left unindexed (broadcast) when
+    the offset is environment-uniform.
+    """
+    row_mask = None if offset.shape[0] == 1 else envs_idx
+    return offset[indices_to_mask(row_mask, links_idx)]
+
+
+def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
+    """Fill the per-geom forward offset for a base link's collision or visual geoms.
+
+    Each geom's stored offset is the (per-variant) morph offset conjugated into the geom's own frame, so the
+    body-frame strip in the relative getters reverts it even for geoms rotated/translated relative to the link. A
+    geom's world pose is 'link_pose . G' with 'link_pose' carrying 'link_offset = morph_offset . alignment' (G is the
+    geom pose relative to the link); reverting only the morph offset from the geom's own frame needs '(link_offset .
+    G)^-1 . morph_offset . (link_offset . G)'. This equals the morph offset itself when the geom is aligned with the
+    link or the offset is a pure translation. 'ranges' are the per-variant geom index ranges, or None when uniform.
+    """
+    for geom in geoms:
+        i_variant = 0 if ranges is None else next(i for i, (start, end) in enumerate(ranges) if start <= geom.idx < end)
+        morph = entity._morph if i_variant == 0 else entity._morph_heterogeneous[i_variant - 1]
+        link_off_pos, link_off_quat = (
+            (entity._variant_offset_pos[i_variant], entity._variant_offset_quat[i_variant])
+            if entity._variant_offset_pos is not None
+            else (entity._offset_pos, entity._offset_quat)
+        )
+        frame_pos, frame_quat = gu.transform_pos_quat_by_trans_quat(
+            geom.init_pos, geom.init_quat, link_off_pos, link_off_quat
+        )
+        t_pos, t_quat = gu.transform_pos_quat_by_trans_quat(
+            frame_pos,
+            frame_quat,
+            np.array(morph.offset_pos, dtype=gs.np_float),
+            np.array(morph.offset_quat, dtype=gs.np_float),
+        )
+        offset_pos[geom.idx], offset_quat[geom.idx] = gu.inv_transform_pos_quat_by_trans_quat(
+            t_pos, t_quat, frame_pos, frame_quat
+        )
 
 
 IS_OLD_TORCH = tuple(map(int, torch.__version__.split(".")[:2])) < (2, 8)
@@ -173,6 +219,55 @@ class KinematicSolver(Solver):
             if joint.type == gs.JOINT_TYPE.FREE:
                 base_links_idx.append(joint.link.idx)
         self._base_links_idx = torch.tensor(base_links_idx, dtype=gs.tc_int, device=gs.device)
+
+        # World<-user pose offset, applied by the relative get/set methods. Links carry the morph offset composed with
+        # the base-link inertial alignment (identity for non-base links); geoms and visual geoms carry only the morph
+        # offset, since alignment re-expresses them into the aligned frame. Heterogeneous entities vary the base-link
+        # offset per environment (one offset per variant), so the link offset is stored per-env when any such entity
+        # has divergent variant offsets, and as a single broadcast row otherwise. Forward offset device tensors are
+        # None when everything is identity, and the relative getters recompute the inverse on the fly.
+        links_offset_per_env = any(
+            entity._variant_offset_pos is not None
+            and not all(
+                np.allclose(pos, entity._variant_offset_pos[0]) and np.allclose(quat, entity._variant_offset_quat[0])
+                for pos, quat in zip(entity._variant_offset_pos, entity._variant_offset_quat)
+            )
+            for entity in self._entities
+        )
+        n_offset_envs = self._B if links_offset_per_env else 1
+        links_offset_pos = np.zeros((n_offset_envs, self.n_links, 3), dtype=gs.np_float)
+        links_offset_quat = np.tile(gu.identity_quat(), (n_offset_envs, self.n_links, 1))
+        vgeoms_offset_pos = np.zeros((self.n_vgeoms, 3), dtype=gs.np_float)
+        vgeoms_offset_quat = np.tile(gu.identity_quat(), (self.n_vgeoms, 1))
+        for entity in self._entities:
+            if links_offset_per_env and entity._variant_offset_pos is not None:
+                variant_idx = _balanced_variant_mapping(len(entity._variant_offset_pos), self._B)
+                links_offset_pos[np.arange(self._B), entity.base_link_idx] = np.stack(
+                    [entity._variant_offset_pos[v] for v in variant_idx]
+                )
+                links_offset_quat[np.arange(self._B), entity.base_link_idx] = np.stack(
+                    [entity._variant_offset_quat[v] for v in variant_idx]
+                )
+            else:
+                links_offset_pos[:, entity.base_link_idx] = entity._offset_pos
+                links_offset_quat[:, entity.base_link_idx] = entity._offset_quat
+            # Only the base link carries the offset; its visual geoms get the morph offset conjugated into their own
+            # frame (child-link geoms inherit the offset through the kinematic chain and keep an identity offset).
+            base_link = entity.links[0]
+            _fill_base_link_geom_offsets(
+                vgeoms_offset_pos, vgeoms_offset_quat, entity, base_link.vgeoms, base_link._variant_vgeom_ranges
+            )
+        # Whether the orientation offset is identity everywhere, used to gate the 'set_quat' backward pass at build
+        # time rather than per call (the offset is fixed once the scene is built).
+        self._links_offset_quat_is_identity = bool(np.allclose(gu.quat_to_xyz(links_offset_quat), 0.0))
+        self._links_offset_pos = self._links_offset_quat = None
+        if not (np.allclose(links_offset_pos, 0.0) and self._links_offset_quat_is_identity):
+            self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
+            self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
+        self._vgeoms_offset_pos = self._vgeoms_offset_quat = None
+        if not (np.allclose(vgeoms_offset_pos, 0.0) and np.allclose(gu.quat_to_xyz(vgeoms_offset_quat), 0.0)):
+            self._vgeoms_offset_pos = torch.from_numpy(vgeoms_offset_pos).to(device=gs.device, dtype=gs.tc_float)
+            self._vgeoms_offset_quat = torch.from_numpy(vgeoms_offset_quat).to(device=gs.device, dtype=gs.tc_float)
 
         self.n_qs_ = max(1, self.n_qs)
         self.n_dofs_ = max(1, self.n_dofs)
@@ -706,11 +801,24 @@ class KinematicSolver(Solver):
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
+        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
+        if relative and self._links_offset_pos is None:
+            relative = False
         pos, links_idx, envs_idx = self._sanitize_io_variables(
             pos, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
         )
         if self.n_envs == 0:
             pos = pos[None]
+
+        if relative and self._links_offset_pos is not None:
+            # Compose the body-frame offset onto the user position while keeping the current orientation, then set the
+            # resulting world position.
+            cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
+            pos = pos + gu.transform_by_quat(offset_pos, user_quat)
+            relative = False
 
         kernel_set_links_pos(
             relative,
@@ -765,11 +873,19 @@ class KinematicSolver(Solver):
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
+        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
+        if relative and self._links_offset_quat is None:
+            relative = False
         quat, links_idx, envs_idx = self._sanitize_io_variables(
             quat, links_idx, self.n_links, "links_idx", envs_idx, (4,), skip_allocation=True
         )
         if self.n_envs == 0:
             quat = quat[None]
+
+        if relative and self._links_offset_quat is not None:
+            # Compose the offset onto the user orientation, then set the resulting world orientation.
+            quat = gu.transform_quat_by_quat(_select_links_offset(self._links_offset_quat, links_idx, envs_idx), quat)
+            relative = False
 
         kernel_set_links_quat(
             relative,
@@ -809,7 +925,14 @@ class KinematicSolver(Solver):
         )
         if self.n_envs == 0:
             quat_grad_ = quat_grad_.unsqueeze(0)
-        assert relative == False, "Backward pass for relative quaternion is not supported yet."
+        # The offset orientation enters 'set_quat' as a constant right-multiplication that is not propagated through
+        # the quaternion gradient, so differentiation is only supported in the world frame without an orientation
+        # offset (the offset position does not affect the orientation gradient).
+        if relative or not self._links_offset_quat_is_identity:
+            gs.raise_exception(
+                "Backward pass for 'set_quat' is only supported with 'relative=False' on entities without an "
+                "orientation offset (no up-axis conversion or inertial alignment)."
+            )
         kernel_set_links_quat_grad(
             relative,
             quat_grad_,
@@ -991,16 +1114,42 @@ class KinematicSolver(Solver):
         self._is_forward_pos_updated = True
         self._is_forward_vel_updated = True
 
-    def get_links_pos(self, links_idx=None, envs_idx=None):
+    def get_links_pos(self, links_idx=None, envs_idx=None, *, relative=False):
         if not gs.use_zerocopy:
             _, links_idx, envs_idx = self._sanitize_io_variables(
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
             )
         tensor = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
+        if relative and self._links_offset_pos is not None:
+            quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
+            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_links_quat(self, links_idx=None, envs_idx=None):
+    def get_links_quat(self, links_idx=None, envs_idx=None, *, relative=False):
         tensor = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+        if relative and self._links_offset_quat is not None:
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
+        return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_vgeoms_pos(self, vgeoms_idx=None, envs_idx=None, *, relative=False):
+        tensor = qd_to_torch(self.vgeoms_state.pos, envs_idx, vgeoms_idx, transpose=True, copy=True)
+        if relative and self._vgeoms_offset_pos is not None:
+            quat = qd_to_torch(self.vgeoms_state.quat, envs_idx, vgeoms_idx, transpose=True, copy=True)
+            offset_pos = self._vgeoms_offset_pos if vgeoms_idx is None else self._vgeoms_offset_pos[vgeoms_idx]
+            offset_quat = self._vgeoms_offset_quat if vgeoms_idx is None else self._vgeoms_offset_quat[vgeoms_idx]
+            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
+            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
+        return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_vgeoms_quat(self, vgeoms_idx=None, envs_idx=None, *, relative=False):
+        tensor = qd_to_torch(self.vgeoms_state.quat, envs_idx, vgeoms_idx, transpose=True, copy=True)
+        if relative and self._vgeoms_offset_quat is not None:
+            offset_quat = self._vgeoms_offset_quat if vgeoms_idx is None else self._vgeoms_offset_quat[vgeoms_idx]
+            tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_vel(self, links_idx=None, envs_idx=None):

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -276,16 +276,15 @@ class KinematicSolver(Solver):
                     links_offset_quat[:, entity._link_start + local_idx] = entity._links_offset_quat[local_idx]
                 vgeoms_ranges = None
             _fill_base_link_geom_offsets(vgeoms_offset_pos, vgeoms_offset_quat, entity, entity.vgeoms, vgeoms_ranges)
-        # Per-link identity flags gate the relative backward passes: a relative set on a link whose offset is identity
-        # is a plain passthrough and stays differentiable, while a non-identity offset drops the composition jacobian.
-        links_offset_quat_is_identity = np.all(
+        # Per-link identity masks gate the relative set/backward paths: a relative set on a link whose offset is
+        # identity is a plain passthrough, while a non-identity offset rewrites the world position or drops the
+        # composition jacobian. Kept as host-side numpy (never used in kernels) so the gates avoid a GPU->host sync.
+        self._links_offset_quat_is_identity = np.all(
             np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0, atol=gs.EPS), axis=2
         ).all(axis=0)
-        links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=2).all(axis=0)
-        self._links_offset_quat_is_identity = torch.from_numpy(links_offset_quat_is_identity).to(device=gs.device)
-        self._links_offset_pos_is_identity = torch.from_numpy(links_offset_pos_is_identity).to(device=gs.device)
+        self._links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=2).all(axis=0)
         self._links_offset_pos = self._links_offset_quat = None
-        if not (links_offset_pos_is_identity.all() and links_offset_quat_is_identity.all()):
+        if not (self._links_offset_pos_is_identity.all() and self._links_offset_quat_is_identity.all()):
             self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
             self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
         self._vgeoms_offset_pos = self._vgeoms_offset_quat = None
@@ -878,20 +877,21 @@ class KinematicSolver(Solver):
     def set_base_links_pos_grad(self, links_idx, envs_idx, relative, pos_grad):
         if links_idx is None:
             links_idx = self._base_links_idx
-        pos_grad_, links_idx, envs_idx = self._sanitize_io_variables(
-            pos_grad.unsqueeze(-2), links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
-        )
-        if self.n_envs == 0:
-            pos_grad_ = pos_grad_.unsqueeze(0)
         # A relative 'set_pos' adds 'R(user_quat) @ offset_pos', which reads the current orientation; that dependency
         # is not propagated, so with a non-zero offset position the backward pass is only supported on links without
         # one. 'relative=False' sets the world position directly and is a plain passthrough.
-        if relative and not self._links_offset_pos_is_identity[links_idx].all():
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        if relative and not self._links_offset_pos_is_identity[idx].all():
             gs.raise_exception(
                 "Backward pass for 'set_pos' with 'relative=True' is only supported on links without an offset "
                 "position (no inertial alignment shifting the link origin). Use 'relative=False' to set the world "
                 "position."
             )
+        pos_grad_, links_idx, envs_idx = self._sanitize_io_variables(
+            pos_grad.unsqueeze(-2), links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
+        )
+        if self.n_envs == 0:
+            pos_grad_ = pos_grad_.unsqueeze(0)
         kernel_set_links_pos_grad(
             pos_grad_,
             links_idx,
@@ -909,6 +909,8 @@ class KinematicSolver(Solver):
         # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
         if relative and self._links_offset_quat is None:
             relative = False
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        pos_is_identity = relative and self._links_offset_pos_is_identity[idx].all()
         quat, links_idx, envs_idx = self._sanitize_io_variables(
             quat, links_idx, self.n_links, "links_idx", envs_idx, (4,), skip_allocation=True
         )
@@ -917,7 +919,7 @@ class KinematicSolver(Solver):
 
         if relative:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            if not self._links_offset_pos_is_identity[links_idx].all():
+            if not pos_is_identity:
                 # The offset position rotates with the orientation, so keep the user-frame position fixed by rewriting
                 # the world position from the current user position and the new user orientation.
                 cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
@@ -970,22 +972,23 @@ class KinematicSolver(Solver):
     def set_base_links_quat_grad(self, links_idx, envs_idx, relative, quat_grad):
         if links_idx is None:
             links_idx = self._base_links_idx
-        quat_grad_, links_idx, envs_idx = self._sanitize_io_variables(
-            quat_grad.unsqueeze(-2), links_idx, self.n_links, "links_idx", envs_idx, (4,), skip_allocation=True
-        )
-        if self.n_envs == 0:
-            quat_grad_ = quat_grad_.unsqueeze(0)
         # A relative 'set_quat' composes the orientation offset (a constant right-multiplication) and, when the offset
         # position is non-zero, also rewrites the world position from the input orientation. Neither jacobian is
         # propagated, so the backward pass is only supported when the targeted links carry no pose offset. With
         # 'relative=False' the world orientation is set directly, which is a plain passthrough and always differentiable.
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
         if relative and not (
-            self._links_offset_quat_is_identity[links_idx].all() and self._links_offset_pos_is_identity[links_idx].all()
+            self._links_offset_quat_is_identity[idx].all() and self._links_offset_pos_is_identity[idx].all()
         ):
             gs.raise_exception(
                 "Backward pass for 'set_quat' with 'relative=True' is only supported on links without a pose offset "
                 "(no up-axis conversion or inertial alignment). Use 'relative=False' to set the world orientation."
             )
+        quat_grad_, links_idx, envs_idx = self._sanitize_io_variables(
+            quat_grad.unsqueeze(-2), links_idx, self.n_links, "links_idx", envs_idx, (4,), skip_allocation=True
+        )
+        if self.n_envs == 0:
+            quat_grad_ = quat_grad_.unsqueeze(0)
         kernel_set_links_quat_grad(
             quat_grad_,
             links_idx,

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -910,7 +910,7 @@ class KinematicSolver(Solver):
         if relative and self._links_offset_quat is None:
             relative = False
         idx = links_idx if isinstance(links_idx, int) else slice(None)
-        pos_is_identity = relative and self._links_offset_pos_is_identity[idx].all()
+        relative_pos_passthrough = relative and self._links_offset_pos_is_identity[idx].all()
         quat, links_idx, envs_idx = self._sanitize_io_variables(
             quat, links_idx, self.n_links, "links_idx", envs_idx, (4,), skip_allocation=True
         )
@@ -919,7 +919,7 @@ class KinematicSolver(Solver):
 
         if relative:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            if not pos_is_identity:
+            if not relative_pos_passthrough:
                 # The offset position rotates with the orientation, so keep the user-frame position fixed by rewriting
                 # the world position from the current user position and the new user orientation.
                 cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -219,7 +219,6 @@ def kernel_get_state_grad(
 
 @qd.kernel(fastcache=True)
 def kernel_set_links_pos(
-    relative: qd.template(),
     pos: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
@@ -237,18 +236,10 @@ def kernel_set_links_pos(
         if links_info.parent_idx[I_l] == -1 and links_info.is_fixed[I_l]:
             for j in qd.static(range(3)):
                 links_state.pos[i_l, i_b][j] = pos[i_b_, i_l_, j]
-            if qd.static(relative):
-                for j in qd.static(range(3)):
-                    links_state.pos[i_l, i_b][j] = links_state.pos[i_l, i_b][j] + links_info.pos[I_l][j]
         else:
             q_start = links_info.q_start[I_l]
             for j in qd.static(range(3)):
                 rigid_global_info.qpos[q_start + j, i_b] = pos[i_b_, i_l_, j]
-            if qd.static(relative):
-                for j in qd.static(range(3)):
-                    rigid_global_info.qpos[q_start + j, i_b] = (
-                        rigid_global_info.qpos[q_start + j, i_b] + rigid_global_info.qpos0[q_start + j, i_b]
-                    )
 
 
 @qd.kernel(fastcache=True)
@@ -292,7 +283,6 @@ def kernel_wake_up_entities_by_links(
 
 @qd.kernel(fastcache=True)
 def kernel_set_links_pos_grad(
-    relative: qd.i32,
     pos_grad: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
@@ -320,7 +310,6 @@ def kernel_set_links_pos_grad(
 
 @qd.kernel(fastcache=True)
 def kernel_set_links_quat(
-    relative: qd.template(),
     quat: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
@@ -335,45 +324,17 @@ def kernel_set_links_quat(
         i_l = links_idx[i_l_]
         I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
 
-        if qd.static(relative):
-            quat_ = qd.Vector(
-                [
-                    quat[i_b_, i_l_, 0],
-                    quat[i_b_, i_l_, 1],
-                    quat[i_b_, i_l_, 2],
-                    quat[i_b_, i_l_, 3],
-                ],
-                dt=gs.qd_float,
-            )
-            if links_info.parent_idx[I_l] == -1 and links_info.is_fixed[I_l]:
-                links_state.quat[i_l, i_b] = gu.qd_transform_quat_by_quat(links_info.quat[I_l], quat_)
-            else:
-                q_start = links_info.q_start[I_l]
-                quat0 = qd.Vector(
-                    [
-                        rigid_global_info.qpos0[q_start + 3, i_b],
-                        rigid_global_info.qpos0[q_start + 4, i_b],
-                        rigid_global_info.qpos0[q_start + 5, i_b],
-                        rigid_global_info.qpos0[q_start + 6, i_b],
-                    ],
-                    dt=gs.qd_float,
-                )
-                quat_ = gu.qd_transform_quat_by_quat(quat0, quat_)
-                for j in qd.static(range(4)):
-                    rigid_global_info.qpos[q_start + j + 3, i_b] = quat_[j]
+        if links_info.parent_idx[I_l] == -1 and links_info.is_fixed[I_l]:
+            for j in qd.static(range(4)):
+                links_state.quat[i_l, i_b][j] = quat[i_b_, i_l_, j]
         else:
-            if links_info.parent_idx[I_l] == -1 and links_info.is_fixed[I_l]:
-                for j in qd.static(range(4)):
-                    links_state.quat[i_l, i_b][j] = quat[i_b_, i_l_, j]
-            else:
-                q_start = links_info.q_start[I_l]
-                for j in qd.static(range(4)):
-                    rigid_global_info.qpos[q_start + j + 3, i_b] = quat[i_b_, i_l_, j]
+            q_start = links_info.q_start[I_l]
+            for j in qd.static(range(4)):
+                rigid_global_info.qpos[q_start + j + 3, i_b] = quat[i_b_, i_l_, j]
 
 
 @qd.kernel(fastcache=True)
 def kernel_set_links_quat_grad(
-    relative: qd.template(),
     quat_grad: qd.types.ndarray(),
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -9,6 +9,7 @@ import torch
 
 import genesis as gs
 import genesis.utils.array_class as array_class
+import genesis.utils.geom as gu
 from genesis.engine.entities import DroneEntity, RigidEntity
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.states import QueriedStates, RigidSolverState
@@ -28,7 +29,7 @@ from genesis.utils.misc import (
 from genesis.utils.sdf import SDF
 
 from ..base_solver import Solver, StateChange, mutates
-from ..kinematic_solver import KinematicSolver
+from ..kinematic_solver import KinematicSolver, _select_links_offset, _fill_base_link_geom_offsets
 from .collider import Collider
 from .constraint import ConstraintSolver, ConstraintSolverIsland
 from .abd.misc import (
@@ -360,6 +361,22 @@ class RigidSolver(KinematicSolver):
 
         self._init_collider()
         self._init_constraint_solver()
+
+        # Morph pose offset of each collision geom, conjugated into the geom's own frame so the relative getters
+        # revert it for geoms rotated relative to the link. Only the base link carries the offset; child-link geoms
+        # inherit it through the kinematic chain and keep an identity offset. Forward offset device tensors, None when
+        # everything is identity; the relative geom getters recompute the inverse.
+        geoms_offset_pos = np.zeros((self.n_geoms, 3), dtype=gs.np_float)
+        geoms_offset_quat = np.tile(gu.identity_quat(), (self.n_geoms, 1))
+        for entity in self._entities:
+            base_link = entity.links[0]
+            _fill_base_link_geom_offsets(
+                geoms_offset_pos, geoms_offset_quat, entity, base_link.geoms, base_link._variant_geom_ranges
+            )
+        self._geoms_offset_pos = self._geoms_offset_quat = None
+        if not (np.allclose(geoms_offset_pos, 0.0) and np.allclose(gu.quat_to_xyz(geoms_offset_quat), 0.0)):
+            self._geoms_offset_pos = torch.from_numpy(geoms_offset_pos).to(device=gs.device, dtype=gs.tc_float)
+            self._geoms_offset_quat = torch.from_numpy(geoms_offset_quat).to(device=gs.device, dtype=gs.tc_float)
 
         # FIXME: when the migration is finished, we will remove the about two lines
         self._func_vel_at_point = func_vel_at_point
@@ -1780,6 +1797,21 @@ class RigidSolver(KinematicSolver):
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
+        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
+        if relative and self._links_offset_pos is None:
+            relative = False
+        # Map a single base link's user position to world here (keeping the current orientation) so the zero-copy
+        # in-place write below still applies, both for an environment-uniform and a per-environment offset. Multi-link
+        # relative sets are composed in the kernel branch instead.
+        if relative and isinstance(links_idx, int):
+            cur_quat = self.get_links_quat(links_idx, envs_idx, relative=False)[..., 0, :]
+            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)[..., 0, :]
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)[..., 0, :]
+            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
+            pos = torch.as_tensor(pos, dtype=gs.tc_float, device=gs.device) + gu.transform_by_quat(
+                offset_pos, user_quat
+            )
+            relative = False
 
         # Zero-copy fast path: single base link, non-relative. Write the position buffer in place instead of
         # launching a kernel. The kernel path below handles relative or multi-link updates, as well as waking up
@@ -1826,6 +1858,16 @@ class RigidSolver(KinematicSolver):
             )
             if self.n_envs == 0:
                 pos = pos[None]
+
+            if relative and self._links_offset_pos is not None:
+                # Compose the body-frame offset onto the user position, keeping the current orientation, then set the
+                # resulting world position absolutely.
+                cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+                offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+                offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+                user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
+                pos = pos + gu.transform_by_quat(offset_pos, user_quat)
+                relative = False
 
             # Raise exception for fixed links with at least one geom and non-batched fixed vertices, except if setting
             # same location for all envs at once
@@ -1901,6 +1943,16 @@ class RigidSolver(KinematicSolver):
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
+        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
+        if relative and self._links_offset_quat is None:
+            relative = False
+        # Compose a single base link's user orientation to world here so the zero-copy in-place write below still
+        # applies, both for an environment-uniform and a per-environment offset. Multi-link relative sets are composed
+        # in the kernel branch instead.
+        if relative and isinstance(links_idx, int):
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)[..., 0, :]
+            quat = gu.transform_quat_by_quat(offset_quat, torch.as_tensor(quat, dtype=gs.tc_float, device=gs.device))
+            relative = False
 
         # Zero-copy fast path: single base link, non-relative. Write the quaternion buffer in place instead of
         # launching a kernel. The kernel path below handles relative or multi-link updates, as well as waking up
@@ -1946,6 +1998,12 @@ class RigidSolver(KinematicSolver):
             )
             if self.n_envs == 0:
                 quat = quat[None]
+
+            if relative and self._links_offset_quat is not None:
+                # Compose the offset onto the user orientation, then set the resulting world orientation absolutely.
+                offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+                quat = gu.transform_quat_by_quat(offset_quat, quat)
+                relative = False
 
             set_all_envs = torch.equal(torch.sort(envs_idx).values, self._scene._envs_idx)
             has_fixed_verts = any(
@@ -2514,7 +2572,12 @@ class RigidSolver(KinematicSolver):
             gs.raise_exception("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
 
     def get_links_pos(
-        self, links_idx=None, envs_idx=None, *, ref: Literal["link_origin", "link_com", "root_com"] = "link_origin"
+        self,
+        links_idx=None,
+        envs_idx=None,
+        *,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        relative=False,
     ):
         if not gs.use_zerocopy:
             _, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2532,6 +2595,14 @@ class RigidSolver(KinematicSolver):
             tensor = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
         else:
             gs.raise_exception("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
+
+        # The pose offset is defined on the link origin, so it is only stripped for the 'link_origin' reference.
+        if relative and ref_idx == 2 and self._links_offset_pos is not None:
+            quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
+            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
 
         return tensor[0] if self.n_envs == 0 else tensor
 
@@ -2608,12 +2679,21 @@ class RigidSolver(KinematicSolver):
         tensor = qd_to_torch(self.geoms_state.friction_ratio, envs_idx, geoms_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_geoms_pos(self, geoms_idx=None, envs_idx=None):
+    def get_geoms_pos(self, geoms_idx=None, envs_idx=None, *, relative=False):
         tensor = qd_to_torch(self.geoms_state.pos, envs_idx, geoms_idx, transpose=True, copy=True)
+        if relative and self._geoms_offset_pos is not None:
+            quat = qd_to_torch(self.geoms_state.quat, envs_idx, geoms_idx, transpose=True, copy=True)
+            offset_pos = self._geoms_offset_pos if geoms_idx is None else self._geoms_offset_pos[geoms_idx]
+            offset_quat = self._geoms_offset_quat if geoms_idx is None else self._geoms_offset_quat[geoms_idx]
+            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
+            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_geoms_quat(self, geoms_idx=None, envs_idx=None):
+    def get_geoms_quat(self, geoms_idx=None, envs_idx=None, *, relative=False):
         tensor = qd_to_torch(self.geoms_state.quat, envs_idx, geoms_idx, transpose=True, copy=True)
+        if relative and self._geoms_offset_quat is not None:
+            offset_quat = self._geoms_offset_quat if geoms_idx is None else self._geoms_offset_quat[geoms_idx]
+            tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_dofs_control_force(self, dofs_idx=None, envs_idx=None):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -363,16 +363,14 @@ class RigidSolver(KinematicSolver):
         self._init_constraint_solver()
 
         # Morph pose offset of each collision geom, conjugated into the geom's own frame so the relative getters
-        # revert it for geoms rotated relative to the link. Only the base link carries the offset; child-link geoms
+        # revert it for geoms rotated relative to the link. Each root link carries its own offset; child-link geoms
         # inherit it through the kinematic chain and keep an identity offset. Forward offset device tensors, None when
         # everything is identity; the relative geom getters recompute the inverse.
         geoms_offset_pos = np.zeros((self.n_geoms, 3), dtype=gs.np_float)
         geoms_offset_quat = np.tile(gu.identity_quat(), (self.n_geoms, 1))
         for entity in self._entities:
-            base_link = entity.links[0]
-            _fill_base_link_geom_offsets(
-                geoms_offset_pos, geoms_offset_quat, entity, base_link.geoms, base_link._variant_geom_ranges
-            )
+            ranges = entity.base_link._variant_geom_ranges if entity._variant_offset_pos is not None else None
+            _fill_base_link_geom_offsets(geoms_offset_pos, geoms_offset_quat, entity, entity.geoms, ranges)
         self._geoms_offset_pos = self._geoms_offset_quat = None
         if not (np.allclose(geoms_offset_pos, 0.0) and np.allclose(gu.quat_to_xyz(geoms_offset_quat), 0.0)):
             self._geoms_offset_pos = torch.from_numpy(geoms_offset_pos).to(device=gs.device, dtype=gs.tc_float)
@@ -1859,7 +1857,7 @@ class RigidSolver(KinematicSolver):
             if self.n_envs == 0:
                 pos = pos[None]
 
-            if relative and self._links_offset_pos is not None:
+            if relative:
                 # Compose the body-frame offset onto the user position, keeping the current orientation, then set the
                 # resulting world position absolutely.
                 cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
@@ -1899,7 +1897,6 @@ class RigidSolver(KinematicSolver):
                 )
 
             kernel_set_links_pos(
-                relative,
                 pos,
                 links_idx,
                 envs_idx,
@@ -1947,9 +1944,10 @@ class RigidSolver(KinematicSolver):
         if relative and self._links_offset_quat is None:
             relative = False
         # Compose a single base link's user orientation to world here so the zero-copy in-place write below still
-        # applies, both for an environment-uniform and a per-environment offset. Multi-link relative sets are composed
-        # in the kernel branch instead.
-        if relative and isinstance(links_idx, int):
+        # applies, both for an environment-uniform and a per-environment offset. This only preserves the user-frame
+        # position when the offset position is identity; a non-zero offset position rotates with the orientation and
+        # is handled (together with multi-link relative sets) in the kernel branch instead.
+        if relative and isinstance(links_idx, int) and self._links_offset_pos_is_identity[links_idx]:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)[..., 0, :]
             quat = gu.transform_quat_by_quat(offset_quat, torch.as_tensor(quat, dtype=gs.tc_float, device=gs.device))
             relative = False
@@ -1999,9 +1997,27 @@ class RigidSolver(KinematicSolver):
             if self.n_envs == 0:
                 quat = quat[None]
 
-            if relative and self._links_offset_quat is not None:
-                # Compose the offset onto the user orientation, then set the resulting world orientation absolutely.
+            if relative:
                 offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+                if not self._links_offset_pos_is_identity[links_idx].all():
+                    # The offset position rotates with the orientation, so keep the user-frame position fixed by
+                    # rewriting the world position from the current user position and the new user orientation.
+                    cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
+                    cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
+                    offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+                    cur_user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
+                    user_pos = cur_pos - gu.transform_by_quat(offset_pos, cur_user_quat)
+                    world_pos = user_pos + gu.transform_by_quat(offset_pos, quat)
+                    kernel_set_links_pos(
+                        world_pos,
+                        links_idx,
+                        envs_idx,
+                        links_info=self.links_info,
+                        links_state=self.links_state,
+                        rigid_global_info=self._rigid_global_info,
+                        static_rigid_sim_config=self._static_rigid_sim_config,
+                    )
+                # Compose the offset onto the user orientation, then set the resulting world orientation absolutely.
                 quat = gu.transform_quat_by_quat(offset_quat, quat)
                 relative = False
 
@@ -2030,7 +2046,6 @@ class RigidSolver(KinematicSolver):
                 )
 
             kernel_set_links_quat(
-                relative,
                 quat,
                 links_idx,
                 envs_idx,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1948,11 +1948,15 @@ class RigidSolver(KinematicSolver):
         if relative and self._links_offset_quat is None:
             relative = False
 
+        # Computed once and reused by the int fast path and the kernel branch below.
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        pos_is_identity = relative and self._links_offset_pos_is_identity[idx].all()
+
         # Compose a single base link's user orientation to world here so the zero-copy in-place write below still
         # applies, both for an environment-uniform and a per-environment offset. This only preserves the user-frame
         # position when the offset position is identity; a non-zero offset position rotates with the orientation and
         # is handled (together with multi-link relative sets) in the kernel branch instead.
-        if relative and isinstance(links_idx, int) and self._links_offset_pos_is_identity[links_idx]:
+        if relative and isinstance(links_idx, int) and pos_is_identity:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)[..., 0, :]
             quat = gu.transform_quat_by_quat(offset_quat, torch.as_tensor(quat, dtype=gs.tc_float, device=gs.device))
             relative = False
@@ -2004,7 +2008,7 @@ class RigidSolver(KinematicSolver):
 
             if relative:
                 offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-                if not self._links_offset_pos_is_identity[links_idx].all():
+                if not pos_is_identity:
                     # The offset position rotates with the orientation, so keep the user-frame position fixed by
                     # rewriting the world position from the current user position and the new user orientation.
                     cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -29,7 +29,7 @@ from genesis.utils.misc import (
 from genesis.utils.sdf import SDF
 
 from ..base_solver import Solver, StateChange, mutates
-from ..kinematic_solver import KinematicSolver, _select_links_offset, _fill_base_link_geom_offsets
+from ..kinematic_solver import KinematicSolver, _select_links_offset, _offset_world_shift, _fill_base_link_geom_offsets
 from .collider import Collider
 from .constraint import ConstraintSolver, ConstraintSolverIsland
 from .abd.misc import (
@@ -372,7 +372,10 @@ class RigidSolver(KinematicSolver):
             ranges = entity.base_link._variant_geom_ranges if entity._variant_offset_pos is not None else None
             _fill_base_link_geom_offsets(geoms_offset_pos, geoms_offset_quat, entity, entity.geoms, ranges)
         self._geoms_offset_pos = self._geoms_offset_quat = None
-        if not (np.allclose(geoms_offset_pos, 0.0) and np.allclose(gu.quat_to_xyz(geoms_offset_quat), 0.0)):
+        if not (
+            np.allclose(geoms_offset_pos, 0.0, atol=gs.EPS)
+            and np.allclose(gu.quat_to_xyz(geoms_offset_quat), 0.0, atol=gs.EPS)
+        ):
             self._geoms_offset_pos = torch.from_numpy(geoms_offset_pos).to(device=gs.device, dtype=gs.tc_float)
             self._geoms_offset_quat = torch.from_numpy(geoms_offset_quat).to(device=gs.device, dtype=gs.tc_float)
 
@@ -1795,9 +1798,11 @@ class RigidSolver(KinematicSolver):
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
+
         # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
         if relative and self._links_offset_pos is None:
             relative = False
+
         # Map a single base link's user position to world here (keeping the current orientation) so the zero-copy
         # in-place write below still applies, both for an environment-uniform and a per-environment offset. Multi-link
         # relative sets are composed in the kernel branch instead.
@@ -1805,9 +1810,8 @@ class RigidSolver(KinematicSolver):
             cur_quat = self.get_links_quat(links_idx, envs_idx, relative=False)[..., 0, :]
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)[..., 0, :]
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)[..., 0, :]
-            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
-            pos = torch.as_tensor(pos, dtype=gs.tc_float, device=gs.device) + gu.transform_by_quat(
-                offset_pos, user_quat
+            pos = torch.as_tensor(pos, dtype=gs.tc_float, device=gs.device) + _offset_world_shift(
+                offset_pos, offset_quat, cur_quat
             )
             relative = False
 
@@ -1863,8 +1867,7 @@ class RigidSolver(KinematicSolver):
                 cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
                 offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
                 offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-                user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
-                pos = pos + gu.transform_by_quat(offset_pos, user_quat)
+                pos = pos + _offset_world_shift(offset_pos, offset_quat, cur_quat)
                 relative = False
 
             # Raise exception for fixed links with at least one geom and non-batched fixed vertices, except if setting
@@ -1940,9 +1943,11 @@ class RigidSolver(KinematicSolver):
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
+
         # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
         if relative and self._links_offset_quat is None:
             relative = False
+
         # Compose a single base link's user orientation to world here so the zero-copy in-place write below still
         # applies, both for an environment-uniform and a per-environment offset. This only preserves the user-frame
         # position when the offset position is identity; a non-zero offset position rotates with the orientation and
@@ -2005,8 +2010,7 @@ class RigidSolver(KinematicSolver):
                     cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)
                     cur_quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
                     offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-                    cur_user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), cur_quat)
-                    user_pos = cur_pos - gu.transform_by_quat(offset_pos, cur_user_quat)
+                    user_pos = cur_pos - _offset_world_shift(offset_pos, offset_quat, cur_quat)
                     world_pos = user_pos + gu.transform_by_quat(offset_pos, quat)
                     kernel_set_links_pos(
                         world_pos,
@@ -2616,8 +2620,7 @@ class RigidSolver(KinematicSolver):
             quat = qd_to_torch(self.links_state.quat, envs_idx, links_idx, transpose=True, copy=True)
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
-            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
+            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
 
         return tensor[0] if self.n_envs == 0 else tensor
 
@@ -2700,8 +2703,7 @@ class RigidSolver(KinematicSolver):
             quat = qd_to_torch(self.geoms_state.quat, envs_idx, geoms_idx, transpose=True, copy=True)
             offset_pos = self._geoms_offset_pos if geoms_idx is None else self._geoms_offset_pos[geoms_idx]
             offset_quat = self._geoms_offset_quat if geoms_idx is None else self._geoms_offset_quat[geoms_idx]
-            user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), quat)
-            tensor = tensor - gu.transform_by_quat(offset_pos, user_quat)
+            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_geoms_quat(self, geoms_idx=None, envs_idx=None, *, relative=False):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1950,13 +1950,13 @@ class RigidSolver(KinematicSolver):
 
         # Computed once and reused by the int fast path and the kernel branch below.
         idx = links_idx if isinstance(links_idx, int) else slice(None)
-        pos_is_identity = relative and self._links_offset_pos_is_identity[idx].all()
+        relative_pos_passthrough = relative and self._links_offset_pos_is_identity[idx].all()
 
         # Compose a single base link's user orientation to world here so the zero-copy in-place write below still
         # applies, both for an environment-uniform and a per-environment offset. This only preserves the user-frame
         # position when the offset position is identity; a non-zero offset position rotates with the orientation and
         # is handled (together with multi-link relative sets) in the kernel branch instead.
-        if relative and isinstance(links_idx, int) and pos_is_identity:
+        if isinstance(links_idx, int) and relative_pos_passthrough:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)[..., 0, :]
             quat = gu.transform_quat_by_quat(offset_quat, torch.as_tensor(quat, dtype=gs.tc_float, device=gs.device))
             relative = False
@@ -2008,7 +2008,7 @@ class RigidSolver(KinematicSolver):
 
             if relative:
                 offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-                if not pos_is_identity:
+                if not relative_pos_passthrough:
                     # The offset position rotates with the orientation, so keep the user-frame position fixed by
                     # rewriting the world position from the current user position and the new user orientation.
                     cur_pos = qd_to_torch(self.links_state.pos, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/ext/pyrender/overlay/plugin.py
+++ b/genesis/ext/pyrender/overlay/plugin.py
@@ -681,8 +681,8 @@ class ImGuiOverlayPlugin(ViewerPlugin):
 
         entity = data.entity
 
-        pos = tensor_to_array(entity.get_pos())
-        quat_wxyz = tensor_to_array(entity.get_quat())
+        pos = tensor_to_array(entity.get_pos(relative=False))
+        quat_wxyz = tensor_to_array(entity.get_quat(relative=False))
         if self._controlled_env_idx is not None:
             pos = pos[self._controlled_env_idx]
             quat_wxyz = quat_wxyz[self._controlled_env_idx]
@@ -732,7 +732,7 @@ class ImGuiOverlayPlugin(ViewerPlugin):
                 # set_quat must be absolute (relative=False), since the KinematicEntity default is relative.
                 entity.set_quat(new_quat_wxyz, envs_idx=self._controlled_env_idx, relative=False)
             else:
-                entity.set_pos(new_mat[:3, 3], envs_idx=self._controlled_env_idx)
+                entity.set_pos(new_mat[:3, 3], envs_idx=self._controlled_env_idx, relative=False)
             self._refresh_visuals()
 
     def _is_gizmo_active(self):

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -6,6 +6,7 @@ rigid object / MPM object / FEM object.
 """
 
 import os
+import xml.etree.ElementTree as ET
 from typing import Annotated, Any, ClassVar, Literal
 from typing_extensions import Self
 
@@ -583,12 +584,17 @@ class FileMorph(Morph):
 
         file = data.get("file", "")
         if isinstance(file, str) and file:
-            abs_file = os.path.abspath(file)
-            if not os.path.exists(abs_file):
-                abs_file = os.path.join(gs.utils.get_assets_dir(), file)
-            if not os.path.exists(abs_file):
-                gs.raise_exception(f"File not found in either current directory or assets directory: '{file}'.")
-            data["file"] = abs_file
+            # Inline XML content (a description built in-memory) parses directly and is passed through untouched to the
+            # loader. A path string does not parse as XML and is resolved against the working and assets directories.
+            try:
+                ET.fromstring(file)
+            except ET.ParseError:
+                abs_file = os.path.abspath(file)
+                if not os.path.exists(abs_file):
+                    abs_file = os.path.join(gs.utils.get_assets_dir(), file)
+                if not os.path.exists(abs_file):
+                    gs.raise_exception(f"File not found in either current directory or assets directory: '{file}'.")
+                data["file"] = abs_file
 
         return data
 
@@ -919,7 +925,13 @@ class MJCF(FileMorph):
         return data
 
     def model_post_init(self, context: Any) -> None:
-        if not self.is_format(MJCF_FORMAT):
+        # Inline XML content parses directly and bypasses the file extension check.
+        try:
+            ET.fromstring(self.file)
+            is_inline_xml = True
+        except (ET.ParseError, TypeError):
+            is_inline_xml = False
+        if not is_inline_xml and not self.is_format(MJCF_FORMAT):
             gs.raise_exception(f"Expected `{MJCF_FORMAT}` extension for MJCF file: {self.file}")
 
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -82,6 +82,16 @@ class Morph(Options):
     quat : tuple, shape (4,), optional
         The initial quaternion (w-x-y-z convention) of the entity at creation time.
         If specified, `euler` will be ignored. Defaults to None.
+    offset_pos : tuple, shape (3,), optional
+        A fixed position offset composed on top of `pos` to obtain the world pose, while `pos` itself stays the value
+        reported by relative getters. Defaults to (0.0, 0.0, 0.0).
+    offset_euler : tuple, shape (3,), optional
+        The orientation offset as an euler angle in degrees (scipy extrinsic x-y-z convention). If specified,
+        `offset_quat` will be ignored. Defaults to None.
+    offset_quat : tuple, shape (4,), optional
+        A fixed orientation offset (w-x-y-z convention) composed on top of `quat` to obtain the world pose, while
+        `quat` itself stays the value reported by relative getters. Up-axis conversions are stored here.
+        Defaults to (1.0, 0.0, 0.0, 0.0).
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision
         purposes. Defaults to True. `visualization` and `collision` cannot both be False.
@@ -100,6 +110,9 @@ class Morph(Options):
     pos: Vec3FType = (0.0, 0.0, 0.0)
     euler: Vec3FType | None = Field(default=None, exclude=True, repr=False)
     quat: UnitVec4FType | None = None
+    offset_pos: Vec3FType = (0.0, 0.0, 0.0)
+    offset_euler: Vec3FType | None = Field(default=None, exclude=True, repr=False)
+    offset_quat: UnitVec4FType = (1.0, 0.0, 0.0, 0.0)
     visualization: StrictBool = True
     collision: StrictBool = True
     requires_jac_and_IK: StrictBool = False
@@ -119,6 +132,11 @@ class Morph(Options):
             data["quat"] = tuple(gu.xyz_to_quat(np.array(euler), rpy=True, degrees=True))
         elif quat is None:
             data["quat"] = (1.0, 0.0, 0.0, 0.0)
+        offset_euler = data.get("offset_euler")
+        if offset_euler is not None and data.get("offset_quat") is not None:
+            gs.raise_exception("'offset_euler' and 'offset_quat' cannot both be set.")
+        if offset_euler is not None:
+            data["offset_quat"] = tuple(gu.xyz_to_quat(np.array(offset_euler), rpy=True, degrees=True))
         return data
 
     def model_post_init(self, context: Any) -> None:
@@ -773,19 +791,19 @@ class Mesh(FileMorph, TetGenMixin):
 
         if is_gltf:
             if self.file_meshes_are_zup:
-                gs.logger.warning(
-                    "Specifying 'file_meshes_are_zup' for GLTF/GLB files is not supported. A rotation will be applied "
-                    "explicitly on the morph instead. Please consider fixing your asset to use Y-UP convention."
+                # GLTF/GLB is Y-up by standard, so a Z-up claim is honored by recording the compensating rotation in
+                # 'offset_quat'. It is post-multiplied on the user orientation to form the world pose, while 'quat'
+                # stays clean and is what relative getters report.
+                gs.logger.info(
+                    "Honoring 'file_meshes_are_zup' for a GLTF/GLB file by recording a compensating rotation in "
+                    "'offset_quat'. Consider fixing your asset to use the standard Y-up convention instead."
                 )
                 y_up_quat = (1.0, -1.0, 0.0, 0.0)
-                if self.quat is None:
-                    self.quat = y_up_quat
-                else:
-                    self.quat = tuple(
-                        gu.transform_quat_by_quat(
-                            np.array(y_up_quat, dtype=gs.np_float), np.array(self.quat, dtype=gs.np_float)
-                        )
+                self.offset_quat = tuple(
+                    gu.transform_quat_by_quat(
+                        np.array(y_up_quat, dtype=gs.np_float), np.array(self.offset_quat, dtype=gs.np_float)
                     )
+                )
                 if self.scale is not None:
                     scale_arr = np.atleast_1d(np.array(self.scale))
                     if scale_arr.size == 3:

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -83,14 +83,19 @@ class Morph(Options):
         The initial quaternion (w-x-y-z convention) of the entity at creation time.
         If specified, `euler` will be ignored. Defaults to None.
     offset_pos : tuple, shape (3,), optional
-        A fixed position offset composed on top of `pos` to obtain the world pose, while `pos` itself stays the value
-        reported by relative getters. Defaults to (0.0, 0.0, 0.0).
+        A fixed pose offset applied in the entity's own body frame on top of the `pos`/`euler` (or `pos`/`quat`) pose.
+        It shifts the world pose used internally by the solver but is stripped back out by the relative getters, so
+        `get_pos`/`get_quat` (which are relative by default) still report `pos`/`quat`. The morph pose and the offset
+        compound exactly like a parent and a child frame: the world pose is
+        `transform_pos_quat_by_trans_quat(offset_pos, offset_quat, pos, quat)`, i.e. the offset is expressed in the body
+        frame defined by `pos`/`quat`. So `offset_pos` rotates together with the orientation rather than being a
+        world-frame shift, and when the orientation is identity it simply adds to `pos`. Defaults to (0.0, 0.0, 0.0).
     offset_euler : tuple, shape (3,), optional
-        The orientation offset as an euler angle in degrees (scipy extrinsic x-y-z convention). If specified,
-        `offset_quat` will be ignored. Defaults to None.
+        The orientation offset `offset_quat` given as an euler angle in degrees (scipy extrinsic x-y-z convention).
+        Setting both `offset_euler` and `offset_quat` raises an error. Defaults to None.
     offset_quat : tuple, shape (4,), optional
-        A fixed orientation offset (w-x-y-z convention) composed on top of `quat` to obtain the world pose, while
-        `quat` itself stays the value reported by relative getters. Up-axis conversions are stored here.
+        A fixed orientation offset (w-x-y-z convention); see `offset_pos` for how it compounds with `pos`/`quat` to
+        form the world pose. Up-axis conversions (e.g. loading a Z-up asset) are stored here.
         Defaults to (1.0, 0.0, 0.0, 0.0).
     visualization : bool, optional
         Whether the entity needs to be visualized. Set it to False if you need a invisible object only for collision

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -979,7 +979,9 @@ def _np_quat_mul(u, v, out=None):
     qq = 0.5 * (xx + (z1 - x1) * (x2 - y2))
 
     if out is None:
-        out_ = np.empty(u_2d.shape, dtype=qq.dtype)
+        # Use the dtype obtained by promoting the inputs (e.g. 'ww', a pure u/v product), not 'qq', whose float64
+        # literal would otherwise upcast a float32 result.
+        out_ = np.empty(u_2d.shape, dtype=ww.dtype)
     else:
         assert out.shape == u.shape
         out_ = out

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -51,9 +51,11 @@ def get_model_name(file_path):
     OSError
         If there is an error reading the file.
     """
-    path = os.path.join(get_assets_dir(), file_path)
-    tree = ET.parse(path)
-    root = tree.getroot()
+    try:
+        # Inline XML content parses directly; a file path does not and falls back to reading from disk.
+        root = ET.fromstring(file_path)
+    except ET.ParseError:
+        root = ET.parse(os.path.join(get_assets_dir(), file_path)).getroot()
     if root.tag == "mujoco":
         return root.attrib.get("model")
     return None
@@ -82,8 +84,9 @@ def build_model(xml, discard_visual, default_armature=None, merge_fixed_links=Fa
             # Best guess for the search path
             asset_path = os.path.dirname(path) if is_valid_path else os.getcwd()
 
-            # Detect whether it is a URDF file or a Mujoco MJCF file
-            root = xml.getroot()
+            # Detect whether it is a URDF file or a Mujoco MJCF file. `ET.parse` yields an ElementTree, while
+            # `ET.fromstring` (inline XML content) yields the root Element directly.
+            root = xml.getroot() if isinstance(xml, ET.ElementTree) else xml
             is_urdf_file = root.tag == "robot"
             mjcf = ET.SubElement(root, "mujoco") if is_urdf_file else root
 

--- a/genesis/vis/camera.py
+++ b/genesis/vis/camera.py
@@ -242,11 +242,11 @@ class Camera(RBC):
             gs.raise_exception("Camera not attached to any rigid link.")
 
         if self._is_batched and self._env_idx is None:
-            link_pos = self._attached_link.get_pos(self._visualizer._context.rendered_envs_idx)
-            link_quat = self._attached_link.get_quat(self._visualizer._context.rendered_envs_idx)
+            link_pos = self._attached_link.get_pos(self._visualizer._context.rendered_envs_idx, relative=False)
+            link_quat = self._attached_link.get_quat(self._visualizer._context.rendered_envs_idx, relative=False)
         else:
-            link_pos = self._attached_link.get_pos(self._env_idx).reshape((-1,))
-            link_quat = self._attached_link.get_quat(self._env_idx).reshape((-1,))
+            link_pos = self._attached_link.get_pos(self._env_idx, relative=False).reshape((-1,))
+            link_quat = self._attached_link.get_quat(self._env_idx, relative=False).reshape((-1,))
         link_T = gu.trans_quat_to_T(link_pos, link_quat)
         transform = torch.matmul(link_T, self._attached_offset_T)
         self.set_pose(transform=transform)
@@ -274,9 +274,9 @@ class Camera(RBC):
 
         if self._is_built:
             if self._is_batched and self._env_idx is None:
-                entity_pos = entity.get_pos(self._visualizer._context.rendered_envs_idx)
+                entity_pos = entity.get_pos(self._visualizer._context.rendered_envs_idx, relative=False)
             else:
-                entity_pos = entity.get_pos(self._env_idx).reshape((-1,))
+                entity_pos = entity.get_pos(self._env_idx, relative=False).reshape((-1,))
             pos_rel = self._pos - entity_pos
         else:
             pos_rel = self._initial_pos - torch.tensor(entity.base_link.pos, dtype=gs.tc_float, device=gs.device)
@@ -322,9 +322,9 @@ class Camera(RBC):
 
         # Query entity and relative camera positions
         if self._is_batched and self._env_idx is None:
-            entity_pos = self._followed_entity.get_pos(self._visualizer._context.rendered_envs_idx)
+            entity_pos = self._followed_entity.get_pos(self._visualizer._context.rendered_envs_idx, relative=False)
         else:
-            entity_pos = self._followed_entity.get_pos(self._env_idx).reshape((-1,))
+            entity_pos = self._followed_entity.get_pos(self._env_idx, relative=False).reshape((-1,))
         follow_pos_rel = self._follow_pos_rel
 
         # Smooth camera movement with a low-pass filter, in particular Exponential Moving Average (EMA) if requested

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -313,7 +313,7 @@ class Viewer(RBC):
         """
         Update the viewer position to follow the specified entity.
         """
-        entity_pos = tensor_to_array(self._followed_entity.get_pos())
+        entity_pos = tensor_to_array(self._followed_entity.get_pos(relative=False))
         if entity_pos.ndim > 1:  # check for multiple envs
             entity_pos = entity_pos[0]
         # numpy < 2.0 doesn't support the copy keyword argument in np.asarray()

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -133,8 +133,8 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
 
                 # Store held point in link-local frame. ray_hit.position is in world coords (with envs_offset baked in
                 # by the raycaster), while link.get_pos returns env-local coords, so subtract the offset to align.
-                link_pos = tensor_to_array(link.get_pos(envs_idx=hit_env_idx).squeeze(0))
-                link_quat = tensor_to_array(link.get_quat(envs_idx=hit_env_idx).squeeze(0))
+                link_pos = tensor_to_array(link.get_pos(envs_idx=hit_env_idx, relative=False).squeeze(0))
+                link_quat = tensor_to_array(link.get_quat(envs_idx=hit_env_idx, relative=False).squeeze(0))
                 hit_env_local = ray_hit.position - self._env_offset
                 self._held_point_local = gu.inv_transform_by_trans_quat(hit_env_local, link_pos, link_quat)
 
@@ -181,11 +181,11 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
                 self._apply_spring_force(ray_hit_plane.position, self.scene.sim.dt)
             else:
                 assert self._held_point_local is not None
-                link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx).squeeze(0))
+                link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx, relative=False).squeeze(0))
                 offset_world = gu.transform_by_quat(self._held_point_local, link_quat)
                 # Mouse target is world; entity position is env-local, so strip the env offset before setting.
                 new_link_pos = ray_hit_plane.position - self._env_offset - offset_world
-                self._held_link.entity.set_pos(new_link_pos, envs_idx=envs_idx)
+                self._held_link.entity.set_pos(new_link_pos, envs_idx=envs_idx, relative=False)
 
     @with_lock
     @override
@@ -210,8 +210,8 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             assert self._held_point_local is not None
 
             envs_idx = self._interact_env_idx
-            link_pos = tensor_to_array(self._held_link.get_pos(envs_idx=envs_idx).squeeze(0))
-            link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx).squeeze(0))
+            link_pos = tensor_to_array(self._held_link.get_pos(envs_idx=envs_idx, relative=False).squeeze(0))
+            link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx, relative=False).squeeze(0))
             held_point_env_local = gu.transform_by_trans_quat(self._held_point_local, link_pos, link_quat)
             held_point_world = held_point_env_local + self._env_offset
 
@@ -326,8 +326,8 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         envs_idx = self._interact_env_idx
 
         # Current link state in env-local frame
-        link_pos = tensor_to_array(self._held_link.get_pos(envs_idx=envs_idx).squeeze(0))
-        link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx).squeeze(0))
+        link_pos = tensor_to_array(self._held_link.get_pos(envs_idx=envs_idx, relative=False).squeeze(0))
+        link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx, relative=False).squeeze(0))
         lin_vel = tensor_to_array(self._held_link.get_vel(envs_idx=envs_idx).squeeze(0))
         ang_vel = tensor_to_array(self._held_link.get_ang(envs_idx=envs_idx).squeeze(0))
 

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -157,11 +157,10 @@ def test_maxvolume(box_obj_path, show_viewer):
 
 
 @pytest.mark.required
-def test_fem_offset_pos(box_obj_path, show_viewer):
-    # The morph pose offset must shift the FEM vertices in the body frame, like rigid/particle/PBD entities. The
-    # orientation is identity here, so the world vertices are translated by exactly 'offset_pos'.
+def test_offset_pos(box_obj_path, show_viewer):
     POS = (0.2, -0.1, 0.3)
     OFFSET_POS = (0.05, 0.0, 0.1)
+
     scene = gs.Scene(
         show_viewer=show_viewer,
     )
@@ -181,6 +180,7 @@ def test_fem_offset_pos(box_obj_path, show_viewer):
         material=gs.materials.FEM.Elastic(),
     )
     scene.build()
+
     offset = box.get_state().pos - box_no_offset.get_state().pos
     assert_allclose(offset, OFFSET_POS, tol=gs.EPS)
 

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -157,6 +157,35 @@ def test_maxvolume(box_obj_path, show_viewer):
 
 
 @pytest.mark.required
+def test_fem_offset_pos(box_obj_path, show_viewer):
+    # The morph pose offset must shift the FEM vertices in the body frame, like rigid/particle/PBD entities. The
+    # orientation is identity here, so the world vertices are translated by exactly 'offset_pos'.
+    POS = (0.2, -0.1, 0.3)
+    OFFSET_POS = (0.05, 0.0, 0.1)
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+    )
+    box = scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file=box_obj_path,
+            pos=POS,
+            offset_pos=OFFSET_POS,
+        ),
+        material=gs.materials.FEM.Elastic(),
+    )
+    box_no_offset = scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file=box_obj_path,
+            pos=POS,
+        ),
+        material=gs.materials.FEM.Elastic(),
+    )
+    scene.build()
+    offset = box.get_state().pos - box_no_offset.get_state().pos
+    assert_allclose(offset, OFFSET_POS, tol=gs.EPS)
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("precision", ["64"])
 @pytest.mark.parametrize(
     "coupler_type, material_model",

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2391,6 +2391,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     # A no-offset entity reports the same pose in the user and world frames.
     assert_allclose(plain_box.get_pos(relative=True), plain_box.get_pos(relative=False), tol=tol)
     assert_allclose(plain_box.get_pos(), (2.0, 0.0, 0.2), tol=tol)
+
     # With both a morph pose and an offset, the relative getter returns the morph pose while the world getter carries
     # the offset composed onto it (the offset position adds in z since the user orientation is identity).
     assert_allclose(posed_box.get_pos(relative=True), POSED_BOX_POS, tol=tol)
@@ -2401,6 +2402,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
         gu.xyz_to_quat(np.array(POSED_BOX_OFFSET_EULER), rpy=True, degrees=True),
         tol=tol,
     )
+
     # Setting the orientation in the user frame keeps the user-frame position fixed: the offset position rotates with
     # the orientation, so the world position is rewritten to preserve the reported relative position. Rotating about x
     # while the offset position is along z makes that offset contribution change, exercising the rewrite.
@@ -6368,11 +6370,13 @@ def test_mesh_align(show_viewer, tol):
             het_obj.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env, relative=False),
             tol=tol,
         )
+
     # The two variants have different geometry, so their aligned world origins differ.
     with np.testing.assert_raises(AssertionError):
         assert_allclose(
             het_obj.get_pos(relative=False, envs_idx=0), het_obj.get_pos(relative=False, envs_idx=1), tol=tol
         )
+
     # The heterogeneous mango variant (env 1) is aligned exactly like the standalone mango: the world<-user offset
     # (COM shift and principal-axis rotation) matches, independent of the base placement.
     het_mango_offset = het_obj.get_pos(relative=False, envs_idx=1) - het_obj.get_pos(relative=True, envs_idx=1)
@@ -6452,11 +6456,10 @@ def test_urdf_align(show_viewer, tol):
 
 @pytest.mark.required
 def test_relative_offset_on_link_relative_geoms(show_viewer, tol):
-    # Geoms posed (rotated/translated) relative to their link, via collision/visual <origin>, combined with a morph
-    # orientation offset. The relative geom getters must revert the offset conjugated into each geom's own frame, not
-    # by a naive body-frame strip at the geom frame (which conjugates the geom pose by the offset and corrupts it).
-    # A convex-decomposed mesh would not exercise this, since its sub-geoms keep an identity frame (geometry sits in
-    # the vertices), so an articulated body with explicit geom origins is used.
+    # To exercise the geom-frame offset strip the geoms MUST sit at non-identity poses relative to their link (explicit
+    # collision/visual <origin>) AND the morph offset MUST be a rotation that does not commute with them - otherwise the
+    # conjugation degenerates to the plain morph offset and a naive (corrupted) strip would still pass. A convex-
+    # decomposed mesh is useless here: its sub-geoms keep an identity frame (geometry lives in the vertices).
     robot = ET.Element("robot", name="posed_geoms")
     link = ET.SubElement(robot, "link", name="body")
     for origin_rpy, origin_xyz in (
@@ -6489,6 +6492,7 @@ def test_relative_offset_on_link_relative_geoms(show_viewer, tol):
     scene.build()
 
     assert len(body.geoms) > 1, "expected multiple geoms posed relative to the link"
+
     # The user orientation is identity, so the world<-user offset rotates each geom about the link origin:
     # geom_world_pos = U_pos + R(offset) * (geom_user_pos - U_pos) and geom_world_quat = offset * geom_user_quat.
     assert_allclose(body.get_quat(relative=True), gu.identity_quat(), tol=tol)
@@ -6503,28 +6507,43 @@ def test_relative_offset_on_link_relative_geoms(show_viewer, tol):
         assert_allclose(geom.get_quat(relative=False), expected_world_quat, tol=tol)
 
 
+def create_two_free_bodies_mjcf(name, pos_a, geom_a, pos_b, geom_b):
+    """Helper to create an MJCF with two free root bodies, each a single box geom offset from its body origin."""
+    mjcf = ET.Element("mujoco", model=name)
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    body_a = ET.SubElement(worldbody, "body", name="a", pos=f"{pos_a[0]} {pos_a[1]} {pos_a[2]}")
+    ET.SubElement(body_a, "joint", name="a_free", type="free")
+    ET.SubElement(
+        body_a, "geom", type="box", size="0.05 0.05 0.05", pos=f"{geom_a[0]} {geom_a[1]} {geom_a[2]}", density="1000"
+    )
+    body_b = ET.SubElement(worldbody, "body", name="b", pos=f"{pos_b[0]} {pos_b[1]} {pos_b[2]}")
+    ET.SubElement(body_b, "joint", name="b_free", type="free")
+    ET.SubElement(
+        body_b, "geom", type="box", size="0.05 0.08 0.03", pos=f"{geom_b[0]} {geom_b[1]} {geom_b[2]}", density="1000"
+    )
+    return mjcf
+
+
 @pytest.mark.required
 def test_multi_root_offset(show_viewer, tol):
-    # One MJCF with two free root bodies, each auto-aligned to its own geometry. Every root's pose offset is tracked
-    # independently, so each root reports its own user-specified pose through the relative (default) getters while the
-    # world frame carries that root's own COM shift. Without per-root tracking, the offsets cross-contaminate.
+    # To exercise per-root offset tracking the entity MUST hold more than one free root (one MJCF, several free
+    # bodies) with DISTINCT per-root geometry, so each root gets its own alignment offset; a single root - or
+    # identical roots - would not surface the cross-contamination bug (one root's offset leaking into another).
     BODY_A_POS = (1.0, 0.0, 0.5)
     BODY_B_POS = (-1.0, 0.0, 0.5)
-    mjcf = ET.Element("mujoco", model="two_bodies")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    body_a = ET.SubElement(worldbody, "body", name="a", pos=f"{BODY_A_POS[0]} {BODY_A_POS[1]} {BODY_A_POS[2]}")
-    ET.SubElement(body_a, "joint", name="a_free", type="free")
-    ET.SubElement(body_a, "geom", type="box", size="0.05 0.05 0.05", pos="0.02 0.01 0.0", density="1000")
-    body_b = ET.SubElement(worldbody, "body", name="b", pos=f"{BODY_B_POS[0]} {BODY_B_POS[1]} {BODY_B_POS[2]}")
-    ET.SubElement(body_b, "joint", name="b_free", type="free")
-    ET.SubElement(body_b, "geom", type="box", size="0.05 0.08 0.03", pos="0.0 0.03 0.02", density="1000")
+    GEOM_A_POS = (0.02, 0.01, 0.0)
+    GEOM_B_POS = (0.0, 0.03, 0.02)
+
     scene = gs.Scene(
         show_viewer=show_viewer,
         show_FPS=False,
     )
     entity = scene.add_entity(
         gs.morphs.MJCF(
-            file=ET.tostring(mjcf, encoding="unicode"),
+            file=ET.tostring(
+                create_two_free_bodies_mjcf("two_bodies", BODY_A_POS, GEOM_A_POS, BODY_B_POS, GEOM_B_POS),
+                encoding="unicode",
+            ),
             align=True,
         ),
     )
@@ -6536,9 +6555,10 @@ def test_multi_root_offset(show_viewer, tol):
     assert_allclose(link_b.get_pos(), BODY_B_POS, tol=tol)
     assert_allclose(link_a.get_quat(), gu.identity_quat(), tol=tol)
     assert_allclose(link_b.get_quat(), gu.identity_quat(), tol=tol)
+
     # The world frame carries each root's own COM shift (the box center), confirming the offsets are not shared.
-    assert_allclose(link_a.get_pos(relative=False), (1.02, 0.01, 0.5), tol=tol)
-    assert_allclose(link_b.get_pos(relative=False), (-1.0, 0.03, 0.52), tol=tol)
+    assert_allclose(link_a.get_pos(relative=False), np.add(BODY_A_POS, GEOM_A_POS), tol=tol)
+    assert_allclose(link_b.get_pos(relative=False), np.add(BODY_B_POS, GEOM_B_POS), tol=tol)
 
     # Both roots free-fall under gravity: the relative getter tracks each user frame, holding x/y and dropping z
     # equally (free fall is mass-independent).

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2349,8 +2349,8 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     robot = scene.add_entity(
         gs.morphs.MJCF(
             file="xml/franka_emika_panda/panda.xml",
-            pos=ROBOT_POS_ZERO,
-            euler=ROBOT_EULER_ZERO,
+            offset_pos=ROBOT_POS_ZERO,
+            offset_euler=ROBOT_EULER_ZERO,
             batch_fixed_verts=batch_fixed_verts,
         ),
     )
@@ -2364,28 +2364,59 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     cube = scene.add_entity(
         gs.morphs.Box(
             size=(0.04, 0.04, 0.04),
-            pos=CUBE_POS_ZERO,
-            euler=CUBE_EULER_ZERO,
+            offset_pos=CUBE_POS_ZERO,
+            offset_euler=CUBE_EULER_ZERO,
+        ),
+    )
+    plain_box = scene.add_entity(
+        gs.morphs.Box(
+            pos=(2.0, 0.0, 0.2),
+            size=(0.04, 0.04, 0.04),
+        ),
+    )
+    POSED_BOX_POS = (2.0, 0.5, 0.3)
+    POSED_BOX_OFFSET_EULER = (0.0, 0.0, 45.0)
+    posed_box = scene.add_entity(
+        gs.morphs.Box(
+            pos=POSED_BOX_POS,
+            size=(0.04, 0.04, 0.04),
+            offset_pos=(0.0, 0.0, 0.5),
+            offset_euler=POSED_BOX_OFFSET_EULER,
         ),
     )
     scene.build(n_envs=2)
 
+    # A no-offset entity reports the same pose in the user and world frames.
+    assert_allclose(plain_box.get_pos(relative=True), plain_box.get_pos(relative=False), tol=tol)
+    assert_allclose(plain_box.get_pos(relative=False), (2.0, 0.0, 0.2), tol=tol)
+    # With both a morph pose and an offset, the relative getter returns the morph pose while the world getter carries
+    # the offset composed onto it (the offset position adds in z since the user orientation is identity).
+    assert_allclose(posed_box.get_pos(relative=True), POSED_BOX_POS, tol=tol)
+    assert_allclose(posed_box.get_quat(relative=True), gu.identity_quat(), tol=tol)
+    assert_allclose(posed_box.get_pos(relative=False), (2.0, 0.5, 0.8), tol=tol)
+    assert_allclose(
+        posed_box.get_quat(relative=False),
+        gu.xyz_to_quat(np.array(POSED_BOX_OFFSET_EULER), rpy=True, degrees=True),
+        tol=tol,
+    )
+
     robot_aabb_init, robot_base_aabb_init = robot.get_AABB(), robot.geoms[0].get_AABB()
     cube_aabb_init, cube_base_aabb_init = cube.get_AABB(), cube.geoms[0].get_AABB()
 
-    # Make sure that it is not possible to end up in an inconsistent state for fixed geometries
+    # Make sure that it is not possible to end up in an inconsistent state for fixed geometries. These place entities
+    # at absolute world positions, so they bypass the pose offset (relative=False).
     pos_delta = np.random.rand(2, 3)
     with nullcontext() if batch_fixed_verts else pytest.raises(gs.GenesisException):
-        robot.set_pos(pos_delta)
+        robot.set_pos(pos_delta, relative=False)
         if show_viewer:
             scene.visualizer.update()
     with nullcontext() if batch_fixed_verts else pytest.raises(gs.GenesisException):
-        robot.set_pos(pos_delta[[0]], envs_idx=[0])
+        robot.set_pos(pos_delta[[0]], envs_idx=[0], relative=False)
         if show_viewer:
             scene.visualizer.update()
-    cube.set_pos(pos_delta[[0]] + (0.0, 0.0, 0.16), envs_idx=[0])
-    cube.set_pos(pos_delta[[1]] + (0.0, 0.0, 0.11), envs_idx=[1])
-    sphere.set_pos(np.tile(pos_delta[[0]], (2, 1)) + 1.0)
+    cube.set_pos(pos_delta[[0]] + (0.0, 0.0, 0.16), envs_idx=[0], relative=False)
+    cube.set_pos(pos_delta[[1]] + (0.0, 0.0, 0.11), envs_idx=[1], relative=False)
+    sphere.set_pos(np.tile(pos_delta[[0]], (2, 1)) + 1.0, relative=False)
     quat_delta = np.random.rand(2, 4)
     with nullcontext() if batch_fixed_verts else pytest.raises(gs.GenesisException):
         robot.set_quat(quat_delta)
@@ -2425,9 +2456,11 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
             pos_zero = torch.tensor(pos_zero, device=gs.device, dtype=gs.tc_float)
             euler_zero = torch.deg2rad(torch.tensor(euler_zero, dtype=gs.tc_float))
             quat_zero = gu.xyz_to_quat(euler_zero, rpy=True)
-            assert_allclose(entity.get_pos(), pos_zero, tol=tol)
+            # The pose lives in the offset, so the world frame (relative=False) carries it; the user frame is identity.
+            assert_allclose(entity.get_pos(relative=False), pos_zero, tol=tol)
+            assert_allclose(entity.get_pos(relative=True), 0.0, tol=tol)
             # Use quaternion for comparison to avoid gymbal lock issue in euler angles
-            quat = entity.get_quat()
+            quat = entity.get_quat(relative=False)
             assert_allclose(quat, quat_zero, tol=tol)
             base_aabb = entity.geoms[0].get_AABB()
             assert base_aabb.shape == ((2, 2, 3) if not entity.geoms[0].is_fixed or batch_fixed_verts else (2, 3))
@@ -2438,14 +2471,14 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
             entity.set_pos(pos_delta, relative=relative)
 
             pos_ref = pos_delta + pos_zero if relative else pos_delta
-            assert_allclose(entity.get_pos(), pos_ref, tol=tol)
+            assert_allclose(entity.get_pos(relative=False), pos_ref, tol=tol)
             assert_allclose(entity.geoms[0].get_AABB(), base_aabb_init + (pos_ref - pos_zero), tol=tol)
             assert_allclose(entity.get_AABB(), entity_aabb_init + (pos_ref - pos_zero), tol=tol)
 
             quat_delta = torch.tile(torch.as_tensor(np.random.rand(4), dtype=gs.tc_float, device=gs.device), (2, 1))
             quat_delta /= torch.linalg.norm(quat_delta, axis=1, keepdim=True)
             entity.set_quat(quat_delta, relative=relative)
-            quat = entity.get_quat()
+            quat = entity.get_quat(relative=False)
             if relative:
                 quat_ref = gu.transform_quat_by_quat(quat_zero, quat_delta)
             else:
@@ -3669,8 +3702,8 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
 
     # Drive a steady torque about z (a wrench) until the nut reaches its release height, then let go: negative torque
     # screws it down onto the head, positive torque unscrews it up and off the shaft tip.
-    z0 = nut.get_pos()[..., 2]
-    prev_yaw = gu.quat_to_xyz(nut.get_quat())[..., 2]
+    z0 = nut.get_pos(relative=False)[..., 2]
+    prev_yaw = gu.quat_to_xyz(nut.get_quat(relative=False))[..., 2]
     total_turn = 0.0
     released_step = None
     z_engaged = z0
@@ -3678,7 +3711,7 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
     z_history = []
     horizon = 4100 if direction == "down" else 4800
     for step in range(horizon):
-        z = nut.get_pos()[..., 2]
+        z = nut.get_pos(relative=False)[..., 2]
         if released_step is None:
             reached = (z < SEAT_RELEASE_Z).all() if direction == "down" else (z > TIP_RELEASE_Z).all()
             if reached:
@@ -3687,8 +3720,8 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
         nut.control_dofs_force([torque if driving else 0.0], dofs_idx_local=(5,))
         scene.step()
 
-        pos = nut.get_pos()
-        rpy = gu.quat_to_xyz(nut.get_quat())
+        pos = nut.get_pos(relative=False)
+        rpy = gu.quat_to_xyz(nut.get_quat(relative=False))
         vel = nut.get_dofs_velocity()
         z_history.append(pos[..., 2])
         yaw = rpy[..., 2]
@@ -3724,7 +3757,7 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
         # a small steady contact jitter in velocity, so the position band is the robust at-rest signal.
         z_window = torch.stack(z_history[-200:], dim=0)
         assert ((z_window.amax(dim=0) - z_window.amin(dim=0)) < 1e-4).all()
-        z_final = nut.get_pos()[..., 2]
+        z_final = nut.get_pos(relative=False)[..., 2]
         assert ((0.019 < z_final) & (z_final < 0.021)).all()
     else:
         # Spun off the tip, fell, and came to rest flat on the ground: its bounding box now sits on the plane and all
@@ -6234,9 +6267,10 @@ def test_ellipsoid(xml_path, show_viewer):
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_mesh_align(show_viewer, tol):
-    INIT_POS = (0.0, 0.0, 0.8)
+    INIT_POS = (0.0, 0.0, 0.1)
 
-    asset_path = get_hf_dataset(pattern="glb/mango.glb")
+    mango_path = get_hf_dataset(pattern="glb/mango.glb")
+    bowl_path = get_hf_dataset(pattern="glb/orange_plastic_bowl.glb")
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -6250,7 +6284,7 @@ def test_mesh_align(show_viewer, tol):
     )
     scene.add_entity(gs.morphs.Plane())
     mango_morph = gs.morphs.Mesh(
-        file=f"{asset_path}/glb/mango.glb",
+        file=f"{mango_path}/glb/mango.glb",
         scale=0.045,
         pos=INIT_POS,
         align=True,
@@ -6267,20 +6301,75 @@ def test_mesh_align(show_viewer, tol):
         mango_morph,
         material=gs.materials.Kinematic(),
     )
-    scene.build()
+    # Heterogeneous entity sharing one link across a bowl and a mango variant. Each variant must be aligned to its own
+    # geometry (link origin at that variant's COM) and report its own offset per environment. The bowl carries a
+    # hard-coded offset to check it composes with the alignment, and the mango variant must end up aligned exactly
+    # like the standalone mango above.
+    HET_POS = (0.5, 0.0, 0.1)
+    het_obj = scene.add_entity(
+        morph=(
+            gs.morphs.Mesh(
+                file=f"{bowl_path}/glb/orange_plastic_bowl.glb",
+                scale=0.1,
+                pos=HET_POS,
+                offset_euler=(30.0, 0.0, 0.0),
+                align=True,
+            ),
+            gs.morphs.Mesh(
+                file=f"{mango_path}/glb/mango.glb",
+                scale=0.045,
+                pos=HET_POS,
+                align=True,
+            ),
+        ),
+        material=gs.materials.Rigid(rho=1000.0),
+    )
+    scene.build(n_envs=2)
 
-    # Alignment is transparent: geom/vgeom world-space pose must equal morph pos/quat regardless of align
+    # Geoms/vgeoms are alignment-transparent, so their world pose equals the morph pose, and without a morph offset
+    # the relative (user-frame) pose matches it too.
     geom, vgeom = mango.geoms[0], mango.vgeoms[0]
-    assert_allclose(geom.get_pos(), INIT_POS, atol=1e-3)
-    assert_allclose(geom.get_quat(), gu.identity_quat(), atol=1e-3)
-    assert_allclose(vgeom.get_pos(), INIT_POS, atol=1e-3)
-    assert_allclose(vgeom.get_quat(), gu.identity_quat(), atol=1e-3)
+    for relative in (False, True):
+        assert_allclose(geom.get_pos(relative=relative), INIT_POS, atol=1e-3)
+        assert_allclose(geom.get_quat(relative=relative), gu.identity_quat(), atol=1e-3)
+        assert_allclose(vgeom.get_pos(relative=relative), INIT_POS, atol=1e-3)
+        assert_allclose(vgeom.get_quat(relative=relative), gu.identity_quat(), atol=1e-3)
 
-    # With align=True, the link frame is placed at the geometry COM
-    assert_allclose(mango.get_links_pos(ref="link_com"), mango.get_pos(), tol=tol)
+    # The relative (user-frame) base pose strips the alignment back to the morph pose.
+    assert_allclose(mango.get_pos(relative=True), INIT_POS, tol=tol)
+    assert_allclose(mango.get_quat(relative=True), gu.identity_quat(), tol=tol)
+    # The world-frame base pose places the link frame at the geometry COM and principal axes.
+    assert_allclose(
+        mango.get_links_pos(links_idx_local=[0], ref="link_com"),
+        mango.get_links_pos(links_idx_local=[0], ref="link_origin"),
+        tol=tol,
+    )
     geom_inertia_i = qd_to_numpy(scene.rigid_solver.links_state.cinr_inertial, transpose=True)[0, 1]
-    geom_quat = tensor_to_array(mango.get_quat())
+    geom_quat = tensor_to_array(mango.get_quat(relative=False))
     assert_allclose(gu.R_to_xyz(gu.quat_to_R(geom_quat) @ uu.principal_axes_rot(geom_inertia_i).T), 0.0, tol=tol)
+
+    # Both variants (env 0 bowl, env 1 mango) strip their own offset back to the user pose, and each variant's link
+    # origin sits at its own COM. The bowl recovers the user frame despite its hard-coded offset, proving the offset
+    # composes with the alignment.
+    for i_env in (0, 1):
+        assert_allclose(het_obj.get_pos(relative=True, envs_idx=i_env), HET_POS, tol=tol)
+        assert_allclose(het_obj.get_quat(relative=True, envs_idx=i_env), gu.identity_quat(), tol=tol)
+        assert_allclose(
+            het_obj.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env),
+            het_obj.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env),
+            tol=tol,
+        )
+    # The two variants have different geometry, so their aligned world origins differ.
+    with np.testing.assert_raises(AssertionError):
+        assert_allclose(
+            het_obj.get_pos(relative=False, envs_idx=0), het_obj.get_pos(relative=False, envs_idx=1), tol=tol
+        )
+    # The heterogeneous mango variant (env 1) is aligned exactly like the standalone mango: the world<-user offset
+    # (COM shift and principal-axis rotation) matches, independent of the base placement.
+    het_mango_offset = het_obj.get_pos(relative=False, envs_idx=1) - het_obj.get_pos(relative=True, envs_idx=1)
+    mango_offset = mango.get_pos(relative=False, envs_idx=0) - mango.get_pos(relative=True, envs_idx=0)
+    assert_allclose(het_mango_offset, mango_offset, tol=tol)
+    assert_allclose(het_obj.get_quat(relative=False, envs_idx=1), mango.get_quat(relative=False, envs_idx=0), tol=tol)
 
     # Same qpos on rigid and kinematic entities must yield matching vAABB
     qpos = (0.3, -0.2, 1.0, 0.6, 0.5, 0.3, 0.0)
@@ -6294,7 +6383,8 @@ def test_mesh_align(show_viewer, tol):
         scene.step()
 
     assert_allclose(mango.get_dofs_velocity(), 0, tol=0.06)
-    assert (-0.005 < mango.get_AABB()[0, 2] < 0.0).all()
+    min_z = mango.get_AABB()[:, 0, 2]
+    assert ((-0.005 < min_z) & (min_z < 0.0)).all()
 
 
 @pytest.mark.slow  # ~200s
@@ -6330,8 +6420,10 @@ def test_urdf_align(show_viewer, tol):
     )
     scene.build()
 
-    # With align=None (auto-True for basic rigid objects), the link frame origin is at the collision geometry COM
-    assert_allclose(fork.get_links_pos(ref="link_com"), fork.get_pos(), tol=tol)
+    # The relative (user-frame) base pose strips the alignment back to the morph pose, while the world-frame base
+    # pose has its link frame origin at the collision geometry COM (auto-align for basic rigid objects).
+    assert_allclose(fork.get_pos(relative=True), INIT_POS, tol=tol)
+    assert_allclose(fork.get_links_pos(ref="link_com"), fork.get_pos(relative=False), tol=tol)
 
     # Same qpos on rigid and kinematic entities must yield matching vAABB
     qpos = (0.3, -0.2, 1.0, 0.6, 0.5, 0.3, 0.0)
@@ -6347,6 +6439,59 @@ def test_urdf_align(show_viewer, tol):
 
     assert_allclose(fork.get_dofs_velocity(), 0, tol=0.05)
     assert (-0.002 < fork.get_AABB()[0, 2] < 0.0).all()
+
+
+@pytest.mark.required
+def test_relative_offset_on_link_relative_geoms(show_viewer, tol):
+    # Geoms posed (rotated/translated) relative to their link, via collision/visual <origin>, combined with a morph
+    # orientation offset. The relative geom getters must revert the offset conjugated into each geom's own frame, not
+    # by a naive body-frame strip at the geom frame (which conjugates the geom pose by the offset and corrupts it).
+    # A convex-decomposed mesh would not exercise this, since its sub-geoms keep an identity frame (geometry sits in
+    # the vertices), so an articulated body with explicit geom origins is used.
+    robot = ET.Element("robot", name="posed_geoms")
+    link = ET.SubElement(robot, "link", name="body")
+    for origin_rpy, origin_xyz in (
+        ("0 0 1.5708", "0.1 0 0"),
+        ("0.7854 0 0", "0 0.1 0.05"),
+        ("0 1.0472 0.5", "0 0 0.1"),
+    ):
+        for group_tag in ("collision", "visual"):
+            group = ET.SubElement(link, group_tag)
+            geom_el = ET.SubElement(group, "geometry")
+            ET.SubElement(geom_el, "box", size="0.05 0.1 0.15")
+            ET.SubElement(group, "origin", rpy=origin_rpy, xyz=origin_xyz)
+    urdf = urdfpy.URDF._from_xml(robot, robot, get_assets_dir())
+
+    BODY_POS = (0.0, 0.0, 0.2)
+    OFFSET_EULER = (20.0, 35.0, 50.0)  # a generic rotation that does not commute with the geom poses
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_FPS=False,
+    )
+    body = scene.add_entity(
+        gs.morphs.URDF(
+            file=urdf,
+            pos=BODY_POS,
+            offset_euler=OFFSET_EULER,
+            align=True,
+        ),
+        material=gs.materials.Rigid(),
+    )
+    scene.build()
+
+    assert len(body.geoms) > 1, "expected multiple geoms posed relative to the link"
+    # The user orientation is identity, so the world<-user offset rotates each geom about the link origin:
+    # geom_world_pos = U_pos + R(offset) * (geom_user_pos - U_pos) and geom_world_quat = offset * geom_user_quat.
+    assert_allclose(body.get_quat(relative=True), gu.identity_quat(), tol=tol)
+    u_pos = tensor_to_array(body.get_pos(relative=True))
+    offset_quat = gu.xyz_to_quat(np.array(OFFSET_EULER), rpy=True, degrees=True)
+    for geom in body.geoms:
+        geom_user_pos = tensor_to_array(geom.get_pos(relative=True))
+        geom_user_quat = tensor_to_array(geom.get_quat(relative=True))
+        expected_world_pos = u_pos + gu.transform_by_quat(geom_user_pos - u_pos, offset_quat)
+        expected_world_quat = gu.transform_quat_by_quat(geom_user_quat, offset_quat)
+        assert_allclose(geom.get_pos(relative=False), expected_world_pos, tol=tol)
+        assert_allclose(geom.get_quat(relative=False), expected_world_quat, tol=tol)
 
 
 @pytest.fixture
@@ -6687,14 +6832,20 @@ def test_heterogeneous_simulation(show_viewer, tol):
     # 4 envs with 2 variants: envs 0-1 get box, envs 2-3 get sphere
     scene_het = gs.Scene(show_viewer=show_viewer)
     scene_het.add_entity(gs.morphs.Plane())
+    # Divergent per-variant yaw offsets, irrelevant to the dynamics of these symmetric primitives dropped flat (so
+    # the world references still match) but stripped per environment by the relative getters.
+    box_offset_euler = (0.0, 0.0, 30.0)
+    sphere_offset_euler = (0.0, 0.0, -45.0)
     morphs_heterogeneous = (
         gs.morphs.Box(
             size=(0.04, 0.04, 0.04),
             pos=(0.0, 0.0, box_drop_height),
+            offset_euler=box_offset_euler,
         ),
         gs.morphs.Sphere(
             radius=0.02,
             pos=(0.1, 0.0, sphere_drop_height),
+            offset_euler=sphere_offset_euler,
         ),
     )
     het_obj = scene_het.add_entity(morph=morphs_heterogeneous)
@@ -6708,6 +6859,15 @@ def test_heterogeneous_simulation(show_viewer, tol):
     assert_allclose(het_pos_init[2, 2], sphere_drop_height, tol=tol)
     assert_allclose(het_pos_init[3, 0], 0.1, tol=tol)
     assert_allclose(het_pos_init[3, 2], sphere_drop_height, tol=tol)
+
+    # The relative getter strips each variant's own offset back to the user frame (identity), while the world frame
+    # carries the per-environment offset.
+    box_offset_quat = gu.xyz_to_quat(np.array(box_offset_euler), rpy=True, degrees=True)
+    sphere_offset_quat = gu.xyz_to_quat(np.array(sphere_offset_euler), rpy=True, degrees=True)
+    assert_allclose(het_obj.get_quat(relative=True), gu.identity_quat(), tol=tol)
+    het_quat_world = het_obj.get_quat(relative=False)
+    assert_allclose(het_quat_world[:2], box_offset_quat, tol=tol)
+    assert_allclose(het_quat_world[2:], sphere_offset_quat, tol=tol)
 
     for _ in range(n_steps):
         scene_het.step()
@@ -7040,6 +7200,21 @@ def _build_two_link_revolute_urdf(name, geom_tag=None, geom_attribs=None, *, lin
     return urdfpy.URDF._from_xml(robot, robot, get_assets_dir())
 
 
+def _build_free_body_urdf(name, com_xyz):
+    """Build a single free-floating link URDF with a box geom and an off-center COM, returning its path."""
+    robot = ET.Element("robot", name=name)
+    link = ET.SubElement(robot, "link", name="body")
+    for group_tag in ("visual", "collision"):
+        group = ET.SubElement(link, group_tag)
+        geom_el = ET.SubElement(group, "geometry")
+        ET.SubElement(geom_el, "box", size="0.04 0.04 0.04")
+    inertial = ET.SubElement(link, "inertial")
+    ET.SubElement(inertial, "mass", value="0.5")
+    ET.SubElement(inertial, "origin", xyz=com_xyz)
+    ET.SubElement(inertial, "inertia", ixx="1e-3", iyy="1e-3", izz="1e-3", ixy="0", ixz="0", iyz="0")
+    return urdfpy.URDF._from_xml(robot, robot, get_assets_dir())
+
+
 @pytest.mark.slow  # ~250s
 @pytest.mark.required
 def test_heterogeneous_robots(show_viewer, tol):
@@ -7125,7 +7300,27 @@ def test_heterogeneous_robots(show_viewer, tol):
             color=(0.0, 0.0, 1.0, 0.4),
         ),
     )
+    # Free-floating single-link URDF objects with different off-center COMs. Unlike the articulated robots above
+    # (which stay unaligned), each variant is a basic rigid object, so its link frame is moved to its own COM.
+    FREE_POS = (3.0, 0.0, 0.2)
+    free_het = scene.add_entity(
+        morph=(
+            gs.morphs.URDF(file=_build_free_body_urdf("free_body_a", "0.02 0 0"), pos=FREE_POS, align=True),
+            gs.morphs.URDF(file=_build_free_body_urdf("free_body_b", "0 0 0.03"), pos=FREE_POS, align=True),
+        ),
+        material=gs.materials.Rigid(rho=200.0),
+    )
     scene.build(n_envs=4, env_spacing=(0.0, 0.5))
+
+    # Each free-body variant (env 0 variant A, env 2 variant B) is aligned to its own COM: the link origin coincides
+    # with the COM, and the relative getter strips the alignment back to the user pose.
+    for i_env in (0, 2):
+        assert_allclose(
+            free_het.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env),
+            free_het.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env),
+            tol=tol,
+        )
+        assert_allclose(free_het.get_pos(relative=True, envs_idx=i_env), FREE_POS, tol=tol)
 
     # Joint structure: both variants share the same joints (root_joint + joint1)
     assert len(het_obj.joints) == 2

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -6867,7 +6867,7 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
 
 @pytest.mark.slow  # ~450s
 @pytest.mark.required
-def test_heterogeneous_simulation(show_viewer, tol):
+def test_heterogeneous_physics_parity(show_viewer, tol):
     """Test heterogeneous simulation by comparing against independent homogeneous simulations.
 
     This test verifies that heterogeneous simulation produces identical physics results
@@ -7292,7 +7292,7 @@ def _build_free_body_urdf(name, com_xyz):
 
 @pytest.mark.slow  # ~250s
 @pytest.mark.required
-def test_heterogeneous_robots(show_viewer, tol):
+def test_heterogeneous_inertial_alignment(show_viewer, tol):
     """Test heterogeneous articulated simulation with vertex-based and primitive collision geometries.
 
     Variant A splits each box primitive into two half-height sub-boxes (top/bottom),
@@ -7396,6 +7396,15 @@ def test_heterogeneous_robots(show_viewer, tol):
             tol=tol,
         )
         assert_allclose(free_het.get_pos(relative=True, envs_idx=i_env), FREE_POS, tol=tol)
+
+    # Relative set_pos on a boolean-masked subset of envs: each selected env's relative getter must report its target
+    # back, stripping its own per-variant offset.
+    mask = torch.tensor([True, False, True, False], device=gs.device)
+    free_new_pos = torch.tensor([[1.0, 0.0, 0.5], [2.0, 0.0, 0.5]], dtype=gs.tc_float, device=gs.device)
+    free_het.set_pos(free_new_pos, envs_idx=mask, relative=True)
+    free_pos = free_het.get_pos(relative=True)
+    assert_allclose(free_pos[[0, 2]], free_new_pos, tol=tol)
+    assert_allclose(free_pos[[1, 3]], FREE_POS, tol=tol)
 
     # Joint structure: both variants share the same joints (root_joint + joint1)
     assert len(het_obj.joints) == 2

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -1593,10 +1593,11 @@ def test_contact_pruning_authored_decomp(gjk_collision, show_viewer):
         show_viewer=show_viewer,
     )
     plane = scene.add_entity(gs.morphs.Plane())
+    pole_pos = (0.0, 0.0, BASE_HEIGHT / 2)
     pole = scene.add_entity(
         morph=gs.morphs.URDF(
             file="tower/base_pole.urdf",
-            pos=(0.0, 0.0, BASE_HEIGHT / 2),
+            pos=pole_pos,
             file_meshes_are_zup=True,
         ),
         material=gs.materials.Rigid(
@@ -1604,15 +1605,19 @@ def test_contact_pruning_authored_decomp(gjk_collision, show_viewer):
         ),
         vis_mode="collision",
     )
+    poss_init = [pole_pos]
+    rpys_init = [(0.0, 0.0, 0.0)]
     rings = []
     height = BASE_HEIGHT
     for i, ring_idx in enumerate(RINGS_ORDER):
+        ring_pos = (0.0, 0.0, height + (RING_HEIGHT - 1e-4) / 2)
+        # Alternate rotational offset along z-axis to avoid lateral contacts
+        ring_yaw = 180 / N_WEDGES * (i % 2)
         ring = scene.add_entity(
             morph=gs.morphs.URDF(
                 file=f"tower/ring_{ring_idx + 1:02d}.urdf",
-                pos=(0.0, 0.0, height + (RING_HEIGHT - 1e-4) / 2),
-                # Alternate rotational offset along z-axis to avoid lateral contacts
-                euler=(0.0, 0.0, 180 / N_WEDGES * (i % 2)),
+                pos=ring_pos,
+                euler=(0.0, 0.0, ring_yaw),
                 file_meshes_are_zup=True,
             ),
             material=gs.materials.Rigid(
@@ -1622,11 +1627,14 @@ def test_contact_pruning_authored_decomp(gjk_collision, show_viewer):
             visualize_contact=True,
         )
         rings.append(ring)
+        poss_init.append(ring_pos)
+        rpys_init.append((0.0, 0.0, np.deg2rad(ring_yaw)))
         height += RING_HEIGHT - 1e-4
+    ball_pos = (0.0, 0.0, height + BALL_HEIGHT)
     ball = scene.add_entity(
         morph=gs.morphs.URDF(
             file="tower/ball.urdf",
-            pos=(0.0, 0.0, height + BALL_HEIGHT),
+            pos=ball_pos,
             file_meshes_are_zup=True,
         ),
         material=gs.materials.Rigid(
@@ -1634,19 +1642,13 @@ def test_contact_pruning_authored_decomp(gjk_collision, show_viewer):
         ),
         vis_mode="collision",
     )
+    poss_init.append(ball_pos)
+    rpys_init.append((0.0, 0.0, 0.0))
     scene.build()
 
     geom_owner = {geom.idx: entity for entity in (plane, pole, *rings, ball) for geom in entity.geoms}
     ring_geoms = {geom.idx for ring in rings for geom in ring.geoms}
     ball_geoms = {geom.idx for geom in ball.geoms}
-
-    poss_init = [
-        qd_to_torch(scene.rigid_solver.links_info.pos, entity._idx_in_solver) for entity in (pole, *rings, ball)
-    ]
-    rpys_init = [
-        gu.quat_to_xyz(qd_to_torch(scene.rigid_solver.links_info.quat, entity._idx_in_solver), rpy=True)
-        for entity in (pole, *rings, ball)
-    ]
 
     # Tiny warm-up to deal with initial penetration (~5e-4)
     for _ in range(2):
@@ -2388,7 +2390,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
 
     # A no-offset entity reports the same pose in the user and world frames.
     assert_allclose(plain_box.get_pos(relative=True), plain_box.get_pos(relative=False), tol=tol)
-    assert_allclose(plain_box.get_pos(relative=False), (2.0, 0.0, 0.2), tol=tol)
+    assert_allclose(plain_box.get_pos(), (2.0, 0.0, 0.2), tol=tol)
     # With both a morph pose and an offset, the relative getter returns the morph pose while the world getter carries
     # the offset composed onto it (the offset position adds in z since the user orientation is identity).
     assert_allclose(posed_box.get_pos(relative=True), POSED_BOX_POS, tol=tol)
@@ -2399,6 +2401,13 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
         gu.xyz_to_quat(np.array(POSED_BOX_OFFSET_EULER), rpy=True, degrees=True),
         tol=tol,
     )
+    # Setting the orientation in the user frame keeps the user-frame position fixed: the offset position rotates with
+    # the orientation, so the world position is rewritten to preserve the reported relative position. Rotating about x
+    # while the offset position is along z makes that offset contribution change, exercising the rewrite.
+    new_quat = gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), rpy=True, degrees=True)
+    posed_box.set_quat(new_quat, relative=True)
+    assert_allclose(posed_box.get_pos(relative=True), POSED_BOX_POS, tol=tol)
+    assert_allclose(posed_box.get_quat(relative=True), new_quat, tol=tol)
 
     robot_aabb_init, robot_base_aabb_init = robot.get_AABB(), robot.geoms[0].get_AABB()
     cube_aabb_init, cube_base_aabb_init = cube.get_AABB(), cube.geoms[0].get_AABB()
@@ -2419,14 +2428,14 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     sphere.set_pos(np.tile(pos_delta[[0]], (2, 1)) + 1.0, relative=False)
     quat_delta = np.random.rand(2, 4)
     with nullcontext() if batch_fixed_verts else pytest.raises(gs.GenesisException):
-        robot.set_quat(quat_delta)
+        robot.set_quat(quat_delta, relative=False)
         if show_viewer:
             scene.visualizer.update()
     with nullcontext() if batch_fixed_verts else pytest.raises(gs.GenesisException):
-        robot.set_quat(quat_delta[[0]], envs_idx=[0])
+        robot.set_quat(quat_delta[[0]], envs_idx=[0], relative=False)
         if show_viewer:
             scene.visualizer.update()
-    cube.set_quat(quat_delta)
+    cube.set_quat(quat_delta, relative=False)
     if show_viewer:
         scene.visualizer.update()
 
@@ -2471,19 +2480,15 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
             entity.set_pos(pos_delta, relative=relative)
 
             pos_ref = pos_delta + pos_zero if relative else pos_delta
-            assert_allclose(entity.get_pos(relative=False), pos_ref, tol=tol)
+            # Round-trip in the frame it was set in: the getter must report back exactly what set_pos received.
+            assert_allclose(entity.get_pos(relative=relative), pos_delta, tol=tol)
             assert_allclose(entity.geoms[0].get_AABB(), base_aabb_init + (pos_ref - pos_zero), tol=tol)
             assert_allclose(entity.get_AABB(), entity_aabb_init + (pos_ref - pos_zero), tol=tol)
 
             quat_delta = torch.tile(torch.as_tensor(np.random.rand(4), dtype=gs.tc_float, device=gs.device), (2, 1))
             quat_delta /= torch.linalg.norm(quat_delta, axis=1, keepdim=True)
             entity.set_quat(quat_delta, relative=relative)
-            quat = entity.get_quat(relative=False)
-            if relative:
-                quat_ref = gu.transform_quat_by_quat(quat_zero, quat_delta)
-            else:
-                quat_ref = quat_delta
-            assert_allclose(quat, quat_ref, tol=tol)
+            assert_allclose(entity.get_quat(relative=relative), quat_delta, tol=tol)
 
 
 @pytest.mark.slow  # ~200s
@@ -4600,7 +4605,9 @@ def test_urdf_parsing(show_viewer, tol):
     root_idx_all = [link.root_idx for link in scene.rigid_solver.links]
     assert len(set(root_idx_all)) == 4
 
-    def _check_entity_positions(relative, tol):
+    def _check_entity_positions(expected_y_spacing, tol):
+        # The four parsing configs are laid out 'expected_y_spacing' apart in y, so their world AABBs must coincide once
+        # that spacing is removed. AABBs are world-frame, so this check is independent of the relative-getter frame.
         nonlocal entities
         AABB_all = []
         for key in ((False, False), (False, True), (True, False), (True, True)):
@@ -4616,33 +4623,35 @@ def test_urdf_parsing(show_viewer, tol):
                 AABB[1] = np.maximum(AABB[1], AABB_i[1])
             AABB_all.append(AABB)
         AABB_diff = np.diff(AABB_all, axis=0)
-        if relative:
-            AABB_diff[..., 1] -= POS_OFFSET
+        AABB_diff[..., 1] -= expected_y_spacing
         assert_allclose(AABB_diff, 0.0, tol=tol)
 
-    # Check that `set_pos` / `set_quat` applies the same transform in all cases
+    # Check that `set_pos` / `set_quat` applies the same transform in all cases. Both frames place every config at the
+    # same pose, so the world AABBs coincide with no residual spacing.
     for relative in (False, True):
         for key in ((False, False), (False, True), (True, False), (True, True)):
             entities[key].set_pos(np.array([0.5, 0.0, 0.0]), relative=relative)
             entities[key].set_quat(np.array([0.0, 0.0, 0.0, 1.0]), relative=relative)
         if show_viewer:
             scene.visualizer.update()
-        _check_entity_positions(relative, tol=tol)
+        _check_entity_positions(0.0, tol=tol)
 
-    # Check that `set_qpos` applies the same absolute transform in all cases
+    # Check that `set_qpos` applies the same absolute transform in all cases. The fixed roots have no free joint to
+    # take a base pose via qpos, so they are placed at the matching absolute world pose with the (relative=False)
+    # setters. All four configs then sit POS_OFFSET apart in y, as at creation.
     door_angle = np.array([1.1])
+    world_quat = tuple(WOLRD_QUAT / np.linalg.norm(WOLRD_QUAT))
     for i, key in enumerate(((False, False), (False, True))):
-        qpos = np.concatenate(
-            ((0.0, (i - 1.5) * POS_OFFSET, 0.0), tuple(WOLRD_QUAT / np.linalg.norm(WOLRD_QUAT)), door_angle)
-        )
+        qpos = np.concatenate(((0.0, (i - 1.5) * POS_OFFSET, 0.0), world_quat, door_angle))
         entities[key].set_qpos(qpos)
     for i, key in enumerate(((True, False), (True, True))):
-        entities[key].set_pos(np.array([0.0, 0.0, 0.0]), relative=True)
-        entities[key].set_quat(np.array([1.0, 0.0, 0.0, 0.0]), relative=True)
+        config_y = ((i + 2) - 1.5) * POS_OFFSET
+        entities[key].set_pos(np.array([0.0, config_y, 0.0]), relative=False)
+        entities[key].set_quat(np.array(world_quat), relative=False)
         entities[key].set_qpos(door_angle)
     if show_viewer:
         scene.visualizer.update()
-    _check_entity_positions(relative=True, tol=tol)
+    _check_entity_positions(POS_OFFSET, tol=tol)
 
     # Add dof damping to stabilitze the physics
     for key in ((False, False), (False, True), (True, False), (True, True)):
@@ -4670,7 +4679,7 @@ def test_urdf_parsing(show_viewer, tol):
         door_pos_diff = torch.diff(torch.concatenate(door_pos_all))
         assert_allclose(door_pos_diff, 0, tol=5e-3)
     assert_allclose(scene.rigid_solver.dofs_state.vel.to_numpy(), 0.0, tol=1e-3)
-    _check_entity_positions(relative=True, tol=2e-3)
+    _check_entity_positions(POS_OFFSET, tol=2e-3)
 
 
 @pytest.mark.slow  # ~200s
@@ -6340,8 +6349,8 @@ def test_mesh_align(show_viewer, tol):
     assert_allclose(mango.get_quat(relative=True), gu.identity_quat(), tol=tol)
     # The world-frame base pose places the link frame at the geometry COM and principal axes.
     assert_allclose(
-        mango.get_links_pos(links_idx_local=[0], ref="link_com"),
-        mango.get_links_pos(links_idx_local=[0], ref="link_origin"),
+        mango.get_links_pos(links_idx_local=[0], ref="link_com", relative=False),
+        mango.get_links_pos(links_idx_local=[0], ref="link_origin", relative=False),
         tol=tol,
     )
     geom_inertia_i = qd_to_numpy(scene.rigid_solver.links_state.cinr_inertial, transpose=True)[0, 1]
@@ -6355,8 +6364,8 @@ def test_mesh_align(show_viewer, tol):
         assert_allclose(het_obj.get_pos(relative=True, envs_idx=i_env), HET_POS, tol=tol)
         assert_allclose(het_obj.get_quat(relative=True, envs_idx=i_env), gu.identity_quat(), tol=tol)
         assert_allclose(
-            het_obj.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env),
-            het_obj.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env),
+            het_obj.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env, relative=False),
+            het_obj.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env, relative=False),
             tol=tol,
         )
     # The two variants have different geometry, so their aligned world origins differ.
@@ -6492,6 +6501,52 @@ def test_relative_offset_on_link_relative_geoms(show_viewer, tol):
         expected_world_quat = gu.transform_quat_by_quat(geom_user_quat, offset_quat)
         assert_allclose(geom.get_pos(relative=False), expected_world_pos, tol=tol)
         assert_allclose(geom.get_quat(relative=False), expected_world_quat, tol=tol)
+
+
+@pytest.mark.required
+def test_multi_root_offset(show_viewer, tol):
+    # One MJCF with two free root bodies, each auto-aligned to its own geometry. Every root's pose offset is tracked
+    # independently, so each root reports its own user-specified pose through the relative (default) getters while the
+    # world frame carries that root's own COM shift. Without per-root tracking, the offsets cross-contaminate.
+    BODY_A_POS = (1.0, 0.0, 0.5)
+    BODY_B_POS = (-1.0, 0.0, 0.5)
+    mjcf = ET.Element("mujoco", model="two_bodies")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    body_a = ET.SubElement(worldbody, "body", name="a", pos=f"{BODY_A_POS[0]} {BODY_A_POS[1]} {BODY_A_POS[2]}")
+    ET.SubElement(body_a, "joint", name="a_free", type="free")
+    ET.SubElement(body_a, "geom", type="box", size="0.05 0.05 0.05", pos="0.02 0.01 0.0", density="1000")
+    body_b = ET.SubElement(worldbody, "body", name="b", pos=f"{BODY_B_POS[0]} {BODY_B_POS[1]} {BODY_B_POS[2]}")
+    ET.SubElement(body_b, "joint", name="b_free", type="free")
+    ET.SubElement(body_b, "geom", type="box", size="0.05 0.08 0.03", pos="0.0 0.03 0.02", density="1000")
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_FPS=False,
+    )
+    entity = scene.add_entity(
+        gs.morphs.MJCF(
+            file=ET.tostring(mjcf, encoding="unicode"),
+            align=True,
+        ),
+    )
+    scene.build()
+
+    link_a, link_b = entity.links
+    # Each root reports its own user-specified pose in the relative frame, independent of the other root.
+    assert_allclose(link_a.get_pos(), BODY_A_POS, tol=tol)
+    assert_allclose(link_b.get_pos(), BODY_B_POS, tol=tol)
+    assert_allclose(link_a.get_quat(), gu.identity_quat(), tol=tol)
+    assert_allclose(link_b.get_quat(), gu.identity_quat(), tol=tol)
+    # The world frame carries each root's own COM shift (the box center), confirming the offsets are not shared.
+    assert_allclose(link_a.get_pos(relative=False), (1.02, 0.01, 0.5), tol=tol)
+    assert_allclose(link_b.get_pos(relative=False), (-1.0, 0.03, 0.52), tol=tol)
+
+    # Both roots free-fall under gravity: the relative getter tracks each user frame, holding x/y and dropping z
+    # equally (free fall is mass-independent).
+    for _ in range(20):
+        scene.step()
+    assert_allclose(link_a.get_pos()[..., :2], BODY_A_POS[:2], tol=tol)
+    assert_allclose(link_b.get_pos()[..., :2], BODY_B_POS[:2], tol=tol)
+    assert_allclose(link_a.get_pos()[..., 2], link_b.get_pos()[..., 2], tol=tol)
 
 
 @pytest.fixture
@@ -7316,8 +7371,8 @@ def test_heterogeneous_robots(show_viewer, tol):
     # with the COM, and the relative getter strips the alignment back to the user pose.
     for i_env in (0, 2):
         assert_allclose(
-            free_het.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env),
-            free_het.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env),
+            free_het.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env, relative=False),
+            free_het.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env, relative=False),
             tol=tol,
         )
         assert_allclose(free_het.get_pos(relative=True, envs_idx=i_env), FREE_POS, tol=tol)
@@ -7340,7 +7395,7 @@ def test_heterogeneous_robots(show_viewer, tol):
     # Variant B has x-offset relative to variant A
     assert_allclose(het_pos_init[0, 0] - het_pos_init[2, 0], 0.5, tol=tol)
     assert_allclose(het_pos_init[1, 0] - het_pos_init[3, 0], 0.5, tol=tol)
-    het_links_pos_init = het_obj.get_links_pos()
+    het_links_pos_init = het_obj.get_links_pos(relative=False)
     assert_allclose(het_links_pos_init.diff(dim=-2), (0.1, 0, 0), tol=tol)
 
     # Same-variant envs produce identical results (balanced block [A, A, B, B])
@@ -7367,8 +7422,8 @@ def test_heterogeneous_robots(show_viewer, tol):
     assert_allclose(mass[0], sphere_base_mass + sphere_moving_mass, tol=tol)
 
     # CoM position: variant B should match explicit URDF inertial origin_xyz
-    com_pos = het_obj.get_links_pos(ref="link_com")
-    origin_pos = het_obj.get_links_pos(ref="link_origin")
+    com_pos = het_obj.get_links_pos(ref="link_com", relative=False)
+    origin_pos = het_obj.get_links_pos(ref="link_origin", relative=False)
     com_offset = com_pos - origin_pos
     # Variant A: CoM offset matches URDF inertial origin
     assert_allclose(com_offset[0, 0], sphere_base_com, tol=tol)
@@ -7426,7 +7481,7 @@ def test_heterogeneous_robots(show_viewer, tol):
     # Check that dof position is correct
     dof_pos = het_obj.get_dofs_position()
     assert_allclose(dof_pos[..., -1], target_dof_pos, tol=1e-3)
-    het_links_pos = het_obj.get_links_pos()
+    het_links_pos = het_obj.get_links_pos(relative=False)
     assert_allclose(het_links_pos[..., 1, 0] - het_links_pos[..., 0, 0], target_dof_pos + 0.1, tol=1e-3)
     assert_allclose(het_links_pos[..., 1, 1:], het_links_pos[..., 0, 1:], tol=5e-3)
 


### PR DESCRIPTION
## Description
Adds morph pose-offset options (`offset_pos` / `offset_quat` / `offset_euler`) and a `relative` keyword on the rigid `get_pos` / `get_quat` / `set_pos` / `set_quat` (and their singular link/geom counterparts, plus the plural `get_links_pos` / `get_links_quat`). The offset captures up-axis (z-up) conversion and inertial alignment, so these accessors default to the user's morph frame instead of the solver's internal COM/principal-axis frame. It is stored per **root link** in the solver (per-environment for heterogeneous variants) and stripped on the fly. Non-rigid entities (FEM / PBD / particle / tool) also compose the offset into their placement.

**Behaviour-affecting points:**
- **`relative` semantics changed.** `relative=True` now means "in the user/offset frame" (the morph pose), not the previous "relative to the initial `qpos0`" (additive); a caller that explicitly passed `relative=True` will see different behaviour.
- **Default flipped to `relative=True`.** `get_pos` / `get_quat` (entity/link/geom and the plural getters) now default to the user frame. For entities that *have* an offset (z-up meshes, inertia-aligned objects, explicit `offset_*`) this returns a different value than before (the world/solver frame); entities without an offset are unchanged. Internal world-frame consumers (sensors, viewer, gizmo, FEM coupling, and `qpos` / FK / IK) stay in the world frame (`relative=False`).
- **Backward pass restriction.** `set_pos` / `set_quat` raise on `relative=True` when the targeted links carry a pose offset, since that composition's dependency is not differentiated; use `relative=False` for gradients.

**Bug fixes:**
- Multi-root entities (one MJCF with several free root bodies) now track the offset per root, instead of accumulating every root's offset into one entity-level offset (which corrupted/dropped the reported poses).
- Heterogeneous variants are now inertia-aligned per variant (previously only the primary was, so an asymmetric variant did not match its homogeneous equivalent).

## How Has This Been / Can This Be Tested?

New tests `test_multi_root_offset`, `test_offset_pos` (FEM) and `test_relative_offset_on_link_relative_geoms` were added; `test_set_root_pose`, `test_mesh_align`, `test_urdf_parsing`, `test_contact_pruning_authored_decomp` and `test_heterogeneous_inertial_alignment` were extended/updated.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

