### PR TITLE
[BUG FIX] Deduplicate BatchRenderer textures without image_path.

### DIFF
--- a/genesis/vis/batch_renderer.py
+++ b/genesis/vis/batch_renderer.py
@@ -128,11 +128,14 @@ class GenesisGeomRetriever:
             geom_texture_indices = []
             for geom_texture in geom_textures:
                 if isinstance(geom_texture, gs.textures.ImageTexture) and geom_texture.image_array is not None:
-                    texture_id = geom_texture.image_path
+                    texture_id = (
+                        ("path", geom_texture.image_path)
+                        if geom_texture.image_path is not None
+                        else ("image_array", id(geom_texture.image_array))
+                    )
                     if texture_id not in texture_indices:
                         texture_idx = num_textures
-                        if texture_id is not None:
-                            texture_indices[texture_id] = texture_idx
+                        texture_indices[texture_id] = texture_idx
                         texture_widths.append(geom_texture.image_array.shape[1])
                         texture_heights.append(geom_texture.image_array.shape[0])
                         assert geom_texture.channel == 4

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -602,6 +602,8 @@ def test_glb_parse_material(glb_file):
 
 @pytest.mark.required
 def test_glb_shared_texture_not_duplicated(tmp_path):
+    from genesis.vis.batch_renderer import GenesisGeomRetriever
+
     n_submeshes = 16
     texture_size = 64
 
@@ -646,6 +648,12 @@ def test_glb_shared_texture_not_duplicated(tmp_path):
     # Hold every array alive before counting so that ids cannot be recycled by the garbage collector.
     rgba_arrays = [geom.surface.get_rgba().image_array for geom in vgeoms]
     assert len({id(array) for array in rgba_arrays}) == 1
+
+    scene.build()
+    retriever = GenesisGeomRetriever(scene.sim.rigid_solver, seg_level="entity")
+    retriever.build()
+    static_args = retriever.retrieve_rigid_meshes_static()
+    assert len(static_args["tex_widths"]) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

This fixes a remaining BatchRenderer texture dedup gap for embedded GLB textures after #2896.

`GenesisGeomRetriever.retrieve_rigid_meshes_static()` was deduplicating textures using `geom_texture.image_path` only. For embedded GLB textures, `image_path` is `None`, so BatchRenderer still packed one texture entry per submesh even when all submeshes already shared the same resolved RGBA texture object and image array.

This change adds a fallback dedup key for textures without an `image_path`, using the shared `image_array` object identity. That lets BatchRenderer reuse a single packed texture entry for embedded textures instead of duplicating `tex_data` once per vgeom.

This PR also extends the existing shared-texture GLB regression test to cover the BatchRenderer packing path directly.

## Related Issue
Resolves Genesis-Embodied-AI/genesis-world#2939

## Motivation and Context

PR #2896 fixed surface-level RGBA texture sharing for GLB submeshes that share a material, but BatchRenderer still duplicated embedded textures later in the pipeline when building `tex_*` arrays.

That meant a GLB with one embedded image and many textured submeshes could still produce one packed texture entry per submesh, causing avoidable memory growth and extra packing work in the BatchRenderer / gs-madrona path.

This change fixes that remaining duplication at the Genesis-side adapter layer. `gs-madrona` already consumes the packed arrays from `retrieve_rigid_meshes_static()`, so the issue is best addressed here.

## How Has This Been / Can This Be Tested?

Tested locally on Ubuntu 22.04.5 with `genesis-world==1.1.1`, NVIDIA RTX 5000 Ada, driver 570.211.01.

Targeted regression test:
```bash
uv run pytest tests/test_mesh.py -k shared_texture --backend=cpu --numprocesses=0
```

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
