### PR TITLE
MJCF: add discard_ground_plane option to skip world-body planes

### DIFF
--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -952,12 +952,17 @@ class MJCF(FileMorph):
     default_armature : float, optional
         Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
         actuated. None to disable. Default to 0.1.
+    discard_ground_plane : bool, optional
+        Whether to skip loading any geom of type ``plane`` attached to the world body. Many MJCF examples (e.g. the
+        MuJoCo ant) ship their own ground plane that overlaps with the scene-level ``gs.morphs.Plane()``, causing
+        root links to spawn embedded in the floor and trigger NaNs. Defaults to False.
     """
 
     pos: Vec3FType | None = None
     quat: UnitVec4FType | None = None
     requires_jac_and_IK: StrictBool = True
     default_armature: float | None = Field(default=0.1, ge=0)
+    discard_ground_plane: StrictBool = False
 
     @model_validator(mode="before")
     @classmethod

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -217,7 +217,8 @@ def parse_xml(morph, surface):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
+    discard_ground_plane = isinstance(morph, gs.morphs.MJCF) and morph.discard_ground_plane
+    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file, discard_ground_plane=discard_ground_plane)
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -628,13 +629,18 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, scale, surface, xml_path):
+def parse_geoms(mj, scale, surface, xml_path, *, discard_ground_plane=False):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
     is_any_col = False
     for i_g in range(mj.ngeom):
         if mj.geom_bodyid[i_g] < 0:
+            continue
+
+        # Optionally drop ground-plane geometry attached to the world body so the MJCF can coexist with a scene-level
+        # `gs.morphs.Plane()` without overlapping floors (see issue #2782).
+        if discard_ground_plane and mj.geom_bodyid[i_g] == 0 and mj.geom_type[i_g] == mujoco.mjtGeom.mjGEOM_PLANE:
             continue
 
         # try parsing a given geometry


### PR DESCRIPTION
## Summary

Many MuJoCo MJCF examples (e.g. ``xml/ant.xml``) ship a `<geom type=\"plane\">` on the worldbody. When such a model is loaded into a Genesis scene that already has a separate ``gs.morphs.Plane()``, the two floors overlap: root links spawn embedded between them and the simulation either NaNs or violently ejects geometry on the first step. The reporter ran into this with the canonical ant example.

This PR adds an opt-in field on the MJCF morph:

```python
robot = scene.add_entity(gs.morphs.MJCF(file=\"xml/ant.xml\", discard_ground_plane=True))
```

When set, `parse_geoms` drops any geom whose type is `mjGEOM_PLANE` and whose parent body is the world (`mj.geom_bodyid == 0`). Non-world planes (e.g. a wall anchored to a fixed body) are deliberately preserved.

Default is False so existing MJCF imports are byte-identical.

Closes #2782.

## Test plan

- [x] Local smoke test on `xml/ant.xml`:
  - Default: total geoms=5, planes=1.
  - `discard_ground_plane=True`: total geoms=4, planes=0; non-plane geoms unchanged.
- [x] `ruff check` + `ruff format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)