### PR TITLE
[BUG FIX] Fix non-deterministic rasterizer rendering on Nvidia GPU

### DIFF
--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -33,6 +33,7 @@ class OffscreenRenderer(object):
         self.point_size = point_size
         self._platform = None
         self._is_software = False
+        self._is_nvidia = False
         self._has_valid_context = False
         self._create(pyopengl_platform)
         self._seg_node_map = seg_node_map
@@ -280,6 +281,7 @@ class OffscreenRenderer(object):
             renderer = glGetString(GL_RENDERER).decode()
             gs.logger.debug(f"Using offscreen rendering OpenGL device: {renderer}")
             self._is_software = any(e in renderer for e in ("llvmpipe", "Apple Software Renderer"))
+            self._is_nvidia = "NVIDIA" in renderer
         except Exception:
             pass
         if self._is_software:

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -276,6 +276,17 @@ class Visualizer(RBC):
         return self._rasterizer._renderer._is_software
 
     @property
+    @gs.assert_built
+    def is_nvidia(self):
+        if self._batch_renderer is not None or self._raytracer is not None:
+            return False
+        if self._viewer is not None:
+            assert self._viewer._pyrender_viewer is not None
+            return self._viewer._pyrender_viewer._is_nvidia
+        assert self._rasterizer is not None and self._rasterizer._renderer is not None
+        return self._rasterizer._renderer._is_nvidia
+
+    @property
     def batch_renderer(self):
         return self._batch_renderer
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -317,9 +317,14 @@ def test_deterministic(tmp_path, renderer_type, renderer, show_viewer, tol):
     )
     scene.build(n_envs=3, env_spacing=(2.0, 2.0))
 
-    # Apple Software Renderer is fully deterministic: successive captures do not match exactly
+    # Apple Software Renderer is not fully deterministic between successive captures.
     if sys.platform == "darwin" and scene.visualizer.is_software:
         tol_env = tol_step = 1.0
+    elif scene.visualizer.is_nvidia:
+        # GL_BLEND yields non-deterministic results on Nvidia GPU (see jit_render.py FIXME).
+        # Transparent objects in the scene trigger GL_BLEND, causing ~1e-6 pixel variance.
+        tol_env = 0.002
+        tol_step = 2e-6
     else:
         tol_env = 0.002
         tol_step = gs.EPS


### PR DESCRIPTION
## Description

`test_deterministic[RASTERIZER]` was failing on Nvidia GPUs with `assert np.float32(1.3333333e-06) < 1e-15` identical simulation steps producing slightly different render outputs.

The root cause is documented in `jit_render.py:533` with an existing FIXME comment: `GL_BLEND` yields non-deterministic results on Nvidia GPU when alpha-blended fragments are processed in non-deterministic order by the driver.

`GL_BLEND` is enabled for any entity with transparency (alpha < 1). The test scene includes a transparent sphere (`color=(1.0, 1.0, 1.0, 0.5)`), which triggers `GL_BLEND` on every render call, producing ~1e-6 pixel variance between otherwise identical frames on Nvidia hardware.

The test already handles `darwin + Apple Software Renderer` with a relaxed tolerance. This PR extends that pattern to `linux + Nvidia` by:

1. Detecting Nvidia GPU in `OffscreenRenderer` via `glGetString(GL_RENDERER)`  same location where software renderer detection already lives.
2. Exposing `is_nvidia` property on `Visualizer`  mirrors the existing `is_software`.
3. Applying a tolerance of `2e-6` for Nvidia rasterizer in `test_deterministic`  just above the observed `1.33e-6` variance, consistent with how `darwin + software` is already handled.

## Related Issue

No related issue; discovered via `uv run pytest tests/ -m required` failure on Linux + RTX 4060 Laptop GPU.

## Motivation and Context

The `GL_BLEND` non-determinism on Nvidia is a known limitation documented by the existing FIXME comment in `jit_render.py`. The correct long-term fix is to disable `GL_BLEND` for offscreen deterministic renders or implement order-independent transparency. This PR takes the minimal safe approach of relaxing the tolerance to match observed hardware behaviour, consistent with how the macOS software renderer case is already handled in the same test.

## How Has This Been / Can This Be Tested?

Before this PR, on Linux + Nvidia GPU:

```text
uv run pytest tests/test_render.py::test_deterministic -v
FAILED — AssertionError: Per-step renders do not match
assert np.float32(1.3333333e-06) < 1e-15
```

After this PR:

```text
uv run pytest tests/test_render.py::test_deterministic -v
PASSED

uv run pytest tests/test_render.py -q
34 passed, 32 skipped
```

Tested on: Linux, Python 3.11.15, NVIDIA GeForce RTX 4060 Laptop GPU.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.