### PR TITLE
[BUG FIX] Raise on `.morph` for heterogeneous entities instead of returning the primary

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1982,6 +1982,17 @@ class KinematicEntity(Entity):
         return len(self._links)
 
     @property
+    def morph(self):
+        """The morph of the entity.
+
+        Raises for heterogeneous entities, where a single morph is ambiguous; use `morphs` for all
+        variants or `main_morph` for the primary one.
+        """
+        if self._enable_heterogeneous:
+            gs.raise_exception("`morph` is ambiguous for heterogeneous entities; use `morphs` or `main_morph`.")
+        return self._morph
+
+    @property
     def main_morph(self):
         """The main morph of the entity (first morph for heterogeneous entities)."""
         return self._morph

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -6989,6 +6989,26 @@ def test_heterogeneous_invalid_material_raises():
         )
 
 
+@pytest.mark.required
+def test_morph_accessor_rejects_heterogeneous_entity():
+    """`.morph` is ambiguous once an entity has heterogeneous variants (#2750): it must raise and steer
+    callers to `.morphs` / `.main_morph` instead of silently returning only the primary morph."""
+    scene = gs.Scene(show_viewer=False)
+    homogeneous = scene.add_entity(gs.morphs.Box(size=(0.04, 0.04, 0.04), pos=(-0.3, 0.0, 0.2)))
+    heterogeneous = scene.add_entity(
+        morph=(
+            gs.morphs.Box(size=(0.04, 0.04, 0.04), pos=(0.0, 0.0, 0.2)),
+            gs.morphs.Sphere(radius=0.02, pos=(0.1, 0.0, 0.2)),
+        )
+    )
+
+    assert homogeneous.morph is homogeneous.main_morph  # unchanged for the common (homogeneous) case
+    with pytest.raises(gs.GenesisException):
+        _ = heterogeneous.morph
+    assert len(heterogeneous.morphs) == 2
+    assert heterogeneous.main_morph is heterogeneous.morphs[0]
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_heterogeneous_fewer_envs_than_variants():


### PR DESCRIPTION
## What

`RigidEntity.morph` returned only the first variant for a heterogeneous entity (one built from a list/tuple of morphs), silently hiding the rest — so `type(entity.morph)` just depended on morph order and the entity looked homogeneous. Per #2750, `.morph` now raises for heterogeneous entities and points callers to `.morphs` (all variants) or `.main_morph` (primary). Homogeneous entities are unchanged.

## Root cause

`.morph` (inherited from `base_entity`) returns `self._morph`, the primary variant, with no awareness of `self._morph_heterogeneous`. `RigidEntity` already exposes `.morphs` and `.main_morph` for the heterogeneous case, so `.morph` was the only ambiguous accessor — matching the note on the issue that it should raise here.

## Test

Added `test_morph_accessor_rejects_heterogeneous_entity` (CPU): a homogeneous entity's `.morph` still returns its morph; a heterogeneous entity's `.morph` raises `GenesisException` while `.morphs` / `.main_morph` keep working. Fails before the change, passes after.

Resolves Genesis-Embodied-AI/Genesis#2750