### PR TITLE
[BUG FIX] Fix scale-dependent degeneracy tolerances in MPR collision detection.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -82,7 +82,8 @@ def mpr_point_tri_depth(mpr_info: array_class.MPRInfo, P, x0, B, C):
     pdir = gs.qd_vec3([0.0, 0.0, 0.0])
     # d = |d1|^2 * |d2|^2 - (d1 . d2)^2 = |d1 x d2|^2 is the Gram determinant of the triangle edges (length^4);
     # comparing it to its own scale v * w makes the degeneracy test the dimensionless sin^2 of the edge angle.
-    if qd.abs(d) < mpr_info.CCD_EPS[None] * v * w:
+    # Must use <= so that degenerate (zero-length) edges are still classified as degenerate.
+    if qd.abs(d) <= mpr_info.CCD_EPS[None] * v * w:
         s = t = -1.0
     else:
         s = (q * r - w * p) / d
@@ -531,17 +532,23 @@ def mpr_discover_portal(
         ret = -1
     else:
         direction = mpr_state.simplex_support.v[0, i_b].cross(mpr_state.simplex_support.v[1, i_b])
+        # The touch test must come first and independently: for a vanishing v1 both sides of the relative
+        # collinearity test vanish as well, which would fall through to normalizing a zero cross product.
+        if (
+            qd.abs(mpr_state.simplex_support.v[1, i_b])
+            < mpr_info.CCD_EPS[None] * mpr_state.simplex_support.v[0, i_b].norm()
+        ).all():
+            ret = 1
         # Relative collinearity test: |v0 x v1|^2 = |v0|^2 * |v1|^2 * sin^2(angle). An absolute epsilon (length^4)
-        # would misclassify non-collinear cm-scale pairs as degenerate, fabricating deep contacts via the segment path.
-        norm_sqr_01 = mpr_state.simplex_support.v[0, i_b].norm_sqr() * mpr_state.simplex_support.v[1, i_b].norm_sqr()
-        if direction.dot(direction) < mpr_info.CCD_EPS[None] * norm_sqr_01:
-            if (
-                qd.abs(mpr_state.simplex_support.v[1, i_b])
-                < mpr_info.CCD_EPS[None] * mpr_state.simplex_support.v[0, i_b].norm()
-            ).all():
-                ret = 1
-            else:
-                ret = 2
+        # would misclassify non-collinear cm-scale pairs as degenerate, fabricating deep contacts via the segment
+        # path. Must use <= so that an exactly zero cross product is still classified as degenerate.
+        elif (
+            direction.dot(direction)
+            <= mpr_info.CCD_EPS[None]
+            * mpr_state.simplex_support.v[0, i_b].norm_sqr()
+            * mpr_state.simplex_support.v[1, i_b].norm_sqr()
+        ):
+            ret = 2
         else:
             direction = direction.normalized()
             v, v1, v2 = compute_support(

--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -339,8 +339,15 @@ def mpr_find_penetr_touch(mpr_state: array_class.MPRState, i_ga, i_gb, i_b):
 @qd.func
 def mpr_find_penetr_segment(mpr_state: array_class.MPRState, i_ga, i_gb, i_b):
     is_col = True
-    penetration = mpr_state.simplex_support.v[1, i_b].norm()
-    normal = -mpr_state.simplex_support.v[1, i_b].normalized()
+    # Anchor the contact direction to the ray (v1 - v0) rather than the raw support point: a degenerate flat-face
+    # support tie can leave v1 with an arbitrary lateral offset, making its direction noise while the ray stays
+    # meaningful. Fall back to v1 if both coincide (fully degenerate difference).
+    direction = mpr_state.simplex_support.v[1, i_b] - mpr_state.simplex_support.v[0, i_b]
+    if direction.norm_sqr() == 0.0:
+        direction = mpr_state.simplex_support.v[1, i_b]
+    direction = direction.normalized()
+    penetration = mpr_state.simplex_support.v[1, i_b].dot(direction)
+    normal = -direction
     pos = (mpr_state.simplex_support.v1[1, i_b] + mpr_state.simplex_support.v2[1, i_b]) * 0.5
 
     return is_col, normal, penetration, pos
@@ -498,10 +505,34 @@ def mpr_discover_portal(
     mpr_state.simplex_support.v[0, i_b] = center_a - center_b
     mpr_state.simplex_size[i_b] = 1
 
-    # Coincident centers (within the solver's absolute length resolution) leave the ray direction undefined; nudge
-    # along +x to get a deterministic ray.
+    # Coincident centers (within the solver's absolute length resolution) leave the ray direction undefined; probe
+    # the three axes and pick the one with the largest Minkowski support extent, which gives portal discovery the
+    # most room to enclose the origin.
     if (qd.abs(mpr_state.simplex_support.v[0, i_b]) < mpr_info.CCD_TOLERANCE[None]).all():
-        mpr_state.simplex_support.v[0, i_b][0] += 10.0 * mpr_info.CCD_TOLERANCE[None]
+        best_extent = gs.qd_float(0.0)
+        best_dir = qd.Vector.zero(gs.qd_float, 3)
+        for i_axis in range(3):
+            probe = qd.Vector.zero(gs.qd_float, 3)
+            probe[i_axis] = 1.0
+            probe_v, probe_v1, probe_v2 = compute_support(
+                geoms_info,
+                collider_state,
+                collider_static_config,
+                support_field_info,
+                probe,
+                i_ga,
+                i_gb,
+                i_b,
+                pos_a,
+                quat_a,
+                pos_b,
+                quat_b,
+            )
+            extent = probe_v.dot(probe)
+            if i_axis == 0 or extent > best_extent:
+                best_extent = extent
+                best_dir = probe
+        mpr_state.simplex_support.v[0, i_b] = best_dir * (10.0 * mpr_info.CCD_TOLERANCE[None])
 
     direction = -mpr_state.simplex_support.v[0, i_b].normalized()
 

--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -12,9 +12,9 @@ class MPR:
         self._solver = rigid_solver
 
         self._mpr_info = array_class.get_mpr_info(
-            # It has been observed in practice that increasing this threshold makes collision detection instable,
-            # which is surprising since 1e-9 is above single precision (which has only 7 digits of precision).
-            CCD_EPS=1e-9 if gs.qd_float == qd.f32 else 1e-10,
+            # Relative tolerance of the geometric degeneracy tests: every comparison scales it by the magnitudes of
+            # its operands, making the tests dimensionless and scene-scale-invariant.
+            CCD_EPS=1e-5 if gs.qd_float == qd.f32 else 1e-10,
             CCD_TOLERANCE=1e-6,
             CCD_ITERATIONS=50,
         )
@@ -80,7 +80,9 @@ def mpr_point_tri_depth(mpr_info: array_class.MPRInfo, P, x0, B, C):
     d = w * v - r * r
     dist = s = t = gs.qd_float(0.0)
     pdir = gs.qd_vec3([0.0, 0.0, 0.0])
-    if qd.abs(d) < mpr_info.CCD_EPS[None]:
+    # d = |d1|^2 * |d2|^2 - (d1 . d2)^2 = |d1 x d2|^2 is the Gram determinant of the triangle edges (length^4);
+    # comparing it to its own scale v * w makes the degeneracy test the dimensionless sin^2 of the edge angle.
+    if qd.abs(d) < mpr_info.CCD_EPS[None] * v * w:
         s = t = -1.0
     else:
         s = (q * r - w * p) / d
@@ -122,14 +124,17 @@ def mpr_portal_dir(mpr_state: array_class.MPRState, i_ga, i_gb, i_b):
 def mpr_portal_encapsules_origin(
     mpr_state: array_class.MPRState, mpr_info: array_class.MPRInfo, direction, i_ga, i_gb, i_b
 ):
+    # Pure sign test: at the boundary both outcomes are equally valid and the result is value-continuous, so any
+    # epsilon would only shift the decision without protecting anything.
     dot = mpr_state.simplex_support.v[1, i_b].dot(direction)
-    return dot > -mpr_info.CCD_EPS[None]
+    return dot > 0.0
 
 
 @qd.func
 def mpr_portal_can_encapsule_origin(mpr_info: array_class.MPRInfo, v, direction):
+    # Pure sign test (see mpr_portal_encapsules_origin).
     dot = v.dot(direction)
-    return dot > -mpr_info.CCD_EPS[None]
+    return dot > 0.0
 
 
 @qd.func
@@ -141,7 +146,7 @@ def mpr_portal_reach_tolerance(
     dv3 = mpr_state.simplex_support.v[3, i_b].dot(direction)
     dv4 = v.dot(direction)
     dot1 = qd.min(dv4 - dv1, dv4 - dv2, dv4 - dv3)
-    return dot1 < mpr_info.CCD_TOLERANCE[None] + mpr_info.CCD_EPS[None] * qd.max(1.0, dot1)
+    return dot1 < mpr_info.CCD_TOLERANCE[None] + mpr_info.CCD_EPS[None] * qd.abs(dv4)
 
 
 @qd.func
@@ -301,7 +306,9 @@ def mpr_find_pos(
 
     sum_ = b.sum()
 
-    if sum_ < mpr_info.CCD_EPS[None]:
+    # Must use <= so that the all-zero weights of the non-mujoco-compatible path (which skips the tetrahedron
+    # volumes above) still enter the portal-direction fallback.
+    if sum_ <= mpr_info.CCD_EPS[None] * qd.abs(b).sum():
         direction = mpr_portal_dir(mpr_state, i_ga, i_gb, i_b)
         b[0] = 0.0
         for i in range(1, 4):
@@ -427,12 +434,13 @@ def mpr_find_penetration(
             b2 = pv3.cross(pv1).dot(direction)
             b3 = pv1.cross(pv2).dot(direction)
             bsum = b1 + b2 + b3
+            babs = qd.abs(b1) + qd.abs(b2) + qd.abs(b3)
             min_b = qd.min(b1, qd.min(b2, b3))
             if not reached:
                 mpr_state.portal_status[i_b] = PORTAL_STATUS.INVALID  # unconverged (hit the iteration cap)
             elif min_b >= 0.0:
                 mpr_state.portal_status[i_b] = PORTAL_STATUS.VALID  # origin projects inside -> exact depth (Thm 4.2)
-            elif bsum > mpr_info.CCD_EPS[None] and (-min_b) <= qd.static(CCD_EXTRAPOLATION_TOL) * bsum:
+            elif bsum > mpr_info.CCD_EPS[None] * babs and (-min_b) <= qd.static(CCD_EXTRAPOLATION_TOL) * bsum:
                 mpr_state.portal_status[i_b] = PORTAL_STATUS.DEGENERATED  # small overshoot -> lower bound (Thm 4.3)
             else:
                 mpr_state.portal_status[i_b] = PORTAL_STATUS.INVALID  # extrapolates too far / degenerate -> unreliable
@@ -489,8 +497,10 @@ def mpr_discover_portal(
     mpr_state.simplex_support.v[0, i_b] = center_a - center_b
     mpr_state.simplex_size[i_b] = 1
 
-    if (qd.abs(mpr_state.simplex_support.v[0, i_b]) < mpr_info.CCD_EPS[None]).all():
-        mpr_state.simplex_support.v[0, i_b][0] += 10.0 * mpr_info.CCD_EPS[None]
+    # Coincident centers (within the solver's absolute length resolution) leave the ray direction undefined; nudge
+    # along +x to get a deterministic ray.
+    if (qd.abs(mpr_state.simplex_support.v[0, i_b]) < mpr_info.CCD_TOLERANCE[None]).all():
+        mpr_state.simplex_support.v[0, i_b][0] += 10.0 * mpr_info.CCD_TOLERANCE[None]
 
     direction = -mpr_state.simplex_support.v[0, i_b].normalized()
 
@@ -517,12 +527,18 @@ def mpr_discover_portal(
     dot = v.dot(direction)
 
     ret = 0
-    if dot < mpr_info.CCD_EPS[None]:
+    if dot < 0.0:
         ret = -1
     else:
         direction = mpr_state.simplex_support.v[0, i_b].cross(mpr_state.simplex_support.v[1, i_b])
-        if direction.dot(direction) < mpr_info.CCD_EPS[None]:
-            if (qd.abs(mpr_state.simplex_support.v[1, i_b]) < mpr_info.CCD_EPS[None]).all():
+        # Relative collinearity test: |v0 x v1|^2 = |v0|^2 * |v1|^2 * sin^2(angle). An absolute epsilon (length^4)
+        # would misclassify non-collinear cm-scale pairs as degenerate, fabricating deep contacts via the segment path.
+        norm_sqr_01 = mpr_state.simplex_support.v[0, i_b].norm_sqr() * mpr_state.simplex_support.v[1, i_b].norm_sqr()
+        if direction.dot(direction) < mpr_info.CCD_EPS[None] * norm_sqr_01:
+            if (
+                qd.abs(mpr_state.simplex_support.v[1, i_b])
+                < mpr_info.CCD_EPS[None] * mpr_state.simplex_support.v[0, i_b].norm()
+            ).all():
                 ret = 1
             else:
                 ret = 2
@@ -543,7 +559,7 @@ def mpr_discover_portal(
                 quat_b,
             )
             dot = v.dot(direction)
-            if dot < mpr_info.CCD_EPS[None]:
+            if dot < 0.0:
                 ret = -1
             else:
                 mpr_state.simplex_support.v1[2, i_b] = v1
@@ -581,7 +597,7 @@ def mpr_discover_portal(
                         quat_b,
                     )
                     dot = v.dot(direction)
-                    if dot < mpr_info.CCD_EPS[None]:
+                    if dot < 0.0:
                         ret = -1
                         break
 
@@ -589,7 +605,7 @@ def mpr_discover_portal(
 
                     va = mpr_state.simplex_support.v[1, i_b].cross(v)
                     dot = va.dot(mpr_state.simplex_support.v[0, i_b])
-                    if dot < -mpr_info.CCD_EPS[None]:
+                    if dot < 0.0:
                         mpr_state.simplex_support.v1[2, i_b] = v1
                         mpr_state.simplex_support.v2[2, i_b] = v2
                         mpr_state.simplex_support.v[2, i_b] = v
@@ -598,7 +614,7 @@ def mpr_discover_portal(
                     if not cont:
                         va = v.cross(mpr_state.simplex_support.v[2, i_b])
                         dot = va.dot(mpr_state.simplex_support.v[0, i_b])
-                        if dot < -mpr_info.CCD_EPS[None]:
+                        if dot < 0.0:
                             mpr_state.simplex_support.v1[1, i_b] = v1
                             mpr_state.simplex_support.v2[1, i_b] = v2
                             mpr_state.simplex_support.v[1, i_b] = v

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4405,6 +4405,49 @@ def test_nan_reset(gs_sim, mode):
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_mpr_thin_box_stack_no_lateral_phantom(n_envs, show_viewer):
+    # Two thin stacked boxes with vertically aligned centers: the MPR seed ray is exactly vertical and the flat-face
+    # support ties leave the first support vertex with a small lateral offset, so the portal-discovery collinearity
+    # test must not misclassify this near-perpendicular configuration as a degenerate segment, whose fallback path
+    # would fabricate a laterally-tilted contact from that arbitrary support tie instead of the true vertical normal.
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            use_gjk_collision=False,
+        ),
+        show_viewer=show_viewer,
+        show_FPS=False,
+    )
+    scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 0.005),
+            size=(0.002, 0.02, 0.01),
+            fixed=True,
+        ),
+    )
+    box = scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 0.01495),
+            size=(0.002, 0.0199, 0.01),
+        ),
+    )
+    scene.build(n_envs=n_envs)
+
+    scene.step()
+    contacts = scene.rigid_solver.collider.get_contacts(to_torch=False)
+    normals = contacts["normal"]
+    assert len(normals) > 0
+    assert_allclose(np.abs(normals[..., 2]), 1, atol=1e-3)
+
+    for _ in range(100):
+        scene.step()
+    pos = box.get_pos()
+    assert_allclose(pos[..., :2], 0, atol=1e-4)
+    assert_allclose(pos[..., 2], 0.015, atol=5e-4)
+
+
+@pytest.mark.required
 def test_box_on_terrain_no_spurious_spin(show_viewer):
     BOX_SIZE = (0.12, 0.06, 0.025)
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4142,13 +4142,16 @@ def test_convexify(euler, show_viewer, gjk_collision):
 
     # Check resting conditions repeateadly rather not just once, for numerical robustness.
     # cam.start_recording()
+    qvel_norminf_all = []
     n_settle = 1250 if euler == (74, 15, 90) else 1000
     for i in range(n_settle + 100):
         scene.step()
         # cam.render()
         if i > n_settle:
-            # FIXME: Why is the tolerance so large? This is basically not checking anything...
-            assert_allclose(gs_sim.rigid_solver.get_dofs_velocity(), 0.0, atol=1.0)
+            qvel = gs_sim.rigid_solver.get_dofs_velocity()
+            qvel_norminf = torch.linalg.norm(qvel, ord=math.inf)
+            qvel_norminf_all.append(qvel_norminf)
+    np.testing.assert_array_less(torch.median(torch.stack(qvel_norminf_all, dim=0)).cpu(), 0.05)
     # cam.stop_recording(save_to_filename="video.mp4", fps=60)
 
     for obj in objs:
@@ -4204,7 +4207,7 @@ def test_convexify_stress(show_viewer):
             scene.add_entity(
                 gs.morphs.MJCF(
                     file=asset_files[name],
-                    pos=(gx * 0.1 - 0.15, gy * 0.13 - 0.19, 0.11 + gz * 0.12),
+                    pos=((gx + 0.5 * (gz % 2)) * 0.1 - 0.18, (gy + 0.5 * (gz % 2)) * 0.145 - 0.265, 0.11 + gz * 0.08),
                     euler=(90.0, 0.0, 0.0),
                 ),
                 vis_mode="collision",
@@ -4213,7 +4216,7 @@ def test_convexify_stress(show_viewer):
     scene.build()
 
     # Wait for the pile to collapse and settle at rest
-    for i in range(1500):
+    for i in range(1000):
         scene.step()
 
     # The pile has settled at rest, fully contained in the tank (no ground/tank penetration, no ejection).
@@ -4411,6 +4414,11 @@ def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer, tol):
         rigid_options=gs.options.RigidOptions(
             use_gjk_collision=False,
         ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.1, -0.08, 0.06),
+            camera_lookat=(0.0, 0.0, 0.01),
+            camera_fov=20,
+        ),
         show_viewer=show_viewer,
     )
     scene.add_entity(
@@ -4419,12 +4427,19 @@ def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer, tol):
             size=(0.002, 0.02, 0.01),
             fixed=True,
         ),
+        surface=gs.surfaces.Default(
+            color=(0, 0, 1),
+        ),
     )
     box = scene.add_entity(
         gs.morphs.Box(
             pos=(0.0, 0.0, 0.01495),
             size=(0.002, 0.0199, 0.01),
         ),
+        surface=gs.surfaces.Default(
+            color=(1, 0, 0),
+        ),
+        visualize_contact=True,
     )
     scene.build()
 

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4405,6 +4405,7 @@ def test_nan_reset(gs_sim, mode):
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("precision", ["32"])
 def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer, tol):
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4405,9 +4405,7 @@ def test_nan_reset(gs_sim, mode):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("n_envs", [0, 2])
-@pytest.mark.parametrize("backend", [gs.cpu])
-def test_mpr_thin_box_stack_no_lateral_phantom(n_envs, show_viewer):
+def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer):
     # Two thin stacked boxes with vertically aligned centers: the MPR seed ray is exactly vertical and the flat-face
     # support ties leave the first support vertex with a small lateral offset, so the portal-discovery collinearity
     # test must not misclassify this near-perpendicular configuration as a degenerate segment, whose fallback path
@@ -4432,7 +4430,7 @@ def test_mpr_thin_box_stack_no_lateral_phantom(n_envs, show_viewer):
             size=(0.002, 0.0199, 0.01),
         ),
     )
-    scene.build(n_envs=n_envs)
+    scene.build()
 
     scene.step()
     contacts = scene.rigid_solver.collider.get_contacts(to_torch=False)

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4406,10 +4406,6 @@ def test_nan_reset(gs_sim, mode):
 
 @pytest.mark.required
 def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer):
-    # Two thin stacked boxes with vertically aligned centers: the MPR seed ray is exactly vertical and the flat-face
-    # support ties leave the first support vertex with a small lateral offset, so the portal-discovery collinearity
-    # test must not misclassify this near-perpendicular configuration as a degenerate segment, whose fallback path
-    # would fabricate a laterally-tilted contact from that arbitrary support tie instead of the true vertical normal.
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             use_gjk_collision=False,

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4405,13 +4405,12 @@ def test_nan_reset(gs_sim, mode):
 
 
 @pytest.mark.required
-def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer):
+def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer, tol):
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             use_gjk_collision=False,
         ),
         show_viewer=show_viewer,
-        show_FPS=False,
     )
     scene.add_entity(
         gs.morphs.Box(
@@ -4432,13 +4431,13 @@ def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer):
     contacts = scene.rigid_solver.collider.get_contacts(to_torch=False)
     normals = contacts["normal"]
     assert len(normals) > 0
-    assert_allclose(np.abs(normals[..., 2]), 1, atol=1e-3)
+    assert_allclose(np.abs(normals[..., 2]), 1, atol=1e2 * tol)
 
     for _ in range(100):
         scene.step()
     pos = box.get_pos()
-    assert_allclose(pos[..., :2], 0, atol=1e-4)
-    assert_allclose(pos[..., 2], 0.015, atol=5e-4)
+    assert_allclose(pos[..., :2], 0, atol=1e1 * tol)
+    assert_allclose(pos[..., 2], 0.015, atol=1e1 * tol)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

Make the geometric degeneracy tests of the MPR pipeline dimensionless: tolerances relative to the operand magnitudes for the guards preceding a division or normalization, exact sign comparisons everywhere else, and `CCD_TOLERANCE` for the coincident-centers seeding. `CCD_EPS` becomes a single relative tolerance, raised from 1e-9 to 1e-5 in single precision.

## Motivation and Context

`CCD_EPS` was an absolute epsilon compared against quantities homogeneous to length^1 up to length^4 depending on the site, so no single value could be correct at every scene scale. In particular, the portal-discovery collinearity test misclassifies clearly non-collinear cm-scale configurations as degenerate segments, fabricating deep laterally-tilted contacts that occasionally escape the MPR->GJK depth gate and eject resting bodies.

## How Has This Been / Can This Be Tested?

New regression test (fails on `main`), collision subset of `test_rigid_physics.py` on CPU and Metal, and a 150k-step conforming-stack repro: velocity spikes eliminated (|v|max 2.2 -> 0.088), penetration and contact count stable, ~30% faster.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
