### PR TITLE
[BUG FIX] Fix contact-pruning bucket merging, zero-copy views of fields past 2^31 bytes, and cooperative-kernel gating.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -128,20 +128,31 @@ class Collider:
             self._init_multicontact_gjk_state()
 
         if gs.use_zerocopy:
-            self._contact_data: dict[str, torch.Tensor] = {}
-            for key, name in (
-                ("link_a", "link_a"),
-                ("link_b", "link_b"),
-                ("geom_a", "geom_a"),
-                ("geom_b", "geom_b"),
-                ("penetration", "penetration"),
-                ("position", "pos"),
-                ("normal", "normal"),
-                ("force", "force"),
-            ):
-                self._contact_data[key] = qd_to_torch(
-                    getattr(self._collider_state.contact_data, name), transpose=True, copy=False
-                )
+            # Probe every view the zero-copy contact query needs (including the per-call n_contacts and
+            # contact_sort_idx ones, which qd_to_torch caches on their fields). If any field sits past 2**31 bytes
+            # in its SNode tree no zero-copy view exists, and get_contacts falls back to the gather-kernel path.
+            self._contact_data: dict[str, torch.Tensor] | None = {}
+            try:
+                qd_to_torch(self._collider_state.n_contacts, copy=False)
+                qd_to_torch(self._collider_state.contact_sort_idx, transpose=True, copy=False)
+                qd_to_torch(self._collider_state.first_time, copy=False)
+                qd_to_torch(self._collider_state.contact_cache.normal, copy=False)
+                qd_to_torch(self._collider_state.contact_cache.penetration, copy=False)
+                for key, name in (
+                    ("link_a", "link_a"),
+                    ("link_b", "link_b"),
+                    ("geom_a", "geom_a"),
+                    ("geom_b", "geom_b"),
+                    ("penetration", "penetration"),
+                    ("position", "pos"),
+                    ("normal", "normal"),
+                    ("force", "force"),
+                ):
+                    self._contact_data[key] = qd_to_torch(
+                        getattr(self._collider_state.contact_data, name), transpose=True, copy=False
+                    )
+            except ValueError:
+                self._contact_data = None
 
         # Make sure that the initial state is clean
         self.clear()
@@ -703,7 +714,7 @@ class Collider:
 
     def reset(self, envs_idx=None, *, cache_only: bool = True) -> None:
         self._contact_data_cache.clear()
-        if gs.use_zerocopy:
+        if gs.use_zerocopy and self._contact_data is not None:
             envs_idx = slice(None) if envs_idx is None else envs_idx
             if not cache_only:
                 first_time = qd_to_torch(self._collider_state.first_time, copy=False)
@@ -740,6 +751,7 @@ class Collider:
 
         if (
             gs.use_zerocopy
+            and self._contact_data is not None
             and not self._solver._use_hibernation
             and (not isinstance(envs_idx, torch.Tensor) or (not IS_OLD_TORCH or envs_idx.dtype == torch.bool))
         ):
@@ -991,7 +1003,7 @@ class Collider:
             not self._collider_static_config.has_prunable_contacts
             and not self._collider_static_config.spatial_sort_supported
         )
-        if gs.use_zerocopy:
+        if gs.use_zerocopy and self._contact_data is not None:
             n_contacts = qd_to_torch(self._collider_state.n_contacts, copy=False)
             if as_tensor or n_envs == 0:
                 n_contacts_max = (n_contacts if n_envs == 0 else n_contacts.max()).item()

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -1091,10 +1091,20 @@ def func_clamp_prune_contacts_coop(
             # sort, hull build, mark-survivors, and deep-pen restore stay serial on lane 0.
             i_cb_start = 0
             while i_cb_start < n_con:
-                key_b = collider_state.contact_sort_key[i_cb_start, i_b]
+                # Bucket boundaries must be derived from the link ids, not from f32 sort-key equality: the key
+                # lmin * 1e7 + lmax loses the lmax bits above 2^24, so distinct link pairs can share a key and
+                # key-equality scanning would merge their buckets into a single hull.
+                i_pc0 = collider_state.contact_sort_idx[i_cb_start, i_b]
+                i_la0 = collider_state.contact_data.link_a[i_pc0, i_b]
+                i_lb0 = collider_state.contact_data.link_b[i_pc0, i_b]
+                i_l_min0 = qd.min(i_la0, i_lb0)
+                i_l_max0 = qd.max(i_la0, i_lb0)
                 i_cb_end = i_cb_start + 1
                 while i_cb_end < n_con:
-                    if collider_state.contact_sort_key[i_cb_end, i_b] != key_b:
+                    i_pc = collider_state.contact_sort_idx[i_cb_end, i_b]
+                    i_la = collider_state.contact_data.link_a[i_pc, i_b]
+                    i_lb = collider_state.contact_data.link_b[i_pc, i_b]
+                    if qd.min(i_la, i_lb) != i_l_min0 or qd.max(i_la, i_lb) != i_l_max0:
                         break
                     i_cb_end += 1
                 n_cb = i_cb_end - i_cb_start

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -493,7 +493,7 @@ class RigidSolver(KinematicSolver):
         enable_cooperative_constraint_kernels = (
             gs.backend != gs.cpu
             and not self.sim.options.requires_grad
-            and not self._options.sparse_solve
+            and not sparse_solve
             and self._sim._B <= 8192
             and self.n_dofs >= 16
         )

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -630,6 +630,21 @@ def _apply_masks(out, value, row_mask, col_mask, keepdim, copy, *, to_torch):
     return out[mask]
 
 
+def _field_in_tree_offset_overflows_i32(value: qd.Field) -> bool:
+    """Whether the field sits past 2**31 bytes in its SNode tree.
+
+    FIXME: Quadrants' 'field_to_dlpack' truncates the in-tree byte offset to signed i32, so the zero-copy view of such
+    a field would silently alias the tree base (fixed upstream in Genesis-Embodied-AI/quadrants#768). Remove this guard
+    once the pinned quadrants release includes the fix.
+    """
+    snode = value.snode.ptr
+    offset = 0
+    while snode is not None:
+        offset += snode.offset_bytes_in_parent_cell
+        snode = snode.parent
+    return offset >= 2**31
+
+
 def qd_to_torch(
     value: qd.Tensor | qd.Field | qd.Ndarray,
     row_mask: int | range | slice | tuple[int, ...] | list[int] | torch.Tensor | np.ndarray | None = None,
@@ -670,6 +685,8 @@ def qd_to_torch(
             is_copy = False
         except AttributeError:
             try:
+                if isinstance(value, qd.Field) and _field_in_tree_offset_overflows_i32(value):
+                    raise ValueError("Zero-copy view unavailable for fields past 2**31 bytes in their SNode tree.")
                 tc = value.to_torch(copy=False)
             except (ValueError, RuntimeError):
                 if copy is False:
@@ -738,6 +755,8 @@ def qd_to_numpy(
             is_copy = False
         except AttributeError:
             try:
+                if isinstance(value, qd.Field) and _field_in_tree_offset_overflows_i32(value):
+                    raise ValueError("Zero-copy view unavailable for fields past 2**31 bytes in their SNode tree.")
                 tc = value.to_torch(copy=False)
             except (RuntimeError, TypeError, ValueError):
                 if copy is False:

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -791,7 +791,12 @@ def qd_zero_grad(value) -> None:
         if value.has_grad():
             grad = value.grad
             if gs.use_zerocopy:
-                qd_to_torch(grad, copy=False).zero_()
+                try:
+                    qd_to_torch(grad, copy=False).zero_()
+                except ValueError:
+                    # No zero-copy view for this buffer (e.g. a field past 2**31 bytes in its SNode tree); fill it in
+                    # place through quadrants instead.
+                    grad.fill(0.0)
             else:
                 grad.fill(0.0)
         return


### PR DESCRIPTION
## Description

Three independent bug fixes, all reproducing on `main`:

- The cooperative contact-pruning kernel delimited buckets by f32 sort-key equality; the key `lmin * 1e7 + lmax` exceeds 2^24 for any scene, so its f32 ulp is above 1 and distinct link pairs can quantize to the same key, merging into a single hull and dropping every contact of the enclosed links. Bucket boundaries are now derived from the link ids, like the serial kernel.
- Quadrants' `field_to_dlpack` truncates the in-tree field byte offset to signed i32, so the zero-copy torch/numpy view of any field placed past 2^31 bytes in its SNode tree silently aliases the tree base: getters return unrelated data and setters corrupt it. Until the upstream fix (Genesis-Embodied-AI/quadrants#768) reaches the pinned release, `qd_to_torch` / `qd_to_numpy` detect the condition and fall back to a copy conversion (guard marked FIXME for removal).
- `enable_cooperative_constraint_kernels` was gated on the raw `sparse_solve` option instead of the resolved setting, enabling the cooperative kernels when `sparse_solve=None` resolves to true.

## Motivation and Context

The pruning bug makes resting stacks lose contacts and tip or sink on GPU (both CUDA and Metal), with step-to-step intermittency caused by the racy narrowphase slot order feeding it different bucket adjacencies. The DLPack truncation silently corrupts any FIELD-mode run whose state trees grow past 2 GiB (a few thousand envs), which is how it was found: a `shadow_hand` benchmark NaN appearing between 6752 and 6784 envs.

## Benchmark report note

The three red rows in the CI benchmark comparison (all field-mode CUDA) were re-measured on exclusive cluster GPUs:

- `franka_accessors` 30000: the baseline is invalid. On `main` this config runs `get_contacts` through zero-copy views of fields past 2^31 bytes in the collider tree - the exact corruption the second commit fixes - and crashes with a CUDA device-side assert on the cluster (the CI baseline number measured corrupt execution). This PR is the first correct run of that config: 11.08M FPS, ~14% below the corrupt-path number because affected fields take the gather-kernel path. That cost disappears once Genesis-Embodied-AI/quadrants#768 (green, unmerged) ships in the pinned quadrants release and the FIXME guard is removed.
- `dex_hand` 4096: parity on exclusive hardware (31,550 vs 31,359 baseline; 12 controlled runs across commits and nodes all land within noise). The CI benchmark job runs several tests concurrently on one GPU, and this row's recorded historical spread is +-6.4%.
- `anymal_uniform` 30000: -0.8% on exclusive hardware (12.16M -> 12.07M), against a -14.0% CI reading.

Note on commit ordering: the copy-fallback guard without the collider fallback commit fails at build for >2 GiB trees, so these commits must land together (squash or merge as one).

## How Has This Been / Can This Be Tested?

- Pruning: the resting-stability test added in #3009 fails before / passes after on Linux CUDA (also reproduced on a cluster GPU node) and Apple Metal; a standalone kernel harness on captured narrowphase inputs matches the serial kernel 20/20 runs after the fix.
- Zero-copy fallback: validated against a quadrants build with the upstream fix reverted (affected field returns correct values through the fallback, unaffected fields keep true zero-copy); a 30-line repro is attached to quadrants#768.
- `tests/test_sensors.py` and `tests/test_rigid_physics_sparse.py` pass locally on Metal.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.

