### PR TITLE
[MISC] Add loop_config kernel names for profiling.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -890,7 +890,7 @@ def add_collision_constraints(
             static_rigid_sim_config=static_rigid_sim_config,
         )
 
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    qd.loop_config(name="add_collision_count", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
         constraint_state.n_constraints[i_b] = constraint_state.n_constraints[i_b] + collider_state.n_contacts[i_b] * 4
 
@@ -3917,7 +3917,7 @@ def _initialize_Jaref_parallel(
 
     # Innermost ndrange axis matches the stride-1 axis of jac so jac loads coalesce: i_c-innermost under the flipped
     # layout, i_b-innermost under canonical.
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+    qd.loop_config(name="init_jaref_parallel", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_c, i_b in qd.ndrange(
         len_constraints, _B, axes=qd.static((1, 0) if static_rigid_sim_config.constraint_layout_batch_first else None)
     ):
@@ -3970,7 +3970,9 @@ def func_solve_init(
     # Skyline envelope for the CPU sparse Cholesky, recomputed each step (the fill-reducing DOF permutation it builds
     # on is fixed at build time). Folded here rather than a standalone kernel to avoid a per-step launch.
     if qd.static(static_rigid_sim_config.sparse_envelope):
-        qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+        qd.loop_config(
+            name="solve_init_sparsity_pattern", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL
+        )
         for i_b in range(_B):
             func_compute_sparsity_pattern(i_b, constraint_state, rigid_global_info)
 
@@ -4024,7 +4026,9 @@ def func_solve_init(
         )
 
         # Pick the best starting point between current state and warmstart
-        qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+        qd.loop_config(
+            name="solve_init_pick_warmstart", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL
+        )
         for i_d, i_b in qd.ndrange(n_dofs, _B):
             if constraint_state.cost_ws[i_b] < constraint_state.cost[i_b]:
                 constraint_state.qacc[i_d, i_b] = constraint_state.qacc_ws[i_d, i_b]


### PR DESCRIPTION
Port the qd.loop_config(name=...) additions from hp/cg-monolith for the four loops that exist unchanged on main: add_collision_count, init_jaref_parallel, solve_init_sparsity_pattern and solve_init_pick_warmstart. Naming these loops lets the kernels be identified during profiling, and lets the changes be dropped from the hp/cg-monolith PR.