### PR TITLE
[MISC] Make benchmarks pytest marker exclusive and never implicitly selected.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,22 @@ def pytest_cmdline_main(config: pytest.Config) -> None:
     except NameError as e:
         raise pytest.UsageError(f"Unknown marker in CLI expression: '{e.name}'")
 
+    # Benchmarks are opt-in and exclusive: they run only via '-m benchmarks' alone. Exclude benchmarks from
+    # any expression that does not name them so they never run implicitly (e.g. '-m "not slow"' would match
+    # them since benchmarks are not slow), and reject combining the 'benchmarks' marker with anything else.
+    markexpr = config.option.markexpr
+    if markexpr and "benchmarks" not in markexpr:
+        config.option.markexpr = f"({markexpr}) and not benchmarks"
+    elif (
+        markexpr
+        and markexpr.strip() != "benchmarks"
+        and Expression.compile(markexpr).evaluate(MarkMatcher.from_markers((pytest.mark.benchmarks,)))
+    ):
+        raise pytest.UsageError(
+            "The 'benchmarks' marker is exclusive and cannot be combined with other markers; "
+            "run benchmarks with '-m benchmarks' alone."
+        )
+
     # Only launch memory monitor from the main process, not from xdist workers
     mem_filepath = config.getoption("--mem-monitoring-filepath")
     if mem_filepath and not os.environ.get("PYTEST_XDIST_WORKER"):


### PR DESCRIPTION
## Description

`is_benchmarks` was computed as "would this marker expression select a benchmark-marked item?". That is true for *any* expression that does not explicitly exclude benchmarks (e.g. `-m 'not slow'`, since a benchmark is not slow), so ordinary runs were silently treated as benchmark runs and benchmark tests were selected implicitly.

Replaced it with `is_benchmarks_run()`, which is true only when the expression selects a benchmark item but not a plain one (i.e. exactly `-m benchmarks`). Combining `benchmarks` with any other marker now raises, and benchmark items are deselected from every non-benchmark run.

## Motivation and Context

For any non-benchmark run whose marker expression did not exclude benchmarks (e.g. `-m 'not slow'`), the false positive forced the GPU backend, capped the xdist workers at the GPU count (`-n8` -> `cannot exceed 1`), ran benchmark tests implicitly, and skipped the `prefer_decomposed_solver` pin - un-pinning the constraint solver so GPU results depended on the perf-dispatch autotuner and looked non-deterministic.

## How Has This Been / Can This Be Tested?

- `pytest -m 'not slow' ... -n8` collects without the worker-cap error and excludes benchmark tests.
- `pytest -m benchmarks` runs only benchmark tests.
- `pytest -m 'benchmarks or slow'` raises a clear `UsageError`.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it.
