### PR TITLE
Document get_pos/get_quat as morph-relative (domain-randomization inverse of set)

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1498,7 +1498,9 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the position in the user frame, with the morph pose offset and inertial alignment
-            stripped, rather than the world frame used by the solver. Defaults to True.
+            stripped, rather than the world frame used by the solver. With ``relative=True`` the returned value is
+            the position *relative to the morph's initial pose*, i.e. the inverse of ``set_pos(..., relative=True)``;
+            this is the canonical form for domain randomization. Defaults to True.
 
         Returns
         -------
@@ -1518,7 +1520,9 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the orientation in the user frame, with the morph pose offset and inertial alignment
-            stripped, rather than the world frame used by the solver. Defaults to True.
+            stripped, rather than the world frame used by the solver. With ``relative=True`` the returned value is
+            the orientation *relative to the morph's initial pose*, i.e. the inverse of
+            ``set_quat(..., relative=True)``; this is the canonical form for domain randomization. Defaults to True.
 
         Returns
         -------
@@ -1699,7 +1703,9 @@ class KinematicEntity(Entity):
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
             Whether 'pos' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
-            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
+            top to reach the world frame used by the solver, rather than directly in the world frame. With
+            ``relative=True`` the argument is interpreted *relative to the morph's initial pose* (the canonical form
+            for domain randomization); ``get_pos(..., relative=True)`` is its inverse. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -1730,7 +1736,9 @@ class KinematicEntity(Entity):
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
             Whether 'quat' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
-            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
+            top to reach the world frame used by the solver, rather than directly in the world frame. With
+            ``relative=True`` the argument is interpreted *relative to the morph's initial pose* (the canonical form
+            for domain randomization); ``get_quat(..., relative=True)`` is its inverse. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """


### PR DESCRIPTION
## Summary

Issue #2730 asks for ``get_quat(..., relative=True)`` returning the orientation *relative to the morph's initial pose* — the canonical form for domain randomization, and the inverse of ``set_quat(..., relative=True)``.

**That implementation already exists** as of PR #2934 (morph pose offset accessors). Both ``get_pos/get_quat`` and ``set_pos/set_quat`` take ``relative=True`` (default), and the round-trip is exercised by ``tests/test_rigid_physics.py:2410-2412``:

```python
posed_box.set_quat(new_quat, relative=True)
...
assert_allclose(posed_box.get_quat(relative=True), new_quat, tol=tol)
```

What was missing is the discoverability hook. The current docstring describes the mechanics — \"morph pose offset and inertial alignment stripped\" — but never connects it to the use case the reporter described (``q_rel = q_curr ⊗ q_init^{-1}``).

This PR adds a one-line callout on all four docstrings naming the inverse pair and the randomization use case, so future users grep-find it.

No code-path or signature changes.

Closes #2730.

## Test plan

- [x] Existing `test_posed_box_*` already exercises the set/get round-trip with `relative=True`.
- [x] `ruff check` + `ruff format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)