### PR TITLE
[BUG FIX] Fix joint-equality reindexing when attaching a floating-base entity.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1244,10 +1244,22 @@ class KinematicEntity(Entity):
                 entity._dof_start -= n_base_dofs
                 entity._q_start -= n_base_qs
             for joint in self._solver.joints[self.joint_start :]:
+                joint._idx -= n_base_joints
                 joint._dof_start -= n_base_dofs
                 joint._q_start -= n_base_qs
             for link in self._solver.links[(self.link_start + 1) :]:
                 link._joint_start -= n_base_joints
+
+            # Joint-equality constraints (e.g. mimic joints) reference joints by global index, which must stay
+            # aligned with the dense joint ordering. Shift those references in lockstep with the joint re-indexing
+            # above. Link-based equalities (connect/weld) are unaffected since no link is removed here.
+            removed_joints_end = self.joint_start + n_base_joints
+            for equality in self._solver.equalities:
+                if equality.type == gs.EQUALITY_TYPE.JOINT:
+                    if equality._eq_obj1id >= removed_joints_end:
+                        equality._eq_obj1id -= n_base_joints
+                    if equality._eq_obj2id >= removed_joints_end:
+                        equality._eq_obj2id -= n_base_joints
 
         # Overwrite parent link
         base_link._parent_idx = parent_link.idx

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -6848,10 +6848,18 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
     with pytest.raises(gs.GenesisException):
         hand.set_quat(0.0)
 
+    # The free box is dynamically isolated from the robot, so its lateral position must stay put while the
+    # gripper actuates. Attaching the floating-base hand re-indexes joints by dropping its free base joint;
+    # the hand's mimic (joint-equality) references must follow that re-indexing, otherwise they alias this
+    # box's free-joint DOFs and the corrupted constraint drags the box sideways as the fingers move.
+    box_pos_init = box.get_pos()
+
     franka.control_dofs_position([-1, 0.8, 1, -2, 1, 0.5, -0.5])
     hand.control_dofs_position([0.04, 0.04])
     for _ in range(30):
         scene.step()
+
+    assert_allclose(box.get_pos()[..., :2], box_pos_init[..., :2], tol=1e-3)
 
     attach_link = franka.get_link("attachment")
     assert_allclose(attach_link.get_pos(), hand.links[0].get_pos(), tol=gs.EPS)


### PR DESCRIPTION
## Description

`RigidEntity.attach()` drops the floating base joint of the child entity and shifts the `dof_start` / `q_start` of all following joints, but it left `joint._idx` and the joint-equality references (`eq_obj1id` / `eq_obj2id`) untouched. Since `joints_info` is built densely by enumeration, those stale absolute indices end up off by `n_base_joints`, so a mimic (joint-equality) constraint of the attached entity reads the wrong `dof_start` -- aliasing the free-joint DOFs of an unrelated entity and dragging it around (or reading out of bounds).

Fix: shift `joint._idx` and the JOINT-type equality references in lockstep with the existing `dof_start` / `q_start` shift. Link-based equalities (connect/weld) are unaffected since `attach()` removes no link.

## Related Issue

Resolves Kashu7100/Eden#589.

## Motivation and Context

Attaching a floating-base entity that carries mimic joints (e.g. a dexterous hand) silently corrupted the dynamics of unrelated free bodies in the scene.

## How Has This Been / Can This Be Tested?

Strengthened `test_merge_entities`: the unrelated free box must keep its lateral position while the attached gripper actuates. On `main` it drifts ~0.04 m in x; with the fix it stays put. Fails for the `is_fixed=False` variants without the fix, passes for all four with it.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
