### PR TITLE
[MISC] Matrix-free per-island noslip solver.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -102,7 +102,6 @@ class Collider:
         self._prune_deep_penetration_ratio = 3.0
         self._prune_max_contacts_per_link_pair = 32
         self._prune_max_contacts_floor = 512
-        self._noslip_max_contacts = 128
 
         self._init_static_config()
         self._use_split_narrowphase = (
@@ -661,13 +660,6 @@ class Collider:
             max_contacts_pruned = np.minimum(link_pairs_n_contacts, self._prune_max_contacts_per_link_pair)
             max_contacts_pruned_total = max(int(max_contacts_pruned.sum()), self._prune_max_contacts_floor)
             max_contacts = min(max_contacts, max_contacts_pruned_total)
-
-        # The noslip dual matrix efc_AR is quadratic in the contact budget, so noslip scenes get a much tighter
-        # default cap: measured noslip workloads (manipulation-style scenes) peak below ~70 simultaneous contact
-        # points, while the worst-case candidate budget is orders of magnitude larger. A denser scene hits the
-        # max_contacts clamp and halts with a request to set 'max_contacts' explicitly, which overrides this cap.
-        if self._solver._options.noslip_iterations > 0 and self._solver._options.max_contacts is None:
-            max_contacts = min(max_contacts, self._noslip_max_contacts)
 
         self._collider_info.max_possible_pairs[None] = n_possible_pairs
         self._collider_info.max_collision_pairs[None] = max_collision_pairs

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -1091,10 +1091,20 @@ def func_clamp_prune_contacts_coop(
             # sort, hull build, mark-survivors, and deep-pen restore stay serial on lane 0.
             i_cb_start = 0
             while i_cb_start < n_con:
-                key_b = collider_state.contact_sort_key[i_cb_start, i_b]
+                # Bucket boundaries must be derived from the link ids, not from f32 sort-key equality: the key
+                # lmin * 1e7 + lmax loses the lmax bits above 2^24, so distinct link pairs can share a key and
+                # key-equality scanning would merge their buckets into a single hull.
+                i_pc0 = collider_state.contact_sort_idx[i_cb_start, i_b]
+                i_la0 = collider_state.contact_data.link_a[i_pc0, i_b]
+                i_lb0 = collider_state.contact_data.link_b[i_pc0, i_b]
+                i_l_min0 = qd.min(i_la0, i_lb0)
+                i_l_max0 = qd.max(i_la0, i_lb0)
                 i_cb_end = i_cb_start + 1
                 while i_cb_end < n_con:
-                    if collider_state.contact_sort_key[i_cb_end, i_b] != key_b:
+                    i_pc = collider_state.contact_sort_idx[i_cb_end, i_b]
+                    i_la = collider_state.contact_data.link_a[i_pc, i_b]
+                    i_lb = collider_state.contact_data.link_b[i_pc, i_b]
+                    if qd.min(i_la, i_lb) != i_l_min0 or qd.max(i_la, i_lb) != i_l_max0:
                         break
                     i_cb_end += 1
                 n_cb = i_cb_end - i_cb_start

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -3,8 +3,6 @@ import quadrants as qd
 import genesis as gs
 import genesis.utils.array_class as array_class
 
-import genesis.engine.solvers.rigid.rigid_solver as rigid_solver
-
 
 @qd.func
 def func_solve_mass_block(
@@ -430,40 +428,33 @@ def func_noslip_batch(
 @qd.func
 def func_dual_finish_batch(
     i_b,
+    i_island,
     dofs_state: array_class.DofsState,
-    entities_info: array_class.EntitiesInfo,
     rigid_global_info: array_class.RigidGlobalInfo,
     constraint_state: array_class.ConstraintState,
+    island_state: array_class.IslandState,
     static_rigid_sim_config: qd.template(),
 ):
-    n_dofs = constraint_state.qfrc_constraint.shape[0]
+    """Map the final constraint forces back to joint space over one island.
 
-    for i_d in range(n_dofs):
-        constraint_state.qfrc_constraint[i_d, i_b] = gs.qd_float(0.0)
-
-    for i_c in range(constraint_state.n_constraints[i_b]):
-        force = constraint_state.efc_force[i_c, i_b]
-        for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
-            i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
-            constraint_state.qfrc_constraint[i_d, i_b] = (
-                constraint_state.qfrc_constraint[i_d, i_b] + constraint_state.jac[i_c, i_d, i_b] * force
-            )
-
-    rigid_solver.func_solve_mass_batch(
-        i_b=i_b,
-        vec=constraint_state.qfrc_constraint,
-        out=constraint_state.qacc,
-        out_bw=None,
-        entities_info=entities_info,
-        rigid_global_info=rigid_global_info,
-        static_rigid_sim_config=static_rigid_sim_config,
-        is_backward=False,
+    The refresh recomputes qfrc_constraint = J^T f and qacc = acc_smooth + M^{-1} J^T f exactly from the swept
+    forces; the remaining work is copying them into the per-dof state.
+    """
+    func_refresh_qacc_batch(
+        i_b, i_island, dofs_state, rigid_global_info, constraint_state, island_state, static_rigid_sim_config
     )
 
-    for i_d in range(n_dofs):
-        constraint_state.qacc[i_d, i_b] = constraint_state.qacc[i_d, i_b] + dofs_state.acc_smooth[i_d, i_b]
-        dofs_state.acc[i_d, i_b] = constraint_state.qacc[i_d, i_b]
+    n_dofs = constraint_state.qfrc_constraint.shape[0]
+    dof_start = gs.qd_int(0)
+    if qd.static(static_rigid_sim_config.enable_per_island_solve):
+        n_dofs = island_state.dof_slices.n[i_island, i_b]
+        dof_start = island_state.dof_slices.start[i_island, i_b]
 
+    for i_d_ in range(n_dofs):
+        i_d = i_d_
+        if qd.static(static_rigid_sim_config.enable_per_island_solve):
+            i_d = island_state.dof_id[dof_start + i_d_, i_b]
+        dofs_state.acc[i_d, i_b] = constraint_state.qacc[i_d, i_b]
         dofs_state.qf_constraint[i_d, i_b] = constraint_state.qfrc_constraint[i_d, i_b]
         dofs_state.force[i_d, i_b] = dofs_state.qf_smooth[i_d, i_b] + constraint_state.qfrc_constraint[i_d, i_b]
 
@@ -472,17 +463,17 @@ def func_dual_finish_batch(
 def kernel_noslip(
     collider_state: array_class.ColliderState,
     dofs_state: array_class.DofsState,
-    entities_info: array_class.EntitiesInfo,
     rigid_global_info: array_class.RigidGlobalInfo,
     constraint_state: array_class.ConstraintState,
     island_state: array_class.IslandState,
     static_rigid_sim_config: qd.template(),
 ):
-    """Noslip pass: matrix-free force-update sweeps followed by the dual finish.
+    """Noslip pass: matrix-free force-update sweep followed by the dual finish, fused per island.
 
     The sweep is a sequential Gauss-Seidel process within an island; islands are independent (A is block-diagonal by
-    island), so under the per-island solve they are spread across the (env, island) grid, otherwise the whole env is
-    swept by one thread.
+    island and both phases touch only the island's own rows and dofs), so under the per-island solve each (env,
+    island) pair runs sweep and finish end-to-end in one thread, otherwise the whole env is one island swept by one
+    thread.
     """
     _B = constraint_state.jac.shape[2]
 
@@ -509,6 +500,15 @@ def kernel_noslip(
                         island_state,
                         static_rigid_sim_config,
                     )
+                    func_dual_finish_batch(
+                        i_b,
+                        i_island,
+                        dofs_state,
+                        rigid_global_info,
+                        constraint_state,
+                        island_state,
+                        static_rigid_sim_config,
+                    )
     else:
         qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
         for i_b in range(_B):
@@ -522,12 +522,9 @@ def kernel_noslip(
                 island_state,
                 static_rigid_sim_config,
             )
-
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        func_dual_finish_batch(
-            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
-        )
+            func_dual_finish_batch(
+                i_b, 0, dofs_state, rigid_global_info, constraint_state, island_state, static_rigid_sim_config
+            )
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -221,6 +221,7 @@ def func_noslip_batch(
     n_rows = constraint_state.n_constraints[i_b]
     row_start = gs.qd_int(0)
     if qd.static(static_rigid_sim_config.enable_per_island_solve):
+        n_dofs = island_state.dof_slices.n[i_island, i_b]
         n_rows = island_state.constraint_slices.n[i_island, i_b]
         row_start = island_state.constraint_slices.start[i_island, i_b]
 

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -7,243 +7,420 @@ import genesis.engine.solvers.rigid.rigid_solver as rigid_solver
 
 
 @qd.func
-def func_build_efc_AR_b_batch(
+def func_solve_mass_block(
+    i_d0,
     i_b,
+    vec: qd.Tensor,
+    rigid_global_info: array_class.RigidGlobalInfo,
+):
+    """LDL^T forward-backward substitution on vec, restricted to the mass-matrix block containing dof i_d0.
+
+    The factor is block-diagonal per kinematic tree, with constant block bounds shared by every member dof
+    (dofs_mass_block_start/end), so a block is solvable independently from any member dof.
+    """
+    block_start = rigid_global_info.dofs_mass_block_start[i_d0]
+    block_end = rigid_global_info.dofs_mass_block_end[i_d0]
+
+    # Step 1: Solve w s.t. L^T @ w = y (backward substitution)
+    for i_d_ in range(block_end - block_start):
+        i_d = block_end - i_d_ - 1
+        curr = vec[i_d, i_b]
+        for j_d in range(i_d + 1, block_end):
+            curr = curr - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * vec[j_d, i_b]
+        vec[i_d, i_b] = curr
+
+    # Step 2: z = D^{-1} @ w
+    for i_d in range(block_start, block_end):
+        vec[i_d, i_b] = vec[i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
+
+    # Step 3: Solve x s.t. L @ x = z (forward substitution)
+    for i_d in range(block_start, block_end):
+        curr = vec[i_d, i_b]
+        for j_d in range(block_start, i_d):
+            curr = curr - rigid_global_info.mass_mat_L[i_d, j_d, i_b] * vec[j_d, i_b]
+        vec[i_d, i_b] = curr
+
+
+@qd.func
+def func_apply_Minv_rows(
+    i_row_0,
+    coef_0,
+    i_row_1,
+    coef_1,
+    i_b,
+    vec: qd.Tensor,
+    jac: qd.Tensor,
+    jac_dofs_idx: qd.Tensor,
+    jac_n_dofs: qd.Tensor,
+    rigid_global_info: array_class.RigidGlobalInfo,
+):
+    """Compute vec = M^{-1} (coef_0 * J[i_row_0]^T + coef_1 * J[i_row_1]^T) over the touched mass blocks.
+
+    Both rows must share the same dof support (e.g. the two edges of a friction-pyramid pair); the walk is driven by
+    i_row_0. The mass matrix is block-diagonal per kinematic tree, so scattering into fully-zeroed blocks and solving
+    only those blocks is exact. Row dofs are sorted, so same-block dofs are contiguous and each block is visited once
+    per pass. Working at block granularity (not entity granularity) keeps the touched dof range within the row's own
+    island, which makes concurrent per-island sweeps of the same env race-free.
+    """
+    block_start_prev = gs.qd_int(-1)
+    for i_d_ in range(jac_n_dofs[i_row_0, i_b]):
+        i_d = jac_dofs_idx[i_row_0, i_d_, i_b]
+        block_start = rigid_global_info.dofs_mass_block_start[i_d]
+        if block_start != block_start_prev:
+            for j_d in range(block_start, rigid_global_info.dofs_mass_block_end[i_d]):
+                vec[j_d, i_b] = gs.qd_float(0.0)
+            block_start_prev = block_start
+        vec[i_d, i_b] = coef_0 * jac[i_row_0, i_d, i_b] + coef_1 * jac[i_row_1, i_d, i_b]
+
+    block_start_prev = gs.qd_int(-1)
+    for i_d_ in range(jac_n_dofs[i_row_0, i_b]):
+        i_d = jac_dofs_idx[i_row_0, i_d_, i_b]
+        block_start = rigid_global_info.dofs_mass_block_start[i_d]
+        if block_start != block_start_prev:
+            func_solve_mass_block(i_d, i_b, vec, rigid_global_info)
+            block_start_prev = block_start
+
+
+@qd.func
+def func_accumulate_row_blocks(
+    i_row,
+    i_b,
+    vec_src: qd.Tensor,
+    vec_dst: qd.Tensor,
+    jac_dofs_idx: qd.Tensor,
+    jac_n_dofs: qd.Tensor,
+    rigid_global_info: array_class.RigidGlobalInfo,
+):
+    """Add vec_src to vec_dst over the mass blocks touched by constraint row i_row."""
+    block_start_prev = gs.qd_int(-1)
+    for i_d_ in range(jac_n_dofs[i_row, i_b]):
+        i_d = jac_dofs_idx[i_row, i_d_, i_b]
+        block_start = rigid_global_info.dofs_mass_block_start[i_d]
+        if block_start != block_start_prev:
+            for j_d in range(block_start, rigid_global_info.dofs_mass_block_end[i_d]):
+                vec_dst[j_d, i_b] = vec_dst[j_d, i_b] + vec_src[j_d, i_b]
+            block_start_prev = block_start
+
+
+@qd.func
+def func_dot_row(
+    i_row,
+    i_b,
+    vec: qd.Tensor,
+    jac: qd.Tensor,
+    jac_dofs_idx: qd.Tensor,
+    jac_n_dofs: qd.Tensor,
+):
+    """Sparse dot product J[i_row] * vec over the row dof support."""
+    s = gs.qd_float(0.0)
+    for i_d_ in range(jac_n_dofs[i_row, i_b]):
+        i_d = jac_dofs_idx[i_row, i_d_, i_b]
+        s += jac[i_row, i_d, i_b] * vec[i_d, i_b]
+    return s
+
+
+@qd.func
+def func_refresh_qacc_batch(
+    i_b,
+    i_island,
     dofs_state: array_class.DofsState,
-    entities_info: array_class.EntitiesInfo,
     rigid_global_info: array_class.RigidGlobalInfo,
     constraint_state: array_class.ConstraintState,
     island_state: array_class.IslandState,
     static_rigid_sim_config: qd.template(),
 ):
-    n_dofs = constraint_state.jac.shape[1]
-    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
-    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
-    nefc = constraint_state.n_constraints[i_b]
+    """Recompute qacc = acc_smooth + M^{-1} J^T f from the current constraint forces, over one island.
 
-    # AR = J M^{-1} J^T is block-diagonal by island: a constraint touches only one island's dofs and M^{-1} is
-    # block-diagonal, so AR[r, c] = 0 whenever constraints r and c belong to different islands. When the partition is
-    # active and the env has more than one island, the cross-island dot products below are skipped (the entry is left
-    # zero), turning the O(nefc^2 n_dofs) dense build into the sum of per-island blocks. A single-island env leaves
-    # constraint_island_idx unresolved (the partition skips it), so the per-pair test is gated on n_islands > 1, where
-    # one island spans the whole env and the full dense build is both correct and already minimal.
-    island_aware = False
-    if qd.static(static_rigid_sim_config.enable_per_island_solve):
-        island_aware = island_state.n_islands[i_b] > 1
-
-    # build AR = J * inv(M) * J^T
-    # do it row-by-row: for each row r, tmp = inv(M) * J[r]^T, then AR[r,:] = J * tmp.
-    # No zeroing pass is needed: the symmetric lower-triangle fill writes every entry of [0, nefc)^2 and
-    # consumers never read beyond nefc.
-    for i_row in range(nefc):
-        isl_r = gs.qd_int(-1)
-        if qd.static(static_rigid_sim_config.enable_per_island_solve):
-            isl_r = island_state.constraint_island_idx[i_row, i_b]
-        # tmp = M^{-1} * Jr^T
-        if qd.static(static_rigid_sim_config.sparse_solve):
-            # Sparse: zero buffer, copy only relevant DOFs
-            for i_d in range(n_dofs):
-                constraint_state.Mgrad[i_d, i_b] = gs.qd_float(0.0)
-            for i_d_ in range(constraint_state.jac_n_dofs[i_row, i_b]):
-                i_d = constraint_state.jac_dofs_idx[i_row, i_d_, i_b]
-                constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
-        else:
-            for i_d in range(n_dofs):
-                constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
-
-        rigid_solver.func_solve_mass_batch(
-            i_b,
-            constraint_state.Mgrad,
-            constraint_state.Mgrad,
-            None,
-            entities_info=entities_info,
-            rigid_global_info=rigid_global_info,
-            static_rigid_sim_config=static_rigid_sim_config,
-            is_backward=False,
-        )
-
-        # TODO: For consistency with other usages, migrate to either the lower or upper variant
-        # and update all remaining use cases that still read both.
-        # AR[r, c] = J[c, :] * Mgrad, only compute lower triangle. The dot is skipped (entry left zero) for a column
-        # in a different island, since that block of AR is structurally zero.
-        for i_col in range(i_row + 1):
-            s = gs.qd_float(0.0)
-            compute = True
-            if qd.static(static_rigid_sim_config.enable_per_island_solve):
-                if island_aware:
-                    compute = island_state.constraint_island_idx[i_col, i_b] == isl_r
-            if compute:
-                if qd.static(static_rigid_sim_config.sparse_solve):
-                    for i_d_ in range(constraint_state.jac_n_dofs[i_col, i_b]):
-                        i_d = constraint_state.jac_dofs_idx[i_col, i_d_, i_b]
-                        s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
-                else:
-                    for i_d in range(n_dofs):
-                        s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
-            constraint_state.efc_AR[i_row, i_col, i_b_AR] = s
-            constraint_state.efc_AR[i_col, i_row, i_b_AR] = s
-
-    # Build efc_b
-    for i_c in range(nefc):
-        v = -constraint_state.aref[i_c, i_b]
-        if qd.static(static_rigid_sim_config.sparse_solve):
-            for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
-                i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
-                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
-        else:
-            for i_d in range(n_dofs):
-                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
-        constraint_state.efc_b[i_c, i_b_AR] = v
-
-
-@qd.func
-def func_solve_mass_entity_row(
-    i_row: qd.int32,
-    i_e: qd.int32,
-    i_b: qd.int32,
-    buf: qd.Tensor,
-    entities_info: array_class.EntitiesInfo,
-    rigid_global_info: array_class.RigidGlobalInfo,
-):
-    """LDL^T forward-backward substitution on buf[i_row, :, i_b].
-
-    Same algorithm as func_solve_mass_entity (forward-only path), but operates
-    on a 3D buffer indexed by (constraint_row, dof, batch). This allows
-    different constraint rows to be solved in parallel since each row uses
-    a separate memory slice.
+    The force-update sweep maintains qacc incrementally; recomputing it exactly at the start of every iteration keeps
+    the accumulated floating-point drift bounded to a single sweep. Under the per-island solve, only the island's own
+    dofs and constraint rows are visited (mass blocks never straddle islands, and each block's first dof appears
+    exactly once in the island's dof list regardless of the skyline dof reorder); otherwise the whole env is one
+    island and the plain index ranges are used.
     """
-    if rigid_global_info.mass_mat_mask[i_e, i_b]:
-        entity_dof_start = entities_info.dof_start[i_e]
-        entity_dof_end = entities_info.dof_end[i_e]
-        n_dofs = entities_info.n_dofs[i_e]
+    n_dofs = constraint_state.qfrc_constraint.shape[0]
+    n_rows = constraint_state.n_constraints[i_b]
+    dof_start = gs.qd_int(0)
+    row_start = gs.qd_int(0)
+    if qd.static(static_rigid_sim_config.enable_per_island_solve):
+        n_dofs = island_state.dof_slices.n[i_island, i_b]
+        n_rows = island_state.constraint_slices.n[i_island, i_b]
+        dof_start = island_state.dof_slices.start[i_island, i_b]
+        row_start = island_state.constraint_slices.start[i_island, i_b]
 
-        # Step 1: Solve w s.t. L^T @ w = y (backward substitution). The mass matrix is block-diagonal per kinematic
-        # tree, so each row only couples to dofs within its own block.
-        for i_d_ in range(n_dofs):
-            i_d = entity_dof_end - i_d_ - 1
-            curr_out = buf[i_row, i_d, i_b]
+    for i_d_ in range(n_dofs):
+        i_d = i_d_
+        if qd.static(static_rigid_sim_config.enable_per_island_solve):
+            i_d = island_state.dof_id[dof_start + i_d_, i_b]
+        constraint_state.qfrc_constraint[i_d, i_b] = gs.qd_float(0.0)
+        constraint_state.qacc[i_d, i_b] = gs.qd_float(0.0)
+
+    for i_c_ in range(n_rows):
+        i_c = i_c_
+        if qd.static(static_rigid_sim_config.enable_per_island_solve):
+            i_c = island_state.constraint_id[row_start + i_c_, i_b]
+        force = constraint_state.efc_force[i_c, i_b]
+        for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
+            i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
+            constraint_state.qfrc_constraint[i_d, i_b] = (
+                constraint_state.qfrc_constraint[i_d, i_b] + constraint_state.jac[i_c, i_d, i_b] * force
+            )
+
+    for i_d_ in range(n_dofs):
+        i_d = i_d_
+        if qd.static(static_rigid_sim_config.enable_per_island_solve):
+            i_d = island_state.dof_id[dof_start + i_d_, i_b]
+        # Solve each mass block once, when visiting its first dof (order-robust, unlike previous-block tracking,
+        # since the island dof list may be permuted by the fill-reducing reorder).
+        if i_d == rigid_global_info.dofs_mass_block_start[i_d]:
+            constraint_state.qacc[i_d, i_b] = constraint_state.qfrc_constraint[i_d, i_b]
             for j_d in range(i_d + 1, rigid_global_info.dofs_mass_block_end[i_d]):
-                curr_out = curr_out - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * buf[i_row, j_d, i_b]
-            buf[i_row, i_d, i_b] = curr_out
+                constraint_state.qacc[j_d, i_b] = constraint_state.qfrc_constraint[j_d, i_b]
+            func_solve_mass_block(i_d, i_b, constraint_state.qacc, rigid_global_info)
 
-        # Step 2: z = D^{-1} @ w
-        for i_d in range(entity_dof_start, entity_dof_end):
-            buf[i_row, i_d, i_b] = buf[i_row, i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
-
-        # Step 3: Solve x s.t. L @ x = z (forward substitution)
-        for i_d in range(entity_dof_start, entity_dof_end):
-            curr_out = buf[i_row, i_d, i_b]
-            for j_d in range(rigid_global_info.dofs_mass_block_start[i_d], i_d):
-                curr_out = curr_out - rigid_global_info.mass_mat_L[i_d, j_d, i_b] * buf[i_row, j_d, i_b]
-            buf[i_row, i_d, i_b] = curr_out
+    for i_d_ in range(n_dofs):
+        i_d = i_d_
+        if qd.static(static_rigid_sim_config.enable_per_island_solve):
+            i_d = island_state.dof_id[dof_start + i_d_, i_b]
+        constraint_state.qacc[i_d, i_b] = constraint_state.qacc[i_d, i_b] + dofs_state.acc_smooth[i_d, i_b]
 
 
 @qd.func
 def func_noslip_batch(
     i_b,
+    i_island,
     collider_state: array_class.ColliderState,
+    dofs_state: array_class.DofsState,
     constraint_state: array_class.ConstraintState,
     rigid_global_info: array_class.RigidGlobalInfo,
+    island_state: array_class.IslandState,
     static_rigid_sim_config: qd.template(),
 ):
+    """Matrix-free noslip force-update sweep over one island (the whole env counts as one island when the per-island
+    solve is off).
+
+    The dual residual of row r is res_r = A f + b = J_r * qacc - aref_r with qacc = acc_smooth + M^{-1} J^T f, so
+    the sweep maintains qacc instead of materializing the dense dual matrix AR = J M^{-1} J^T: each force update
+    propagates to qacc through an M^{-1} solve restricted to the mass blocks the row touches, and the 1x1/2x2
+    diagonal blocks of A needed by the updates are recomputed on the fly the same way. This keeps the pass linear in
+    the number of constraints (times the row support size) per iteration, instead of quadratic. A is block-diagonal
+    by island and the updates touch only the row's own mass blocks, so concurrent sweeps of different islands of the
+    same env are race-free and equivalent to the env-wide sweep.
+    """
     EPS = rigid_global_info.EPS[None]
-    n_dofs = constraint_state.jac.shape[1]
-    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
-    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
 
     # temp variables
-    res = qd.Vector.zero(gs.qd_float, 5)
-    old_force = qd.Vector.zero(gs.qd_float, 5)
-    bc = qd.Vector.zero(gs.qd_float, 5)
-    Ac = qd.Vector.zero(gs.qd_float, 9)
+    res = qd.Vector.zero(gs.qd_float, 2)
+    old_force = qd.Vector.zero(gs.qd_float, 2)
+    bc = qd.Vector.zero(gs.qd_float, 2)
+    Ac = qd.Vector.zero(gs.qd_float, 4)
 
-    n_con = collider_state.n_contacts[i_b]
+    n_dofs = constraint_state.qfrc_constraint.shape[0]
     ne = constraint_state.n_constraints_equality[i_b]
     nf = constraint_state.n_constraints_frictionloss[i_b]
     const_start = ne + nf
+    const_end = const_start + 4 * collider_state.n_contacts[i_b]
+
+    n_rows = constraint_state.n_constraints[i_b]
+    row_start = gs.qd_int(0)
+    if qd.static(static_rigid_sim_config.enable_per_island_solve):
+        n_rows = island_state.constraint_slices.n[i_island, i_b]
+        row_start = island_state.constraint_slices.start[i_island, i_b]
 
     scale = 1.0 / (rigid_global_info.meaninertia[i_b] * qd.max(1.0, n_dofs))
 
     for i_iter in range(rigid_global_info.noslip_iterations[None]):
+        func_refresh_qacc_batch(
+            i_b, i_island, dofs_state, rigid_global_info, constraint_state, island_state, static_rigid_sim_config
+        )
+
         improvement = gs.qd_float(0.0)
-        if i_iter == 0:
-            for i_c in range(constraint_state.n_constraints[i_b]):
+
+        # Sweep the island's constraint rows in ascending order (the per-island grouping is index-ordered):
+        # dry-friction (dof frictionloss) rows get a 1-dof update, and every other collision row is the base of an
+        # opposing pyramid-edge pair (j_efc, j_efc + 1) projected with the normal force fixed. Equality and joint
+        # limit rows only contribute to the iter-0 improvement correction.
+        for i_c_ in range(n_rows):
+            i_c = i_c_
+            if qd.static(static_rigid_sim_config.enable_per_island_solve):
+                i_c = island_state.constraint_id[row_start + i_c_, i_b]
+
+            if i_iter == 0:
                 improvement += 0.5 * constraint_state.efc_force[i_c, i_b] ** 2 * constraint_state.diag[i_c, i_b]
 
-        for i_c in range(ne, ne + nf):
-            res = func_residual_constraint_force(
-                res=res,
-                i_b=i_b,
-                i_efc=i_c,
-                dim=1,
-                constraint_state=constraint_state,
-                static_rigid_sim_config=static_rigid_sim_config,
-            )
-            old_force[0] = constraint_state.efc_force[i_c, i_b]
-            constraint_state.efc_force[i_c, i_b] -= res[0] / constraint_state.efc_AR[i_c, i_c, i_b_AR]
-            if constraint_state.efc_force[i_c, i_b] < -constraint_state.efc_frictionloss[i_c, i_b]:
-                constraint_state.efc_force[i_c, i_b] = -constraint_state.efc_frictionloss[i_c, i_b]
-            elif constraint_state.efc_force[i_c, i_b] > constraint_state.efc_frictionloss[i_c, i_b]:
-                constraint_state.efc_force[i_c, i_b] = constraint_state.efc_frictionloss[i_c, i_b]
-            delta = constraint_state.efc_force[i_c, i_b] - old_force[0]
-            improvement -= 0.5 * delta**2 / constraint_state.efc_AR[i_c, i_c, i_b_AR] + delta * res[0]
+            if i_c >= ne and i_c < ne + nf:
+                # Each row runs two phases through the single func_apply_Minv_rows call site: phase 0 computes the
+                # diagonal entry A[i_c, i_c] = J M^{-1} J^T and updates the force, phase 1 propagates the force
+                # change to qacc (skipped when the force did not move).
+                delta = gs.qd_float(0.0)
+                for i_phase in range(2):
+                    coef = gs.qd_float(1.0)
+                    if i_phase == 1:
+                        coef = delta
+                    if i_phase == 0 or delta != 0.0:
+                        func_apply_Minv_rows(
+                            i_c,
+                            coef,
+                            i_c,
+                            0.0,
+                            i_b,
+                            constraint_state.Mgrad,
+                            constraint_state.jac,
+                            constraint_state.jac_dofs_idx,
+                            constraint_state.jac_n_dofs,
+                            rigid_global_info,
+                        )
+                        if i_phase == 0:
+                            A_diag = func_dot_row(
+                                i_c,
+                                i_b,
+                                constraint_state.Mgrad,
+                                constraint_state.jac,
+                                constraint_state.jac_dofs_idx,
+                                constraint_state.jac_n_dofs,
+                            )
+                            res[0] = (
+                                func_dot_row(
+                                    i_c,
+                                    i_b,
+                                    constraint_state.qacc,
+                                    constraint_state.jac,
+                                    constraint_state.jac_dofs_idx,
+                                    constraint_state.jac_n_dofs,
+                                )
+                                - constraint_state.aref[i_c, i_b]
+                            )
 
-        # Project contact friction (pyramidal 4-edge) with normal fixed
-        for i_col in range(n_con):
-            base = const_start + i_col * 4
-            for j2 in qd.static(range(2)):
-                j_efc = base + j2 * 2
-                res = func_residual_constraint_force(
-                    res=res,
-                    i_b=i_b,
-                    i_efc=j_efc,
-                    dim=2,
-                    constraint_state=constraint_state,
-                    static_rigid_sim_config=static_rigid_sim_config,
-                )
-                for i2 in qd.static(range(2)):
-                    old_force[i2] = constraint_state.efc_force[j_efc + i2, i_b]
-                Ac = func_extract_block_matrix_from_AR(
-                    Ac=Ac,
-                    i_b=i_b,
-                    start=j_efc,
-                    n=2,
-                    constraint_state=constraint_state,
-                    static_rigid_sim_config=static_rigid_sim_config,
-                )
-                for j in qd.static(range(2)):
-                    bc[j] = res[j]
-                    for k in qd.static(range(2)):
-                        bc[j] -= Ac[j * 2 + k] * old_force[k]
-                mid = 0.5 * (constraint_state.efc_force[j_efc, i_b] + constraint_state.efc_force[j_efc + 1, i_b])
-                y = 0.5 * (constraint_state.efc_force[j_efc, i_b] - constraint_state.efc_force[j_efc + 1, i_b])
-                K1 = Ac[0] + Ac[3] - Ac[1] - Ac[2]
-                K0 = mid * (Ac[0] - Ac[3]) + bc[0] - bc[1]
-                if K1 < EPS:
-                    constraint_state.efc_force[j_efc, i_b] = constraint_state.efc_force[j_efc + 1, i_b] = mid
-                else:
-                    y = -K0 / K1
-                    if y < -mid:
-                        constraint_state.efc_force[j_efc, i_b] = 0
-                        constraint_state.efc_force[j_efc + 1, i_b] = 2 * mid
-                    elif y > mid:
-                        constraint_state.efc_force[j_efc, i_b] = 2 * mid
-                        constraint_state.efc_force[j_efc + 1, i_b] = 0
+                            old_force[0] = constraint_state.efc_force[i_c, i_b]
+                            constraint_state.efc_force[i_c, i_b] -= res[0] / A_diag
+                            if constraint_state.efc_force[i_c, i_b] < -constraint_state.efc_frictionloss[i_c, i_b]:
+                                constraint_state.efc_force[i_c, i_b] = -constraint_state.efc_frictionloss[i_c, i_b]
+                            elif constraint_state.efc_force[i_c, i_b] > constraint_state.efc_frictionloss[i_c, i_b]:
+                                constraint_state.efc_force[i_c, i_b] = constraint_state.efc_frictionloss[i_c, i_b]
+                            delta = constraint_state.efc_force[i_c, i_b] - old_force[0]
+                            improvement -= 0.5 * delta**2 * A_diag + delta * res[0]
+                        else:
+                            func_accumulate_row_blocks(
+                                i_c,
+                                i_b,
+                                constraint_state.Mgrad,
+                                constraint_state.qacc,
+                                constraint_state.jac_dofs_idx,
+                                constraint_state.jac_n_dofs,
+                                rigid_global_info,
+                            )
+            elif i_c >= const_start and i_c < const_end and (i_c - const_start) % 2 == 0:
+                j_efc = i_c
+
+                # Three phases through the single func_apply_Minv_rows call site: phases 0 and 1 compute the
+                # symmetric 2x2 block of A (both rows share the same dof support, so two block solves and three
+                # sparse dots suffice), then the force update runs at the end of phase 1, and phase 2 propagates the
+                # force change to qacc (skipped when the forces did not move).
+                delta_0 = gs.qd_float(0.0)
+                delta_1 = gs.qd_float(0.0)
+                for i_phase in range(3):
+                    coef_0 = gs.qd_float(0.0)
+                    coef_1 = gs.qd_float(0.0)
+                    if i_phase == 0:
+                        coef_0 = 1.0
+                    elif i_phase == 1:
+                        coef_1 = 1.0
                     else:
-                        constraint_state.efc_force[j_efc, i_b] = mid + y
-                        constraint_state.efc_force[j_efc + 1, i_b] = mid - y
-                cost_change = func_cost_change(
-                    i_b=i_b,
-                    Ac=Ac,
-                    force=constraint_state.efc_force,
-                    force_start=j_efc,
-                    old_force=old_force,
-                    res=res,
-                    dim=2,
-                    eps=EPS,
-                )
+                        coef_0 = delta_0
+                        coef_1 = delta_1
+                    if i_phase < 2 or delta_0 != 0.0 or delta_1 != 0.0:
+                        func_apply_Minv_rows(
+                            j_efc,
+                            coef_0,
+                            j_efc + 1,
+                            coef_1,
+                            i_b,
+                            constraint_state.Mgrad,
+                            constraint_state.jac,
+                            constraint_state.jac_dofs_idx,
+                            constraint_state.jac_n_dofs,
+                            rigid_global_info,
+                        )
+                        if i_phase == 2:
+                            func_accumulate_row_blocks(
+                                j_efc,
+                                i_b,
+                                constraint_state.Mgrad,
+                                constraint_state.qacc,
+                                constraint_state.jac_dofs_idx,
+                                constraint_state.jac_n_dofs,
+                                rigid_global_info,
+                            )
+                        else:
+                            for i2 in qd.static(range(2)):
+                                if i_phase == 0 or i2 == 1:
+                                    s = func_dot_row(
+                                        j_efc + i2,
+                                        i_b,
+                                        constraint_state.Mgrad,
+                                        constraint_state.jac,
+                                        constraint_state.jac_dofs_idx,
+                                        constraint_state.jac_n_dofs,
+                                    )
+                                    if i_phase == 0:
+                                        Ac[i2] = s
+                                    else:
+                                        Ac[3] = s
 
-                improvement -= cost_change
+                    if i_phase == 1:
+                        Ac[2] = Ac[1]
+                        for i2 in qd.static(range(2)):
+                            res[i2] = (
+                                func_dot_row(
+                                    j_efc + i2,
+                                    i_b,
+                                    constraint_state.qacc,
+                                    constraint_state.jac,
+                                    constraint_state.jac_dofs_idx,
+                                    constraint_state.jac_n_dofs,
+                                )
+                                - constraint_state.aref[j_efc + i2, i_b]
+                            )
+                            old_force[i2] = constraint_state.efc_force[j_efc + i2, i_b]
+
+                        for j in qd.static(range(2)):
+                            bc[j] = res[j]
+                            for k in qd.static(range(2)):
+                                bc[j] -= Ac[j * 2 + k] * old_force[k]
+                        mid = 0.5 * (
+                            constraint_state.efc_force[j_efc, i_b] + constraint_state.efc_force[j_efc + 1, i_b]
+                        )
+                        y = 0.5 * (constraint_state.efc_force[j_efc, i_b] - constraint_state.efc_force[j_efc + 1, i_b])
+                        K1 = Ac[0] + Ac[3] - Ac[1] - Ac[2]
+                        K0 = mid * (Ac[0] - Ac[3]) + bc[0] - bc[1]
+                        if K1 < EPS:
+                            constraint_state.efc_force[j_efc, i_b] = constraint_state.efc_force[j_efc + 1, i_b] = mid
+                        else:
+                            y = -K0 / K1
+                            if y < -mid:
+                                constraint_state.efc_force[j_efc, i_b] = 0
+                                constraint_state.efc_force[j_efc + 1, i_b] = 2 * mid
+                            elif y > mid:
+                                constraint_state.efc_force[j_efc, i_b] = 2 * mid
+                                constraint_state.efc_force[j_efc + 1, i_b] = 0
+                            else:
+                                constraint_state.efc_force[j_efc, i_b] = mid + y
+                                constraint_state.efc_force[j_efc + 1, i_b] = mid - y
+                        cost_change = func_cost_change(
+                            i_b=i_b,
+                            Ac=Ac,
+                            force=constraint_state.efc_force,
+                            force_start=j_efc,
+                            old_force=old_force,
+                            res=res,
+                            dim=2,
+                            eps=EPS,
+                        )
+
+                        improvement -= cost_change
+
+                        delta_0 = constraint_state.efc_force[j_efc, i_b] - old_force[0]
+                        delta_1 = constraint_state.efc_force[j_efc + 1, i_b] - old_force[1]
+
         improvement *= scale
 
         if improvement < rigid_global_info.noslip_tolerance[None]:
@@ -261,14 +438,15 @@ def func_dual_finish_batch(
 ):
     n_dofs = constraint_state.qfrc_constraint.shape[0]
 
-    # zero
     for i_d in range(n_dofs):
         constraint_state.qfrc_constraint[i_d, i_b] = gs.qd_float(0.0)
 
-        for i_c in range(constraint_state.n_constraints[i_b]):
+    for i_c in range(constraint_state.n_constraints[i_b]):
+        force = constraint_state.efc_force[i_c, i_b]
+        for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
+            i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
             constraint_state.qfrc_constraint[i_d, i_b] = (
-                constraint_state.qfrc_constraint[i_d, i_b]
-                + constraint_state.jac[i_c, i_d, i_b] * constraint_state.efc_force[i_c, i_b]
+                constraint_state.qfrc_constraint[i_d, i_b] + constraint_state.jac[i_c, i_d, i_b] * force
             )
 
     rigid_solver.func_solve_mass_batch(
@@ -291,7 +469,7 @@ def func_dual_finish_batch(
 
 
 @qd.kernel(fastcache=True)
-def kernel_noslip_fused(
+def kernel_noslip(
     collider_state: array_class.ColliderState,
     dofs_state: array_class.DofsState,
     entities_info: array_class.EntitiesInfo,
@@ -300,127 +478,53 @@ def kernel_noslip_fused(
     island_state: array_class.IslandState,
     static_rigid_sim_config: qd.template(),
 ):
-    """Serialized noslip pass: build AR/b, run the force-update sweep, and finish, one env at a time.
+    """Noslip pass: matrix-free force-update sweeps followed by the dual finish.
 
-    Processing each env end-to-end keeps its efc_AR block (written by the build, consumed by the sweep) cache-hot, and
-    allows efc_AR/efc_b to be allocated with a single batch slot shared by all envs.
+    The sweep is a sequential Gauss-Seidel process within an island; islands are independent (A is block-diagonal by
+    island), so under the per-island solve they are spread across the (env, island) grid, otherwise the whole env is
+    swept by one thread.
     """
     _B = constraint_state.jac.shape[2]
 
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        func_build_efc_AR_b_batch(
-            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, island_state, static_rigid_sim_config
-        )
-        func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
-        func_dual_finish_batch(
-            i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
-        )
-
-
-@qd.kernel(fastcache=True)
-def kernel_noslip_decomposed(
-    collider_state: array_class.ColliderState,
-    dofs_state: array_class.DofsState,
-    entities_info: array_class.EntitiesInfo,
-    rigid_global_info: array_class.RigidGlobalInfo,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    """Decomposed noslip pass: parallel MinvJT solve, parallel AR/b build, force-update sweep, and dual finish.
-
-    Each top-level loop is an independent offloaded task with its own launch shape, with implicit barriers in
-    between. The MinvJT solve runs one thread per (row, env): each thread copies J[row] into its own MinvJT row and
-    solves M^{-1} in place via the row-indexed LDL^T substitution, with no shared buffers between rows. The AR build
-    runs one thread per (row, col, env) - nefc^2 * n_envs independent threads (~490K for typical scenes) - computing
-    AR[row, col, i_b] = sum_d J[col, d, i_b] * MinvJT[row, d, i_b]. On the serialized path, kernel_noslip_fused is
-    used instead.
-    """
-    len_c = constraint_state.MinvJT.shape[0]
-    _B = constraint_state.jac.shape[2]
-    n_dofs = constraint_state.jac.shape[1]
-
-    for i_row, i_b in qd.ndrange(len_c, _B):
-        if i_row < constraint_state.n_constraints[i_b]:
-            # Copy J[row] into MinvJT[row] (per-row buffer)
-            for i_d in range(n_dofs):
-                constraint_state.MinvJT[i_row, i_d, i_b] = constraint_state.jac[i_row, i_d, i_b]
-
-            # In-place solve: MinvJT[row] = M^{-1} @ J[row]
-            for i_0 in (
-                range(rigid_global_info.n_awake_entities[i_b])
-                if qd.static(static_rigid_sim_config.use_hibernation)
-                else range(entities_info.n_links.shape[0])
-            ):
-                i_e = (
-                    rigid_global_info.awake_entities[i_0, i_b]
-                    if qd.static(static_rigid_sim_config.use_hibernation)
-                    else i_0
-                )
-                func_solve_mass_entity_row(i_row, i_e, i_b, constraint_state.MinvJT, entities_info, rigid_global_info)
-
-    for i_row, i_col, i_b in qd.ndrange(len_c, len_c, _B):
-        nefc = constraint_state.n_constraints[i_b]
-        if i_row < nefc and i_col < nefc:
-            s = gs.qd_float(0.0)
-            for i_d in range(n_dofs):
-                s += constraint_state.jac[i_col, i_d, i_b] * constraint_state.MinvJT[i_row, i_d, i_b]
-            constraint_state.efc_AR[i_row, i_col, i_b] = s
-        else:
-            constraint_state.efc_AR[i_row, i_col, i_b] = gs.qd_float(0.0)
-
-    # Build efc_b
-    for i_c, i_b in qd.ndrange(len_c, _B):
-        if i_c < constraint_state.n_constraints[i_b]:
-            v = -constraint_state.aref[i_c, i_b]
-            for i_d in range(n_dofs):
-                v += constraint_state.jac[i_c, i_d, i_b] * dofs_state.acc_smooth[i_d, i_b]
-            constraint_state.efc_b[i_c, i_b] = v
-
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        func_noslip_batch(i_b, collider_state, constraint_state, rigid_global_info, static_rigid_sim_config)
+    if qd.static(static_rigid_sim_config.enable_per_island_solve):
+        # max_islands bounds the per-env island count (at most one island per link); the guard skips the unused tail.
+        max_islands = island_state.dof_slices.start.shape[0]
+        qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
+        for i_b, i_island in qd.ndrange(_B, max_islands):
+            if i_island < island_state.n_islands[i_b]:
+                run_island = True
+                if qd.static(static_rigid_sim_config.use_hibernation):
+                    run_island = not island_state.is_hibernated[i_island, i_b]
+                if run_island:
+                    func_noslip_batch(
+                        i_b,
+                        i_island,
+                        collider_state,
+                        dofs_state,
+                        constraint_state,
+                        rigid_global_info,
+                        island_state,
+                        static_rigid_sim_config,
+                    )
+    else:
+        qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
+        for i_b in range(_B):
+            func_noslip_batch(
+                i_b,
+                0,
+                collider_state,
+                dofs_state,
+                constraint_state,
+                rigid_global_info,
+                island_state,
+                static_rigid_sim_config,
+            )
 
     qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
         func_dual_finish_batch(
             i_b, dofs_state, entities_info, rigid_global_info, constraint_state, static_rigid_sim_config
         )
-
-
-@qd.func
-def func_extract_block_matrix_from_AR(
-    Ac,
-    i_b: int,
-    start: int,
-    n: int,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
-    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
-    for j in range(n):
-        for k in range(n):
-            Ac[j * n + k] = constraint_state.efc_AR[start + j, start + k, i_b_AR]
-    return Ac
-
-
-@qd.func
-def func_residual_constraint_force(
-    res,
-    i_b: int,
-    i_efc: int,
-    dim: int,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    # On the fused serialized path, efc_AR/efc_b are allocated with a single batch slot shared by all envs.
-    i_b_AR = 0 if qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL) else i_b
-    for j in range(dim):
-        res[j] = constraint_state.efc_b[i_efc + j, i_b_AR]
-        for k in range(constraint_state.n_constraints[i_b]):
-            res[j] += constraint_state.efc_AR[i_efc + j, k, i_b_AR] * constraint_state.efc_force[k, i_b]
-    return res
 
 
 @qd.func
@@ -451,43 +555,3 @@ def func_cost_change(
             force[force_start + i, i_b] = old_force[i]
         change = 0.0
     return change
-
-
-@qd.kernel(fastcache=True)
-def compute_A_diag(
-    entities_info: array_class.EntitiesInfo,
-    rigid_global_info: array_class.RigidGlobalInfo,
-    constraint_state: array_class.ConstraintState,
-    static_rigid_sim_config: qd.template(),
-):
-    _B = constraint_state.jac.shape[2]
-    n_dofs = constraint_state.jac.shape[1]
-    qd.loop_config(serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_b in range(_B):
-        # For each constraint row i: Ai = Ji * M^{-1} * Ji^T
-        for i_c in range(constraint_state.n_constraints[i_b]):
-            # tmp = M^{-1} * Ji^T
-            for i_d in range(n_dofs):
-                constraint_state.Mgrad[i_d, i_b] = constraint_state.jac[i_c, i_d, i_b]
-
-            rigid_solver.func_solve_mass_batch(
-                i_b,
-                constraint_state.Mgrad,
-                constraint_state.Mgrad,
-                None,
-                entities_info=entities_info,
-                rigid_global_info=rigid_global_info,
-                static_rigid_sim_config=static_rigid_sim_config,
-                is_backward=False,
-            )
-
-            # Ai = Ji * tmp
-            aii = gs.qd_float(0.0)
-            if qd.static(static_rigid_sim_config.sparse_solve):
-                for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
-                    i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
-                    aii += constraint_state.jac[i_c, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
-            else:
-                for i_d in range(n_dofs):
-                    aii += constraint_state.jac[i_c, i_d, i_b] * constraint_state.Mgrad[i_d, i_b]
-            constraint_state.efc_A_diag[i_c, i_b] = aii

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -488,9 +488,12 @@ def kernel_noslip(
 
     if qd.static(static_rigid_sim_config.enable_per_island_solve):
         # max_islands bounds the per-env island count (at most one island per link); the guard skips the unused tail.
+        # Iterate islands-major so that consecutive GPU lanes sweep the same island index across consecutive envs:
+        # envs are replicas of one scene, so lanes execute identical control flow (island sizes match) and the
+        # batch-contiguous field reads coalesce, instead of adjacent lanes diverging on different islands of one env.
         max_islands = island_state.dof_slices.start.shape[0]
         qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
-        for i_b, i_island in qd.ndrange(_B, max_islands):
+        for i_island, i_b in qd.ndrange(max_islands, _B):
             if i_island < island_state.n_islands[i_b]:
                 run_island = True
                 if qd.static(static_rigid_sim_config.use_hibernation):

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -25,22 +25,35 @@ from . import noslip as constraint_noslip
 
 
 @qd.func
-def _sort_relevant_dofs_descending(
+def _dedup_and_sort_relevant_dofs(
     constraint_state: array_class.ConstraintState,
     i_con: qd.int32,
     n: qd.int32,
     i_b: qd.int32,
     static_rigid_sim_config: qd.template(),
 ):
-    """Insertion sort jac_dofs_idx[i_con, :n, i_b] in descending order.
+    """Deduplicate jac_dofs_idx[i_con, :n, i_b], finalize jac_n_dofs, and insertion-sort in descending order.
 
-    Only the sparse skyline / incremental Cholesky relies on globally descending DOF order; the J.v / J^T.v products
-    and the per-island solves are order-independent. So the sort is skipped unless sparse_solve is set - it is a
-    serial (data-dependent) loop that would otherwise serialize the parallel contact-assembly kernel on GPU. The
-    array is typically <= 14 elements, so O(n^2) is fine.
+    A row coupling two links of the same kinematic tree walks both ancestor chains, so shared ancestor DOFs are
+    appended twice while the dense jac entry accumulates both contributions. Every sparse consumer (J.v / J^T.v
+    products, Hessian assembly, noslip residuals) treats the list as a set, so duplicates must be compacted here.
+    Only the sparse skyline / incremental Cholesky relies on globally descending DOF order, so the sort stays
+    skipped unless sparse_solve is set. The array is typically <= 14 elements, so O(n^2) is fine.
     """
+    n_unique = gs.qd_int(0)
+    for i in range(n):
+        key = constraint_state.jac_dofs_idx[i_con, i, i_b]
+        is_duplicate = False
+        for j in range(n_unique):
+            if constraint_state.jac_dofs_idx[i_con, j, i_b] == key:
+                is_duplicate = True
+        if not is_duplicate:
+            constraint_state.jac_dofs_idx[i_con, n_unique, i_b] = key
+            n_unique = n_unique + 1
+    constraint_state.jac_n_dofs[i_con, i_b] = n_unique
+
     if qd.static(static_rigid_sim_config.sparse_solve):
-        for i in range(1, n):
+        for i in range(1, n_unique):
             key = constraint_state.jac_dofs_idx[i_con, i, i_b]
             j = i - 1
             while j >= 0 and constraint_state.jac_dofs_idx[i_con, j, i_b] < key:
@@ -690,7 +703,7 @@ def _add_friction_constraint(
             link = links_info.parent_idx[link_maybe_batch]
 
     constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-    _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+    _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
     imp, aref = gu.imp_aref(contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration)
 
     diag = invweight + contact_data_friction * contact_data_friction * invweight
@@ -868,7 +881,7 @@ def _add_collision_constraints_per_contact(
                         link = links_info.parent_idx[link_maybe_batch]
 
                 constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-                _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+                _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
                 imp, aref = gu.imp_aref(
                     contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration
                 )
@@ -1019,7 +1032,7 @@ def func_equality_connect(
         constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
         # Sort needed: DOFs from two entities are only descending within each
         # entity. Incremental Cholesky requires globally descending order.
-        _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+        _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
         pos_diff = global_anchor1 - global_anchor2
         penetration = pos_diff.norm()
@@ -1121,7 +1134,7 @@ def func_equality_joint(
         constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_dof2
         con_n_dofs += 1
     constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-    _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+    _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
 
 @qd.kernel(fastcache=True)
@@ -1502,7 +1515,7 @@ def func_equality_weld(
                 link = links_info.parent_idx[link_maybe_batch]
 
         constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-        _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+        _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
         imp, aref = gu.imp_aref(sol_params, -pos_imp, jac_qvel, pos_error[i])
         diag = qd.max(invweight[0] * (1 - imp) / imp, EPS)
@@ -1563,7 +1576,7 @@ def func_equality_weld(
 
     for i_con in range(n_con, n_con + 3):
         constraint_state.jac_n_dofs[i_con, i_b] = con_n_dofs
-        _sort_relevant_dofs_descending(constraint_state, i_con, con_n_dofs, i_b, static_rigid_sim_config)
+        _dedup_and_sort_relevant_dofs(constraint_state, i_con, con_n_dofs, i_b, static_rigid_sim_config)
 
     for i_con in range(n_con, n_con + 3):
         imp, aref = gu.imp_aref(sol_params, -pos_imp, jac_qvel[i_con - n_con], rot_error[i_con - n_con])

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -318,7 +318,6 @@ class ConstraintSolver:
         constraint_noslip.kernel_noslip(
             self._collider._collider_state,
             self._solver.dofs_state,
-            self._solver.entities_info,
             self._solver._rigid_global_info,
             self.constraint_state,
             self.island_state,

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -302,29 +302,15 @@ class ConstraintSolver:
         )
 
     def noslip(self):
-        if self._solver._para_level >= gs.PARA_LEVEL.PARTIAL:
-            # GPU (any n_envs): one kernel decomposed into per-phase offloaded tasks, so that each phase keeps its
-            # own parallel launch shape.
-            constraint_noslip.kernel_noslip_decomposed(
-                self._collider._collider_state,
-                self._solver.dofs_state,
-                self._solver.entities_info,
-                self._solver._rigid_global_info,
-                self.constraint_state,
-                self._solver._static_rigid_sim_config,
-            )
-        else:
-            # Serialized (CPU): single fused kernel processing each env end-to-end, so that the per-env AR scratch stays
-            # cache-hot between the AR build and the force-update sweep (func_noslip_batch).
-            constraint_noslip.kernel_noslip_fused(
-                self._collider._collider_state,
-                self._solver.dofs_state,
-                self._solver.entities_info,
-                self._solver._rigid_global_info,
-                self.constraint_state,
-                self.island_state,
-                self._solver._static_rigid_sim_config,
-            )
+        constraint_noslip.kernel_noslip(
+            self._collider._collider_state,
+            self._solver.dofs_state,
+            self._solver.entities_info,
+            self._solver._rigid_global_info,
+            self.constraint_state,
+            self.island_state,
+            self._solver._static_rigid_sim_config,
+        )
 
     def get_equality_constraints(self, as_tensor: bool = True, to_torch: bool = True):
         # Early return if already pre-computed

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -31,6 +31,7 @@ def _append_relevant_dof(
     i_d: qd.int32,
     n: qd.int32,
     i_b: qd.int32,
+    dedup: qd.int32,
 ):
     """Append dof i_d to jac_dofs_idx[i_con, :n, i_b] unless already present, returning the new count.
 
@@ -38,12 +39,15 @@ def _append_relevant_dof(
     twice: every sparse consumer (J.v / J^T.v products, Hessian assembly, noslip residuals) treats the list as a
     set, and appending duplicates blindly can push the count past the row capacity (n_dofs), spilling into the next
     row. The serialized CPU assembly rebuilds rows in index order and self-heals the spill, but the parallel GPU
-    assembly does not, leaving clobbered supports. The list is typically <= 14 elements, so the O(n) scan is fine.
+    assembly does not, leaving clobbered supports. Duplicates only ever arise while walking the second chain of a
+    row whose links share a kinematic root, so callers pass dedup=False everywhere else and the O(n) scan - which
+    costs >10% on contact-heavy free-body scenes - is skipped.
     """
     is_new = True
-    for j in range(n):
-        if constraint_state.jac_dofs_idx[i_con, j, i_b] == i_d:
-            is_new = False
+    if dedup:
+        for j in range(n):
+            if constraint_state.jac_dofs_idx[i_con, j, i_b] == i_d:
+                is_new = False
     if is_new:
         constraint_state.jac_dofs_idx[i_con, n, i_b] = i_d
         n = n + 1
@@ -681,6 +685,7 @@ def _add_friction_constraint(
         for i_d in range(n_dofs):
             constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
 
+    same_root = link_b > -1 and links_info.root_idx[link_a_maybe_batch] == links_info.root_idx[link_b_maybe_batch]
     con_n_dofs = 0
     jac_qvel = gs.qd_float(0.0)
     for i_ab in range(2):
@@ -709,7 +714,9 @@ def _add_friction_constraint(
                 jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                 constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
+                con_n_dofs = _append_relevant_dof(
+                    constraint_state, n_con, i_d, con_n_dofs, i_b, i_ab == 1 and same_root
+                )
 
             link = links_info.parent_idx[link_maybe_batch]
 
@@ -858,6 +865,9 @@ def _add_collision_constraints_per_contact(
                     for i_d in range(n_dofs):
                         constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
 
+                same_root = (
+                    link_b > -1 and links_info.root_idx[link_a_maybe_batch] == links_info.root_idx[link_b_maybe_batch]
+                )
                 con_n_dofs = 0
                 jac_qvel = gs.qd_float(0.0)
                 for i_ab in range(2):
@@ -886,7 +896,9 @@ def _add_collision_constraints_per_contact(
                             jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                             constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                            con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
+                            con_n_dofs = _append_relevant_dof(
+                                constraint_state, n_con, i_d, con_n_dofs, i_b, i_ab == 1 and same_root
+                            )
 
                         link = links_info.parent_idx[link_maybe_batch]
 
@@ -1006,6 +1018,9 @@ def func_equality_connect(
             for i_d in range(n_dofs):
                 constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
 
+        same_root = (
+            link2_idx > -1 and links_info.root_idx[link_a_maybe_batch] == links_info.root_idx[link_b_maybe_batch]
+        )
         jac_qvel = gs.qd_float(0.0)
         for i_ab in range(2):
             sign = gs.qd_float(1.0)
@@ -1034,7 +1049,9 @@ def func_equality_connect(
                     jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                     constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                    con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
+                    con_n_dofs = _append_relevant_dof(
+                        constraint_state, n_con, i_d, con_n_dofs, i_b, i_ab == 1 and same_root
+                    )
 
                 link = links_info.parent_idx[link_maybe_batch]
 
@@ -1482,6 +1499,7 @@ def func_equality_weld(
     invweight = links_info.invweight[link_a_maybe_batch] + links_info.invweight[link_b_maybe_batch]
 
     # --- Position part (first 3 constraints) ---
+    same_root = link2_idx > -1 and links_info.root_idx[link_a_maybe_batch] == links_info.root_idx[link_b_maybe_batch]
     for i in range(3):
         n_con = qd.atomic_add(constraint_state.n_constraints[i_b], 1)
         qd.atomic_add(constraint_state.n_constraints_equality[i_b], 1)
@@ -1519,7 +1537,9 @@ def func_equality_weld(
                     jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                     constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                    con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
+                    con_n_dofs = _append_relevant_dof(
+                        constraint_state, n_con, i_d, con_n_dofs, i_b, i_ab == 1 and same_root
+                    )
                 link = links_info.parent_idx[link_maybe_batch]
 
         constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
@@ -1559,7 +1579,9 @@ def func_equality_weld(
                 # it so sparse assembly does not drop them. (The position part above does the same per constraint.)
                 n_dofs_new = con_n_dofs
                 for i_con in range(n_con, n_con + 3):
-                    n_dofs_new = _append_relevant_dof(constraint_state, i_con, i_d, con_n_dofs, i_b)
+                    n_dofs_new = _append_relevant_dof(
+                        constraint_state, i_con, i_d, con_n_dofs, i_b, i_ab == 1 and same_root
+                    )
                 con_n_dofs = n_dofs_new
             link = links_info.parent_idx[link_maybe_batch]
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -25,35 +25,48 @@ from . import noslip as constraint_noslip
 
 
 @qd.func
-def _dedup_and_sort_relevant_dofs(
+def _append_relevant_dof(
+    constraint_state: array_class.ConstraintState,
+    i_con: qd.int32,
+    i_d: qd.int32,
+    n: qd.int32,
+    i_b: qd.int32,
+):
+    """Append dof i_d to jac_dofs_idx[i_con, :n, i_b] unless already present, returning the new count.
+
+    A row coupling two links of the same kinematic tree walks both ancestor chains, so shared ancestor DOFs come up
+    twice: every sparse consumer (J.v / J^T.v products, Hessian assembly, noslip residuals) treats the list as a
+    set, and appending duplicates blindly can push the count past the row capacity (n_dofs), spilling into the next
+    row. The serialized CPU assembly rebuilds rows in index order and self-heals the spill, but the parallel GPU
+    assembly does not, leaving clobbered supports. The list is typically <= 14 elements, so the O(n) scan is fine.
+    """
+    is_new = True
+    for j in range(n):
+        if constraint_state.jac_dofs_idx[i_con, j, i_b] == i_d:
+            is_new = False
+    if is_new:
+        constraint_state.jac_dofs_idx[i_con, n, i_b] = i_d
+        n = n + 1
+    return n
+
+
+@qd.func
+def _sort_relevant_dofs_descending(
     constraint_state: array_class.ConstraintState,
     i_con: qd.int32,
     n: qd.int32,
     i_b: qd.int32,
     static_rigid_sim_config: qd.template(),
 ):
-    """Deduplicate jac_dofs_idx[i_con, :n, i_b], finalize jac_n_dofs, and insertion-sort in descending order.
+    """Insertion sort jac_dofs_idx[i_con, :n, i_b] in descending order.
 
-    A row coupling two links of the same kinematic tree walks both ancestor chains, so shared ancestor DOFs are
-    appended twice while the dense jac entry accumulates both contributions. Every sparse consumer (J.v / J^T.v
-    products, Hessian assembly, noslip residuals) treats the list as a set, so duplicates must be compacted here.
-    Only the sparse skyline / incremental Cholesky relies on globally descending DOF order, so the sort stays
-    skipped unless sparse_solve is set. The array is typically <= 14 elements, so O(n^2) is fine.
+    Only the sparse skyline / incremental Cholesky relies on globally descending DOF order; the J.v / J^T.v products
+    and the per-island solves are order-independent. So the sort is skipped unless sparse_solve is set - it is a
+    serial (data-dependent) loop that would otherwise serialize the parallel contact-assembly kernel on GPU. The
+    array is typically <= 14 elements, so O(n^2) is fine.
     """
-    n_unique = gs.qd_int(0)
-    for i in range(n):
-        key = constraint_state.jac_dofs_idx[i_con, i, i_b]
-        is_duplicate = False
-        for j in range(n_unique):
-            if constraint_state.jac_dofs_idx[i_con, j, i_b] == key:
-                is_duplicate = True
-        if not is_duplicate:
-            constraint_state.jac_dofs_idx[i_con, n_unique, i_b] = key
-            n_unique = n_unique + 1
-    constraint_state.jac_n_dofs[i_con, i_b] = n_unique
-
     if qd.static(static_rigid_sim_config.sparse_solve):
-        for i in range(1, n_unique):
+        for i in range(1, n):
             key = constraint_state.jac_dofs_idx[i_con, i, i_b]
             j = i - 1
             while j >= 0 and constraint_state.jac_dofs_idx[i_con, j, i_b] < key:
@@ -696,13 +709,12 @@ def _add_friction_constraint(
                 jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                 constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
-                con_n_dofs = con_n_dofs + 1
+                con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
 
             link = links_info.parent_idx[link_maybe_batch]
 
     constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-    _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+    _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
     imp, aref = gu.imp_aref(contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration)
 
     diag = invweight + contact_data_friction * contact_data_friction * invweight
@@ -874,13 +886,12 @@ def _add_collision_constraints_per_contact(
                             jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                             constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                            constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
-                            con_n_dofs = con_n_dofs + 1
+                            con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
 
                         link = links_info.parent_idx[link_maybe_batch]
 
                 constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-                _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+                _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
                 imp, aref = gu.imp_aref(
                     contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration
                 )
@@ -1023,15 +1034,14 @@ def func_equality_connect(
                     jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                     constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                    constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
-                    con_n_dofs = con_n_dofs + 1
+                    con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
 
                 link = links_info.parent_idx[link_maybe_batch]
 
         constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
         # Sort needed: DOFs from two entities are only descending within each
         # entity. Incremental Cholesky requires globally descending order.
-        _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+        _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
         pos_diff = global_anchor1 - global_anchor2
         penetration = pos_diff.norm()
@@ -1133,7 +1143,7 @@ def func_equality_joint(
         constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_dof2
         con_n_dofs += 1
     constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-    _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+    _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
 
 @qd.kernel(fastcache=True)
@@ -1509,12 +1519,11 @@ def func_equality_weld(
                     jac_qvel = jac_qvel + jac * dofs_state.vel[i_d, i_b]
                     constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
-                    constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_d
-                    con_n_dofs = con_n_dofs + 1
+                    con_n_dofs = _append_relevant_dof(constraint_state, n_con, i_d, con_n_dofs, i_b)
                 link = links_info.parent_idx[link_maybe_batch]
 
         constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs
-        _dedup_and_sort_relevant_dofs(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
+        _sort_relevant_dofs_descending(constraint_state, n_con, con_n_dofs, i_b, static_rigid_sim_config)
 
         imp, aref = gu.imp_aref(sol_params, -pos_imp, jac_qvel, pos_error[i])
         diag = qd.max(invweight[0] * (1 - imp) / imp, EPS)
@@ -1548,9 +1557,10 @@ def func_equality_weld(
 
                 # The 3 orientation constraints share the same support (the DOFs along both kinematic chains); record
                 # it so sparse assembly does not drop them. (The position part above does the same per constraint.)
+                n_dofs_new = con_n_dofs
                 for i_con in range(n_con, n_con + 3):
-                    constraint_state.jac_dofs_idx[i_con, con_n_dofs, i_b] = i_d
-                con_n_dofs = con_n_dofs + 1
+                    n_dofs_new = _append_relevant_dof(constraint_state, i_con, i_d, con_n_dofs, i_b)
+                con_n_dofs = n_dofs_new
             link = links_info.parent_idx[link_maybe_batch]
 
     jac_qvel = qd.Vector([0.0, 0.0, 0.0])
@@ -1575,7 +1585,7 @@ def func_equality_weld(
 
     for i_con in range(n_con, n_con + 3):
         constraint_state.jac_n_dofs[i_con, i_b] = con_n_dofs
-        _dedup_and_sort_relevant_dofs(constraint_state, i_con, con_n_dofs, i_b, static_rigid_sim_config)
+        _sort_relevant_dofs_descending(constraint_state, i_con, con_n_dofs, i_b, static_rigid_sim_config)
 
     for i_con in range(n_con, n_con + 3):
         imp, aref = gu.imp_aref(sol_params, -pos_imp, jac_qvel[i_con - n_con], rot_error[i_con - n_con])

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -271,13 +271,10 @@ class ConstraintState:
     Ma_ws: qd.Tensor
     grad: qd.Tensor
     Mgrad: qd.Tensor
-    MinvJT: qd.Tensor
     search: qd.Tensor
     efc_D: qd.Tensor
     efc_frictionloss: qd.Tensor
     efc_force: qd.Tensor
-    efc_b: qd.Tensor
-    efc_AR: qd.Tensor
     active: qd.Tensor
     prev_active: qd.Tensor
     qfrc_constraint: qd.Tensor
@@ -398,14 +395,6 @@ def get_constraint_state(constraint_solver, solver):
     )
 
     jac_shape = (len_constraints_, solver.n_dofs_, _B)
-    # The decomposed (parallel) noslip build computes MinvJT and efc_AR/efc_b for all envs before the force-update
-    # sweep. The serialized path instead fuses build, sweep, and finish per env (kernel_noslip_fused): each env consumes
-    # its AR block right after writing it, so a single batch slot shared by all envs suffices. This keeps the scratch
-    # cache-hot across the fused phases and shrinks its memory footprint by n_envs, and MinvJT is never needed.
-    noslip = solver._options.noslip_iterations > 0
-    noslip_decomposed = noslip and solver._static_rigid_sim_config.para_level >= gs.PARA_LEVEL.PARTIAL
-    efc_AR_shape = maybe_shape((len_constraints_, len_constraints_, _B if noslip_decomposed else 1), noslip)
-    efc_b_shape = maybe_shape((len_constraints_, _B if noslip_decomposed else 1), noslip)
     # The sparse-Jacobian representation is always active, so its index buffers are always allocated. The skyline DOF
     # permutation/envelope buffers stay gated on sparse_solve (CPU-only skyline Cholesky).
     jac_dofs_idx_shape = jac_shape
@@ -415,12 +404,6 @@ def get_constraint_state(constraint_solver, solver):
     if math.prod(jac_shape) > np.iinfo(np.int32).max:
         gs.raise_exception(
             f"Jacobian shape (n_constraints={len_constraints_}, n_dofs={solver.n_dofs_}, n_envs={_B}) is too large."
-        )
-    if math.prod(efc_AR_shape) > np.iinfo(np.int32).max:
-        gs.raise_exception(
-            f"efc_AR shape (n_constraints={len_constraints_}, n_constraints={len_constraints_}, "
-            f"n_envs={efc_AR_shape[2]}) is too large. Consider setting a smaller 'max_contacts' in RigidOptions "
-            "to reduce the size of reserved memory."
         )
 
     # /!\ Changing allocation order of these tensors may reduce runtime speed by >10%  /!\
@@ -450,7 +433,6 @@ def get_constraint_state(constraint_solver, solver):
         Ma_ws=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         grad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         Mgrad=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
-        MinvJT=V(dtype=gs.qd_float, shape=maybe_shape(jac_shape, noslip_decomposed)),
         search=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         qfrc_constraint=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
         qacc=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),
@@ -474,8 +456,6 @@ def get_constraint_state(constraint_solver, solver):
         dof_sort_key=V(dtype=gs.qd_float, shape=sparse_dof_shape),
         incr_changed_idx=V(dtype=gs.qd_int, shape=(len_constraints_, _B), layout=serial_layout),
         incr_n_changed=V(dtype=gs.qd_int, shape=(_B,)),
-        efc_b=V(dtype=gs.qd_float, shape=efc_b_shape),
-        efc_AR=V(dtype=gs.qd_float, shape=efc_AR_shape),
         # Layout-flippable constraint-state tensors: allocated as qd.Tensor wrappers, optionally with
         # ``layout=(1, 0)`` to physically store as (_B, len_constraints_). Canonical shape stays (len_constraints_, _B);
         # kernel-body indexing ``Jaref[i_c, i_b]`` is rewritten by the AST when ``layout != None``.

--- a/tests/test_rigid_physics_sparse.py
+++ b/tests/test_rigid_physics_sparse.py
@@ -4,6 +4,8 @@ import pytest
 
 from genesis.utils.misc import tensor_to_array
 
+from .utils import assert_allclose
+
 
 @pytest.mark.slow("gpu")  # gpu ~250s
 @pytest.mark.required
@@ -55,3 +57,28 @@ def test_sparse_solve_no_nan(backend, precision):
         pos = tensor_to_array(box.get_pos())
         assert not np.any(np.isnan(pos)), f"box_{i} has NaN position"
         assert np.all(np.abs(pos) < 10), f"box_{i} has unreasonable position: {pos}"
+
+
+@pytest.mark.required
+def test_self_collision_sparse_dense_consistency():
+    # Pose folding the arm into link2 / left_finger contact: rows coupling two links of the same kinematic tree carry
+    # both ancestor chains in their dof support, which the sparse consumers must treat as a set.
+    vels = []
+    for sparse_solve in (False, True):
+        scene = gs.Scene(
+            rigid_options=gs.options.RigidOptions(
+                noslip_iterations=2,
+                sparse_solve=sparse_solve,
+            ),
+            show_viewer=False,
+        )
+        franka = scene.add_entity(
+            morph=gs.morphs.MJCF(
+                file="xml/franka_emika_panda/panda.xml",
+            ),
+        )
+        scene.build()
+        franka.set_qpos([-0.2326, -1.6055, 1.7372, -2.7745, 0.1091, 0.9083, 0.4493, 0.0384, 0.0258])
+        scene.step()
+        vels.append(tensor_to_array(franka.get_dofs_velocity()))
+    assert_allclose(vels[0], vels[1], rtol=1e-4, atol=1e-5)

--- a/tests/test_rigid_physics_sparse.py
+++ b/tests/test_rigid_physics_sparse.py
@@ -11,19 +11,12 @@ from .utils import assert_allclose
 @pytest.mark.slow("gpu")  # gpu ~250s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_sparse_noslip_resting_stability(backend, show_viewer):
-    # FIXME: Resting boxes never settle on Apple Metal (tipping and mm-scale penetration); this reproduces on a
-    # pristine tree with noslip disabled and with box_box_detection, so it is a backend issue, not a solver-pass one.
-    if sys.platform == "darwin" and backend == gs.gpu:
-        pytest.xfail(reason="Resting box stacks are unstable on Apple Metal.")
-
+def test_sparse_noslip_resting_stability(show_viewer):
     TABLE_Z = 0.762
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
-            dt=1.0 / 30,
-            substeps=4,
-            gravity=(0, 0, -9.81),
+            dt=0.004,
         ),
         rigid_options=gs.options.RigidOptions(
             noslip_iterations=2,
@@ -70,6 +63,7 @@ def test_sparse_noslip_resting_stability(backend, show_viewer):
             surface=gs.surfaces.Default(
                 color=(0.3 + 0.7 * (i % 4) / 3, 0.3 + 0.7 * (i // 4) / 3, 0.5, 1.0),
             ),
+            visualize_contact=True,
         )
         boxes.append(box)
 
@@ -78,7 +72,7 @@ def test_sparse_noslip_resting_stability(backend, show_viewer):
     # Hold the arm at its initial configuration, otherwise it collapses under gravity and sweeps the boxes off.
     franka.control_dofs_position(franka.get_qpos())
 
-    for _ in range(60):
+    for _ in range(80):
         scene.step()
 
     # The boxes must come to rest flat on the table top, neither penetrating nor bouncing, and noslip must prevent

--- a/tests/test_rigid_physics_sparse.py
+++ b/tests/test_rigid_physics_sparse.py
@@ -20,7 +20,11 @@ def test_sparse_noslip_resting_stability(backend, show_viewer):
     TABLE_Z = 0.762
 
     scene = gs.Scene(
-        sim_options=gs.options.SimOptions(dt=1.0 / 30, substeps=4, gravity=(0, 0, -9.81)),
+        sim_options=gs.options.SimOptions(
+            dt=1.0 / 30,
+            substeps=4,
+            gravity=(0, 0, -9.81),
+        ),
         rigid_options=gs.options.RigidOptions(
             noslip_iterations=2,
             max_collision_pairs=128,
@@ -54,11 +58,18 @@ def test_sparse_noslip_resting_stability(backend, show_viewer):
         x = 0.4 + 0.12 * (i % 4)
         y = -0.25 + 0.12 * (i // 4)
         box = scene.add_entity(
-            material=gs.materials.Rigid(friction=0.5),
+            material=gs.materials.Rigid(
+                friction=0.5,
+            ),
             # Drop from just above the resting height: a high drop makes the landing chaotic across precisions,
             # while the point here is the stability of the resting contacts.
-            morph=gs.morphs.Box(pos=(x, y, 0.75 * TABLE_Z + 0.025), size=(0.04, 0.04, 0.04)),
-            surface=gs.surfaces.Default(color=(0.3 + 0.7 * (i % 4) / 3, 0.3 + 0.7 * (i // 4) / 3, 0.5, 1.0)),
+            morph=gs.morphs.Box(
+                pos=(x, y, 0.75 * TABLE_Z + 0.025),
+                size=(0.04, 0.04, 0.04),
+            ),
+            surface=gs.surfaces.Default(
+                color=(0.3 + 0.7 * (i % 4) / 3, 0.3 + 0.7 * (i // 4) / 3, 0.5, 1.0),
+            ),
         )
         boxes.append(box)
 

--- a/tests/test_rigid_physics_sparse.py
+++ b/tests/test_rigid_physics_sparse.py
@@ -1,8 +1,9 @@
+import sys
+
 import genesis as gs
-import numpy as np
 import pytest
 
-from genesis.utils.misc import tensor_to_array
+import genesis.utils.geom as gu
 
 from .utils import assert_allclose
 
@@ -10,8 +11,14 @@ from .utils import assert_allclose
 @pytest.mark.slow("gpu")  # gpu ~250s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_sparse_solve_no_nan(backend, precision):
+def test_sparse_noslip_resting_stability(backend):
+    # FIXME: Resting boxes never settle on Apple Metal (tipping and mm-scale penetration); this reproduces on a
+    # pristine tree with noslip disabled and with box_box_detection, so it is a backend issue, not a solver-pass one.
+    if sys.platform == "darwin" and backend == gs.gpu:
+        pytest.xfail(reason="Resting box stacks are unstable on Apple Metal.")
+
     TABLE_Z = 0.762
+
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(dt=1.0 / 30, substeps=4, gravity=(0, 0, -9.81)),
         rigid_options=gs.options.RigidOptions(
@@ -22,7 +29,7 @@ def test_sparse_solve_no_nan(backend, precision):
         show_viewer=False,
     )
 
-    scene.add_entity(
+    franka = scene.add_entity(
         morph=gs.morphs.URDF(
             file="urdf/panda_bullet/panda.urdf",
             pos=(0, 0, TABLE_Z),
@@ -39,36 +46,44 @@ def test_sparse_solve_no_nan(backend, precision):
 
     boxes = []
     for i in range(16):
-        x = 0.25 + 0.12 * (i % 5)
-        y = -0.25 + 0.12 * (i // 5)
+        # Keep the grid clear of the arm: boxes dropped closer to the base land on the panda instead of the table.
+        x = 0.4 + 0.12 * (i % 4)
+        y = -0.25 + 0.12 * (i // 4)
         box = scene.add_entity(
             material=gs.materials.Rigid(friction=0.5),
-            morph=gs.morphs.Box(pos=(x, y, TABLE_Z + 0.08), size=(0.04, 0.04, 0.04)),
+            # Drop from just above the resting height: a high drop makes the landing chaotic across precisions,
+            # while the point here is the stability of the resting contacts.
+            morph=gs.morphs.Box(pos=(x, y, 0.75 * TABLE_Z + 0.025), size=(0.04, 0.04, 0.04)),
         )
         boxes.append(box)
 
     scene.build()
 
-    for step in range(20):
+    # Hold the arm at its initial configuration, otherwise it collapses under gravity and sweeps the boxes off.
+    franka.control_dofs_position(franka.get_qpos())
+
+    for _ in range(60):
         scene.step()
 
-    # Verify no NaN in positions
-    for i, box in enumerate(boxes):
-        pos = tensor_to_array(box.get_pos())
-        assert not np.any(np.isnan(pos)), f"box_{i} has NaN position"
-        assert np.all(np.abs(pos) < 10), f"box_{i} has unreasonable position: {pos}"
+    # The boxes must come to rest flat on the table top, neither penetrating nor bouncing, and noslip must prevent
+    # any sideways creep or spin away from the drop pose.
+    assert_allclose([box.get_pos()[2] for box in boxes], 0.75 * TABLE_Z + 0.02, tol=2e-4)
+    assert_allclose([box.get_pos()[:2] for box in boxes], [box.morph.pos[:2] for box in boxes], tol=1e-5)
+    assert_allclose([gu.quat_to_xyz(box.get_quat()) for box in boxes], 0.0, tol=1e-5)
+    assert_allclose([box.get_vel() for box in boxes], 0.0, tol=1e-4)
+    assert_allclose([box.get_ang() for box in boxes], 0.0, tol=5e-4)
 
 
 @pytest.mark.required
-def test_self_collision_sparse_dense_consistency():
+def test_self_collision_sparse_dense_consistency(tol):
     # Pose folding the arm into link2 / left_finger contact: rows coupling two links of the same kinematic tree carry
     # both ancestor chains in their dof support, which the sparse consumers must treat as a set.
     vels = []
     for sparse_solve in (False, True):
         scene = gs.Scene(
             rigid_options=gs.options.RigidOptions(
-                noslip_iterations=2,
                 sparse_solve=sparse_solve,
+                noslip_iterations=2,
             ),
             show_viewer=False,
         )
@@ -79,6 +94,9 @@ def test_self_collision_sparse_dense_consistency():
         )
         scene.build()
         franka.set_qpos([-0.2326, -1.6055, 1.7372, -2.7745, 0.1091, 0.9083, 0.4493, 0.0384, 0.0258])
+
         scene.step()
-        vels.append(tensor_to_array(franka.get_dofs_velocity()))
-    assert_allclose(vels[0], vels[1], rtol=1e-4, atol=1e-5)
+
+        vels.append(franka.get_dofs_velocity())
+
+    assert_allclose(*vels, tol=tol)

--- a/tests/test_rigid_physics_sparse.py
+++ b/tests/test_rigid_physics_sparse.py
@@ -11,7 +11,7 @@ from .utils import assert_allclose
 @pytest.mark.slow("gpu")  # gpu ~250s
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_sparse_noslip_resting_stability(backend):
+def test_sparse_noslip_resting_stability(backend, show_viewer):
     # FIXME: Resting boxes never settle on Apple Metal (tipping and mm-scale penetration); this reproduces on a
     # pristine tree with noslip disabled and with box_box_detection, so it is a backend issue, not a solver-pass one.
     if sys.platform == "darwin" and backend == gs.gpu:
@@ -26,7 +26,11 @@ def test_sparse_noslip_resting_stability(backend):
             max_collision_pairs=128,
             sparse_solve=True,
         ),
-        show_viewer=False,
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.7, -1.1, 1.4),
+            camera_lookat=(0.4, 0.0, 0.75),
+        ),
+        show_viewer=show_viewer,
     )
 
     franka = scene.add_entity(
@@ -54,6 +58,7 @@ def test_sparse_noslip_resting_stability(backend):
             # Drop from just above the resting height: a high drop makes the landing chaotic across precisions,
             # while the point here is the stability of the resting contacts.
             morph=gs.morphs.Box(pos=(x, y, 0.75 * TABLE_Z + 0.025), size=(0.04, 0.04, 0.04)),
+            surface=gs.surfaces.Default(color=(0.3 + 0.7 * (i % 4) / 3, 0.3 + 0.7 * (i // 4) / 3, 0.5, 1.0)),
         )
         boxes.append(box)
 


### PR DESCRIPTION
## Description

Rewrite the noslip pass to be matrix-free and parallel over (env, island):

- The sweep maintains `qacc = acc_smooth + M^-1 J^T f` and evaluates residuals as `res_r = J_r * qacc - aref_r` instead of materializing the dense dual matrix `AR = J M^-1 J^T`: cost drops from `O(nefc^2)` to `O(nefc * row_support)` per iteration, and the quadratic `efc_AR` / `efc_b` / `MinvJT` buffers are removed, along with the silent 128-contact cap they motivated.
- Force updates propagate to `qacc` through `M^-1` restricted to the row's mass blocks, which never cross islands, so islands are swept concurrently on the (env, island) grid with per-island early-break.
- Bug fix: the frictionloss improvement term divided by `A[i, i]` where MuJoCo divides by the precomputed *inverse* diagonal, i.e. multiplies; only the early-break criterion was affected.
- Bug fix: same-tree constraint rows listed shared ancestor dofs twice in `jac_dofs_idx`, double-counting them in every sparse consumer and overflowing the row capacity into the next row under the parallel GPU assembly. Now deduplicated during the chain walk - only for rows whose links share a kinematic root, since cross-tree rows cannot repeat DOFs and the scan costs up to 16% on contact-heavy free-body scenes - with a sparse/dense consistency regression test.

## Motivation and Context

The dense `AR` dominated noslip cost and made many-env GPU noslip impossible (int32 raise at 4096 envs). On `shadow_hand_cubes` (`noslip_iterations=2`, equal contact budget, env-FPS):

| | 512 envs | 2048 envs | 4096 envs |
|---|---|---|---|
| before | 649 | 341 | raises |
| after | 2472 | 6378 | 6005 |

CPU (`tower.py`, 3000 steps): 115.4s -> 24.0s. Apple Metal (same scene and budget as the table, 512 envs): 143 -> 672 env-FPS. Kernel compile times improve as well.

## How Has This Been / Can This Be Tested?

`test_noslip_iterations` on CPU and Metal, `test_solve_correctness` (islands + noslip), and `test_rigid_physics_sparse.py` all pass. `examples/collision/tower.py` with `noslip_iterations=3` stays arrested over the full horizon, matching the previous implementation.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.





