### PR TITLE
[MISC] Partition mass matrix per kinematic tree to allow factoring them separately.

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -879,33 +879,29 @@ class RigidSolver(KinematicSolver):
                 j_l = self.links[j_l].parent_idx
         self._rigid_global_info.mass_parent_mask.from_numpy(mass_parent_mask)
 
-        # Partition each entity's DOFs into contiguous, independently-factorable blocks. The mass matrix is
-        # block-diagonal across kinematic trees, so the per-block bounds let the assemble/factor/solve restrict to one
-        # tree's DOFs instead of the whole (possibly multi-free-body) entity. Trees are merged into one block only when
-        # their DOF intervals interleave (so a block stays a contiguous range); a single-tree entity yields one block
-        # spanning the whole entity, leaving its behavior unchanged.
+        # Partition each entity's DOFs into contiguous, independently-factorable blocks. M is block-diagonal between
+        # DOFs whose links are not kinematic ancestor/descendant of one another, so the per-block bounds let the
+        # assemble/factor/solve restrict to one block instead of the whole entity. A block is the set of DOFs coupled
+        # through a chain of moving joints; a fixed link (0 DOFs) does not couple, so several bodies attached to the
+        # world - or the independent arms of a fixed-base robot - factor as separate per-branch blocks. Each DOF's block
+        # is rooted at the topmost DOF-bearing ancestor reachable before the world; DOFs are numbered depth-first, so a
+        # block is a contiguous range whose root link's first DOF is the block start.
         links_by_idx = {link.idx: link for link in self.links}
-        tree_lo: dict[int, int] = {}
-        tree_hi: dict[int, int] = {}
+        block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
         for link in self.links:
             if link.n_dofs == 0:
                 continue
-            root = link
-            while root.parent_idx != -1:
-                root = links_by_idx[root.parent_idx]
-            tree_lo[root.idx] = min(tree_lo.get(root.idx, link.dof_start), link.dof_start)
-            tree_hi[root.idx] = max(tree_hi.get(root.idx, link.dof_end), link.dof_end)
-        block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
-        block_end = np.arange(1, self.n_dofs_ + 1, dtype=gs.np_int)
-        merged: list[list[int]] = []
-        for lo, hi in sorted(zip(tree_lo.values(), tree_hi.values())):
-            if merged and lo < merged[-1][1]:
-                merged[-1][1] = max(merged[-1][1], hi)
-            else:
-                merged.append([lo, hi])
-        for lo, hi in merged:
-            block_start[lo:hi] = lo
-            block_end[lo:hi] = hi
+            root_link = link
+            node = link
+            while node.parent_idx != -1:
+                node = links_by_idx[node.parent_idx]
+                if node.n_dofs > 0:
+                    root_link = node
+            block_start[link.dof_start : link.dof_end] = root_link.dof_start
+        block_end = np.empty(self.n_dofs_, dtype=gs.np_int)
+        for i_d in range(self.n_dofs_):
+            block_end[block_start[i_d]] = i_d + 1
+        block_end = block_end[block_start]
         self._rigid_global_info.dofs_mass_block_start.from_numpy(block_start)
         self._rigid_global_info.dofs_mass_block_end.from_numpy(block_end)
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -368,6 +368,23 @@ def long_chain():
 
 
 @pytest.fixture(scope="session")
+def two_fixed_branches():
+    # One entity whose worldbody holds two independent chains, each rigidly attached to the (fixed) world. Their DOFs
+    # are kinematically decoupled, so the mass matrix is block-diagonal and must partition into one block per branch.
+    mjcf = ET.Element("mujoco", model="two_fixed_branches")
+    ET.SubElement(mjcf, "compiler", angle="radian")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    for name, x in (("a", 0.0), ("b", 1.0)):
+        body = ET.SubElement(worldbody, "body", name=f"{name}root", pos=f"{x} 0 1")
+        ET.SubElement(body, "geom", type="capsule", fromto="0 0 0 0 0 0.06", size="0.02", density="500")
+        for i in range(4):
+            body = ET.SubElement(body, "body", name=f"{name}{i}", pos="0 0 0.06")
+            ET.SubElement(body, "joint", name=f"j{name}{i}", type="hinge", axis="0 1 0", damping="0.1")
+            ET.SubElement(body, "geom", type="capsule", fromto="0 0 0 0 0 0.06", size="0.02", density="500")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def hinge_slide():
     mjcf = ET.Element("mujoco", model="hinge_slide")
 
@@ -3367,6 +3384,38 @@ def test_mass_mat(xml_path, show_viewer, tol):
     mass_mat_chain_L, mass_mat_chain_D_inv = long_chain.get_mass_mat(decompose=True)
     mass_mat_chain_rec = mass_mat_chain_L.T @ torch.diag(1.0 / mass_mat_chain_D_inv) @ mass_mat_chain_L
     assert_allclose(mass_mat_chain_rec, mass_mat_chain, tol=tol)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("model_name", ["two_fixed_branches"])
+def test_mass_block_partition(xml_path, show_viewer, tol):
+    # Two chains rigidly attached to the fixed world are kinematically independent: the mass matrix is block-diagonal,
+    # so it must partition into one mass block per branch (factoring two n/2 blocks instead of one dense n block).
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            enable_collision=False,
+        ),
+        show_viewer=show_viewer,
+    )
+    entity = scene.add_entity(
+        gs.morphs.MJCF(
+            file=xml_path,
+        ),
+    )
+    scene.build(n_envs=0)
+
+    n_dofs = entity.n_dofs
+    branch = n_dofs // 2
+    block_start = qd_to_numpy(scene.rigid_solver._rigid_global_info.dofs_mass_block_start)
+    block_end = qd_to_numpy(scene.rigid_solver._rigid_global_info.dofs_mass_block_end)
+    assert_allclose(block_start, [0] * branch + [branch] * branch, tol=0)
+    assert_allclose(block_end, [branch] * branch + [n_dofs] * branch, tol=0)
+
+    # The two branches do not couple, and the LTDL factor reconstructs the (block-diagonal) mass matrix.
+    mass_mat = tensor_to_array(entity.get_mass_mat(decompose=False))
+    assert_allclose(mass_mat[:branch, branch:], 0.0, tol=tol)
+    mass_mat_L, mass_mat_D_inv = entity.get_mass_mat(decompose=True)
+    assert_allclose(mass_mat_L.T @ torch.diag(1.0 / mass_mat_D_inv) @ mass_mat_L, mass_mat, tol=tol)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

The per-entity mass-matrix block partition rooted each block by walking `parent_idx` up to the world (`-1`). Branches rigidly attached to the world - several chains/objects in one MJCF entity, or the independent arms of a fixed-base robot - therefore collapsed into a single block, even though their DOFs are kinematically decoupled and M is block-diagonal across them. They were factored as one dense `O(n^3)` block instead of a sum of per-branch cubes, in every mass path (assemble, factor, solve).

This roots each block at the topmost DOF-bearing ancestor reachable before the world: a fixed (0-DOF) link separates its branches, while branches under a shared movable ancestor stay together. DOFs are numbered depth-first, so each block stays a contiguous range.

## How Has This Been / Can This Be Tested?

New `test_mass_block_partition`: two chains rigidly attached to the world must partition into one block per branch

## Checklist:

- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it.
- [x] I have added tests to cover my changes.
