### PR TITLE
[MISC] Cache mesh processing to speed up adding many identical entities.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -384,8 +384,9 @@ def destroy():
         if scene is not None:
             scene.destroy()
 
-    # Release cached RGBA textures so large image arrays from destroyed scenes are not retained globally.
-    surfaces.clear_rgba_cache()
+    # Release every module-level asset cache (parsed meshes, baked RGBA textures, ...) so the large arrays they hold
+    # for destroyed scenes are not retained globally.
+    _clear_caches()
 
     # Destroy all externally registered modules
     for _init_fun, destroy_fun in _module_registry:
@@ -460,6 +461,7 @@ sys.excepthook = _custom_excepthook
 
 from .ext import _trimesh_patch
 from .utils.misc import get_src_dir as _get_src_dir
+from .utils.misc import clear_caches as _clear_caches
 
 # Eagerly load native extensions under redirected stderr to silence dlopen-time noise (e.g. macOS
 # objc duplicate-class warnings when several libraries ship their own copy of GLFW).

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -104,15 +104,13 @@ def _align_geoms_to_inertia(cg_infos, vg_infos, file_inertial):
         for cg_info in cg_infos:
             if not (cg_info.get("contype", 0) or cg_info.get("conaffinity", 0)):
                 continue
-            tmesh = cg_info["mesh"].trimesh
-            if not tmesh.is_watertight:
-                tmesh = tmesh.convex_hull
-            if tmesh.volume > 0:
+            mesh_inertial_info = cg_info["mesh"].get_inertial_info()
+            if mesh_inertial_info.volume > 0:
                 geoms_inertial_info.append(
                     (
-                        tmesh.mass,
-                        tmesh.center_mass,
-                        tmesh.moment_inertia,
+                        mesh_inertial_info.mass,
+                        mesh_inertial_info.center_mass,
+                        mesh_inertial_info.moment_inertia,
                         np.array(cg_info.get("pos", gu.zero_pos())),
                         np.array(cg_info.get("quat", gu.identity_quat())),
                     )

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -1,6 +1,5 @@
 import os
 import pickle as pkl
-from itertools import chain
 from typing import TYPE_CHECKING
 
 import igl
@@ -119,13 +118,9 @@ class RigidGeom(RBC):
                 "decimation. (see FileMorph options)"
             )
 
-        # Compute adjacency graph
-        tmesh = trimesh.Trimesh(vertices=self._init_verts, faces=self._init_faces, process=False)
-        all_vert_neighbors_list = tmesh.vertex_neighbors
-        assert self.n_verts == len(all_vert_neighbors_list)
-        self.vert_neighbors = np.array(tuple(chain.from_iterable(all_vert_neighbors_list)), dtype=gs.np_int)
-        self.vert_n_neighbors = np.array(tuple(map(len, all_vert_neighbors_list)), dtype=gs.np_int)
-        self.vert_neighbor_start = np.array((0, *np.cumsum(self.vert_n_neighbors)[:-1]), dtype=gs.np_int)
+        # Adjacency graph, shared by reference with sibling geoms that back the same processed geometry.
+        self.vert_neighbors, self.vert_n_neighbors, self.vert_neighbor_start = mesh.get_vert_adjacency()
+        assert self.n_verts == len(self.vert_n_neighbors)
 
         # NOTE: sdf size is from the center of the lower voxel cell to the center of the upper voxel cell. Add
         # padding. The cell size is anisotropic - each axis is sized independently to its own extent - so a thin
@@ -140,6 +135,9 @@ class RigidGeom(RBC):
         per_axis_upper = grid_size / max(self._material.sdf_min_res - 1, 2)
         self._sdf_cell_size = gs.EPS + np.clip(self._material.sdf_cell_size, per_axis_lower, per_axis_upper)
         self._sdf_res = np.ceil(grid_size / self._sdf_cell_size).astype(gs.np_int) + 1
+        # Constant once the SDF resolution is fixed. Cached because the solver re-reads it for every geom on each
+        # 'add_entity' (to lay out cell offsets), which would otherwise recompute the product for every prior geom.
+        self._n_cells = int(np.prod(self._sdf_res))
         self._sdf_grad_delta = (
             np.zeros(3, dtype=gs.np_float) if self.type == gs.GEOM_TYPE.TERRAIN else self._sdf_cell_size * 1e-2
         )
@@ -698,7 +696,7 @@ class RigidGeom(RBC):
         """
         Number of cells in the geom's signed distance field (SDF).
         """
-        return np.prod(self.sdf_res)
+        return self._n_cells
 
     @property
     def n_verts(self) -> int:

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -1,10 +1,12 @@
 import os
 import pickle as pkl
-from typing import Any
+from itertools import chain
+from typing import Any, NamedTuple
 
 import fast_simplification
 import numpy as np
 import trimesh
+from scipy.spatial import QhullError
 
 import genesis as gs
 import genesis.utils.gltf as gltf_utils
@@ -14,6 +16,15 @@ import genesis.utils.point_cloud as pc
 from genesis.options.surfaces import Surface
 from genesis.repr_base import RBC
 from genesis.utils.misc import redirect_libc_stderr
+
+
+class MeshInertialInfo(NamedTuple):
+    """Mass properties of a mesh in its own frame; center_mass and moment_inertia are None for degenerate geometry."""
+
+    volume: float
+    mass: float
+    center_mass: "np.ndarray | None"
+    moment_inertia: "np.ndarray | None"
 
 
 class Mesh(RBC):
@@ -65,6 +76,18 @@ class Mesh(RBC):
         self._metadata: dict[str, Any] = metadata or {}
         self._color = np.array([1.0, 1.0, 1.0, 1.0], dtype=gs.np_float)
 
+        # Geometry-derived data (independent of appearance) computed lazily and reused. When the same processed
+        # collision geometry backs many entities, these are shared by reference so each entity reads them instead of
+        # recomputing the unique-edge list and the vertex-adjacency graph.
+        self._unique_edges: "np.ndarray | None" = None
+        self._vert_adjacency: "tuple[np.ndarray, np.ndarray, np.ndarray] | None" = None
+        self._is_convex: "bool | None" = None
+        self._inertial_info: "MeshInertialInfo | None" = None
+        # A mesh sharing another's processed geometry (a cached collision template) delegates its inertia query to that
+        # source, so the (convex-hull) mass-property computation runs at most once per geometry and only when an entity
+        # actually needs it - never eagerly for e.g. fixed or articulated assets whose link frames are not aligned.
+        self._inertial_info_source: "Mesh | None" = None
+
         # By default, all meshes are considered zup, unless the "FileMorph.file_meshes_are_zup" option was set to False
         self._metadata.setdefault("imported_as_zup", True)
 
@@ -105,6 +128,7 @@ class Mesh(RBC):
         if self._mesh.vertices.shape[0] > 3:
             self._mesh = trimesh.convex.convex_hull(self._mesh)
             self._metadata["convexified"] = True
+        self._invalidate_geometry_cache()
         self.clear_visuals()
 
     def watertighten(self, aggressiveness=7):
@@ -124,6 +148,7 @@ class Mesh(RBC):
         )
         self._mesh = trimesh.Trimesh(vertices=v, faces=f, process=False)
         self._metadata["watertightened"] = True
+        self._invalidate_geometry_cache()
         self.clear_visuals()
 
     def decimate(self, decimate_face_num, decimate_aggressiveness):
@@ -143,6 +168,7 @@ class Mesh(RBC):
             )
             self._metadata["decimated"] = True
 
+        self._invalidate_geometry_cache()
         self.clear_visuals()
 
     def remesh(self, edge_len_abs=None, edge_len_ratio=0.01, fix=True):
@@ -183,6 +209,7 @@ class Mesh(RBC):
                 pkl.dump((verts, faces), file)
 
         self._mesh = trimesh.Trimesh(vertices=verts, faces=faces)
+        self._invalidate_geometry_cache()
         self.clear_visuals()
 
     def tetrahedralize(self, tet_cfg):
@@ -234,19 +261,76 @@ class Mesh(RBC):
         self._surface = gs.surfaces.Default()
         self._surface.update_texture()
 
+    def _invalidate_geometry_cache(self):
+        # Drop memoized geometry-derived data (unique edges, vertex adjacency, convexity, inertia) when the underlying
+        # trimesh is replaced or its vertices change, so the next query recomputes from the current geometry instead of
+        # returning stale topology or inertia.
+        self._unique_edges = None
+        self._vert_adjacency = None
+        self._is_convex = None
+        self._inertial_info = None
+        self._inertial_info_source = None
+
     def get_unique_edges(self):
         """
         Get the unique edges of the mesh.
         """
-        r_face = np.roll(self.faces, 1, axis=1)
-        edges = np.concatenate(np.array([self.faces, r_face]).T)
+        if self._unique_edges is None:
+            r_face = np.roll(self.faces, 1, axis=1)
+            edges = np.concatenate(np.array([self.faces, r_face]).T)
 
-        # do a first pass to remove duplicates
-        edges.sort(axis=1)
-        edges = np.unique(edges, axis=0)
-        edges = edges[edges[:, 0] != edges[:, 1]]
+            # do a first pass to remove duplicates
+            edges.sort(axis=1)
+            edges = np.unique(edges, axis=0)
+            self._unique_edges = edges[edges[:, 0] != edges[:, 1]]
 
-        return edges
+        return self._unique_edges
+
+    def get_inertial_info(self):
+        """
+        Get the mass properties of the geometry in its own frame as a MeshInertialInfo.
+
+        Non-watertight geometry is closed by its convex hull first so the volume integral is well-defined; a degenerate
+        geometry reports a zero volume and no mass distribution. The result is memoized and shared by reference across
+        entities backed by the same geometry.
+        """
+        if self._inertial_info_source is not None:
+            return self._inertial_info_source.get_inertial_info()
+        if self._inertial_info is None:
+            # A degenerate geometry (zero / ill-defined volume) makes trimesh's mass-property integral divide by zero,
+            # yielding a non-finite center of mass; a more degenerate one (fewer than 4 non-coplanar vertices) makes the
+            # convex-hull closure of a non-watertight mesh raise instead. Either way the geom carries no inertia: report
+            # a zero volume so the caller skips it, rather than crashing or letting NaNs propagate into the composed
+            # inertia (and emitting a warning).
+            with np.errstate(invalid="ignore", divide="ignore"):
+                try:
+                    tmesh = self._mesh if self._mesh.is_watertight else self._mesh.convex_hull
+                    volume = float(tmesh.volume)
+                    center_mass = tmesh.center_mass
+                except QhullError:
+                    volume, center_mass = 0.0, None
+                if volume > 0.0 and np.all(np.isfinite(center_mass)):
+                    self._inertial_info = MeshInertialInfo(volume, tmesh.mass, center_mass, tmesh.moment_inertia)
+                else:
+                    self._inertial_info = MeshInertialInfo(0.0, 0.0, None, None)
+        return self._inertial_info
+
+    def get_vert_adjacency(self):
+        """
+        Get the per-vertex adjacency graph as flat arrays (vert_neighbors, vert_n_neighbors, vert_neighbor_start).
+
+        vert_neighbors concatenates each vertex's neighbor indices, vert_n_neighbors holds the neighbor count of each
+        vertex, and vert_neighbor_start the offset of each vertex's slice into vert_neighbors.
+        """
+        if self._vert_adjacency is None:
+            tmesh = trimesh.Trimesh(vertices=self.verts, faces=self.faces, process=False)
+            vert_neighbors_list = tmesh.vertex_neighbors
+            vert_neighbors = np.array(tuple(chain.from_iterable(vert_neighbors_list)), dtype=gs.np_int)
+            vert_n_neighbors = np.array(tuple(map(len, vert_neighbors_list)), dtype=gs.np_int)
+            vert_neighbor_start = np.array((0, *np.cumsum(vert_n_neighbors)[:-1]), dtype=gs.np_int)
+            self._vert_adjacency = (vert_neighbors, vert_n_neighbors, vert_neighbor_start)
+
+        return self._vert_adjacency
 
     def copy(self):
         """
@@ -463,6 +547,7 @@ class Mesh(RBC):
         Apply a 4x4 transformation matrix (translation on the right column) to the mesh.
         """
         self._mesh.apply_transform(T)
+        self._invalidate_geometry_cache()
 
     @property
     def uid(self):
@@ -483,7 +568,13 @@ class Mesh(RBC):
         """
         Whether the mesh is convex.
         """
-        return self.metadata.get("convexified", self._mesh.is_convex)
+        # 'dict.get' would evaluate the (expensive) convexity test eagerly even when the flag is already set, so branch
+        # explicitly. The trimesh fallback is memoized to stay cheap when many entities share the same geometry.
+        if "convexified" in self.metadata:
+            return self.metadata["convexified"]
+        if self._is_convex is None:
+            self._is_convex = bool(self._mesh.is_convex)
+        return self._is_convex
 
     @property
     def metadata(self):
@@ -506,6 +597,7 @@ class Mesh(RBC):
         """
         assert len(verts) == len(self.verts)
         self._mesh.vertices = verts
+        self._invalidate_geometry_cache()
 
     @property
     def faces(self):

--- a/genesis/options/surfaces.py
+++ b/genesis/options/surfaces.py
@@ -1,4 +1,3 @@
-import functools
 import math
 from typing import Any, ClassVar, Literal
 from typing_extensions import Self
@@ -9,6 +8,7 @@ from pydantic import Field, StrictBool, model_validator
 import genesis as gs
 from genesis.typing import FArrayType, UnitInterval, ValidFloat
 from genesis.utils import mesh as mu
+from genesis.utils.misc import SizeCappedCache
 
 from .misc import FoamOptions
 from .options import Options
@@ -207,12 +207,23 @@ class Surface(Options):
         return opacity
 
 
-@functools.lru_cache(maxsize=128)
+# 512 MiB of merged RGBA textures, bounded by the byte size of the image arrays they hold (full-resolution textures
+# dominate the footprint; a count-based bound would not reflect it). The entry count is also capped so that flat-color
+# surfaces (no image array, e.g. per-geom randomized collision colors) cannot accumulate unbounded. Dropped on genesis
+# teardown like the other caches.
+_RGBA_CACHE = SizeCappedCache(max_bytes=512 * 1024 * 1024, max_entries=8192)
+
+
 def _make_rgba(color_texture: Texture | None, opacity_texture: Texture | None, batch: bool) -> "BatchTexture | Texture":
     # Resolve a surface's color and opacity textures into a single RGBA texture. The result is memoized on the input
     # texture instances: surfaces sharing the same textures (e.g. all textured submeshes of a GLB) then reuse a single
     # merged array instead of allocating one full-resolution copy each. A texture update swaps in a new instance, which
     # is a natural cache miss, so no explicit invalidation is needed.
+    cache_key = (color_texture, opacity_texture, batch)
+    cached = _RGBA_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
     all_textures = []
     for texture in (color_texture, opacity_texture):
         textures = texture.textures if isinstance(texture, BatchTexture) else [texture]
@@ -266,13 +277,14 @@ def _make_rgba(color_texture: Texture | None, opacity_texture: Texture | None, b
 
         rgba_textures.append(rgba_texture)
 
-    return BatchTexture(textures=rgba_textures) if batch else rgba_textures[0]
-
-
-def clear_rgba_cache() -> None:
-    # Drop the memoized RGBA textures, releasing the strong references their large image arrays would otherwise keep
-    # alive. Called on genesis destroy so textures from gone scenes do not stay resident.
-    _make_rgba.cache_clear()
+    result = BatchTexture(textures=rgba_textures) if batch else rgba_textures[0]
+    n_bytes = sum(
+        t.image_array.nbytes
+        for t in (result.textures if isinstance(result, BatchTexture) else [result])
+        if isinstance(t, ImageTexture) and t.image_array is not None
+    )
+    _RGBA_CACHE.put(cache_key, result, n_bytes)
+    return result
 
 
 ############################ Surface types ############################

--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -29,7 +29,7 @@ class Texture(Options):
     # Pydantic disables hashing for models with a field-based __eq__; its only opt-in (model_config frozen=True) also
     # forbids the in-place edits done during setup (apply_cutoff, check_dim reassign image_array/color). Restore
     # identity hashing instead: textures are shared by reference and stable once a surface is built, so their identity
-    # is a valid key for caches such as the get_rgba lru_cache.
+    # is a valid key for caches such as the get_rgba cache.
     __hash__ = object.__hash__
 
     def __init__(self, **data):

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -19,6 +19,8 @@ import genesis as gs
 
 from . import geom as gu
 from .misc import (
+    SizeCappedCache,
+    register_cache_clear,
     get_assets_dir,
     get_cvx_cache_dir,
     get_exr_cache_dir,
@@ -326,7 +328,96 @@ def convex_decompose(mesh, coacd_options):
     return mesh_parts
 
 
+# 512 MiB of processed collision geometry. Sized by the geometry footprint actually retained (vertices and faces of
+# the cached meshes), so a few large assets or many small ones are both bounded without an arbitrary entry count.
+_COLLISION_GEOMS_CACHE = SizeCappedCache(max_bytes=512 * 1024 * 1024)
+
+
 def postprocess_collision_geoms(
+    g_infos,
+    decimate,
+    decimate_face_num,
+    decimate_aggressiveness,
+    convexify,
+    decompose_error_threshold,
+    coacd_options,
+    watertighten,
+):
+    # Convexification / decomposition of a collision mesh (convex hull and coacd decomposition) is the dominant cost of
+    # adding a file-based entity, and a scene built from many copies of the same asset would otherwise redo it for every
+    # entity. The result is memoized on the geometry of the input collision meshes (quantized vertices and faces) and on
+    # every option / per-geom field that can change the outcome. The processed meshes are immutable (their vertices are
+    # only read downstream, alignment is folded into the link frame), so the cached ones are shared across entities,
+    # which also collapses their memory footprint. Only fresh g_info dicts are handed back so the caller can re-express
+    # the per-geom pose in place without corrupting the template.
+    if not g_infos:
+        return []
+
+    key_parts = [
+        bool(decimate),
+        int(decimate_face_num),
+        int(decimate_aggressiveness),
+        bool(convexify),
+        float(decompose_error_threshold),
+        -1 if watertighten is None else int(watertighten),
+        coacd_options.model_dump(),
+    ]
+    for g_info in g_infos:
+        mesh = g_info["mesh"]
+        geom_type = g_info.get("type")
+        friction = g_info.get("friction")
+        sol_params = g_info.get("sol_params")
+        key_parts += [
+            discretize_array_for_hashing(mesh.verts),
+            np.ascontiguousarray(mesh.faces),
+            -1 if geom_type is None else int(geom_type),
+            int(g_info.get("contype", 0)),
+            int(g_info.get("conaffinity", 0)),
+            float("nan") if friction is None else float(friction),
+            np.zeros(0) if sol_params is None else np.ascontiguousarray(sol_params, dtype=np.float64),
+            np.ascontiguousarray(g_info.get("pos", gu.zero_pos()), dtype=np.float64),
+            np.ascontiguousarray(g_info.get("quat", gu.identity_quat()), dtype=np.float64),
+        ]
+    key = get_hashkey(*key_parts)
+
+    cached = _COLLISION_GEOMS_CACHE.get(key)
+    if cached is None:
+        cached = _postprocess_collision_geoms_impl(
+            g_infos,
+            decimate,
+            decimate_face_num,
+            decimate_aggressiveness,
+            convexify,
+            decompose_error_threshold,
+            coacd_options,
+            watertighten,
+        )
+        n_bytes = sum(g_info["mesh"].verts.nbytes + g_info["mesh"].faces.nbytes for g_info in cached)
+        _COLLISION_GEOMS_CACHE.put(key, cached, n_bytes)
+
+    # Hand back per-entity geoms that share the cached geometry and its derived data (edges, vertex adjacency, inertia)
+    # with the template, but own their trimesh and surface. This keeps appearance per-entity (each entity gets an
+    # independent, e.g. randomized, collision color) while the heavy geometry is computed once and its arrays are
+    # shared. Edges and adjacency are always needed, so they are populated up front; inertia is queried lazily through
+    # the template (only entities that align their link frame need it) to avoid eager convex-hull work.
+    result = []
+    for g_info in cached:
+        template = g_info["mesh"]
+        template_tmesh = template.trimesh
+        mesh = gs.Mesh(
+            mesh=trimesh.Trimesh(vertices=template_tmesh.vertices, faces=template_tmesh.faces, process=False),
+            surface=gs.surfaces.Collision(),
+            uvs=template.uvs,
+            metadata=template.metadata.copy(),
+        )
+        mesh._unique_edges = template.get_unique_edges()
+        mesh._vert_adjacency = template.get_vert_adjacency()
+        mesh._inertial_info_source = template
+        result.append({**g_info, "mesh": mesh})
+    return result
+
+
+def _postprocess_collision_geoms_impl(
     g_infos,
     decimate,
     decimate_face_num,
@@ -538,7 +629,7 @@ def postprocess_collision_geoms(
 
         # Try again to convexify then apply convex decomposition if not possible
         if must_decompose and is_merged:
-            return postprocess_collision_geoms(
+            return _postprocess_collision_geoms_impl(
                 g_infos,
                 decimate,
                 decimate_face_num,
@@ -627,9 +718,22 @@ def postprocess_collision_geoms(
     return _g_infos
 
 
+@lru_cache(maxsize=32)
+def _load_trimesh_scene_cached(path, group_by_material, mtime) -> "trimesh.Scene":
+    # Parsing a mesh file from disk (read + decode) is by far the dominant cost of adding a file-based entity, and a
+    # scene built from many copies of the same asset (e.g. a grid of identical objects) would otherwise re-parse the
+    # exact same bytes for every entity. The result is keyed by file modification time so an edited asset is reloaded.
+    # The returned scene is treated as an immutable template - callers copy each geometry out before applying scale or
+    # surface - so it is never mutated and is safe to share across entities.
+    return trimesh.load(path, force="scene", group_material=group_by_material, process=False)
+
+
+register_cache_clear(_load_trimesh_scene_cached.cache_clear)
+
+
 def parse_mesh_trimesh(path, group_by_material, scale, is_mesh_zup, surface) -> "list[gs.Mesh]":
     meshes: list[gs.Mesh] = []
-    scene = trimesh.load(path, force="scene", group_material=group_by_material, process=False)
+    scene = _load_trimesh_scene_cached(path, group_by_material, os.path.getmtime(path))
     for tmesh in scene.geometry.values():
         if not isinstance(tmesh, trimesh.Trimesh):
             gs.raise_exception(f"Mesh type not supported: {path}")

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -8,6 +8,7 @@ import numbers
 import os
 import random
 import sys
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import field
 from importlib import import_module
@@ -301,6 +302,69 @@ def get_exr_cache_dir():
 
 def get_usd_cache_dir():
     return os.path.join(get_cache_dir(), "usd")
+
+
+_CLEARABLE_CACHES: list[Callable[[], None]] = []
+
+
+def register_cache_clear(cache_clear: Callable[[], None]) -> None:
+    """Register a callback that drops a module-level cache, invoked by clear_caches on genesis teardown.
+
+    Pass the cache's own clearing method, e.g. the cache_clear of a functools.lru_cache or the clear of a manual dict
+    cache. This lets module-level asset caches (parsed meshes, baked textures, ...) release the large arrays they hold
+    for destroyed scenes without the teardown path having to know about each one.
+    """
+    _CLEARABLE_CACHES.append(cache_clear)
+
+
+def clear_caches() -> None:
+    """Drop every cache registered through register_cache_clear."""
+    for cache_clear in _CLEARABLE_CACHES:
+        cache_clear()
+
+
+class SizeCappedCache:
+    """An LRU cache bounded by the total byte footprint of its values rather than by their count.
+
+    Each value is stored together with an explicit size in bytes; once the running total exceeds max_bytes the
+    least-recently-used entries are evicted until it fits again (the most-recent entry is always kept). This suits
+    caching a handful of large, scene-independent arrays - such as processed collision geometry - where the number of
+    distinct entries is a poor proxy for the memory actually held. An optional max_entries also caps the entry count,
+    so values whose reported size is small or zero (e.g. flat-color textures) cannot accumulate without bound. It
+    registers itself with register_cache_clear so it is dropped together with the other asset caches on genesis
+    teardown.
+    """
+
+    def __init__(self, max_bytes: int, max_entries: "int | None" = None) -> None:
+        self._max_bytes = max_bytes
+        self._max_entries = max_entries
+        self._store: "OrderedDict[Any, tuple[Any, int]]" = OrderedDict()
+        self._total_bytes = 0
+        register_cache_clear(self.clear)
+
+    def get(self, key: Any) -> Any:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        self._store.move_to_end(key)
+        return entry[0]
+
+    def put(self, key: Any, value: Any, n_bytes: int) -> None:
+        previous = self._store.pop(key, None)
+        if previous is not None:
+            self._total_bytes -= previous[1]
+        self._store[key] = (value, n_bytes)
+        self._total_bytes += n_bytes
+        while len(self._store) > 1 and (
+            self._total_bytes > self._max_bytes
+            or (self._max_entries is not None and len(self._store) > self._max_entries)
+        ):
+            _, (_, evicted_bytes) = self._store.popitem(last=False)
+            self._total_bytes -= evicted_bytes
+
+    def clear(self) -> None:
+        self._store.clear()
+        self._total_bytes = 0
 
 
 def geometric_mean(a, b):


### PR DESCRIPTION
## Description

Adding many identical mesh entities re-ran the whole mesh pipeline for every entity (file parsing, convex decomposition, vertex adjacency/edges, SDF cell count, inertia), even for byte-identical morphs. These are now memoized so identical morphs reuse the processed geometry, and identical entities share the same frozen vertex/edge/adjacency arrays (also lowering memory). Appearance stays per-entity: geometry is shared but each entity keeps its own surface, so e.g. randomized collision colors are unchanged.

Caching is module-level and released on `gs.destroy` through a single new `clear_caches()` entrypoint; the large caches (processed collision geometry, merged RGBA textures) use a byte-bounded LRU (`SizeCappedCache`). The existing RGBA texture cache and teardown were folded into this (removing `clear_rgba_cache`).

Also fixes a latent divide-by-zero (`RuntimeWarning` + NaN inertia) on degenerate collision sub-meshes, which are now skipped.

## Motivation and Context

Building scenes with more than ~100 identical entities was impractically slow, and the cost was entirely redundant per-entity mesh reprocessing. Adding 432 identical ducks now takes ~2.9 s instead of ~74 s.

## How Has This Been / Can This Be Tested?

`python examples/rigid/hibernation.py --scene ducks` builds the 432-duck scene in ~3 s (was ~74 s) and settles/hibernates identically. `pytest tests/test_mesh.py` passes, including under `-W error::RuntimeWarning`.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (MISC)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
