### PR TITLE
[MISC] Scale hibernation ang vel threshold by DOF swept radius.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -1,9 +1,12 @@
+import numpy as np
 import quadrants as qd
 import torch
 
 import genesis as gs
+import genesis.utils.geom as gu
+from genesis.engine.entities.rigid_entity.rigid_link import RigidLink
 from genesis.utils import array_class
-from genesis.utils.misc import DeprecationError
+from genesis.utils.misc import DeprecationError, tensor_to_array
 from genesis.repr_base import RBC
 
 
@@ -376,6 +379,80 @@ class RigidJoint(RBC):
         Returns the invweight of the dofs of the joint.
         """
         return self._dofs_invweight
+
+    @property
+    def dofs_length(self):
+        """
+        Returns the characteristic length of each dof, used to put dof velocities on a common linear (m/s) scale.
+        Shape is (n_dofs,), or (n_dofs, n_envs) for a heterogeneous entity whose variants differ per environment.
+
+        A translational dof has length 1, so its velocity is already a linear speed. A rotational dof has the swept
+        radius of the body as its length, so that multiplying it by an angular velocity gives the linear surface speed
+        that rotation produces; this makes a single velocity tolerance meaningful across mixed dofs (e.g. for
+        hibernation). By default the radius is per-axis: the largest perpendicular distance from that dof's own
+        rotation axis (through the joint anchor) to the geometry. With MuJoCo compatibility it is instead MuJoCo's
+        dof_length: a single bounding-sphere radius about the body COM, shared by every rotational dof. For a
+        heterogeneous entity each variant's geoms are active in their own environments, so the radius is per env.
+        """
+        n_dofs = self.n_dofs
+        enable_heterogeneous = self._solver._enable_heterogeneous
+        n_envs = self._solver._B
+        shape = (n_dofs, n_envs) if enable_heterogeneous else (n_dofs,)
+        lengths = np.ones(shape, dtype=gs.np_float)
+        if n_dofs == 0:
+            return lengths
+
+        # A kinematic/avatar link has no collision geometry to size against.
+        if not isinstance(self.link, RigidLink):
+            return lengths
+
+        geoms = self.link.geoms
+        if not geoms:
+            return lengths
+
+        # Reduce a per-geom radius to the body radius: one value, or one per env (maxing over the geoms active in each
+        # env, which for a heterogeneous entity are only its own variant's).
+        masks = [None if geom.active_envs_mask is None else tensor_to_array(geom.active_envs_mask) for geom in geoms]
+
+        def body_radius(per_geom_radius):
+            if not enable_heterogeneous:
+                return max(per_geom_radius)
+            radius = np.zeros(n_envs, dtype=gs.np_float)
+            for value, mask in zip(per_geom_radius, masks):
+                if mask is None:
+                    radius = np.maximum(radius, value)
+                else:
+                    radius[mask] = np.maximum(radius[mask], value)
+            return radius
+
+        if self._solver._enable_mujoco_compatibility:
+            # MuJoCo's dof_length: one body radius shared by every rotational dof, the largest geom bounding radius
+            # plus its COM-to-geom-origin distance.
+            com = self.link.inertial_pos
+            radii = [
+                np.linalg.norm(geom.init_verts, axis=1).max() + np.linalg.norm(com - geom.init_pos) for geom in geoms
+            ]
+            radius = body_radius(radii)
+            for i_d in range(n_dofs):
+                if np.linalg.norm(self._dofs_motion_ang[i_d]) >= gs.EPS:  # rotational dof
+                    lengths[i_d] = radius
+        else:
+            # Per rotational dof, the largest perpendicular distance from its rotation axis (through the joint anchor)
+            # to the geometry. Tighter than one shared sphere, and correct for an offset hinge (where the body rotates
+            # about one end rather than its COM).
+            anchor = self.pos
+            verts = [
+                gu.transform_by_trans_quat(geom.init_verts, geom.init_pos, geom.init_quat) - anchor for geom in geoms
+            ]
+            for i_d in range(n_dofs):
+                axis = self._dofs_motion_ang[i_d]
+                axis_norm = np.linalg.norm(axis)
+                if axis_norm < gs.EPS:
+                    continue  # translational dof, length stays 1
+                axis = axis / axis_norm
+                perp = [np.linalg.norm(v - np.outer(v @ axis, axis), axis=1).max() for v in verts]
+                lengths[i_d] = body_radius(perp)
+        return lengths
 
     @property
     def dofs_frictionloss(self):

--- a/genesis/engine/solvers/rigid/abd/forward_kinematics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_kinematics.py
@@ -1265,6 +1265,7 @@ def kernel_update_vverts_for_vgeoms(
 @qd.func
 def func_hibernate__for_all_awake_islands_either_hiberanate_or_update_aabb_sort_buffer(
     dofs_state: array_class.DofsState,
+    dofs_info: array_class.DofsInfo,
     entities_state: array_class.EntitiesState,
     entities_info: array_class.EntitiesInfo,
     links_info: array_class.LinksInfo,
@@ -1303,14 +1304,18 @@ def func_hibernate__for_all_awake_islands_either_hiberanate_or_update_aabb_sort_
                     if links_state.is_hibernated[link_idx, i_b]:
                         continue
 
-                    # A link is ready to sleep once its maximum absolute DOF velocity has stayed below the tolerance
-                    # for hibernation_min_steps consecutive steps. Every awake link is visited each step so its counter
-                    # stays current even when its island will not sleep this step; the loop never breaks early.
+                    # A link is ready to sleep once its maximum DOF speed has stayed below the tolerance for
+                    # hibernation_min_steps consecutive steps. Every awake link is visited each step so its counter
+                    # stays current even when its island will not sleep this step; the loop never breaks early. Each
+                    # DOF velocity is weighted by dofs_info.dof_length (1 for translation, the swept radius for
+                    # rotation) so the tolerance is a single linear speed across mixed DOFs: rotational jitter of a
+                    # small body produces a tiny surface speed and no longer keeps it awake.
                     min_steps = qd.static(static_rigid_sim_config.hibernation_min_steps)
                     link_I = [link_idx, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else link_idx
                     max_vel = gs.qd_float(0.0)
                     for i_d in range(links_info.dof_start[link_I], links_info.dof_end[link_I]):
-                        max_vel = qd.max(max_vel, qd.abs(dofs_state.vel[i_d, i_b]))
+                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                        max_vel = qd.max(max_vel, dofs_info.dof_length[I_d] * qd.abs(dofs_state.vel[i_d, i_b]))
 
                     if max_vel < max_vel_thresh:
                         if links_state.awake_steps[link_idx, i_b] < min_steps:

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -218,6 +218,54 @@ def kernel_init_dof_fields(
 
 
 @qd.kernel(fastcache=True)
+def kernel_reset_hibernation(
+    envs_idx: qd.types.ndarray(),
+    links_info: array_class.LinksInfo,
+    links_state: array_class.LinksState,
+    dofs_state: array_class.DofsState,
+    geoms_state: array_class.GeomsState,
+    entities_state: array_class.EntitiesState,
+    island_state: array_class.IslandState,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    static_rigid_sim_config: qd.template(),
+):
+    # Wake every body in the given envs and rebuild the compact awake lists. A scene whose state is set (reset or
+    # set_state) must resume fully awake: the restored positions and velocities are a discontinuity, and any body left
+    # hibernated would stay frozen and never be re-simulated. DOFs are gathered per link (so a DOF-less scene reports
+    # zero awake DOFs even though its DOF buffers are padded to at least one slot).
+    n_links = links_state.is_hibernated.shape[0]
+    n_geoms = geoms_state.is_hibernated.shape[0]
+    n_entities = entities_state.is_hibernated.shape[0]
+    max_islands = island_state.is_hibernated.shape[0]
+
+    qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_b_ in range(envs_idx.shape[0]):
+        i_b = envs_idx[i_b_]
+        n_awake_dofs = 0
+        for i_l in range(n_links):
+            links_state.is_hibernated[i_l, i_b] = False
+            links_state.awake_steps[i_l, i_b] = 0
+            island_state.hibernated_next_link[i_l, i_b] = -1
+            rigid_global_info.awake_links[i_l, i_b] = i_l
+            link_I = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
+            for i_d_ in range(links_info.n_dofs[link_I]):
+                i_d = links_info.dof_start[link_I] + i_d_
+                dofs_state.is_hibernated[i_d, i_b] = False
+                rigid_global_info.awake_dofs[n_awake_dofs, i_b] = i_d
+                n_awake_dofs = n_awake_dofs + 1
+        rigid_global_info.n_awake_links[i_b] = n_links
+        rigid_global_info.n_awake_dofs[i_b] = n_awake_dofs
+        for i_g in range(n_geoms):
+            geoms_state.is_hibernated[i_g, i_b] = False
+        for i_e in range(n_entities):
+            entities_state.is_hibernated[i_e, i_b] = False
+            rigid_global_info.awake_entities[i_e, i_b] = i_e
+        rigid_global_info.n_awake_entities[i_b] = n_entities
+        for i_island in range(max_islands):
+            island_state.is_hibernated[i_island, i_b] = 0
+
+
+@qd.kernel(fastcache=True)
 def kernel_init_link_fields(
     links_parent_idx: qd.types.ndarray(),
     links_root_idx: qd.types.ndarray(),

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -47,6 +47,7 @@ from .abd.misc import (
     kernel_init_invweight,
     kernel_init_meaninertia,
     kernel_init_dof_fields,
+    kernel_reset_hibernation,
     kernel_init_link_fields,
     kernel_update_heterogeneous_link_info,
     kernel_init_joint_fields,
@@ -261,10 +262,11 @@ class RigidSolver(KinematicSolver):
                 "`use_hibernation=True` requires `use_contact_island=True`, as hibernation builds on islands."
             )
 
-        # Resolve the hibernation velocity tolerance to the residual-velocity floor of the float precision: 32-bit
-        # contact solves leave a larger resting-velocity jitter than 64-bit, so a body settles below a coarser floor.
+        # Resolve the hibernation velocity tolerance. MuJoCo compatibility uses MuJoCo's own default (1e-4); otherwise
+        # use a coarser floor that a body reliably settles below across float precisions and dense contact piles, where
+        # the contact solve leaves a larger residual resting-velocity jitter.
         if options.hibernation_thresh_vel is None:
-            self._hibernation_thresh_vel = 5e-3 if gs.qd_float == qd.f32 else 1e-4
+            self._hibernation_thresh_vel = 1e-4 if self._enable_mujoco_compatibility else 2e-3
         else:
             self._hibernation_thresh_vel = options.hibernation_thresh_vel
 
@@ -363,6 +365,7 @@ class RigidSolver(KinematicSolver):
         self._init_vert_fields()
         self._init_geom_fields()
         self._init_equality_fields()
+        self._init_dof_length()
 
         self._init_invweight_and_meaninertia(force_update=False)
         self._func_update_geoms(self._scene._envs_idx, force_update_fixed_geoms=True)
@@ -418,18 +421,21 @@ class RigidSolver(KinematicSolver):
 
         # Islands only reduce work when the scene splits into several blocks. With a single dense-coupled tree (one
         # island) the partition is pure overhead, so disable it in computation even if the user opted in. Hibernation
-        # is the exception: it builds on the island partition (the per-island is_hibernated flags), so it keeps islands
-        # on even for a single island, which then takes the serial tile-fallback path. The differentiable solve reads
-        # the dense global Hessian (nt_H), not the per-island tiles, so islands stay off under requires_grad regardless.
-        self._use_contact_island = (
-            self._use_contact_island
-            and (has_multi_island_structure or self._use_hibernation)
-            and not self._requires_grad
-        )
+        # does not force islands on (a scene with no island structure has nothing to gain from sleeping a lone tree);
+        # use_hibernation is gated off below to follow this decision. The differentiable solve reads the dense global
+        # Hessian (nt_H), not the per-island tiles, so islands stay off under requires_grad regardless.
+        self._use_contact_island = self._use_contact_island and has_multi_island_structure and not self._requires_grad
 
         # Hibernation builds on the island partition, so it cannot outlive islands being turned off by any gate above.
         # Re-sync it to the final island decision so the two never disagree.
         self._use_hibernation = self._use_hibernation and self._use_contact_island
+
+        # A heterogeneous entity has a different body size (hence rotational dof_length) per variant, so its dof_length
+        # is genuinely per-env and dofs_info must be batched to hold it. dof_length is read only by the hibernation
+        # rest test, so this is needed exactly when both features are active. We must update options because
+        # get_dofs_info reads from solver._options.batch_dofs_info.
+        if self._enable_heterogeneous and self._use_hibernation:
+            self._options.batch_dofs_info = True
 
         # sparse_solve=None resolves automatically: the skyline-envelope solver pays off on CPU only when the scene
         # has block structure, whereas a single dense-coupled tree gains nothing and pays the per-step envelope tax. An
@@ -993,6 +999,25 @@ class RigidSolver(KinematicSolver):
                 edges_info=self.edges_info,
                 static_rigid_sim_config=self._static_rigid_sim_config,
             )
+
+    def _init_dof_length(self):
+        # Characteristic length of each dof (1 for translation, the body radius for rotation), used to weight dof
+        # velocities in the hibernation rest test. Computed here, after geom dispatch, because a heterogeneous entity's
+        # per-variant geoms (and hence body radius) are only assigned to environments at that point. Only needed when
+        # hibernation is on, which already implies use_contact_island and a non-differentiable solve.
+        if not self._use_hibernation:
+            return
+
+        joints = self.joints
+        if sum(joint.n_dofs for joint in joints) == 0:
+            return
+
+        # dofs_length is per-env only for a heterogeneous entity; broadcast the shared row across envs when dofs_info
+        # is batched (always so for a heterogeneous entity, optionally for a homogeneous one).
+        dof_length = np.concatenate([joint.dofs_length for joint in joints], axis=0)
+        if self._options.batch_dofs_info and dof_length.ndim == 1:
+            dof_length = np.broadcast_to(dof_length[:, None], (len(dof_length), self._B))
+        self.dofs_info.dof_length.from_numpy(dof_length)
 
     def _init_geom_fields(self):
         self.geoms_info: array_class.GeomsInfo = self.data_manager.geoms_info
@@ -1771,6 +1796,31 @@ class RigidSolver(KinematicSolver):
             cfrc_ang_dst = qd_to_torch(self.links_state.cfrc_applied_ang, transpose=True, copy=False)
             mass_dst = qd_to_torch(self.links_state.mass_shift, transpose=True, copy=False)
             fric_dst = qd_to_torch(self.geoms_state.friction_ratio, transpose=True, copy=False)
+            # Setting the state is a discontinuity: wake every body in the affected envs (a body left hibernated would
+            # stay frozen), restoring the flags and the compact awake lists alongside the other state buffers.
+            if self._use_hibernation:
+                links_hibernated_dst = qd_to_torch(self.links_state.is_hibernated, transpose=True, copy=False)
+                awake_steps_dst = qd_to_torch(self.links_state.awake_steps, transpose=True, copy=False)
+                dofs_hibernated_dst = qd_to_torch(self.dofs_state.is_hibernated, transpose=True, copy=False)
+                geoms_hibernated_dst = qd_to_torch(self.geoms_state.is_hibernated, transpose=True, copy=False)
+                entities_hibernated_dst = qd_to_torch(self.entities_state.is_hibernated, transpose=True, copy=False)
+                islands_hibernated_dst = qd_to_torch(
+                    self.constraint_solver.island_state.is_hibernated, transpose=True, copy=False
+                )
+                islands_next_link_dst = qd_to_torch(
+                    self.constraint_solver.island_state.hibernated_next_link, transpose=True, copy=False
+                )
+                awake_links_dst = qd_to_torch(self._rigid_global_info.awake_links, transpose=True, copy=False)
+                awake_dofs_dst = qd_to_torch(self._rigid_global_info.awake_dofs, transpose=True, copy=False)
+                awake_entities_dst = qd_to_torch(self._rigid_global_info.awake_entities, transpose=True, copy=False)
+                n_awake_links_dst = qd_to_torch(self._rigid_global_info.n_awake_links, copy=False)
+                n_awake_dofs_dst = qd_to_torch(self._rigid_global_info.n_awake_dofs, copy=False)
+                n_awake_entities_dst = qd_to_torch(self._rigid_global_info.n_awake_entities, copy=False)
+                # Fill to the padded buffer capacity but keep n_awake at the real count below, so a scene with no
+                # DOFs writes its padded slot yet reports zero awake DOFs.
+                awake_links_src = torch.arange(self.n_links_, device=gs.device, dtype=gs.tc_int)
+                awake_dofs_src = torch.arange(self.n_dofs_, device=gs.device, dtype=gs.tc_int)
+                awake_entities_src = torch.arange(self.n_entities_, device=gs.device, dtype=gs.tc_int)
 
             if envs_idx is not None and not isinstance(envs_idx, torch.Tensor):
                 (envs_idx,) = indices_to_mask(envs_idx)
@@ -1796,6 +1846,20 @@ class RigidSolver(KinematicSolver):
                 torch.where(envs_mask[:, None], state.mass_shift, mass_dst, out=mass_dst)
                 if self.n_geoms:
                     torch.where(envs_mask[:, None], state.friction_ratio, fric_dst, out=fric_dst)
+                if self._use_hibernation:
+                    links_hibernated_dst.masked_fill_(envs_mask[:, None], 0)
+                    awake_steps_dst.masked_fill_(envs_mask[:, None], 0)
+                    dofs_hibernated_dst.masked_fill_(envs_mask[:, None], 0)
+                    geoms_hibernated_dst.masked_fill_(envs_mask[:, None], 0)
+                    entities_hibernated_dst.masked_fill_(envs_mask[:, None], 0)
+                    islands_hibernated_dst.masked_fill_(envs_mask[:, None], 0)
+                    islands_next_link_dst.masked_fill_(envs_mask[:, None], -1)
+                    torch.where(envs_mask[:, None], awake_links_src, awake_links_dst, out=awake_links_dst)
+                    torch.where(envs_mask[:, None], awake_dofs_src, awake_dofs_dst, out=awake_dofs_dst)
+                    torch.where(envs_mask[:, None], awake_entities_src, awake_entities_dst, out=awake_entities_dst)
+                    n_awake_links_dst.masked_fill_(envs_mask, self.n_links)
+                    n_awake_dofs_dst.masked_fill_(envs_mask, self.n_dofs)
+                    n_awake_entities_dst.masked_fill_(envs_mask, self.n_entities)
             else:
                 if self.n_qs:
                     errno[envs_idx] = 0
@@ -1812,6 +1876,20 @@ class RigidSolver(KinematicSolver):
                 mass_dst[envs_idx] = state.mass_shift[envs_idx]
                 if self.n_geoms:
                     fric_dst[envs_idx] = state.friction_ratio[envs_idx]
+                if self._use_hibernation:
+                    links_hibernated_dst[envs_idx] = 0
+                    awake_steps_dst[envs_idx] = 0
+                    dofs_hibernated_dst[envs_idx] = 0
+                    geoms_hibernated_dst[envs_idx] = 0
+                    entities_hibernated_dst[envs_idx] = 0
+                    islands_hibernated_dst[envs_idx] = 0
+                    islands_next_link_dst[envs_idx] = -1
+                    awake_links_dst[envs_idx] = awake_links_src
+                    awake_dofs_dst[envs_idx] = awake_dofs_src
+                    awake_entities_dst[envs_idx] = awake_entities_src
+                    n_awake_links_dst[envs_idx] = self.n_links
+                    n_awake_dofs_dst[envs_idx] = self.n_dofs
+                    n_awake_entities_dst[envs_idx] = self.n_entities
             if gs.backend == gs.metal:
                 torch.mps.synchronize()
         else:
@@ -1833,6 +1911,18 @@ class RigidSolver(KinematicSolver):
                 rigid_global_info=self._rigid_global_info,
                 static_rigid_sim_config=self._static_rigid_sim_config,
             )
+            if self._use_hibernation:
+                kernel_reset_hibernation(
+                    envs_idx,
+                    links_info=self.links_info,
+                    links_state=self.links_state,
+                    dofs_state=self.dofs_state,
+                    geoms_state=self.geoms_state,
+                    entities_state=self.entities_state,
+                    island_state=self.constraint_solver.island_state,
+                    rigid_global_info=self._rigid_global_info,
+                    static_rigid_sim_config=self._static_rigid_sim_config,
+                )
 
         if not partial:
             if not isinstance(envs_idx, torch.Tensor):
@@ -3308,6 +3398,7 @@ def kernel_step_2(
     if qd.static(static_rigid_sim_config.use_hibernation):
         func_hibernate__for_all_awake_islands_either_hiberanate_or_update_aabb_sort_buffer(
             dofs_state=dofs_state,
+            dofs_info=dofs_info,
             entities_state=entities_state,
             entities_info=entities_info,
             links_info=links_info,

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -480,9 +480,11 @@ class RigidOptions(Options):
         Whether to put bodies that have come to rest to sleep, so the solver skips them until they are disturbed. It
         quietly has no effect on a body that is differentiable, prunable, or under no-slip friction. Defaults to False.
     hibernation_thresh_vel : float, optional
-        Velocity tolerance for hibernation: a body sleeps once its maximum absolute DOF velocity stays below this for
-        a few consecutive steps, and a whole island sleeps once all its bodies are ready. If None, it is set to the
-        residual-velocity floor of the solver's float precision: 1e-4 at 64-bit, 5e-3 at 32-bit. Defaults to None.
+        Velocity tolerance for hibernation, in meters per second: a body sleeps once its maximum DOF speed stays below
+        this for a few consecutive steps, and a whole island sleeps once all its bodies are ready. Each rotational DOF
+        is weighted by the body's swept radius, so the tolerance is a single linear speed that applies uniformly to
+        translation and rotation. If None, it is set to 1e-4 when MuJoCo compatibility is enabled (matching MuJoCo's
+        default) and 2e-3 otherwise. Defaults to None.
     max_dynamic_constraints : int, optional
         Maximum number of dynamic constraints (like suction cup). Defaults to 8.
     use_gjk_collision: bool, optional

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1526,6 +1526,7 @@ class DofsInfo:
     act_gain: qd.Tensor
     act_bias: qd.Tensor
     force_range: qd.Tensor
+    dof_length: qd.Tensor
 
 
 def get_dofs_info(solver):
@@ -1544,6 +1545,7 @@ def get_dofs_info(solver):
         act_gain=V(dtype=gs.qd_float, shape=shape),
         act_bias=V(dtype=gs.qd_vec3, shape=shape),
         force_range=V(dtype=gs.qd_vec2, shape=shape),
+        dof_length=V(dtype=gs.qd_float, shape=shape),
     )
 
 

--- a/tests/test_rigid_physics_island.py
+++ b/tests/test_rigid_physics_island.py
@@ -419,7 +419,8 @@ def test_hibernation_with_pruning(show_viewer, n_envs):
     # so link-pair pruning collapses them into a logical permutation in contact_sort_idx. Islands read contacts through
     # that permutation and hibernation advects the resting contacts while the body sleeps, so pruning, islands and
     # hibernation all run together. contact_pruning_tolerance is set explicitly to keep pruning on alongside islands.
-    # The duck must reach the plane without tunnelling, hibernate, and then stay frozen in place.
+    # Two separated ducks give two islands (hibernation does not keep a single-island scene partitioned). Each duck
+    # must reach the plane without tunnelling, hibernate, and then stay frozen in place.
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=1.0 / 100.0,
@@ -432,32 +433,76 @@ def test_hibernation_with_pruning(show_viewer, n_envs):
         show_viewer=show_viewer,
     )
     scene.add_entity(gs.morphs.Plane())
-    duck = scene.add_entity(
-        gs.morphs.Mesh(
-            file="meshes/duck.obj",
-            scale=0.02,
-            pos=(0.0, 0.0, 0.1),
-            euler=(90.0, 0.0, 0.0),
-        ),
-    )
+    ducks = [
+        scene.add_entity(
+            gs.morphs.Mesh(
+                file="meshes/duck.obj",
+                scale=0.02,
+                pos=(0.4 * i, 0.0, 0.1),
+                euler=(90.0, 0.0, 0.0),
+            ),
+        )
+        for i in range(2)
+    ]
     scene.build(n_envs=n_envs)
     solver = scene.rigid_solver
 
     def asleep():
-        return qd_to_numpy(solver.entities_state.is_hibernated, duck.idx).all()
+        return all(qd_to_numpy(solver.entities_state.is_hibernated, duck.idx).all() for duck in ducks)
 
     for _ in range(200):
         scene.step()
-        assert (tensor_to_array(duck.get_pos())[..., 2] > -0.05).all()
+        assert all((tensor_to_array(duck.get_pos())[..., 2] > -0.05).all() for duck in ducks)
         if asleep():
             break
     assert asleep()
-    z_rest = tensor_to_array(duck.get_pos())[..., 2]
+    z_rest = [tensor_to_array(duck.get_pos())[..., 2] for duck in ducks]
 
     for _ in range(100):
         scene.step()
     assert asleep()
-    assert_allclose(duck.get_pos()[..., 2], z_rest, atol=1e-5)
+    for duck, z in zip(ducks, z_rest):
+        assert_allclose(duck.get_pos()[..., 2], z, atol=1e-5)
+
+    # Resetting wakes every body: the restored state is a discontinuity, so a body left hibernated would stay frozen
+    # and never be resimulated. After reset the ducks are awake again, with their flags cleared and awake counter zeroed.
+    scene.reset()
+    assert not any(qd_to_numpy(solver.entities_state.is_hibernated, duck.idx).any() for duck in ducks)
+    assert (qd_to_numpy(solver.links_state.awake_steps) == 0).all()
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("mujoco_compatibility", [False, True])
+def test_dof_length_scales_with_body_size(mujoco_compatibility):
+    # dof_length puts each rotational dof velocity on a linear (m/s) scale by the body radius (1 for translation), so
+    # the same angular velocity reads as a larger surface speed on a larger body. A free sphere gets a rotational
+    # dof_length equal to its radius - both with our per-axis swept radius and with MuJoCo's COM bounding sphere
+    # (gated behind mujoco_compatibility), since the two coincide for a sphere. dof_length is stored per environment,
+    # so a heterogeneous entity gets a different radius per variant (each variant's geoms are active only in its own
+    # envs). The two sphere variants map to envs 0-1 and 2-3; the homogeneous spheres make the scene multi-island so
+    # hibernation (and thus dof_length) is active.
+    radii = (0.1, 0.3)
+    variant_radii = (0.02, 0.06)
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            use_contact_island=True,
+            use_hibernation=True,
+            enable_mujoco_compatibility=mujoco_compatibility,
+        ),
+        show_viewer=False,
+    )
+    spheres = [scene.add_entity(gs.morphs.Sphere(radius=r, pos=(2.0 * i, 0.0, 1.0))) for i, r in enumerate(radii)]
+    het = scene.add_entity(morph=tuple(gs.morphs.Sphere(radius=r, pos=(0.0, 2.0, 1.0)) for r in variant_radii))
+    scene.build(n_envs=4)
+
+    dof_length = qd_to_numpy(scene.rigid_solver.dofs_info.dof_length)
+    for sphere, radius in zip(spheres, radii):
+        dof_length_sphere = dof_length[sphere.dof_start : sphere.dof_start + sphere.n_dofs]
+        assert_allclose(dof_length_sphere[:3], 1.0, tol=gs.EPS)
+        assert_allclose(dof_length_sphere[3:], radius, tol=gs.EPS)
+    rotational = dof_length[het.dof_start + 3 : het.dof_start + 6]  # (3, n_envs)
+    assert_allclose(rotational[:, [0, 1]], variant_radii[0], tol=gs.EPS)
+    assert_allclose(rotational[:, [2, 3]], variant_radii[1], tol=gs.EPS)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

Hibernation's rest test now weights each DOF velocity by a characteristic length (`1` for translation, the body's swept radius for rotation), so the tolerance is a single linear speed across translation and rotation. Previously a small body's unweighted angular jitter kept it awake indefinitely in contact piles.

`scene.reset()` / `set_state` now wake all bodies in the affected envs (hibernation state previously survived a reset, leaving bodies frozen). Done in place on the existing zero-copy path, with `kernel_reset_hibernation` as the non-zerocopy fallback.

## Motivation and Context

Bodies hibernate sooner and more reliably (e.g. the `ducks` showcase went from ~half the bodies stuck awake to nearly all asleep).

## How Has This Been / Can This Be Tested?

`pytest tests/test_rigid_physics_island.py -k hibernation` (includes a new reset-wake assertion). Manually: `python examples/rigid/hibernation.py --scene ducks`.

## Checklist:
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
