### PR TITLE
[BUG FIX] Fix race condition causing ImGui plugin to crash during scene rebuild.

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -213,6 +213,9 @@ class Viewer(pyglet.window.Window):
         self._offscreen_event = Event()
         self._offscreen_pending_render = None
         self._offscreen_pending_close = None
+        # Renderers retired by rebind() on the stepping thread, waiting to be deleted on the
+        # thread that owns the GL context (see _flush_retired_renderers).
+        self._retired_renderers = []
         self._offscreen_semaphore = Semaphore(0)
         self._offscreen_result = None
 
@@ -512,7 +515,11 @@ class Viewer(pyglet.window.Window):
             self._scene = context._scene
             self._seg_node_map = context.seg_node_map
             if self._renderer is not None:
-                self._renderer.delete()
+                # rebind() runs on the stepping thread, which has no current GL context: deleting GL objects
+                # here segfaults. Retire the old renderer instead; the render thread deletes it right before
+                # its next draw, so shared GL objects (e.g. reused textures) are released - and re-uploaded -
+                # before the new renderer can record them as live (see _flush_retired_renderers).
+                self._retired_renderers.append(self._renderer)
             self._renderer = Renderer(*self._viewport_size, context.jit, self.render_flags["point_size"])
             self._setup_main_camera()
             self.plugins = []
@@ -684,7 +691,8 @@ class Viewer(pyglet.window.Window):
             if self.scene.has_node(self._direct_light):
                 self.scene.remove_node(self._direct_light)
 
-        # Delete renderer
+        # Delete renderer, along with any renderer retired by a rebind() that never drew again
+        self._flush_retired_renderers()
         if self._renderer is not None:
             try:
                 self._renderer.delete()
@@ -780,6 +788,8 @@ class Viewer(pyglet.window.Window):
             # Make OpenGL context current
             self.switch_to()
 
+            self._flush_retired_renderers()
+
             if self._offscreen_pending_close is not None:
                 # Extract request right away
                 (target,) = self._offscreen_pending_close
@@ -818,6 +828,16 @@ class Viewer(pyglet.window.Window):
             if self._run_in_thread:
                 self._offscreen_semaphore.release()
 
+    def _flush_retired_renderers(self):
+        """Delete renderers retired by rebind(). Must run with the GL context current, before the
+        replacement renderer draws (see rebind)."""
+        while self._retired_renderers:
+            renderer = self._retired_renderers.pop()
+            try:
+                renderer.delete()
+            except (OpenGL.error.GLError, OpenGL.error.NullFunctionError):
+                pass
+
     def on_draw(self):
         """Redraw the scene into the viewing window."""
         if self._renderer is None:
@@ -826,6 +846,8 @@ class Viewer(pyglet.window.Window):
         with self.render_lock if self._run_in_thread or not self.auto_start else nullcontext():
             # Make OpenGL context current
             self.switch_to()
+
+            self._flush_retired_renderers()
 
             # Render the scene
             self.clear()

--- a/tests/test_imgui_overlay.py
+++ b/tests/test_imgui_overlay.py
@@ -1,6 +1,7 @@
 """Screenshot integration test for ImGuiOverlayPlugin."""
 
 import os
+import sys
 
 import numpy as np
 import pytest
@@ -9,7 +10,7 @@ import genesis as gs
 from genesis.ext.pyrender.overlay import ImGuiOverlayPlugin
 
 from .conftest import IS_INTERACTIVE_VIEWER_AVAILABLE
-from .utils import assert_allclose, rgb_array_to_png_bytes
+from .utils import assert_allclose, assert_pixel_match, rgb_array_to_png_bytes
 
 try:
     import imgui_bundle  # noqa: F401
@@ -92,7 +93,7 @@ def _apply_deterministic_imgui_overrides(monkeypatch):
     monkeypatch.setattr(ImGuiOverlayPlugin, "_capture_pending_entities_kwargs", _capture_pending_entities_basename)
 
 
-def _build_default_scene(*, enable_gui):
+def _build_default_scene(*, enable_gui, run_in_thread=False):
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
             # Keep ``res`` small enough to fit the virtual display area of GitHub-hosted Apple M1 macos-15 runners:
@@ -100,10 +101,10 @@ def _build_default_scene(*, enable_gui):
             res=(640, 480),
             camera_pos=(4.5, -1.2, 2.5),
             camera_lookat=(0.0, -1.2, 0.5),
-            # The capture path at the end of this test calls ``pyrender_viewer.on_draw`` and reads the window
-            # framebuffer directly. That can only run on the thread that owns the GL context, so run the viewer
-            # in the test thread instead of its own background thread.
-            run_in_thread=False,
+            # The snapshot test keeps the default ``run_in_thread=False``: its capture path calls
+            # ``pyrender_viewer.on_draw`` and reads the window framebuffer directly, which can only run on the
+            # thread that owns the GL context.
+            run_in_thread=run_in_thread,
             # ``_render_help_text`` rasterizes "[i]: show keyboard instructions" via Genesis's own font path,
             # which is not byte-identical across software / hardware renderers; disable it so the captured
             # frame contains only the deterministic ImGui overlay.
@@ -300,7 +301,18 @@ def test_scene_rebuild():
     # enable_gui makes the overlay own an InteractiveScene and rebuild the scene in place: the same Scene
     # object (and its viewer) stay valid across a rebuild, driven entirely through scene.step() with no
     # manual InteractiveScene. A Rebuild click only queues the request; scene.step() applies it on its thread.
-    scene = _build_default_scene(enable_gui=True)
+    scene = _build_default_scene(enable_gui=True, run_in_thread=(sys.platform == "linux"))
+    # A UV-mapped mesh with an image texture, so the capture comparison below catches the renderer swap invalidating
+    # GL textures shared across the rebuild.
+    scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file="meshes/duck/duck.obj",
+            scale=0.001,
+            pos=(0.8, -0.8, 0.2),
+            fixed=True,
+        ),
+        name="duck",
+    )
     scene.build()
 
     scene_id = id(scene)
@@ -312,8 +324,15 @@ def test_scene_rebuild():
     window_before = scene.viewer._pyrender_viewer
     # Move the camera off its default so the rebuild has to restore the exact viewpoint (including roll),
     # not reset it to the ViewerOptions default.
-    scene.viewer.set_camera_pose(pos=np.array([2.0, 1.3, 1.7]), lookat=np.array([0.1, -0.2, 0.4]))
+    scene.viewer.set_camera_pose(pos=np.array([2.3, 1.5, 1.9]), lookat=np.array([0.1, -0.2, 0.1]))
     camera_pose_before = scene.viewer.camera_pose.copy()
+
+    # Pause so stepping only applies the rebuild without advancing the dynamics: the scene state must be identical
+    # for the pre/post-rebuild captures.
+    interactive.pause()
+    rgb_before, *_ = window_before.render_offscreen(
+        window_before._camera_node, window_before._renderer, rgb=True, depth=False, seg=False, normal=False
+    )
 
     interactive.rebuild(entities_kwargs=plugin._pending_entities_kwargs)
     scene.step()
@@ -323,4 +342,17 @@ def test_scene_rebuild():
     assert scene.viewer._pyrender_viewer is window_before
     assert [entity.name for entity in scene.entities] == names_before
     assert_allclose(scene.viewer.camera_pose, camera_pose_before, atol=1e-4)
+    qpos_before = scene.rigid_solver.get_qpos()
+
+    rgb_after, *_ = window_before.render_offscreen(
+        window_before._camera_node, window_before._renderer, rgb=True, depth=False, seg=False, normal=False
+    )
+    assert not window_before._retired_renderers, "Retired renderer was not deleted on the render thread."
+    # The rebuilt scene is static, so the captures must match; a renderer retired after the rebuilt scene's first
+    # draw would leave the duck texture invalid and shift the image. Use the same blurred pixel-match comparison
+    # as the snapshot tests, which tolerates the few-pixel jitter software renderers produce on any platform while
+    # still catching a stale-texture regression (which shifts a whole region).
+    assert_pixel_match(rgb_after, rgb_before, err_msg="Rebuilt scene renders differently.")
+
     scene.step()
+    assert_allclose(scene.rigid_solver.get_qpos(), qpos_before, tol=gs.EPS)


### PR DESCRIPTION
## Bug

Clicking **Rebuild Scene** in the ImGui overlay (or any queued `InteractiveScene.rebuild()`) segfaults the process on Linux when the viewer runs threaded (`run_in_thread=True`, the default).

### Root cause

The rebuild is applied by the scene pre-step callback on the **stepping thread**. There, `Viewer.rebind()` called `self._renderer.delete()`, which issues GL calls (`glDeleteProgram`, ...) — but the stepping thread has **no current GL context**; the context is current on the render thread. Faulthandler trace at the crash:

```
Current thread (stepping thread):
  OpenGL/platform/baseplatform.py:487 __call__
  genesis/ext/pyrender/shader_program.py:137 _remove_from_context
  genesis/ext/pyrender/shader_program.py:186 delete
  genesis/ext/pyrender/renderer.py:321 delete
  genesis/ext/pyrender/viewer.py:512 rebind
  genesis/vis/viewer.py:83 build
  genesis/engine/scene.py:905 build
  genesis/engine/interactive_scene.py:334 _apply_rebuild
  genesis/engine/interactive_scene.py:109 _pre_step
  genesis/engine/scene.py:1037 step
```

### Repro

```python
import genesis as gs
from genesis.ext.pyrender.overlay import ImGuiOverlayPlugin

gs.init()
scene = gs.Scene(viewer_options=gs.options.ViewerOptions(enable_gui=True), show_viewer=True)
scene.add_entity(morph=gs.morphs.Plane(), name="plane")
scene.add_entity(morph=gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"), name="franka")
scene.build()

plugin = next(p for p in scene.viewer.plugins if isinstance(p, ImGuiOverlayPlugin))
plugin.interactive_scene.pause()
for _ in range(100):
    scene.step()
plugin.interactive_scene.rebuild(entities_kwargs=plugin._pending_entities_kwargs)  # = Rebuild Scene button
for _ in range(30):
    scene.step()  # SIGSEGV without this fix
print("REBUILD OK")
```

(Equivalently: run `examples/gui/imgui_joint_control.py` and click **Rebuild Scene**.)

## Fix

`rebind()` retires the old renderer into `Viewer._retired_renderers` instead of deleting it; the render thread flushes that list — under `render_lock`, with the GL context current — at the top of `on_draw` and of the offscreen step, with a fallback flush on close. `Renderer.__init__` is GL-free (lazy caches), so constructing the replacement on the stepping thread is fine.

The deletion must happen not just on the right thread but **before the rebuilt scene's first draw** (review feedback): a late delete (e.g. a deferred clock tick firing after an in-flight draw) would let the new renderer's `_update_context` record scene textures still bound to the context by the old renderer (`Texture._add_to_context` returns early on a live `_texid`), and the delete would then invalidate them — textured assets would render broken after rebuild and never re-upload. Since `_apply_rebuild` holds `render_lock` for the whole rebuild, flushing at the top of `on_draw` guarantees the old renderer is deleted before the first new draw, and the shared textures are re-uploaded.

## Validation

- `test_imgui_overlay.py::test_scene_rebuild` extended (per review): the viewer now runs threaded on Linux, the scene includes a fixed textured mesh, and offscreen captures of the paused scene are compared before/after the rebuild. Verified to segfault with the old stepping-thread delete; catches stale-texture renders from a late delete; passes with this fix.
- `tests/test_viewer.py` (unchanged by this PR, 7 passed) and `test_imgui_overlay.py::test_runtime_plugin_toggle_and_pause` pass.
- Repro above: segfault before, `REBUILD OK` after (Linux, threaded viewer, X11).
- Exercised end-to-end from a downstream tool (Eden's `eden arrange`): rebuild applies, entity handles re-bind, viewer window stays alive, loop continues for thousands of frames.

### Related (not fixed here)

Rebuild with `enable_default_keybinds=True` hits a second latent bug: `rebind()` re-runs `DefaultControlsPlugin.build`, re-registering its keybinds into the preserved, never-cleared `Keybindings` registry → `ValueError: Key 'r' already assigned to 'record_video'`. It is currently masked because `enable_gui=True` force-disables default keybinds (the extended rebuild test uses `enable_gui=True`, so it does not hit it either). A proper fix needs keybind ownership tracking (the viewer also registers protected built-ins at init), so it is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

