### PR TITLE
Revert "[MISC] Significantly improve non-batched CPU simulation speed (up to 30%). (#2991)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==1.1.0",
+    "quadrants==1.0.2",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",


### PR DESCRIPTION
This reverts PR #2991, which bumped the `quadrants` dependency from `1.0.2` to `1.1.0`.

Reverting restores `quadrants==1.0.2` in `pyproject.toml`.