### PR TITLE
[BUG FIX] Fix go2_backflip RL training example.

### DIFF
--- a/examples/locomotion/go2_backflip.py
+++ b/examples/locomotion/go2_backflip.py
@@ -132,7 +132,7 @@ def main():
     policy = torch.jit.load(f"./backflip/{args.exp_name}.pt")
     policy.to(device=gs.device)
 
-    obs, _ = env.reset()
+    obs = env.reset()
     with torch.no_grad():
         while True:
             actions = policy(obs)


### PR DESCRIPTION
## Description
The change here https://github.com/Genesis-Embodied-AI/genesis-world/commit/043960829507ab03ce359e6a97ac63c0c0d4475b#diff-c9e3853aba220342efbefc93fb41b9ef5096a6ef189f8e2f973642779c813c97L247 has introduced a bug in the go2_backflip example where 2 values are expected out of the env.reset call.

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#2985

## Motivation and Context
Examples should run without crashing.

## How Has This Been / Can This Be Tested?
I ran the example using `python examples/locomotion/go2_backflip.py`

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
