### PR TITLE
[BUG FIX] Fix offscreen rendering using wrong resolution when interactive viewer is enabled.

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -798,19 +798,26 @@ class Viewer(pyglet.window.Window):
                 # Update context, just in case is not already done before
                 self.gs_context.update()
 
-                # Render current frame from camera viewpoint. Force the renderer back to the originally
-                # requested viewport size so the offscreen FBO honors what the caller asked for even when the
-                # window has since been clamped to a smaller content area by the OS (e.g. macOS CI runners).
                 self._offscreen_results = []
                 self.render_flags["offscreen"] = True
                 self.render_flags["skip_markers"] = skip_markers
-                saved_viewport = (target.viewport_width, target.viewport_height)
-                target.viewport_width, target.viewport_height = self._offscreen_viewport_size
-                try:
+                if target is self._renderer:
+                    # The interactive window's own renderer tracks the OS window content area, which the OS may clamp
+                    # below the requested resolution (e.g. a viewport larger than a macOS runner can allocate). Force
+                    # it to the requested viewport size so the offscreen result matches what the caller asked for, then
+                    # restore the live window size so on-screen drawing keeps following the window.
+                    saved_viewport = (target.viewport_width, target.viewport_height)
+                    target.viewport_width, target.viewport_height = self._offscreen_viewport_size
+                    try:
+                        self.clear()
+                        retval = self._render(camera, target, normal)
+                    finally:
+                        target.viewport_width, target.viewport_height = saved_viewport
+                else:
+                    # A per-camera offscreen FBO is already sized to that camera's own resolution and is independent of
+                    # the window, so its viewport is authoritative and must not be overridden with the window size.
                     self.clear()
                     retval = self._render(camera, target, normal)
-                finally:
-                    target.viewport_width, target.viewport_height = saved_viewport
                 self._offscreen_result = retval if retval else (None, None)
                 self.render_flags["offscreen"] = False
                 self.render_flags["skip_markers"] = False

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2084,6 +2084,49 @@ def test_render_offscreen_oversized_resolution(renderer):
 
 @pytest.mark.required
 @pytest.mark.parametrize("renderer_type", [RENDERER_TYPE.RASTERIZER])
+@pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason=SKIP_NO_VIEWER)
+def test_camera_render_honors_resolution_with_viewer(renderer):
+    # A camera renders into its own offscreen FBO, sized to the camera resolution and independent of the
+    # interactive window. With an interactive viewer shown, the rendered image must still match the camera
+    # resolution, not the (different) viewer resolution, otherwise it no longer matches the camera intrinsics.
+    viewer_res = (640, 480)
+    camera_res = (360, 240)
+    box_halfsize = 0.5
+    camera_dist = 3.0
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            res=viewer_res,
+        ),
+        renderer=renderer,
+        show_viewer=True,
+        show_FPS=False,
+    )
+    scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 0.0, 0.0),
+            size=(2.0 * box_halfsize, 2.0 * box_halfsize, 2.0 * box_halfsize),
+            fixed=True,
+        ),
+    )
+    camera = scene.add_camera(
+        res=camera_res,
+        pos=(0.0, 0.0, camera_dist),
+        lookat=(0.0, 0.0, 0.0),
+        near=1.0,
+        far=10.0,
+    )
+    scene.build()
+
+    rgb, depth, _, _ = camera.render(rgb=True, depth=True)
+    assert rgb.shape[:2] == (camera_res[1], camera_res[0])
+    assert depth.shape[:2] == (camera_res[1], camera_res[0])
+
+    # The on-axis center pixel hits the front face of the box, at metric depth camera_dist - box_halfsize.
+    assert_allclose(depth[camera_res[1] // 2, camera_res[0] // 2], camera_dist - box_halfsize, atol=1e-3)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("renderer_type", [RENDERER_TYPE.RASTERIZER])
 def test_set_vverts(renderer, show_viewer):
     scene = gs.Scene(
         renderer=renderer,


### PR DESCRIPTION
## What

Fixes #2927. With `show_viewer=True`, an offscreen `camera.render()` returned images at the interactive viewer's resolution instead of the camera's configured `res`, so the rendered shape no longer matched `camera.intrinsics` and `camera.render_pointcloud()` failed.

## Root cause

In `Viewer._event_loop_step_offscreen` the render target's viewport was unconditionally forced to `self._offscreen_viewport_size` (the interactive window's requested size) before rendering. But `render_offscreen` is called with two different kinds of target:

- A **per-camera offscreen FBO** (`rasterizer._camera_targets[uid]`, a `pyrender.Renderer` sized to `camera.res`), independent of the OS window. Forcing the window size onto it produced the wrong resolution -- this is the reported bug.
- The **viewer's own renderer** (`self._renderer`), whose viewport follows `on_resize` and can be clamped below the requested size by the OS (e.g. a viewport larger than a macOS runner can allocate). Here the override is required, and is exercised by the `@required` test `test_render_offscreen_oversized_resolution`.

A blanket removal of the override fixes the camera case but regresses the oversized-viewer case. The fix scopes the override to `target is self._renderer` and renders per-camera FBOs at their own authoritative viewport.

## Test

Adds `test_camera_render_honors_resolution_with_viewer`: with a viewer at `(640, 480)` and a camera at `(360, 240)`, asserts the rendered rgb/depth shape matches the camera resolution and that the on-axis center pixel reports the correct metric depth of the box. The test fails on the previous (unconditional-override) behavior and passes with the fix; `test_render_offscreen_oversized_resolution` remains green.

## Credit

Root-cause diagnosis from @HaozheZhang6's #2927 / #2937 investigation. This PR supersedes #2937 with a fix scoped to the camera target so the macOS clamping path is preserved, plus a regression test.