### PR TITLE
[BUG FIX] Fix mass-matrix lower-triangular indexing on Apple Metal.

### DIFF
--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -23,6 +23,7 @@ from .misc import (
     func_wakeup_island,
     func_check_index_range,
     func_add_safe_backward,
+    linear_to_lower_tri,
 )
 
 # Block size (warp width) for the cooperative mass_mat_assemble path. Used only when
@@ -407,9 +408,9 @@ def func_compute_mass_matrix(
             i_pair = tid
             while i_pair < n_lower_tri:
                 # Compressed lower-tri-inclusive index (matches tiled func_factor_mass): i_pair = i_d_ * (i_d_ + 1) / 2
-                # + j_d_, with j_d_ in [0, i_d_].
-                i_d_ = qd.cast((qd.sqrt(8 * i_pair + 1) - 1) // 2, qd.i32)
-                j_d_ = i_pair - i_d_ * (i_d_ + 1) // 2
+                # + j_d_, with j_d_ in [0, i_d_]. The fast-math-robust inversion is required here: a raw sqrt drops the
+                # j=0 entry of every perfect-square row on GPU, leaving M missing long-range coupling -> indefinite.
+                i_d_, j_d_ = linear_to_lower_tri(i_pair)
                 i_d = d_s + i_d_
                 j_d = d_s + j_d_
                 # The mass matrix is block-diagonal per kinematic tree, so only within-block (j_d in i_d's block) pairs
@@ -673,8 +674,7 @@ def func_factor_mass(
 
                     i_pair = tid
                     while i_pair < n_lower_tri:
-                        i_d_ = qd.cast((qd.sqrt(8 * i_pair + 1) - 1) // 2, qd.i32)
-                        j_d_ = i_pair - i_d_ * (i_d_ + 1) // 2
+                        i_d_, j_d_ = linear_to_lower_tri(i_pair)
                         i_d = entity_dof_start + i_d_
                         j_d = entity_dof_start + j_d_
                         mass_mat[i_d_, j_d_] = rigid_global_info.mass_mat[i_d, j_d, i_b]
@@ -729,8 +729,7 @@ def func_factor_mass(
                     i_pair = tid
                     n_strict_lower_tri = n_dofs * (n_dofs - 1) // 2
                     while i_pair < n_strict_lower_tri:
-                        i_d_ = qd.cast((qd.sqrt(8 * i_pair + 1) + 1) // 2, qd.i32)
-                        j_d_ = i_pair - i_d_ * (i_d_ - 1) // 2
+                        i_d_, j_d_ = linear_to_lower_tri(i_pair, strict=True)
                         i_d = entity_dof_start + i_d_
                         j_d = entity_dof_start + j_d_
                         rigid_global_info.mass_mat_L[i_d, j_d, i_b] = mass_mat[i_d_, j_d_]

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -6,6 +6,32 @@ import genesis.utils.geom as gu
 
 
 @qd.func
+def linear_to_lower_tri(i_pair: qd.i32, strict: qd.template() = False):
+    """Convert a linear index into (row, col) of a lower-triangular matrix.
+
+    Maps i_pair -> (i_d1, i_d2) over the lower triangle in the order (0,0), (1,0), (1,1), (2,0), ...
+    (i_pair = i_d1 * (i_d1 + 1) / 2 + i_d2, i_d2 in [0, i_d1]). When ``strict`` the diagonal is excluded, mapping over
+    the strict lower triangle (1,0), (2,0), (2,1), (3,0), ... (i_pair = i_d1 * (i_d1 - 1) / 2 + i_d2, i_d2 in [0, i_d1)).
+
+    Uses a float sqrt with an integer post-correction to handle GPUs whose sqrt is not correctly rounded for perfect
+    squares (observed on Apple Metal where e.g. sqrt(11881) returns ~108.999 instead of 109). Without it the row index
+    lands one short on every j=0 boundary, silently dropping those matrix entries.
+    """
+    offset = qd.static(1.0 if strict else -1.0)
+    i_d1 = qd.cast(qd.floor((qd.sqrt(qd.cast(8 * i_pair + 1, gs.qd_float)) + offset) / 2.0), qd.i32)
+    i_d2 = qd.i32(0)
+    if qd.static(strict):
+        if (i_d1 + 1) * i_d1 // 2 <= i_pair:
+            i_d1 = i_d1 + 1
+        i_d2 = i_pair - i_d1 * (i_d1 - 1) // 2
+    else:
+        if (i_d1 + 1) * (i_d1 + 2) // 2 <= i_pair:
+            i_d1 = i_d1 + 1
+        i_d2 = i_pair - i_d1 * (i_d1 + 1) // 2
+    return i_d1, i_d2
+
+
+@qd.func
 def func_wakeup_island(
     i_island,
     i_b,

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -10,6 +10,7 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 from genesis.engine.solvers.rigid.abd import func_solve_mass_batch
+from genesis.engine.solvers.rigid.abd.misc import linear_to_lower_tri
 from genesis.utils.misc import qd_to_torch, indices_to_mask, assign_indexed_tensor
 
 from .island import (
@@ -1791,24 +1792,6 @@ def kernel_delete_weld_constraint(
 # =====================================================================================================================
 
 # ====================================== Hessian Matrix & Cholesky Factorization ======================================
-
-
-@qd.func
-def linear_to_lower_tri(i_pair: qd.i32):
-    """Convert a linear index into (row, col) of a lower-triangular matrix.
-
-    Maps i_pair -> (i_d1, i_d2) such that the linear sequence 0,1,2,... visits
-    (0,0), (1,0), (1,1), (2,0), (2,1), (2,2), ...
-
-    Uses a float sqrt approximation with an integer post-correction to handle
-    GPUs whose sqrt is not correctly rounded for perfect squares (observed on
-    Apple Metal where e.g. sqrt(11881) returns ~108.999 instead of 109).
-    """
-    i_d1 = qd.cast(qd.floor((qd.sqrt(qd.cast(8 * i_pair + 1, gs.qd_float)) - 1.0) / 2.0), qd.i32)
-    if (i_d1 + 1) * (i_d1 + 2) // 2 <= i_pair:
-        i_d1 = i_d1 + 1
-    i_d2 = i_pair - i_d1 * (i_d1 + 1) // 2
-    return i_d1, i_d2
 
 
 @qd.kernel

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -351,6 +351,23 @@ def double_ball_pendulum():
 
 
 @pytest.fixture(scope="session")
+def long_chain():
+    # Single kinematic tree with enough DOFs that its mass submatrix exceeds GPU shared memory, so the cooperative
+    # >shared-cap mass assemble runs - the path whose lower-triangular linear-index inversion must stay exact on GPUs
+    # with an imprecise sqrt.
+    mjcf = ET.Element("mujoco", model="long_chain")
+    ET.SubElement(mjcf, "compiler", angle="radian")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    body = ET.SubElement(worldbody, "body", name="root", pos="0 0 2")
+    ET.SubElement(body, "geom", type="sphere", size="0.03", density="500")
+    for i in range(128):
+        body = ET.SubElement(body, "body", name=f"l{i}", pos="0 0 0.1")
+        ET.SubElement(body, "joint", name=f"j{i}", type="hinge", axis=("1 0 0", "0 1 0", "0 0 1")[i % 3], damping="0.1")
+        ET.SubElement(body, "geom", type="capsule", fromto="0 0 0 0 0 0.1", size="0.02", density="500")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def hinge_slide():
     mjcf = ET.Element("mujoco", model="hinge_slide")
 
@@ -3292,7 +3309,8 @@ def test_apply_external_forces(xml_path, show_viewer):
 
 @pytest.mark.slow  # ~250s
 @pytest.mark.required
-def test_mass_mat(show_viewer, tol):
+@pytest.mark.parametrize("model_name", ["long_chain"])
+def test_mass_mat(xml_path, show_viewer, tol):
     # Create and build the scene
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -3315,8 +3333,17 @@ def test_mass_mat(show_viewer, tol):
         vis_mode="collision",
         visualize_contact=True,
     )
+    # High-DOF single tree: its mass submatrix exceeds GPU shared memory, exercising the cooperative >shared-cap
+    # assemble (the low-DOF frankas exercise the under-cap shared-memory factor instead).
+    long_chain = scene.add_entity(
+        gs.morphs.MJCF(
+            file=xml_path,
+            pos=(5, 0, 2),
+        ),
+    )
     scene.build()
 
+    # Two identical entities must yield identical mass matrices, and the LTDL factor must reconstruct it.
     mass_mat_1 = franka1.get_mass_mat(decompose=False)
     mass_mat_2 = franka2.get_mass_mat(decompose=False)
     assert mass_mat_1.shape == (franka1.n_dofs, franka1.n_dofs)
@@ -3325,6 +3352,14 @@ def test_mass_mat(show_viewer, tol):
     mass_mat_L, mass_mat_D_inv = franka1.get_mass_mat(decompose=True)
     mass_mat = mass_mat_L.T @ torch.diag(1.0 / mass_mat_D_inv) @ mass_mat_L
     assert_allclose(mass_mat, mass_mat_1, tol=tol)
+
+    # The cooperative >shared-cap assemble maps a flat lane index to a lower-triangular (row, col) via a float sqrt;
+    # on GPUs whose sqrt undershoots perfect squares (Apple Metal: sqrt(15129) -> 122.999 instead of 123) a naive
+    # inversion lands one row short on every j=0 boundary and silently drops the long-range coupling entries, leaving
+    # the assembled mass matrix indefinite. A real joint-space mass matrix is always symmetric positive-definite.
+    mass_mat_chain = tensor_to_array(long_chain.get_mass_mat(decompose=False))
+    assert_allclose(mass_mat_chain, mass_mat_chain.T, tol=tol)
+    assert np.linalg.eigvalsh(0.5 * (mass_mat_chain + mass_mat_chain.T)).min() > 0.0
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

The cooperative GPU mass-matrix assemble and factor map a flat lane index to a lower-triangular `(row, col)` with a raw float `sqrt`. On GPUs whose `sqrt` undershoots perfect squares (e.g. Apple Metal: `sqrt(15129) -> 122.999` instead of `123`), the row index lands one short on every `j=0` boundary, so M's long-range coupling entries are silently dropped and the assembled mass matrix becomes indefinite (negative pivot) for a single high-DOF kinematic tree (`n_dofs` above the shared-memory cap, ~48+). On Metal this quietly degraded high-DOF bodies (SMPL-X, dexterous hands, long chains) rather than crashing, because the LDL^T factor tolerates the bad pivot.

The constraint Hessian already used a post-corrected inversion (`linear_to_lower_tri`); this PR propagates it to the mass kernels:

- Move `linear_to_lower_tri` to `abd/misc.py` and add a `linear_to_strict_lower_tri` companion (diagonal-excluded).
- Use them in the three mass assemble/factor sites instead of the raw inline `sqrt`.

## How Has This Been / Can This Be Tested?

`test_mass_mat` now also builds a 128-DOF single tree (exceeds the shared-memory cap, so it takes the cooperative assemble) and asserts the assembled mass matrix is symmetric positive-definite. This fails on current `main` (min eigenvalue ~ -321 on Metal) and passes with the fix (+0.10). The existing low-DOF Franka checks (mass-matrix equality and LTDL reconstruction) are unchanged and cover the under-cap factor path.

## Checklist:

- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it.
- [x] I have added tests to cover my changes.
