### PR TITLE
[BUG FIX] offscreen camera renders at viewer resolution when show_viewer=True

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -798,19 +798,17 @@ class Viewer(pyglet.window.Window):
                 # Update context, just in case is not already done before
                 self.gs_context.update()
 
-                # Render current frame from camera viewpoint. Force the renderer back to the originally
-                # requested viewport size so the offscreen FBO honors what the caller asked for even when the
-                # window has since been clamped to a smaller content area by the OS (e.g. macOS CI runners).
+                # Render current frame from camera viewpoint. ``target`` is the camera's own
+                # offscreen FBO, already sized to the camera's configured resolution, so render at
+                # that size. Forcing it to ``self._offscreen_viewport_size`` (the interactive
+                # window's size) made offscreen camera renders come out at the viewer resolution
+                # whenever ``show_viewer=True`` (#2927); the camera FBO is independent of the window
+                # so it is never subject to the OS window clamping that override was guarding against.
                 self._offscreen_results = []
                 self.render_flags["offscreen"] = True
                 self.render_flags["skip_markers"] = skip_markers
-                saved_viewport = (target.viewport_width, target.viewport_height)
-                target.viewport_width, target.viewport_height = self._offscreen_viewport_size
-                try:
-                    self.clear()
-                    retval = self._render(camera, target, normal)
-                finally:
-                    target.viewport_width, target.viewport_height = saved_viewport
+                self.clear()
+                retval = self._render(camera, target, normal)
                 self._offscreen_result = retval if retval else (None, None)
                 self.render_flags["offscreen"] = False
                 self.render_flags["skip_markers"] = False

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -798,11 +798,10 @@ class Viewer(pyglet.window.Window):
                 # Update context, just in case is not already done before
                 self.gs_context.update()
 
-                # ``target`` is the camera's own offscreen FBO, already sized to the camera's configured resolution,
-                # so render at that size and never resize it to ``self._offscreen_viewport_size`` (the interactive
-                # window size). The camera FBO is independent of the window: forcing the window size onto it renders
-                # the camera at the wrong resolution, and unlike the window the FBO is never subject to the OS
-                # content-area clamping that such a resize would otherwise be guarding against.
+                # ``target`` is the camera's own offscreen FBO, already sized to the camera's configured resolution;
+                # render at that size and do not resize it to ``self._offscreen_viewport_size``. That viewport tracks
+                # the interactive window, a surface distinct from this FBO; forcing it onto the FBO would render the
+                # camera at the window's resolution instead of its own.
                 self._offscreen_results = []
                 self.render_flags["offscreen"] = True
                 self.render_flags["skip_markers"] = skip_markers

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -798,12 +798,11 @@ class Viewer(pyglet.window.Window):
                 # Update context, just in case is not already done before
                 self.gs_context.update()
 
-                # Render current frame from camera viewpoint. ``target`` is the camera's own
-                # offscreen FBO, already sized to the camera's configured resolution, so render at
-                # that size. Forcing it to ``self._offscreen_viewport_size`` (the interactive
-                # window's size) made offscreen camera renders come out at the viewer resolution
-                # whenever ``show_viewer=True`` (#2927); the camera FBO is independent of the window
-                # so it is never subject to the OS window clamping that override was guarding against.
+                # ``target`` is the camera's own offscreen FBO, already sized to the camera's configured resolution,
+                # so render at that size and never resize it to ``self._offscreen_viewport_size`` (the interactive
+                # window size). The camera FBO is independent of the window: forcing the window size onto it renders
+                # the camera at the wrong resolution, and unlike the window the FBO is never subject to the OS
+                # content-area clamping that such a resize would otherwise be guarding against.
                 self._offscreen_results = []
                 self.render_flags["offscreen"] = True
                 self.render_flags["skip_markers"] = skip_markers


### PR DESCRIPTION
## What

Fixes #2927. An offscreen `camera.render()` returned images at the **interactive viewer's** resolution instead of the camera's configured `res` when `show_viewer=True`, so `camera.intrinsics` no longer matched the rendered image shape and `camera.render_pointcloud()` failed.

## Root cause

In `Viewer._event_loop_step_offscreen` (`genesis/ext/pyrender/viewer.py`), the camera's offscreen render target was forced to `self._offscreen_viewport_size` (the interactive window's size) before rendering:

```python
saved_viewport = (target.viewport_width, target.viewport_height)
target.viewport_width, target.viewport_height = self._offscreen_viewport_size
```

`target` is the camera's own offscreen FBO, already sized to the camera's resolution and independent of the OS window — so the window-clamping workaround that override was added for doesn't apply to it. The override just made every camera render come out at the viewer's size whenever a viewer existed. The fix renders at the target's own viewport. (`show_viewer=False` doesn't go through the viewer, which is why it was already correct.)

## Verification

Using the issue's repro (rasterizer, camera `res=(360, 240)`):

| | before | after |
|---|---|---|
| `show_viewer=True` depth shape (H, W) | `(512, 682)` ❌ | `(240, 360)` ✅ |
| `show_viewer=True` `render_pointcloud()` | fails | works ✅ |
| `show_viewer=False` depth shape | `(240, 360)` ✅ | `(240, 360)` ✅ (no regression) |

Verified on Linux + GPU backend under a virtual display (Xvfb).

I drafted a regression test in `tests/test_render.py` (assert `depth.shape == configured res`, parametrized like `test_render_api`), but the bug path only triggers when an interactive viewer is actually available — happy to add it in whatever form fits your CI's display/EGL setup.