### PR TITLE
[MISC] Speed up CPU rigid constraint solver via skyline column bounds and inactive-constraint skip.

### DIFF
--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -347,7 +347,6 @@ class KinematicSolver(Solver):
             batch_links_info=self._options.batch_links_info,
             batch_dofs_info=False,
             batch_joints_info=False,
-            enable_heterogeneous=self._enable_heterogeneous,
             enable_mujoco_compatibility=False,
             enable_multi_contact=False,
             enable_collision=False,

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -2619,10 +2619,10 @@ def func_cholesky_factor_direct_batch(
             # computes dof_env_col_end in its solve init, so it can bound the row sweep by the column height; other
             # configs (GPU per-island) may factor without computing the envelope, whose 0-default would wrongly
             # truncate, so they keep the full scan.
-            j_d_hi = n
+            j_d_end = n
             if qd.static(static_rigid_sim_config.sparse_solve and not static_rigid_sim_config.sparse_envelope):
-                j_d_hi = island_state.dof_env_col_end[dof_base + i_d, i_b] + 1
-            for j_d in range(i_d + 1, j_d_hi):
+                j_d_end = island_state.dof_env_col_end[dof_base + i_d, i_b] + 1
+            for j_d in range(i_d + 1, j_d_end):
                 j_start = island_state.dof_env_start_local[dof_base + j_d, i_b]
                 if j_start <= i_d:
                     j_dg = island_state.dof_id[dof_base + j_d, i_b]
@@ -3200,64 +3200,93 @@ def func_hessian_and_cholesky_factor_incremental_sparse_batch(
 
 
 @qd.func
-def func_rank1_update_island_constraint(
+def func_rank_batch_update_island(
     i_b,
     i_island,
-    i_c,
+    batch_ic,
+    n_u,
     island_state: array_class.IslandState,
     constraint_state: array_class.ConstraintState,
     rigid_global_info: array_class.RigidGlobalInfo,
+    static_rigid_sim_config: qd.template(),
 ) -> bool:
-    """Apply one constraint's rank-1 update/downdate to its island's Cholesky block of L, in place in nt_H.
+    """Apply batched rank-1 updates/downdates to the island's Cholesky block of L, in place in nt_H, fused into a
+    single column sweep.
 
-    The update runs over the island's local DOF positions ascending (dof_id is ascending, so local order is global-DOF
-    order = the factor's processing order), bounded to the per-island skyline envelope (dof_env_start_local). nt_vec is
-    the rank-1 working vector, indexed by global DOF; it self-clears as columns are consumed (the caller zeroes the
-    island's entries once up front so a degenerate break leaves it clean). Returns whether the downdate went indefinite,
-    in which case the caller refactors the island directly.
+    A rank-1 rotation at column ld only reads state produced by earlier updates at that column and by its own
+    rotations at earlier columns, so interleaving the n_u updates per column computes bit-identical results to running
+    them sequentially, while visiting each L column once instead of n_u times (amortized index and envelope lookups,
+    and n_u independent rotation chains per column). The sweep runs over ascending island-local positions from the
+    batch's first support row, bounded per column by the skyline height (dof_env_col_end). nt_vec holds one
+    working vector per batch slot, flattened slot-minor ([i_d * hessian_rank_update_batch + i_u]); the caller zeroes
+    the island's entries once per incremental attempt. Returns whether any downdate went indefinite, in which case the caller refactors the island directly
+    (discarding the partially updated L, so the fused ordering is unobservable).
     """
     EPS = rigid_global_info.EPS[None]
     dof_base = island_state.dof_slices.start[i_island, i_b]
     n = island_state.dof_slices.n[i_island, i_b]
-    sign = 1.0 if constraint_state.active[i_c, i_b] else -1.0
-    efc_D_sqrt = qd.sqrt(constraint_state.efc_D[i_c, i_b])
 
-    # Rows before the constraint's first support DOF hold an exact zero in nt_vec, so the sweep starts there.
+    signs = qd.Vector.zero(gs.qd_float, static_rigid_sim_config.hessian_rank_update_batch)
+    # Rows before the batch's first support DOF hold an exact zero in every working vector, so the sweep starts there.
     ld_start = n
-    for k_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
-        gd = constraint_state.jac_dofs_idx[i_c, k_, i_b]
-        constraint_state.nt_vec[gd, i_b] = constraint_state.jac[i_c, gd, i_b] * efc_D_sqrt
-        ld_support = island_state.dof_local_pos[gd, i_b]
-        if ld_support < ld_start:
-            ld_start = ld_support
+    for i_u in qd.static(range(static_rigid_sim_config.hessian_rank_update_batch)):
+        if i_u < n_u:
+            i_c = batch_ic[i_u]
+            signs[i_u] = 1.0 if constraint_state.active[i_c, i_b] else -1.0
+            efc_D_sqrt = qd.sqrt(constraint_state.efc_D[i_c, i_b])
+            for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
+                i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
+                slot_base = i_d * static_rigid_sim_config.hessian_rank_update_batch
+                constraint_state.nt_vec[slot_base + i_u, i_b] = constraint_state.jac[i_c, i_d, i_b] * efc_D_sqrt
+                ld_support = island_state.dof_local_pos[i_d, i_b]
+                if ld_support < ld_start:
+                    ld_start = ld_support
 
     is_degenerated = False
     for ld in range(ld_start, n):
-        gk = island_state.dof_id[dof_base + ld, i_b]
-        vk = constraint_state.nt_vec[gk, i_b]
-        if qd.abs(vk) > EPS:
-            Lkk = constraint_state.nt_H[i_b, gk, gk]
-            tmp = Lkk * Lkk + sign * vk * vk
-            if tmp < EPS:
-                is_degenerated = True
-                break
-            r = qd.sqrt(tmp)
-            cinv = Lkk / r
-            c = r / Lkk
-            s = vk / Lkk
-            constraint_state.nt_H[i_b, gk, gk] = r
-            # Only rows whose envelope reaches column ld can couple; col_end bounds them so a banded island sweeps
-            # its bandwidth instead of every row below ld.
-            for jd in range(ld + 1, island_state.dof_env_col_end[dof_base + ld, i_b] + 1):
-                if island_state.dof_env_start_local[dof_base + jd, i_b] <= ld:
-                    gj = island_state.dof_id[dof_base + jd, i_b]
-                    constraint_state.nt_H[i_b, gj, gk] = (
-                        constraint_state.nt_H[i_b, gj, gk] + sign * s * constraint_state.nt_vec[gj, i_b]
-                    ) * cinv
-                    constraint_state.nt_vec[gj, i_b] = (
-                        c * constraint_state.nt_vec[gj, i_b] - s * constraint_state.nt_H[i_b, gj, gk]
-                    )
-            constraint_state.nt_vec[gk, i_b] = gs.qd_float(0.0)
+        i_dg = island_state.dof_id[dof_base + ld, i_b]
+        slot_base = i_dg * static_rigid_sim_config.hessian_rank_update_batch
+        # Diagonal phase: chain each update's rotation parameters through Lkk, in batch order (the same value each
+        # update would read had the previous ones fully completed - column-local state only).
+        cs = qd.Vector.zero(gs.qd_float, static_rigid_sim_config.hessian_rank_update_batch)
+        ss = qd.Vector.zero(gs.qd_float, static_rigid_sim_config.hessian_rank_update_batch)
+        cinvs = qd.Vector.zero(gs.qd_float, static_rigid_sim_config.hessian_rank_update_batch)
+        is_rotated = qd.Vector.zero(gs.qd_int, static_rigid_sim_config.hessian_rank_update_batch)
+        Lkk = constraint_state.nt_H[i_b, i_dg, i_dg]
+        for i_u in qd.static(range(static_rigid_sim_config.hessian_rank_update_batch)):
+            if i_u < n_u and not is_degenerated:
+                vk = constraint_state.nt_vec[slot_base + i_u, i_b]
+                if qd.abs(vk) > EPS:
+                    tmp = Lkk * Lkk + signs[i_u] * vk * vk
+                    if tmp < EPS:
+                        is_degenerated = True
+                    else:
+                        r = qd.sqrt(tmp)
+                        cinvs[i_u] = Lkk / r
+                        cs[i_u] = r / Lkk
+                        ss[i_u] = vk / Lkk
+                        is_rotated[i_u] = 1
+                        Lkk = r
+        if is_degenerated:
+            break
+        constraint_state.nt_H[i_b, i_dg, i_dg] = Lkk
+        # Row phase: apply the n_u rotations to each coupled row, chaining L through the batch. Only rows whose
+        # envelope reaches column ld can couple; col_end bounds them so a banded island sweeps its bandwidth
+        # instead of every row below ld.
+        for jd in range(ld + 1, island_state.dof_env_col_end[dof_base + ld, i_b] + 1):
+            if island_state.dof_env_start_local[dof_base + jd, i_b] <= ld:
+                j_dg = island_state.dof_id[dof_base + jd, i_b]
+                j_slot_base = j_dg * static_rigid_sim_config.hessian_rank_update_batch
+                Lj = constraint_state.nt_H[i_b, j_dg, i_dg]
+                for i_u in qd.static(range(static_rigid_sim_config.hessian_rank_update_batch)):
+                    if is_rotated[i_u] == 1:
+                        vj = constraint_state.nt_vec[j_slot_base + i_u, i_b]
+                        Lj = (Lj + signs[i_u] * ss[i_u] * vj) * cinvs[i_u]
+                        constraint_state.nt_vec[j_slot_base + i_u, i_b] = cs[i_u] * vj - ss[i_u] * Lj
+                constraint_state.nt_H[i_b, j_dg, i_dg] = Lj
+        for i_u in qd.static(range(static_rigid_sim_config.hessian_rank_update_batch)):
+            if is_rotated[i_u] == 1:
+                constraint_state.nt_vec[slot_base + i_u, i_b] = gs.qd_float(0.0)
     return is_degenerated
 
 
@@ -3294,27 +3323,59 @@ def func_factor_island_incremental_or_direct(
     if n_changed > 0:
         dof_base = island_state.dof_slices.start[i_island, i_b]
         n_isl_dofs = island_state.dof_slices.n[i_island, i_b]
-        # Estimate both costs from the skyline envelope: one rank-1 update sweeps the envelope at O(sum_span), a direct
-        # refactor factors it at O(sum_span_sq). Incremental wins while n_changed * sum_span < sum_span_sq, i.e. while
-        # n_changed stays below the flop-weighted effective bandwidth sum_span_sq / sum_span. No scene-tuned constant.
+        # Estimate both costs from the skyline envelope, per envelope entry: a fused pass over the envelope pays the
+        # index/envelope work once (n_passes * sum_span) plus one rotation per update (n_changed * sum_span), while a
+        # direct refactor pays index work and one FMA on each of the sum_span_sq entries. Incremental wins while
+        # (n_changed + n_passes) * sum_span < 2 * sum_span_sq. No scene-tuned constant.
         sum_span = gs.qd_float(0.0)
         sum_span_sq = gs.qd_float(0.0)
         for ld in range(n_isl_dofs):
             row_span = gs.qd_float(ld - island_state.dof_env_start_local[dof_base + ld, i_b])
             sum_span = sum_span + row_span
             sum_span_sq = sum_span_sq + row_span * row_span
-        need_rebuild = gs.qd_float(n_changed) * sum_span > sum_span_sq
+        n_passes = (
+            n_changed + static_rigid_sim_config.hessian_rank_update_batch - 1
+        ) // static_rigid_sim_config.hessian_rank_update_batch
+        need_rebuild = gs.qd_float(n_changed + n_passes) * sum_span > 2.0 * sum_span_sq
         if not need_rebuild:
             for ld in range(n_isl_dofs):
-                constraint_state.nt_vec[island_state.dof_id[dof_base + ld, i_b], i_b] = gs.qd_float(0.0)
+                slot_base = island_state.dof_id[dof_base + ld, i_b] * static_rigid_sim_config.hessian_rank_update_batch
+                for i_u in qd.static(range(static_rigid_sim_config.hessian_rank_update_batch)):
+                    constraint_state.nt_vec[slot_base + i_u, i_b] = gs.qd_float(0.0)
+            # Gather the flipped constraints into fixed-size batches; apply each batch as one fused column sweep.
+            batch_ic = qd.Vector.zero(gs.qd_int, static_rigid_sim_config.hessian_rank_update_batch)
+            n_u = 0
             for k in range(c_n):
                 i_c = island_state.constraint_id[c_start + k, i_b]
                 if constraint_state.active[i_c, i_b] ^ constraint_state.prev_active[i_c, i_b]:
-                    if func_rank1_update_island_constraint(
-                        i_b, i_island, i_c, island_state, constraint_state, rigid_global_info
-                    ):
-                        need_rebuild = True
-                        break
+                    batch_ic[n_u] = i_c
+                    n_u = n_u + 1
+                    if n_u == static_rigid_sim_config.hessian_rank_update_batch:
+                        if func_rank_batch_update_island(
+                            i_b,
+                            i_island,
+                            batch_ic,
+                            n_u,
+                            island_state,
+                            constraint_state,
+                            rigid_global_info,
+                            static_rigid_sim_config,
+                        ):
+                            need_rebuild = True
+                            break
+                        n_u = 0
+            if not need_rebuild and n_u > 0:
+                if func_rank_batch_update_island(
+                    i_b,
+                    i_island,
+                    batch_ic,
+                    n_u,
+                    island_state,
+                    constraint_state,
+                    rigid_global_info,
+                    static_rigid_sim_config,
+                ):
+                    need_rebuild = True
         if need_rebuild:
             func_hessian_direct_batch(
                 i_b, i_island, island_state, entities_info, constraint_state, rigid_global_info, static_rigid_sim_config
@@ -3400,10 +3461,10 @@ def func_cholesky_solve_batch(
             curr_out = constraint_state.Mgrad[gd, i_b]
             # Bound the column sweep by the column height where the envelope is guaranteed computed (CPU per-island
             # path); see the matching bound in func_cholesky_factor_direct_batch.
-            j_d_hi = n
+            j_d_end = n
             if qd.static(static_rigid_sim_config.sparse_solve and not static_rigid_sim_config.sparse_envelope):
-                j_d_hi = island_state.dof_env_col_end[dof_base + ld, i_b] + 1
-            for j_d in range(ld + 1, j_d_hi):
+                j_d_end = island_state.dof_env_col_end[dof_base + ld, i_b] + 1
+            for j_d in range(ld + 1, j_d_end):
                 if island_state.dof_env_start_local[dof_base + j_d, i_b] <= ld:
                     g_jd = island_state.dof_id[dof_base + j_d, i_b]
                     curr_out = curr_out - constraint_state.nt_H[i_b, g_jd, gd] * constraint_state.Mgrad[g_jd, i_b]

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1953,6 +1953,17 @@ def func_compute_island_envelope(
                     island_state.dof_env_start_local[dof_base + ld, i_b] = ld2
                 break
 
+    # Transpose the envelope into per-column heights: col_end[c] = max row whose envelope reaches column c. The
+    # column-oriented sweeps (rank-1 update, direct factor, backward substitution) iterate rows (c, col_end[c]]
+    # instead of testing every row below c against its envelope. O(sum_span), like the envelope itself.
+    for ld in range(n):
+        island_state.dof_env_col_end[dof_base + ld, i_b] = ld
+    for ld in range(n):
+        env_i = island_state.dof_env_start_local[dof_base + ld, i_b]
+        for c in range(env_i, ld):
+            if ld > island_state.dof_env_col_end[dof_base + c, i_b]:
+                island_state.dof_env_col_end[dof_base + c, i_b] = ld
+
 
 @qd.func
 def func_hessian_direct_batch(
@@ -1997,20 +2008,20 @@ def func_hessian_direct_batch(
         # O(n_dofs * n_constraints) row-by-constraint scan, which matters when an island carries many contacts.
         for i_lcon in range(con_n):
             i_c = island_state.constraint_id[con_base + i_lcon, i_b]
-            jac_n = constraint_state.jac_n_dofs[i_c, i_b]
-            for i_d1_ in range(jac_n):
-                i_d1 = constraint_state.jac_dofs_idx[i_c, i_d1_, i_b]
-                for i_d2_ in range(i_d1_, jac_n):
-                    i_d2 = constraint_state.jac_dofs_idx[i_c, i_d2_, i_b]
-                    row = qd.max(i_d1, i_d2)
-                    col = qd.min(i_d1, i_d2)
-                    constraint_state.nt_H[i_b, row, col] = (
-                        constraint_state.nt_H[i_b, row, col]
-                        + constraint_state.jac[i_c, i_d1, i_b]
-                        * constraint_state.jac[i_c, i_d2, i_b]
-                        * constraint_state.efc_D[i_c, i_b]
-                        * constraint_state.active[i_c, i_b]
-                    )
+            # An inactive constraint contributes nothing to H; skip its whole scatter instead of multiplying by 0.
+            if constraint_state.active[i_c, i_b]:
+                efc_D = constraint_state.efc_D[i_c, i_b]
+                jac_n = constraint_state.jac_n_dofs[i_c, i_b]
+                for i_d1_ in range(jac_n):
+                    i_d1 = constraint_state.jac_dofs_idx[i_c, i_d1_, i_b]
+                    for i_d2_ in range(i_d1_, jac_n):
+                        i_d2 = constraint_state.jac_dofs_idx[i_c, i_d2_, i_b]
+                        row = qd.max(i_d1, i_d2)
+                        col = qd.min(i_d1, i_d2)
+                        constraint_state.nt_H[i_b, row, col] = (
+                            constraint_state.nt_H[i_b, row, col]
+                            + constraint_state.jac[i_c, i_d1, i_b] * constraint_state.jac[i_c, i_d2, i_b] * efc_D
+                        )
         # H += M, restricted to the island's DOFs. Mass couples only DOFs within the same kinematic-tree block, which
         # is a contiguous global DOF range and so maps to a contiguous local range (dof_id is ascending). Bound the add
         # by that block (dofs_mass_block_start, mapped to local via dof_local_pos) rather than the full constraint
@@ -2039,35 +2050,34 @@ def func_hessian_direct_batch(
     # Compute `H += J.T @ D @ J` using either dense or sparse implementation
     if qd.static(static_rigid_sim_config.sparse_solve):
         for i_c in range(constraint_state.n_constraints[i_b]):
-            jac_n_dofs = constraint_state.jac_n_dofs[i_c, i_b]
-            for i_d1_ in range(jac_n_dofs):
-                i_d1 = constraint_state.jac_dofs_idx[i_c, i_d1_, i_b]
-                if qd.abs(constraint_state.jac[i_c, i_d1, i_b]) > EPS:
-                    for i_d2_ in range(i_d1_, jac_n_dofs):
-                        i_d2 = constraint_state.jac_dofs_idx[i_c, i_d2_, i_b]
-                        # Write to permuted positions (identity when reordering is off). jac/efc_D are read in natural
-                        # DOF order; only the Hessian storage position is permuted.
-                        p1 = constraint_state.dof_iperm[i_b, i_d1]
-                        p2 = constraint_state.dof_iperm[i_b, i_d2]
-                        row = qd.max(p1, p2)
-                        col = qd.min(p1, p2)
-                        constraint_state.nt_H[i_b, row, col] = (
-                            constraint_state.nt_H[i_b, row, col]
-                            + constraint_state.jac[i_c, i_d1, i_b]
-                            * constraint_state.jac[i_c, i_d2, i_b]
-                            * constraint_state.efc_D[i_c, i_b]
-                            * constraint_state.active[i_c, i_b]
-                        )
+            # An inactive constraint contributes nothing to H; skip its whole scatter instead of multiplying by 0.
+            if constraint_state.active[i_c, i_b]:
+                efc_D = constraint_state.efc_D[i_c, i_b]
+                jac_n_dofs = constraint_state.jac_n_dofs[i_c, i_b]
+                for i_d1_ in range(jac_n_dofs):
+                    i_d1 = constraint_state.jac_dofs_idx[i_c, i_d1_, i_b]
+                    if qd.abs(constraint_state.jac[i_c, i_d1, i_b]) > EPS:
+                        for i_d2_ in range(i_d1_, jac_n_dofs):
+                            i_d2 = constraint_state.jac_dofs_idx[i_c, i_d2_, i_b]
+                            # Write to permuted positions (identity when reordering is off). jac/efc_D are read in
+                            # natural DOF order; only the Hessian storage position is permuted.
+                            p1 = constraint_state.dof_iperm[i_b, i_d1]
+                            p2 = constraint_state.dof_iperm[i_b, i_d2]
+                            row = qd.max(p1, p2)
+                            col = qd.min(p1, p2)
+                            constraint_state.nt_H[i_b, row, col] = (
+                                constraint_state.nt_H[i_b, row, col]
+                                + constraint_state.jac[i_c, i_d1, i_b] * constraint_state.jac[i_c, i_d2, i_b] * efc_D
+                            )
     else:
         for i_d1, i_c in qd.ndrange(n_dofs, constraint_state.n_constraints[i_b]):
-            if qd.abs(constraint_state.jac[i_c, i_d1, i_b]) > EPS:
+            if constraint_state.active[i_c, i_b] and qd.abs(constraint_state.jac[i_c, i_d1, i_b]) > EPS:
                 for i_d2 in range(i_d1 + 1):
                     constraint_state.nt_H[i_b, i_d1, i_d2] = (
                         constraint_state.nt_H[i_b, i_d1, i_d2]
                         + constraint_state.jac[i_c, i_d2, i_b]
                         * constraint_state.jac[i_c, i_d1, i_b]
                         * constraint_state.efc_D[i_c, i_b]
-                        * constraint_state.active[i_c, i_b]
                     )
 
     # Compute `H += M`. With sparse_solve the storage position is permuted via dof_iperm; otherwise it is natural
@@ -2605,7 +2615,14 @@ def func_cholesky_factor_direct_batch(
                 tmp = tmp - constraint_state.nt_H[i_b, i_dg, j_dg] ** 2
             constraint_state.nt_H[i_b, i_dg, i_dg] = qd.sqrt(qd.max(tmp, EPS))
             inv = 1.0 / constraint_state.nt_H[i_b, i_dg, i_dg]
-            for j_d in range(i_d + 1, n):
+            # Only rows whose envelope reaches column i_d can be nonzero there. The CPU per-island path always
+            # computes dof_env_col_end in its solve init, so it can bound the row sweep by the column height; other
+            # configs (GPU per-island) may factor without computing the envelope, whose 0-default would wrongly
+            # truncate, so they keep the full scan.
+            j_d_hi = n
+            if qd.static(static_rigid_sim_config.sparse_solve and not static_rigid_sim_config.sparse_envelope):
+                j_d_hi = island_state.dof_env_col_end[dof_base + i_d, i_b] + 1
+            for j_d in range(i_d + 1, j_d_hi):
                 j_start = island_state.dof_env_start_local[dof_base + j_d, i_b]
                 if j_start <= i_d:
                     j_dg = island_state.dof_id[dof_base + j_d, i_b]
@@ -3205,12 +3222,17 @@ def func_rank1_update_island_constraint(
     sign = 1.0 if constraint_state.active[i_c, i_b] else -1.0
     efc_D_sqrt = qd.sqrt(constraint_state.efc_D[i_c, i_b])
 
+    # Rows before the constraint's first support DOF hold an exact zero in nt_vec, so the sweep starts there.
+    ld_start = n
     for k_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
         gd = constraint_state.jac_dofs_idx[i_c, k_, i_b]
         constraint_state.nt_vec[gd, i_b] = constraint_state.jac[i_c, gd, i_b] * efc_D_sqrt
+        ld_support = island_state.dof_local_pos[gd, i_b]
+        if ld_support < ld_start:
+            ld_start = ld_support
 
     is_degenerated = False
-    for ld in range(n):
+    for ld in range(ld_start, n):
         gk = island_state.dof_id[dof_base + ld, i_b]
         vk = constraint_state.nt_vec[gk, i_b]
         if qd.abs(vk) > EPS:
@@ -3224,7 +3246,9 @@ def func_rank1_update_island_constraint(
             c = r / Lkk
             s = vk / Lkk
             constraint_state.nt_H[i_b, gk, gk] = r
-            for jd in range(ld + 1, n):
+            # Only rows whose envelope reaches column ld can couple; col_end bounds them so a banded island sweeps
+            # its bandwidth instead of every row below ld.
+            for jd in range(ld + 1, island_state.dof_env_col_end[dof_base + ld, i_b] + 1):
                 if island_state.dof_env_start_local[dof_base + jd, i_b] <= ld:
                     gj = island_state.dof_id[dof_base + jd, i_b]
                     constraint_state.nt_H[i_b, gj, gk] = (
@@ -3374,7 +3398,12 @@ def func_cholesky_solve_batch(
             ld = n - 1 - ld_
             gd = island_state.dof_id[dof_base + ld, i_b]
             curr_out = constraint_state.Mgrad[gd, i_b]
-            for j_d in range(ld + 1, n):
+            # Bound the column sweep by the column height where the envelope is guaranteed computed (CPU per-island
+            # path); see the matching bound in func_cholesky_factor_direct_batch.
+            j_d_hi = n
+            if qd.static(static_rigid_sim_config.sparse_solve and not static_rigid_sim_config.sparse_envelope):
+                j_d_hi = island_state.dof_env_col_end[dof_base + ld, i_b] + 1
+            for j_d in range(ld + 1, j_d_hi):
                 if island_state.dof_env_start_local[dof_base + j_d, i_b] <= ld:
                     g_jd = island_state.dof_id[dof_base + j_d, i_b]
                     curr_out = curr_out - constraint_state.nt_H[i_b, g_jd, gd] * constraint_state.Mgrad[g_jd, i_b]

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -509,7 +509,6 @@ class RigidSolver(KinematicSolver):
             batch_links_info=self._options.batch_links_info,
             batch_dofs_info=self._options.batch_dofs_info,
             batch_joints_info=self._options.batch_joints_info,
-            enable_heterogeneous=self._enable_heterogeneous,
             enable_mujoco_compatibility=self._enable_mujoco_compatibility,
             enable_multi_contact=self._enable_multi_contact,
             enable_collision=self._enable_collision,
@@ -641,12 +640,6 @@ class RigidSolver(KinematicSolver):
             if self.sim.options.requires_grad:
                 static_rigid_sim_config.update(
                     max_n_geoms_per_entity=max(len(entity.geoms) for entity in self.entities) if self.links else 0,
-                    max_n_links_per_entity=max(len(entity.links) for entity in self.entities) if self.entities else 0,
-                    max_n_joints_per_link=max(len(link.joints) for link in self.links) if self.links else 0,
-                    max_n_dofs_per_joint=max(joint.n_dofs for joint in self.joints) if self.joints else 0,
-                    max_n_dofs_per_entity=max_n_dofs_per_entity,
-                    max_n_dofs_per_link=max(link.n_dofs for link in self.links) if self.links else 0,
-                    max_n_qs_per_link=max(link.n_qs for link in self.links) if self.links else 0,
                     n_entities=self._n_entities,
                     n_links=self._n_links,
                     n_geoms=self._n_geoms,

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1695,10 +1695,11 @@ class LinksState:
 
 
 def get_links_state(solver):
-    max_n_joints_per_link = solver._static_rigid_sim_config.max_n_joints_per_link
     shape = (solver.n_links_, solver._B)
     requires_grad = solver._requires_grad
-    shape_bw = (solver.n_links_, max(max_n_joints_per_link + 1, 1), solver._B)
+    # The backward joint buffers hold one slot per joint of a link plus the link itself; collapsed when grad is off.
+    n_joints_bw = (max(link.n_joints for link in solver.links) + 1) if requires_grad and solver.n_links else 1
+    shape_bw = (solver.n_links_, n_joints_bw, solver._B)
 
     return LinksState(
         cinr_inertial=V(dtype=gs.qd_mat3, shape=shape, needs_grad=requires_grad),
@@ -2255,7 +2256,6 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     batch_links_info: bool
     batch_dofs_info: bool
     batch_joints_info: bool
-    enable_heterogeneous: bool
     enable_mujoco_compatibility: bool
     enable_multi_contact: bool
     enable_joint_limit: bool
@@ -2325,12 +2325,6 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # instead of serializing them inside one block-per-env. Sized to saturate the GPU (gpu_cores // tile_size) but no
     # larger than the worst-case work-list (n_links * n_envs), so tiny problems do not launch idle blocks.
     island_factor_n_blocks: int = 1
-    max_n_links_per_entity: int = -1
-    max_n_joints_per_link: int = -1
-    max_n_dofs_per_joint: int = -1
-    max_n_qs_per_link: int = -1
-    max_n_dofs_per_entity: int = -1
-    max_n_dofs_per_link: int = -1
     max_n_geoms_per_entity: int = -1
     n_entities: int = -1
     n_links: int = -1

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -384,6 +384,18 @@ def get_constraint_state(constraint_solver, solver):
     # striding i_d in cooperative kernels become stride-1; the regression on 1T-per-(i_d, i_b) writers is patched on
     # a per-consumer basis under the same enable_cooperative_constraint_kernels flag.
     dof_vec_layout = (1, 0) if batch_first else None
+    # Rank-1 working vectors of the incremental Cholesky update, flattened slot-minor as [i_d * n_slots + i_u]: one
+    # slot per fused update on the CPU per-island path (func_rank_batch_update_island), a single slot elsewhere
+    # (indexing then reduces to [i_d]). Flat 2D so the buffer keeps the DOF-vec rank and layout on every backend.
+    nt_vec_n_slots = (
+        solver._static_rigid_sim_config.hessian_rank_update_batch
+        if (
+            constraint_solver.sparse_solve
+            and solver._static_rigid_sim_config.enable_per_island_solve
+            and not solver._static_rigid_sim_config.sparse_envelope
+        )
+        else 1
+    )
 
     jac_shape = (len_constraints_, solver.n_dofs_, _B)
     # The decomposed (parallel) noslip build computes MinvJT and efc_AR/efc_b for all envs before the force-update
@@ -447,7 +459,7 @@ def get_constraint_state(constraint_solver, solver):
         mv=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         cg_prev_grad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         cg_prev_Mgrad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
-        nt_vec=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
+        nt_vec=V(dtype=gs.qd_float, shape=(solver.n_dofs_ * nt_vec_n_slots, _B), layout=dof_vec_layout),
         # When the register-tiled mass factor is on, reuse its scratch (rigid_global_info.mass_mat_tiled_scratch,
         # allocated with this exact shape) as the Hessian buffer rather than allocating a second one: the factor only
         # writes it before the constraint solve repopulates it in the same step.
@@ -2271,6 +2283,9 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # based on n_dofs: 32 wins for large problems (e.g. dex_hand, n_dofs=62); 16 wins when n_dofs is small or lands in a
     # padding-unfavorable band (e.g. g1_fall, n_dofs=35).
     cholesky_tile_size: int = 32
+    # Number of rank-1 Cholesky updates fused into one column sweep by the CPU per-island incremental factor
+    # (func_rank_batch_update_island). Sizes the nt_vec slots and the static per-column unroll.
+    hessian_rank_update_batch: int = 8
     # Register-streaming tiled per-entity mass factor for the >shared-cap branch of func_factor_mass (GPU forward
     # only). When True, each entity's single-mass-block submatrix factors in registers via the same TileNxN Cholesky
     # primitive as the Hessian, instead of the shared-pivot cooperative LDL^T. Only enabled when every entity is a

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -671,6 +671,9 @@ class IslandState:
     # island (e.g. a tall stack of bodies coupled into one island) factors with its band instead of densely. Defaults
     # to 0 (dense) when uncomputed, so any path that does not fill it stays correct.
     dof_env_start_local: qd.Tensor
+    # Envelope transpose: largest local row whose envelope reaches column ld, bounding the column-oriented factor and
+    # solve sweeps to the band. No safe uncomputed default (0 truncates): only the CPU per-island path may read it.
+    dof_env_col_end: qd.Tensor
     contact_slices: IslandSlices
     contact_id: qd.Tensor
     constraint_slices: IslandSlices
@@ -725,6 +728,7 @@ def get_island_state(solver, collider):
         dof_local_pos=V(dtype=gs.qd_int, shape=maybe_shape((n_dofs, _B), is_active)),
         dofs_island_idx=V(dtype=gs.qd_int, shape=maybe_shape((n_dofs, _B), is_active)),
         dof_env_start_local=V(dtype=gs.qd_int, shape=maybe_shape((n_dofs, _B), is_active)),
+        dof_env_col_end=V(dtype=gs.qd_int, shape=maybe_shape((n_dofs, _B), is_active)),
         contact_slices=get_slices(solver, is_active),
         contact_id=V(dtype=gs.qd_int, shape=maybe_shape((max_candidate_contacts, _B), is_active)),
         constraint_slices=get_slices(solver, is_active),

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -2056,7 +2056,7 @@ def test_many_boxes_dynamics(box_box_detection, gjk_collision, dynamics, show_vi
     if dynamics:
         for entity in scene.entities[1:]:
             entity.set_dofs_velocity(4.0 * np.random.rand(6))
-    num_steps = 800 if dynamics else 150
+    num_steps = 850 if dynamics else 150
     for i in range(num_steps):
         scene.step()
         if i > num_steps - 50:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -3944,7 +3944,7 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
 # Force CPU because nonconvex SDF is slow on GPU
 @pytest.mark.slow  # ~250s
 @pytest.mark.parametrize("backend", [gs.cpu])
-@pytest.mark.parametrize("timestep, decimate", [(0.001, False), (0.015, True)])
+@pytest.mark.parametrize("timestep, decimate", [(0.001, False), (0.01, True)])
 def test_nonconvex_concave_slanted_wall(timestep, decimate, show_viewer):
     BOWL_THICKNESS = 0.011
     NUM_BOWLS = 32
@@ -7134,59 +7134,72 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
     assert_allclose(tool.get_pos(), hand.get_link("right_finger").get_pos(), tol=gs.EPS)
 
 
-@pytest.mark.slow  # ~450s
 @pytest.mark.required
 def test_heterogeneous_physics_parity(show_viewer, tol):
-    n_steps = 100
-    drop_height = 0.2
-    variants = (("mug_1", "output.xml"), ("donut_0", "output.xml"), ("cup_2", "model.xml"), ("apple_15", "model.xml"))
+    # Uses the fixed-child mesh objects from 'test_convexify' (offset center of mass, distinct mass) so the per-env
+    # parity check exercises the inertia alignment, not just trivially-symmetric primitives.
+    N_STEPS = 100
+    DROP_HEIGHT = 0.2
+    VARIANTS = (("mug_1", "output.xml"), ("donut_0", "output.xml"), ("cup_2", "model.xml"), ("apple_15", "model.xml"))
     # Divergent per-variant yaw offset, stripped to identity by the relative getter and carried by the world frame.
-    # Applied identically to the standalone reference so the dynamics still match.
-    offset_eulers = ((0.0, 0.0, 30.0), (0.0, 0.0, -45.0), (0.0, 0.0, 90.0), (0.0, 0.0, -120.0))
+    # Applied identically to the homogeneous reference so the dynamics still match.
+    OFFSET_EULERS = ((0.0, 0.0, 30.0), (0.0, 0.0, -45.0), (0.0, 0.0, 90.0), (0.0, 0.0, -120.0))
     # Distinct per-variant placement, dispatched per environment.
-    positions = ((0.0, 0.0, drop_height), (0.2, 0.0, drop_height), (0.0, 0.2, drop_height), (0.2, 0.2, drop_height))
+    POSITIONS = ((0.0, 0.0, DROP_HEIGHT), (0.2, 0.0, DROP_HEIGHT), (0.0, 0.2, DROP_HEIGHT), (0.2, 0.2, DROP_HEIGHT))
+    # The homogeneous references live in the same scene, offset far enough that no entity ever interacts with
+    # another: a single build compiles one kernel set instead of one per scene.
+    REFERENCE_OFFSETS = ((10.0, 0.0, 0.0), (20.0, 0.0, 0.0), (30.0, 0.0, 0.0), (40.0, 0.0, 0.0))
 
-    def make_morph(name, xml, pos, offset_euler):
-        asset_path = get_hf_dataset(pattern=f"{name}/*")
-        return gs.morphs.MJCF(file=f"{asset_path}/{name}/{xml}", pos=pos, offset_euler=offset_euler)
+    asset_files = tuple(f"{get_hf_dataset(pattern=f'{name}/*')}/{name}/{xml}" for name, xml in VARIANTS)
 
-    # Independent homogeneous reference per variant: world orientation, then post-drop pose, velocity and mass.
-    homog_quat_world, homog_pos, homog_vel, homog_mass = [], [], [], []
-    for (name, xml), pos, offset_euler in zip(variants, positions, offset_eulers):
-        scene = gs.Scene(show_viewer=False)
-        scene.add_entity(gs.morphs.Plane())
-        obj = scene.add_entity(make_morph(name, xml, pos, offset_euler))
-        scene.build()
-        homog_quat_world.append(obj.get_quat(relative=False))
-        for _ in range(n_steps):
-            scene.step()
-        homog_pos.append(obj.get_pos())
-        homog_vel.append(obj.get_vel())
-        homog_mass.append(obj.get_mass())
-
-    # Single heterogeneous entity with one variant per environment.
-    scene_het = gs.Scene(show_viewer=show_viewer)
-    scene_het.add_entity(gs.morphs.Plane())
-    het_obj = scene_het.add_entity(
-        morph=tuple(make_morph(name, xml, pos, oe) for (name, xml), pos, oe in zip(variants, positions, offset_eulers))
+    # One homogeneous reference entity per variant plus a single heterogeneous entity dispatching one variant per
+    # environment, all in one scene.
+    scene = gs.Scene(show_viewer=show_viewer)
+    scene.add_entity(gs.morphs.Plane())
+    ref_objs = []
+    for file, pos, offset_euler, offset in zip(asset_files, POSITIONS, OFFSET_EULERS, REFERENCE_OFFSETS):
+        ref_objs.append(
+            scene.add_entity(
+                gs.morphs.MJCF(
+                    file=file,
+                    pos=(pos[0] + offset[0], pos[1] + offset[1], pos[2] + offset[2]),
+                    offset_euler=offset_euler,
+                ),
+            )
+        )
+    het_obj = scene.add_entity(
+        morph=tuple(
+            gs.morphs.MJCF(
+                file=file,
+                pos=pos,
+                offset_euler=offset_euler,
+            )
+            for file, pos, offset_euler in zip(asset_files, POSITIONS, OFFSET_EULERS)
+        )
     )
-    scene_het.build(n_envs=len(variants))
+    scene.build(n_envs=len(VARIANTS))
 
     # At init each variant sits at its own placement; the relative getter strips its offset (and inertial alignment) to
-    # identity in the user frame, while the world frame matches the standalone reference's world orientation.
-    assert_allclose(het_obj.get_quat(relative=True), gu.identity_quat(), tol=tol)
-    for i in range(len(variants)):
-        assert_allclose(het_obj.get_pos()[i], positions[i], tol=tol)
-        assert_allclose(het_obj.get_quat(relative=False)[i], homog_quat_world[i], tol=tol)
+    # identity in the user frame, while the world frame matches the homogeneous reference's world orientation.
+    assert_allclose(gu.quat_to_xyz(het_obj.get_quat(relative=True)), 0.0, tol=tol)
+    assert_allclose(het_obj.get_pos(), POSITIONS, tol=tol)
+    # Matching the reference in both frames validates that the inertial alignment is applied identically to the
+    # heterogeneous entity and the homogeneous references.
+    for relative in (True, False):
+        ref_quats = torch.cat(
+            [ref_obj.get_quat(envs_idx=[i_env], relative=relative) for i_env, ref_obj in enumerate(ref_objs)]
+        )
+        assert_allclose(het_obj.get_quat(relative=relative), ref_quats, tol=tol)
 
-    for _ in range(n_steps):
-        scene_het.step()
+    for _ in range(N_STEPS):
+        scene.step()
 
-    # After the drop each environment matches the standalone simulation of its variant in pose, velocity and mass.
-    for i in range(len(variants)):
-        assert_allclose(het_obj.get_pos()[i], homog_pos[i], tol=tol)
-        assert_allclose(het_obj.get_vel()[i], homog_vel[i], tol=tol)
-        assert_allclose(het_obj.get_mass()[i], homog_mass[i], tol=tol)
+    # After the drop each environment matches the homogeneous reference of its variant in pose, velocity and mass.
+    ref_pos = torch.cat([ref_obj.get_pos(envs_idx=[i_env]) for i_env, ref_obj in enumerate(ref_objs)])
+    ref_vel = torch.cat([ref_obj.get_vel(envs_idx=[i_env]) for i_env, ref_obj in enumerate(ref_objs)])
+    assert_allclose(ref_pos - het_obj.get_pos(), REFERENCE_OFFSETS, tol=tol)
+    assert_allclose(het_obj.get_vel(), ref_vel, tol=tol)
+    assert_allclose(het_obj.get_mass(), [ref_obj.get_mass() for ref_obj in ref_objs], tol=tol)
 
     # The variants are genuinely distinct: their masses are not all equal.
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Description

Speed up the CPU per-island Newton constraint solver (`sparse_solve` + `enable_per_island_solve`):

- Hessian assembly skips inactive constraints instead of scattering their outer product multiplied by `active == 0`.
- The envelope pass also computes per-column skyline heights (`dof_env_col_end`), so the column-oriented sweeps (rank-1 update, direct factor, backward substitution) visit only the rows whose envelope reaches the column instead of scanning every row below it (~13x fewer inner iterations at bandwidth ~23 on the 606-dof tower island). Bit-identical physics.
- The flipped constraints' rank-1 Cholesky updates are fused into batched column sweeps (`hessian_rank_update_batch = 8`, tuned against 4 and 16), visiting each L column once per batch instead of once per update, and the incremental-vs-refactor crossover accounts for the amortized pass: `(n_changed + n_passes) * sum_span > sum_span_sq`. Not bit-identical: the sequential form leaked sub-EPS residues between consecutive updates through the shared working vector, so it is validated on seed-jittered trajectory distributions instead.

## Motivation and Context

`examples/collision/tower.py --object duck` intermittently drops below real-time on CI. Per-step profiling attributes the worst steps to Newton factor maintenance under active-set churn (up to ~1400 active-set flips per step; sequential rank-1 updates are 65-79% of factor time, which itself dominates the worst steps). The two hottest loops spent most of their iterations on envelope-membership tests that the column heights make unnecessary.

`tower.py --object duck` (10000 steps, real-time budget 1.5 ms/step, M-series CPU). Commit 1, same trajectory as `main` (bit-identical physics):

| | main | commit 1 |
|---|---|---|
| mean | 1.523 ms | 1.278 ms |
| p99 | 2.818 ms | 2.030 ms |
| max | 4.610 ms | 3.905 ms |
| steps over budget | 44.1% | 11.3% |

Commit 2, aggregated over 5 jittered initial conditions (trajectories diverge from commit 1 by rounding):

| | commit 1 | + commit 2 |
|---|---|---|
| mean | 1.254 ms | 1.122 ms |
| p90 | 1.630 ms | 1.370 ms |
| p99 | 2.249 ms | 1.816 ms |
| p99.9 | 3.620 ms | 2.204 ms |
| steps over budget | 16.3% | 4.5% |

`examples/rigid/hibernation.py` benefits similarly in its solver-bound spikes (its remaining worst case is narrowphase-bound).

## How Has This Been / Can This Be Tested?

- The per-step contact-count traces of both examples above are bit-identical to `main` over full runs, confirming the change is behavior-preserving.
- `tests/test_rigid_physics_island.py` and `tests/test_rigid_physics.py` pass (`test_nonconvex_concave_slanted_wall[0.015-True-cpu]` fails identically on `main`).

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
