### PR TITLE
Cap mpr_refine_portal() loop to CCD_ITERATIONS to prevent GPU hang

### DIFF
--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -248,7 +248,13 @@ def mpr_refine_portal(
     quat_b: qd.types.vector(4),
 ):
     ret = 1
+    iterations = gs.qd_int(0)
     while True:
+        if iterations > mpr_info.CCD_ITERATIONS[None]:
+            ret = -1
+            break
+        iterations = iterations + 1
+
         direction = mpr_portal_dir(mpr_state, i_ga, i_gb, i_b)
 
         if mpr_portal_encapsules_origin(mpr_state, mpr_info, direction, i_ga, i_gb, i_b):


### PR DESCRIPTION
## Summary

`mpr_refine_portal()` in `genesis/engine/solvers/rigid/collider/mpr.py` had an unbounded `while True:` loop, inconsistent with the neighbouring MPR paths:

- `mpr_find_penetration()` already bails on `iterations > mpr_info.CCD_ITERATIONS[None]`.
- `mpr_discover_portal()` caps on `num_trials == 15` for the documented rare deadlock.
- GJK/EPA paths also have explicit caps.

The reporter in #2815 traced a rare non-deterministic hang of `scene.step()` during sustained nearly-planar batched contacts to this loop, and confirmed that locally bounding the loop eliminates the hang in their reproduction.

This change adopts the exact same guard pattern used by `mpr_find_penetration` and returns `-1` on exhaustion. The caller in `mpr_run` already treats `res < 0` as a degenerate miss (no contact recorded), so cap-exhausted iterations behave identically to the existing `mpr_portal_reach_tolerance` bail-out below.

Closes #2815.

## Test plan

- [x] `ruff check` + `ruff format` pass.
- [x] Diff is +6 lines, semantically identical to the existing CCD guard.
- [ ] CI rigid/contact suite (will run on PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)