### PR TITLE
[FEATURE] Add joint torque sensor (closes #2983)

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -3741,6 +3741,44 @@ class RigidEntity(KinematicEntity):
         dofs_idx = self._get_global_idx(dofs_idx_local, self.n_dofs, self._dof_start, unsafe=True)
         return self._solver.get_dofs_force(dofs_idx, envs_idx)
 
+    @gs.assert_built
+    def get_dofs_actuation_force(self, dofs_idx_local=None, envs_idx=None):
+        """
+        Get the torque transmitted through the entity's joints, i.e. the joint torque sensor measurement.
+
+        This is the actuation-side force ``qf_applied + qf_passive``: the actuator/applied generalized
+        force (motor torque from the controller, plus any `set_dofs_force` contribution) combined with the
+        passive joint force (damping/friction and spring). It is the total torque a sensor mounted in
+        series with the actuator would measure.
+
+        Note
+        ----
+        This differs from the two other force getters:
+
+        - `get_dofs_force` returns the *net* force on each dof (mass times acceleration), which converges
+          to zero for a robot at rest and therefore does not capture the gravity-support torque.
+        - `get_dofs_control_force` returns the raw motor command before passive/actuator losses.
+
+        At rest with a controller holding position, this getter reports the gravity-support torque on each
+        joint. If gravity compensation is enabled for the entity (which removes gravity from its dynamics),
+        no gravity term appears here, since the simulated robot carries no gravity load; keep gravity
+        enabled and let the controller compensate to read a real gravity load.
+
+        Parameters
+        ----------
+        dofs_idx_local : None | array_like, optional
+            The indices of the dofs to get. If None, all dofs will be returned. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        force : torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
+            The torque transmitted through the entity's dofs.
+        """
+        dofs_idx = self._get_global_idx(dofs_idx_local, self.n_dofs, self._dof_start, unsafe=True)
+        return self._solver.get_dofs_actuation_force(dofs_idx, envs_idx)
+
     # ------------------------------------------------------------------------------------
     # ----------------------------- DOF property getters ---------------------------------
     # ------------------------------------------------------------------------------------

--- a/genesis/engine/sensors/__init__.py
+++ b/genesis/engine/sensors/__init__.py
@@ -4,6 +4,7 @@ from . import (
     contact_force,
     depth_camera,
     imu,
+    joint_torque,
     kinematic_tactile,
     point_cloud_tactile,
     probe,

--- a/genesis/engine/sensors/joint_torque.py
+++ b/genesis/engine/sensors/joint_torque.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+import genesis as gs
+from genesis.options.sensors import JointTorque as JointTorqueSensorOptions
+from genesis.utils.misc import concat_with_tensor, make_tensor_field
+
+from .base_sensor import SimpleSensor, SimpleSensorMetadata
+
+if TYPE_CHECKING:
+    from genesis.engine.solvers import RigidSolver
+
+    from .sensor_manager import SensorManager
+
+
+@dataclass
+class JointTorqueSensorMetadata(SimpleSensorMetadata):
+    """
+    Shared metadata for all joint torque sensors.
+    """
+
+    solver: "RigidSolver | None" = None
+    # Global dof indices measured across all joint torque sensors, concatenated in sensor order. Each
+    # sensor owns a contiguous slice (mirrors `ContactSensorMetadata.expanded_links_idx`).
+    dofs_idx: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+
+
+class JointTorqueSensor(SimpleSensor[JointTorqueSensorOptions, None, JointTorqueSensorMetadata]):
+    """
+    Sensor that returns the torque transmitted through the joints of the associated RigidEntity.
+
+    Reports the actuation-side generalized force ``qf_applied + qf_passive`` (see
+    ``RigidEntity.get_dofs_actuation_force``), i.e. the quantity a torque sensor mounted in series with the
+    actuator would measure.
+    """
+
+    def _local_dofs_idx(self) -> torch.Tensor:
+        """Local dof indices this sensor measures (all of the entity's dofs when none were specified)."""
+        if len(self._options.dofs_idx_local) > 0:
+            return torch.as_tensor(self._options.dofs_idx_local, dtype=gs.tc_int, device=gs.device)
+        entity = self._manager._sim.entities[self._options.entity_idx]
+        return torch.arange(entity.n_dofs, dtype=gs.tc_int, device=gs.device)
+
+    def build(self):
+        super().build()
+
+        if self._shared_metadata.solver is None:
+            self._shared_metadata.solver = self._manager._sim.rigid_solver
+
+        entity = self._manager._sim.entities[self._options.entity_idx]
+        dofs_idx_global = self._local_dofs_idx() + entity.dof_start
+        self._shared_metadata.dofs_idx = concat_with_tensor(self._shared_metadata.dofs_idx, dofs_idx_global, dim=0)
+
+    def _get_return_format(self) -> tuple[int, ...]:
+        return (self._local_dofs_idx().numel(),)
+
+    @classmethod
+    def _get_cache_dtype(cls) -> torch.dtype:
+        return gs.tc_float
+
+    @classmethod
+    def _update_raw_data(
+        cls, shared_context: None, shared_metadata: JointTorqueSensorMetadata, raw_data_T: torch.Tensor
+    ):
+        assert shared_metadata.solver is not None
+        force = shared_metadata.solver.get_dofs_actuation_force(dofs_idx=shared_metadata.dofs_idx)
+        if shared_metadata.solver.n_envs == 0:
+            force = force[None]
+        # `force` is (B, total_dofs); raw buffer is (total_dofs, B).
+        raw_data_T[:] = force.T

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2628,6 +2628,18 @@ class RigidSolver(KinematicSolver):
         tensor = qd_to_torch(self.dofs_state.force, envs_idx, dofs_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
 
+    def get_dofs_actuation_force(self, dofs_idx=None, envs_idx=None):
+        # Torque transmitted through each joint: the actuator/applied generalized force (`qf_applied`,
+        # which holds the clamped control command and any `set_dofs_force` contribution) plus the passive
+        # joint force (`qf_passive`: damping/friction + spring). This is the joint-torque-sensor quantity,
+        # as opposed to `get_dofs_force` (net force ~ M*qacc, ~0 at rest) and `get_dofs_control_force`
+        # (pre-loss motor command).
+        # `applied` is a fresh copy (fancy dof indexing forces copy=True), so accumulate into it in place.
+        applied = qd_to_torch(self.dofs_state.qf_applied, envs_idx, dofs_idx, transpose=True, copy=True)
+        passive = qd_to_torch(self.dofs_state.qf_passive, envs_idx, dofs_idx, transpose=True, copy=True)
+        applied.add_(passive)
+        return applied[0] if self.n_envs == 0 else applied
+
     def get_dofs_kp(self, dofs_idx=None, envs_idx=None):
         if not self._options.batch_dofs_info and envs_idx is not None:
             gs.raise_exception("`envs_idx` cannot be specified for non-batched dofs info.")

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from genesis.engine.sensors.base_sensor import Sensor
     from genesis.engine.sensors.contact_force import ContactForceSensor, ContactSensor
     from genesis.engine.sensors.imu import IMUSensor
+    from genesis.engine.sensors.joint_torque import JointTorqueSensor
     from genesis.engine.sensors.raycaster import RaycasterSensor
     from genesis.engine.sensors.surface_distance_probe import SurfaceDistanceProbeSensor
 
@@ -302,6 +303,52 @@ class ContactForce(RigidSensorOptionsMixin["ContactForceSensor"], SimpleSensorOp
         super().model_post_init(context)
         if np.any(np.array(self.max_force) <= np.array(self.min_force)):
             gs.raise_exception(f"min_force should be less than max_force, got: {self.min_force} and {self.max_force}")
+
+
+class JointTorque(SimpleSensorOptions["JointTorqueSensor"]):
+    """
+    Sensor that returns the torque transmitted through the joints of the associated RigidEntity.
+
+    This measures the actuation-side generalized force ``qf_applied + qf_passive`` (the actuator/applied
+    torque combined with the passive joint force from damping/friction and springs), as a sensor mounted
+    in series with the actuator would. Unlike the net dof force (which converges to zero at rest), this
+    retains the gravity-support torque when the entity is held against gravity.
+
+    Note
+    ----
+    A Cartesian contact wrench enters the dynamics through the constraint force, not ``qf_applied``, so it
+    is reflected here only once the controller responds to it. If gravity compensation is enabled for the
+    entity (which removes gravity from its dynamics), no gravity term appears in the reading.
+
+    Parameters
+    ----------
+    entity_idx : int
+        The global entity index of the RigidEntity to which this sensor is attached. Required.
+    dofs_idx_local : array-like[int], optional
+        The local dof indices of the entity to measure. If empty (the default), all of the entity's dofs
+        are measured.
+    """
+
+    dofs_idx_local: OptionalIArrayType = Field(default_factory=tuple)
+
+    def validate_scene(self, scene: "Scene"):
+        from genesis.engine.entities import RigidEntity
+
+        super().validate_scene(scene)
+        if self.entity_idx < 0:
+            gs.raise_exception("JointTorque sensor requires `entity_idx` to be set to a RigidEntity.")
+        if self.entity_idx >= len(scene.entities):
+            gs.raise_exception(f"Invalid entity index {self.entity_idx}.")
+        entity = scene.entities[self.entity_idx]
+        if not isinstance(entity, RigidEntity):
+            gs.raise_exception(f"Entity at index {self.entity_idx} is not a RigidEntity.")
+        if len(self.dofs_idx_local) > 0:
+            dofs = np.array(self.dofs_idx_local)
+            if np.any(dofs < 0) or np.any(dofs >= entity.n_dofs):
+                gs.raise_exception(
+                    f"JointTorque sensor dofs_idx_local should be in range [0, {entity.n_dofs}). "
+                    f"Got {self.dofs_idx_local}."
+                )
 
 
 class TemperatureProperties(NamedTuple):

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -450,7 +450,7 @@ def test_add_and_read_all_registered_sensors():
         sensor_kwargs = {}
         if issubclass(option_cls, gs.sensors.BaseCameraOptions):
             continue  # skip camera options
-        if issubclass(option_cls, gs.sensors.RigidSensorOptionsMixin):
+        if issubclass(option_cls, (gs.sensors.RigidSensorOptionsMixin, gs.sensors.JointTorque)):
             sensor_kwargs.update(
                 entity_idx=box.idx,
             )
@@ -649,6 +649,72 @@ def test_imu_sensor(show_viewer, tol, n_envs):
     scene.step()
     assert_allclose(imu.read().lin_acc, BIAS, tol=tol)
     assert_allclose(imu.read().mag, MAG_FIELD, tol=tol)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_joint_torque_sensor(show_viewer, tol, n_envs):
+    """The joint torque sensor reports the torque transmitted through the joints (`qf_applied + qf_passive`).
+
+    Unlike the net dof force (`get_dofs_force`, ~0 at rest), it retains the gravity-support torque when the
+    arm is held against gravity, and it tracks an externally commanded joint torque.
+    """
+    DT = 1e-2
+    MOTORS = (0, 1, 2, 3, 4, 5, 6)
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(dt=DT, gravity=(0.0, 0.0, -9.81)),
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    franka = scene.add_entity(gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"))
+
+    sensor = scene.add_sensor(gs.sensors.JointTorque(entity_idx=franka.idx, dofs_idx_local=MOTORS))
+    # Default (no dofs_idx_local) measures all dofs of the entity.
+    sensor_all = scene.add_sensor(gs.sensors.JointTorque(entity_idx=franka.idx))
+
+    scene.build(n_envs=n_envs)
+    assert sensor.read().shape[-1] == len(MOTORS)
+    assert sensor_all.read().shape[-1] == franka.n_dofs
+
+    franka.set_dofs_kp(np.array([4500.0, 4500.0, 3500.0, 3500.0, 2000.0, 2000.0, 2000.0, 100.0, 100.0]))
+    franka.set_dofs_kv(np.array([450.0, 450.0, 350.0, 350.0, 200.0, 200.0, 200.0, 10.0, 10.0]))
+
+    # Hold a bent pose (gravity-loaded) with a stiff PD controller and let it settle.
+    qpos_hold = np.array([0.0, 0.4, 0.0, -1.5, 0.0, 1.2, 0.0])
+    franka.set_qpos(np.concatenate([qpos_hold, np.zeros(franka.n_dofs - 7)]))
+    for _ in range(300):
+        franka.control_dofs_position(qpos_hold, MOTORS)
+        scene.step()
+
+    reading = sensor.read()
+    # The sensor matches the public helper (qf_applied + qf_passive) exactly.
+    assert_equal(reading, franka.get_dofs_actuation_force(MOTORS))
+    # The net dof force is ~0 at rest (the quantity reported in the original issue)...
+    assert_allclose(franka.get_dofs_force(MOTORS), 0.0, tol=1e-2)
+    # ...while the torque sensor retains the nonzero gravity-support torque.
+    assert tensor_to_array(reading.abs().max()) > 1.0
+
+    # The reading is the true gravity-support torque: feeding it back open-loop in force mode (no position
+    # controller) holds the arm against gravity. This gravity-compensation feedforward holds over a short
+    # horizon -- pure feedforward without feedback is only marginally stable, so it eventually drifts.
+    qpos_star = franka.get_qpos()
+    tau_ff = franka.get_dofs_actuation_force()  # all dofs, so the fingers are held too
+    for _ in range(25):
+        franka.control_dofs_force(tau_ff)
+        scene.step()
+    assert_allclose(franka.get_qpos(), qpos_star, tol=1e-2)
+
+    # An externally commanded joint torque is reflected by the sensor. Drive joint 6 (a low gravity-load
+    # wrist joint reading ~0 under PD hold) in force mode with a known torque while the other joints stay
+    # under PD hold, and read after a single step before the joint spins up (so the passive damping term,
+    # which grows with velocity, is still negligible).
+    APPLIED = 5.0
+    franka.control_dofs_position(qpos_hold[:6], MOTORS[:6])
+    franka.control_dofs_force(np.array([APPLIED]), (MOTORS[6],))
+    scene.step()
+    assert_allclose(sensor.read()[..., 6], APPLIED, tol=1e-2)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Summary

Adds a **joint torque sensor** — the torque transmitted through each joint — closing #2983. Real collaborative robots place a torque sensor in series with the actuator and close an impedance/compliance loop on it; this exposes the same signal in simulation.

The issue reporter found `get_dofs_force` reads ~0 for a stationary arm. That's expected: it returns the *net* generalized force (`≈ M·q̈`), which is zero at rest and so omits the gravity-support torque. The transmitted torque is the **actuation-side** force `qf_applied + qf_passive` (actuator/applied command + passive damping/friction & spring), which retains the gravity term when the arm holds against gravity.

## What's added

- **`RigidSolver.get_dofs_actuation_force`** / **`RigidEntity.get_dofs_actuation_force`** — expose `qf_applied + qf_passive`. Docstrings contrast it with `get_dofs_force` (net force) and `get_dofs_control_force` (pre-loss motor command), and note the gravity-compensation caveat.
- **`gs.sensors.JointTorque`** options + **`JointTorqueSensor`** — plug into the existing sensor framework (`scene.add_sensor`, recorders), measuring a selected set of DOFs (defaults to all of the entity's DOFs).
- **Tests** (`tests/test_sensors.py`, `n_envs ∈ {0, 2}`) on a gravity-loaded Franka:
  - at rest the reading equals the helper and is non-zero, while `get_dofs_force` stays ~0;
  - feeding the reading back open-loop in force mode holds the arm (gravity-compensation feed-forward);
  - an externally commanded joint torque is read back.

## Notes / scope

- This is the **closed-form** definition (`qf_applied + qf_passive`). A Cartesian contact wrench enters via the constraint force, so it's reflected only once the controller reacts. An exact-fidelity variant (RNE-post-constraint projection of the link interaction force, à la MuJoCo's joint torque sensor / `cfrc_int`) is a natural follow-up.
- Genesis gravity compensation removes gravity from the entity's dynamics, so with that flag on the reading carries no gravity term (the simulated robot has no gravity load) — documented in the docstrings.

Closes #2983

🤖 Generated with [Claude Code](https://claude.com/claude-code)
