### PR TITLE
[BUG FIX] Fix textures when loading GLB meshes with multiple materials.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -587,13 +587,32 @@ class KinematicEntity(Entity):
                     )
                 )
         if morph.collision:
-            # Merge them as a single one if requested
             if morph.merge_submeshes_for_collision and len(meshes) > 1:
-                tmesh = trimesh.util.concatenate([mesh.trimesh for mesh in meshes])
-                mesh = gs.Mesh.from_trimesh(mesh=tmesh, surface=gs.surfaces.Collision())
-                meshes = (mesh,)
+                # Merge every submesh into a single collision geom if requested.
+                collision_groups = [list(meshes)]
+            else:
+                # A source mesh node split into several visual materials is one physical body, so its submeshes are
+                # merged into a single collision geom rather than split per material. Pieces meant to collide
+                # separately must be authored as separate nodes. Meshes with no source node are each their own body.
+                collision_groups = []
+                groups_by_node = {}
+                for mesh in meshes:
+                    node_index = mesh.metadata.get("node_index")
+                    if node_index is None:
+                        collision_groups.append([mesh])
+                        continue
+                    group = groups_by_node.get(node_index)
+                    if group is None:
+                        group = groups_by_node[node_index] = []
+                        collision_groups.append(group)
+                    group.append(mesh)
 
-            for mesh in meshes:
+            for group in collision_groups:
+                if len(group) == 1:
+                    mesh = group[0]
+                else:
+                    tmesh = trimesh.util.concatenate([submesh.trimesh for submesh in group])
+                    mesh = gs.Mesh.from_trimesh(mesh=tmesh, surface=gs.surfaces.Collision())
                 g_infos.append(
                     dict(
                         contype=morph.contype,

--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -389,16 +389,18 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
             if normals is None:
                 normals = trimesh.Trimesh(points, triangles, process=False).vertex_normals
 
-            # A single glTF mesh may hold several primitives with distinct materials. When not grouping by
-            # material, primitives must still be separated by material so each keeps its own surface and texture,
-            # otherwise primitives sharing a node would be merged under the first primitive's material.
+            # A single glTF mesh may hold several primitives with distinct materials. When not grouping by material,
+            # primitives must still be separated by material so each keeps its own surface and texture; otherwise
+            # primitives sharing a mesh would be merged under the first primitive's material and the rest lost.
             group_idx = primitive.material if group_by_material else (i, primitive.material)
             mesh_info, first_created = mesh_infos.get(group_idx)
             if first_created:
-                mesh_info.set_property(
-                    surface=material,
-                    metadata={"mesh_path": path, "name": material_name if group_by_material else mesh_name},
-                )
+                metadata = {"mesh_path": path, "name": material_name if group_by_material else mesh_name}
+                if not group_by_material:
+                    # Record the source mesh node so per-material submeshes can be regrouped into one physical body
+                    # (e.g. merged into a single collision geom) while still rendering with their own textures.
+                    metadata["node_index"] = i
+                mesh_info.set_property(surface=material, metadata=metadata)
             mesh_info.append(points, triangles, normals, uvs)
     meshes = mesh_infos.export_meshes(scale=scale, is_mesh_zup=is_mesh_zup)
     for mesh in meshes:

--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -389,7 +389,10 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
             if normals is None:
                 normals = trimesh.Trimesh(points, triangles, process=False).vertex_normals
 
-            group_idx = primitive.material if group_by_material else i
+            # A single glTF mesh may hold several primitives with distinct materials. When not grouping by
+            # material, primitives must still be separated by material so each keeps its own surface and texture,
+            # otherwise primitives sharing a node would be merged under the first primitive's material.
+            group_idx = primitive.material if group_by_material else (i, primitive.material)
             mesh_info, first_created = mesh_infos.get(group_idx)
             if first_created:
                 mesh_info.set_property(

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,9 +1,11 @@
+import io
 import os
 import platform
 from contextlib import nullcontext
 
 import xml.etree.ElementTree as ET
 import numpy as np
+import pygltflib
 import pytest
 import trimesh
 from PIL import Image
@@ -654,6 +656,102 @@ def test_glb_shared_texture_not_duplicated(tmp_path):
     retriever.build()
     static_args = retriever.retrieve_rigid_meshes_static()
     assert len(static_args["tex_widths"]) == 1
+
+
+@pytest.mark.required
+def test_glb_multi_primitive_distinct_materials(tmp_path):
+    # A single glTF mesh may hold several primitives with distinct materials/textures. With the default
+    # group_by_material=False, each primitive must stay a separate Genesis mesh keeping its own texture.
+    # Merging them under the first primitive's material silently drops the other textures.
+    texture_size = 16
+    prim_colors = np.array([[220, 30, 30], [30, 50, 220]], dtype=np.uint8)
+    n_prims = len(prim_colors)
+
+    # Pack one triangle per primitive (offset along x) plus one solid-color PNG per primitive into the binary blob.
+    parts = []
+    accessors = []
+    for i in range(n_prims):
+        x = 2.0 * i
+        positions = np.array([[x, 0.0, 0.0], [x + 1.0, 0.0, 0.0], [x, 1.0, 0.0]], dtype=np.float32)
+        uvs = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+        indices = np.array([0, 1, 2], dtype=np.uint16)
+        parts.append((positions.tobytes(), 34962))
+        parts.append((uvs.tobytes(), 34962))
+        parts.append((indices.tobytes(), 34963))
+        accessors.append(
+            pygltflib.Accessor(
+                bufferView=3 * i,
+                componentType=5126,
+                count=3,
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            )
+        )
+        accessors.append(pygltflib.Accessor(bufferView=3 * i + 1, componentType=5126, count=3, type="VEC2"))
+        accessors.append(pygltflib.Accessor(bufferView=3 * i + 2, componentType=5123, count=3, type="SCALAR"))
+    for color in prim_colors:
+        image = Image.fromarray(np.broadcast_to(color, (texture_size, texture_size, 3)).copy())
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        parts.append((buffer.getvalue(), None))
+
+    blob = b""
+    buffer_views = []
+    for data, target in parts:
+        blob += b"\x00" * ((4 - len(blob) % 4) % 4)
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data), target=target))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0)],
+        meshes=[
+            pygltflib.Mesh(
+                primitives=[
+                    pygltflib.Primitive(
+                        attributes=pygltflib.Attributes(POSITION=3 * i, TEXCOORD_0=3 * i + 1),
+                        indices=3 * i + 2,
+                        material=i,
+                    )
+                    for i in range(n_prims)
+                ]
+            )
+        ],
+        materials=[
+            pygltflib.Material(
+                pbrMetallicRoughness=pygltflib.PbrMetallicRoughness(
+                    baseColorTexture=pygltflib.TextureInfo(index=i, texCoord=0)
+                )
+            )
+            for i in range(n_prims)
+        ],
+        textures=[pygltflib.Texture(source=i) for i in range(n_prims)],
+        images=[pygltflib.Image(bufferView=3 * n_prims + i, mimeType="image/png") for i in range(n_prims)],
+        accessors=accessors,
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    glb_path = tmp_path / "multi_primitive.glb"
+    gltf.save_binary(str(glb_path))
+
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        str(glb_path),
+        group_by_material=False,
+        scale=None,
+        is_mesh_zup=False,
+        surface=gs.surfaces.Default(),
+    )
+
+    # One mesh per material rather than a single merged mesh, each keeping its own distinct base-color texture.
+    assert len(gs_meshes) == n_prims
+    dominant_channels = []
+    for gs_mesh in gs_meshes:
+        texture = gs_mesh.surface.texture
+        assert isinstance(texture, gs.textures.ImageTexture)
+        dominant_channels.append(int(np.argmax(texture.image_array[..., :3].mean(axis=(0, 1)))))
+    assert sorted(dominant_channels) == [0, 2]
 
 
 @pytest.fixture

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -660,21 +660,24 @@ def test_glb_shared_texture_not_duplicated(tmp_path):
 
 @pytest.mark.required
 def test_glb_multi_primitive_distinct_materials(tmp_path):
-    # A single glTF mesh may hold several primitives with distinct materials/textures. With the default
-    # group_by_material=False, each primitive must stay a separate Genesis mesh keeping its own texture.
-    # Merging them under the first primitive's material silently drops the other textures.
+    # A single glTF mesh node may hold several primitives with distinct materials/textures. With the default
+    # group_by_material=False, each primitive becomes its own visual mesh so all its textures render (merging them
+    # under the first primitive's material would silently drop the others), but the node is one physical body, so
+    # its primitives are merged into a single collision geom. Separately colliding pieces are authored as nodes.
     texture_size = 16
     prim_colors = np.array([[220, 30, 30], [30, 50, 220]], dtype=np.uint8)
     n_prims = len(prim_colors)
 
-    # Pack one triangle per primitive (offset along x) plus one solid-color PNG per primitive into the binary blob.
+    # One axis-aligned box per primitive plus one solid-color PNG per primitive, packed into a single glTF mesh
+    # (one node) with one primitive per material. The boxes share a face so their union is convex, so merging them
+    # per node yields a single convex collision geom.
+    box = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
     parts = []
     accessors = []
     for i in range(n_prims):
-        x = 2.0 * i
-        positions = np.array([[x, 0.0, 0.0], [x + 1.0, 0.0, 0.0], [x, 1.0, 0.0]], dtype=np.float32)
-        uvs = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
-        indices = np.array([0, 1, 2], dtype=np.uint16)
+        positions = (box.vertices + np.array([0.5 + i, 0.0, 0.0])).astype(np.float32)
+        uvs = np.zeros((len(positions), 2), dtype=np.float32)
+        indices = box.faces.astype(np.uint32)
         parts.append((positions.tobytes(), 34962))
         parts.append((uvs.tobytes(), 34962))
         parts.append((indices.tobytes(), 34963))
@@ -682,14 +685,16 @@ def test_glb_multi_primitive_distinct_materials(tmp_path):
             pygltflib.Accessor(
                 bufferView=3 * i,
                 componentType=5126,
-                count=3,
+                count=len(positions),
                 type="VEC3",
                 min=positions.min(axis=0).tolist(),
                 max=positions.max(axis=0).tolist(),
             )
         )
-        accessors.append(pygltflib.Accessor(bufferView=3 * i + 1, componentType=5126, count=3, type="VEC2"))
-        accessors.append(pygltflib.Accessor(bufferView=3 * i + 2, componentType=5123, count=3, type="SCALAR"))
+        accessors.append(pygltflib.Accessor(bufferView=3 * i + 1, componentType=5126, count=len(uvs), type="VEC2"))
+        accessors.append(
+            pygltflib.Accessor(bufferView=3 * i + 2, componentType=5125, count=indices.size, type="SCALAR")
+        )
     for color in prim_colors:
         image = Image.fromarray(np.broadcast_to(color, (texture_size, texture_size, 3)).copy())
         buffer = io.BytesIO()
@@ -744,7 +749,7 @@ def test_glb_multi_primitive_distinct_materials(tmp_path):
         surface=gs.surfaces.Default(),
     )
 
-    # One mesh per material rather than a single merged mesh, each keeping its own distinct base-color texture.
+    # One visual mesh per material rather than a single merged mesh, each keeping its own distinct base-color texture.
     assert len(gs_meshes) == n_prims
     dominant_channels = []
     for gs_mesh in gs_meshes:
@@ -752,6 +757,19 @@ def test_glb_multi_primitive_distinct_materials(tmp_path):
         assert isinstance(texture, gs.textures.ImageTexture)
         dominant_channels.append(int(np.argmax(texture.image_array[..., :3].mean(axis=(0, 1)))))
     assert sorted(dominant_channels) == [0, 2]
+
+    scene = gs.Scene(show_viewer=False)
+    entity = scene.add_entity(
+        gs.morphs.Mesh(
+            file=str(glb_path),
+            file_meshes_are_zup=False,
+        ),
+    )
+    scene.build()
+    # Textures render per material (one visual geom each), but the node is a single physical body, so its
+    # primitives are merged into one collision geom rather than split by material.
+    assert len(entity.vgeoms) == n_prims
+    assert len(entity.geoms) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

A single glTF mesh can hold several primitives with distinct materials/textures. With the default `group_by_material=False`, `parse_mesh_glb` grouped primitives only by their node index, so all primitives of one mesh merged into a single Genesis mesh and kept only the *first* primitive's material. The other primitives' textures were silently dropped and their geometry sampled the wrong texture through its own UVs.

Fix: when not grouping by material, key by `(node_index, primitive.material)` so primitives with different materials stay separate. Single-primitive meshes and `group_by_material=True` are unaffected; multi-material meshes now yield one mesh per material.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#2982

## Motivation and Context

The reporter's 180 MB scene is a single glTF mesh with 3 primitives, each using a different 8K texture. On `main` all three merged under texture 0, so two thirds of the scene rendered with the wrong texture mapped through the wrong UVs.

## How Has This Been / Can This Be Tested?

New regression test `tests/test_mesh.py::test_glb_multi_primitive_distinct_materials` builds a one-mesh/two-primitive/two-texture GLB and asserts each material stays a separate mesh with its own texture. Fails on `main` (`assert 1 == 2`), passes here. Existing GLB/material/texture tests in `test_mesh.py` still pass.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
