### PR TITLE
[MISC] Clarify deprecated 'gs view' help text.

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -172,7 +172,7 @@ def main():
     launch_args.add_argument("-l", "--link_frame", action="store_true", default=False, help="Show link frame")
 
     subparsers.add_parser("launch", parents=[launch_args], help="Visualize a given asset (Mesh/URDF/MJCF/USD)")
-    subparsers.add_parser("view", parents=[launch_args], help="[DEPRECATED] Alias of 'launch'.")
+    subparsers.add_parser("view", parents=[launch_args], help="[DEPRECATED] Use 'gs launch' instead.")
 
     parser_play = subparsers.add_parser("play", help="Interactive viewer with ImGui joint controls and simulation")
     parser_play.add_argument(


### PR DESCRIPTION
## Description
The `gs view` subparser help text read `[DEPRECATED] Alias of 'launch'.` which tells the user the command is deprecated but not what to use instead.

The runtime warning message already says `"Use 'gs launch' instead"` because this aligns the help text to say the same thing so users get the migration path from both `gs --help` and `gs view --help`.

## Related Issue
No related issue; self-contained UX improvement.

## Motivation and Context
Before:
```bash
view    [DEPRECATED] Alias of 'launch'.
```
After:
```bash
view    [DEPRECATED] Use 'gs launch' instead.
```

## How Has This Been / Can This Be Tested?
```bash
uv run python -m genesis._main --help
# view line now reads: [DEPRECATED] Use 'gs launch' instead.
```

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.