### PR TITLE
[MISC] More robust nonconvex collision detection.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -133,7 +133,18 @@ class RigidGeom(RBC):
         grid_size = (upper - lower).max() * padding_ratio + (upper - lower)
         per_axis_lower = grid_size / (self._material.sdf_max_res - 1)
         per_axis_upper = grid_size / max(self._material.sdf_min_res - 1, 2)
-        self._sdf_cell_size = gs.EPS + np.clip(self._material.sdf_cell_size, per_axis_lower, per_axis_upper)
+        # The material cell size is the target. A convex geom has no thin wall to tunnel through, so it keeps that
+        # target. A non-convex geom tunnels when the cell is coarser than its thinnest wall, so the target is shrunk
+        # to fit 2 cells across the wall (its area-weighted p25 thickness) whenever that is finer; the per-axis clip
+        # below still bounds it to [sdf_min_res, sdf_max_res]. The shrink applies to all three axes, not just the
+        # wall's normal axis: the certified penetration bounds that hold shell contacts apart need lattice points
+        # near the contact in every direction, so a wall must be finely sampled along its tangent axes too (see
+        # estimate_wall_thickness).
+        cell_size_target = self._material.sdf_cell_size
+        if not self._is_convex:
+            wall_thickness = mu.estimate_wall_thickness(self._sdf_verts, self._sdf_faces)
+            cell_size_target = min(cell_size_target, wall_thickness / 2.0)
+        self._sdf_cell_size = gs.EPS + np.clip(cell_size_target, per_axis_lower, per_axis_upper)
         self._sdf_res = np.ceil(grid_size / self._sdf_cell_size).astype(gs.np_int) + 1
         # Constant once the SDF resolution is fixed. Cached because the solver re-reads it for every geom on each
         # 'add_entity' (to lay out cell offsets), which would otherwise recompute the product for every prior geom.
@@ -151,9 +162,8 @@ class RigidGeom(RBC):
         self._gsd_path = mu.get_gsd_path(
             self._init_verts,
             self._init_faces,
-            self._material.sdf_cell_size,
-            self._material.sdf_min_res,
-            self._material.sdf_max_res,
+            self._sdf_res,
+            self._sdf_cell_size,
         )
 
         # loading pre-computed cache if available

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -312,7 +312,12 @@ class Mesh(RBC):
             # inertia (and emitting a warning).
             with np.errstate(invalid="ignore", divide="ignore"):
                 try:
-                    tmesh = self._mesh if self._mesh.is_watertight else self._mesh.convex_hull
+                    tmesh = self._mesh
+                    if not self._mesh.is_watertight:
+                        gs.logger.warning(
+                            "Mesh is not watertight. Falling back to convex hull for estimating inertial properties."
+                        )
+                        tmesh = self._mesh.convex_hull
                     volume = float(tmesh.volume)
                     if volume < 0.0:
                         # Inward-facing winding gives a negative volume and inverted mass properties (e.g. a closed

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -541,6 +541,7 @@ def kernel_init_geom_fields(
     geoms_coup_restitution: qd.types.ndarray(),
     geoms_is_fixed: qd.types.ndarray(),
     geoms_is_decomp: qd.types.ndarray(),
+    geoms_is_hollow: qd.types.ndarray(),
     # Quadrants variables
     geoms_info: array_class.GeomsInfo,
     geoms_state: array_class.GeomsState,
@@ -584,6 +585,7 @@ def kernel_init_geom_fields(
         geoms_info.friction[i_g] = geoms_friction[i_g]
 
         geoms_info.is_convex[i_g] = geoms_is_convex[i_g]
+        geoms_info.is_hollow[i_g] = geoms_is_hollow[i_g]
         geoms_info.needs_coup[i_g] = geoms_needs_coup[i_g]
         geoms_info.contype[i_g] = geoms_contype[i_g]
         geoms_info.conaffinity[i_g] = geoms_conaffinity[i_g]

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -344,10 +344,9 @@ def func_add_polytope_vertex_contacts_sdf(
                 # Reject the override when A wraps around B: the center-to-center line is then B's through-axis and
                 # the axis "overlap" is the pass-through extent, not a real interpenetration, so resolving along it
                 # would eject A. The pose-robust signature is that A's own center lies in a cavity rather than inside
-                # A's material, so query A's SDF at A's center: positive for such a hollow/annular A, negative for the
+                # A's material (the build-time is_hollow flag): true for such a hollow/annular A, false for the
                 # solid A of the genuine crossed-thin-geom regime.
-                sd_a_self = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_world, i_ga, ga_pos, ga_quat)
-                if sd_a_self > EPS:
+                if geoms_info.is_hollow[i_ga]:
                     use_closing_dir = False
                     if sd_center < 0.0:
                         # B's material occupies A's center: B passes through A's cavity (a nut around a bolt shaft).
@@ -368,10 +367,9 @@ def func_add_polytope_vertex_contacts_sdf(
                     # the center-to-center axis passes through that cavity, so the axis overlap measures pass-through
                     # extent rather than material interpenetration - flooring pen_emit with it catapults a solid A
                     # resting inside or beside the hollow B. The genuine crossed-thin-geom regime this override
-                    # targets has both bodies solid (their centers inside their own material), so requiring
-                    # sd_b_self <= EPS preserves it while restoring the standard SDF-gradient path for hollow B.
-                    sd_b_self = sdf.sdf_func_world_local(geoms_info, sdf_info, center_b_world, i_gb, gb_pos, gb_quat)
-                    if sd_b_self > EPS:
+                    # targets has both bodies solid (their centers inside their own material), so requiring a
+                    # non-hollow B preserves it while restoring the standard SDF-gradient path for hollow B.
+                    if geoms_info.is_hollow[i_gb]:
                         use_closing_dir = False
                         sd_b_center = sdf.sdf_func_world_local(
                             geoms_info, sdf_info, center_b_world, i_ga, ga_pos, ga_quat
@@ -604,9 +602,10 @@ def func_add_polytope_vertex_contacts_sdf_shell(
     frame_axis = qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float)
     if closing_line.norm() > EPS:
         frame_axis = gu.qd_normalize(closing_line, EPS)
-    e_ref = qd.Vector([1.0, 0.0, 0.0], dt=gs.qd_float)
-    if qd.abs(frame_axis[0]) > 0.7:
-        e_ref = qd.Vector([0.0, 1.0, 0.0], dt=gs.qd_float)
+    # Fixed oblique reference direction: any axis-dependent choice relabels every bucket in one step when the
+    # axis crosses its switching surface; a constant reference is continuous everywhere except exact alignment,
+    # which no physical stacking axis hits.
+    e_ref = qd.Vector([0.36, 0.48, 0.8], dt=gs.qd_float)
     t1_ref = gu.qd_normalize(frame_axis.cross(e_ref), EPS)
     t2_ref = frame_axis.cross(t1_ref)
     frame_origin = 0.5 * (center_a_world + gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat))
@@ -616,6 +615,8 @@ def func_add_polytope_vertex_contacts_sdf_shell(
     acc_w = qd.Vector.zero(gs.qd_float, n_buckets)
     acc_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
     acc_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+    acc_pm = qd.Vector.zero(gs.qd_float, n_buckets)
+    acc_pmp = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
     sup_c = qd.Vector.zero(gs.qd_float, n_buckets)
     sup_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
     sup_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
@@ -688,8 +689,7 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                 closing_dir = center_a_world_p - center_b_world
                 if closing_dir.norm() > EPS:
                     closing_normal = gu.qd_normalize(closing_dir, EPS)
-                    sd_a_self = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_world_p, j_ga, ja_pos, ja_quat)
-                    if sd_a_self > EPS:
+                    if geoms_info.is_hollow[j_ga]:
                         use_closing_dir = False
                         if sd_center < 0.0:
                             enclosed_axis = True
@@ -697,10 +697,7 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                             normal_center = closing_normal
                             axis_normal = True
                     else:
-                        sd_b_self = sdf.sdf_func_world_local(
-                            geoms_info, sdf_info, center_b_world, j_gb, jb_pos, jb_quat
-                        )
-                        if sd_b_self > EPS:
+                        if geoms_info.is_hollow[j_gb]:
                             use_closing_dir = False
                             sd_b_center = sdf.sdf_func_world_local(
                                 geoms_info, sdf_info, center_b_world, j_ga, ja_pos, ja_quat
@@ -804,36 +801,81 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                                 pen_emit = approach_depth_pair
                             rel_ref = vertex_pos - frame_origin
                             az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
-                            az_scaled = (az_ref + qd.math.pi) * (n_buckets / (2.0 * qd.math.pi))
-                            i_bucket = qd.min(qd.max(qd.cast(az_scaled, gs.qd_int), 0), n_buckets - 1)
+                            # Two sub-buckets per azimuth sector, split by normal hemisphere: a crossed wall has
+                            # penetrating verts on BOTH faces with opposed normals, and merging them would cancel the
+                            # aggregate exactly when the crossing needs resistance from each side. The split also keeps
+                            # phase-1 members from annihilating phase-0 members of the opposite face.
+                            i_bucket = 0
+                            i_bucket_2 = 0
+                            w_hat = gs.qd_float(1.0)
+                            if qd.static(n_buckets >= 2):
+                                # Hat-weighted azimuthal binning: a member splits its weight linearly between the two
+                                # nearest sector centers, so rotating past a sector boundary moves weight continuously
+                                # instead of relocating it in one step - a hard handoff modulates the emitted forces
+                                # and, combined with any standing lateral bias, ratchets a softly-stacked column.
+                                az_scaled = (az_ref + qd.math.pi) * ((n_buckets // 2) / (2.0 * qd.math.pi))
+                                u_hat = az_scaled - 0.5
+                                i_sec = qd.cast(qd.floor(u_hat), gs.qd_int)
+                                frac_hat = u_hat - qd.cast(i_sec, gs.qd_float)
+                                i_sec = qd.raw_mod(i_sec + (n_buckets // 2), n_buckets // 2)
+                                i_sec_2 = qd.raw_mod(i_sec + 1, n_buckets // 2)
+                                w_hat = 1.0 - frac_hat
+                                i_bucket = 2 * i_sec
+                                i_bucket_2 = 2 * i_sec_2
+                                # Hemisphere sign from whichever direction is well-conditioned for this face: seating
+                                # faces align with the closing axis, side walls are perpendicular to it and split on
+                                # the local radial instead - otherwise their sub-bucket assignment is FP-noise-driven
+                                # and opposite faces can still share a bucket and cancel.
+                                n_shared = phase_sign * normal_v
+                                rad_ref = gu.qd_normalize(rel_ref - rel_ref.dot(frame_axis) * frame_axis, EPS)
+                                split_dot = n_shared.dot(frame_axis)
+                                rad_dot = n_shared.dot(rad_ref)
+                                if qd.abs(rad_dot) > qd.abs(split_dot):
+                                    split_dot = rad_dot
+                                if split_dot > 0.0:
+                                    i_bucket = i_bucket + 1
+                                    i_bucket_2 = i_bucket_2 + 1
                             if pen_emit > 0.0:
-                                acc_w[i_bucket] += pen_emit
-                                for j in qd.static(range(3)):
-                                    acc_pos[i_bucket, j] += pen_emit * vertex_pos[j]
-                                    acc_n[i_bucket, j] += phase_sign * pen_emit * normal_v[j]
+                                for k_hat in qd.static(range(2)):
+                                    i_bkt = i_bucket if k_hat == 0 else i_bucket_2
+                                    w_b = (w_hat if k_hat == 0 else 1.0 - w_hat) * pen_emit
+                                    acc_w[i_bkt] += w_b
+                                    for j in qd.static(range(3)):
+                                        acc_pos[i_bkt, j] += w_b * vertex_pos[j]
+                                        acc_n[i_bkt, j] += phase_sign * w_b * normal_v[j]
+                                if pen_emit > acc_pm[i_bucket]:
+                                    acc_pm[i_bucket] = pen_emit
+                                    for j in qd.static(range(3)):
+                                        acc_pmp[i_bucket, j] = vertex_pos[j]
                             elif is_support:
-                                sup_c[i_bucket] += 1.0
-                                for j in qd.static(range(3)):
-                                    sup_pos[i_bucket, j] += vertex_pos[j]
-                                    sup_n[i_bucket, j] += phase_sign * normal_v[j]
+                                for k_hat in qd.static(range(2)):
+                                    i_bkt = i_bucket if k_hat == 0 else i_bucket_2
+                                    w_b = w_hat if k_hat == 0 else 1.0 - w_hat
+                                    sup_c[i_bkt] += w_b
+                                    for j in qd.static(range(3)):
+                                        sup_pos[i_bkt, j] += w_b * vertex_pos[j]
+                                        sup_n[i_bkt, j] += phase_sign * w_b * normal_v[j]
             else:
-                # Seeds: the phase-0 aggregate centroids plus the image of B's center (covers the zero-contact
-                # crossing). Only penetrations past a quarter-cell floor are considered, keeping grid noise out.
+                # Seeds: the deepest phase-0 member per bucket plus the images of B's center and the overlap
+                # midpoint (covering zero-contact crossings). Members are admitted over the same near-surface band
+                # as phase 0, so the thin-wall taper keeps its continuity across pen_v = 0.
                 seen_verts = qd.Vector.zero(gs.qd_int, n_max)
                 n_seen = 0
-                for i_seed in range(n_buckets + 1):
+                for i_seed in range(n_buckets + 2):
                     i_v_min = -1
                     if i_seed == 0:
                         i_v_min = sdf.sdf_func_find_closest_vert(
                             geoms_state, geoms_info, sdf_info, center_b_world, j_ga, i_b
                         )
-                    elif acc_w[i_seed - 1] > 0.0:
+                    elif i_seed == 1:
+                        i_v_min = sdf.sdf_func_find_closest_vert(
+                            geoms_state, geoms_info, sdf_info, frame_origin, j_ga, i_b
+                        )
+                    elif acc_w[i_seed - 2] > 0.0:
+                        # Seed from the bucket's deepest member: a real surface point, unlike the weighted centroid
+                        # which sits off-surface and can climb into the wrong basin.
                         seed_pos = qd.Vector(
-                            [
-                                acc_pos[i_seed - 1, 0] / acc_w[i_seed - 1],
-                                acc_pos[i_seed - 1, 1] / acc_w[i_seed - 1],
-                                acc_pos[i_seed - 1, 2] / acc_w[i_seed - 1],
-                            ],
+                            [acc_pmp[i_seed - 2, 0], acc_pmp[i_seed - 2, 1], acc_pmp[i_seed - 2, 2]],
                             dt=gs.qd_float,
                         )
                         i_v_min = sdf.sdf_func_find_closest_vert(geoms_state, geoms_info, sdf_info, seed_pos, j_ga, i_b)
@@ -883,21 +925,15 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                                 i_v = collider_info.vert_neighbors[i_c]
                             vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
                             pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
-                            if pen_v > 0.25 * margin:
+                            if pen_v > -margin:
                                 grad_v = sdf.sdf_func_grad_world_local_consistent(
                                     geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
                                 )
                                 grad_norm = grad_v.norm()
                                 pen_emit = gs.qd_float(0.0)
-                                is_support = False
                                 if grad_norm > 0.9:
                                     if pen_v > 0.0:
                                         pen_emit = pen_v
-                                    elif qd.static(i_phase == 0):
-                                        # Zero-depth support contacts: verts touching within the grid-noise pen scale
-                                        # damp the closing velocity without exerting static force. Crossed solids are
-                                        # excluded (damping the far side of the overlap stalls the escape).
-                                        is_support = pen_v > -synthetic_pen_max and not use_closing_dir
                                 elif use_closing_dir or axis_normal or enclosed_axis:
                                     # Sub-cell thin walls are uncertifiable by the lattice, yet these band verts are the
                                     # only carriers of the coupling across the wall: keep the synthetic depths,
@@ -909,11 +945,6 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                                             pen_emit = synthetic_pen_max * (1.0 + pen_v / margin)
                                     elif pen_v > 0.0:
                                         pen_emit = synthetic_pen_max
-                                else:
-                                    # Outside the thin-wall regimes an uncertain (smoothed or seam) pen is not trusted
-                                    # at all; the vert still damps the closing velocity as a zero-depth support contact.
-                                    if qd.static(i_phase == 0):
-                                        is_support = pen_v > -synthetic_pen_max
                                 normal_v = normal_center
                                 if enclosed_axis or axis_normal:
                                     # Concave shells: the pair-level reference normal cannot resist lateral shear, so
@@ -929,7 +960,6 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                                             # support contact there, damping the far side stalls the crossing-escape
                                             # creep.
                                             normal_v = -normal_v
-                                            is_support = False
                                     else:
                                         normal_v = -a_vnormal
                                 elif (
@@ -948,18 +978,52 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                                     pen_emit = approach_depth_pair
                                 rel_ref = vertex_pos - frame_origin
                                 az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
-                                az_scaled = (az_ref + qd.math.pi) * (n_buckets / (2.0 * qd.math.pi))
-                                i_bucket = qd.min(qd.max(qd.cast(az_scaled, gs.qd_int), 0), n_buckets - 1)
+                                # Two sub-buckets per azimuth sector, split by normal hemisphere: a crossed wall has
+                                # penetrating verts on BOTH faces with opposed normals, and merging them would cancel the
+                                # aggregate exactly when the crossing needs resistance from each side. The split also keeps
+                                # phase-1 members from annihilating phase-0 members of the opposite face.
+                                i_bucket = 0
+                                i_bucket_2 = 0
+                                w_hat = gs.qd_float(1.0)
+                                if qd.static(n_buckets >= 2):
+                                    # Hat-weighted azimuthal binning: a member splits its weight linearly between the two
+                                    # nearest sector centers, so rotating past a sector boundary moves weight continuously
+                                    # instead of relocating it in one step - a hard handoff modulates the emitted forces
+                                    # and, combined with any standing lateral bias, ratchets a softly-stacked column.
+                                    az_scaled = (az_ref + qd.math.pi) * ((n_buckets // 2) / (2.0 * qd.math.pi))
+                                    u_hat = az_scaled - 0.5
+                                    i_sec = qd.cast(qd.floor(u_hat), gs.qd_int)
+                                    frac_hat = u_hat - qd.cast(i_sec, gs.qd_float)
+                                    i_sec = qd.raw_mod(i_sec + (n_buckets // 2), n_buckets // 2)
+                                    i_sec_2 = qd.raw_mod(i_sec + 1, n_buckets // 2)
+                                    w_hat = 1.0 - frac_hat
+                                    i_bucket = 2 * i_sec
+                                    i_bucket_2 = 2 * i_sec_2
+                                    # Hemisphere sign from whichever direction is well-conditioned for this face: seating
+                                    # faces align with the closing axis, side walls are perpendicular to it and split on
+                                    # the local radial instead - otherwise their sub-bucket assignment is FP-noise-driven
+                                    # and opposite faces can still share a bucket and cancel.
+                                    n_shared = phase_sign * normal_v
+                                    rad_ref = gu.qd_normalize(rel_ref - rel_ref.dot(frame_axis) * frame_axis, EPS)
+                                    split_dot = n_shared.dot(frame_axis)
+                                    rad_dot = n_shared.dot(rad_ref)
+                                    if qd.abs(rad_dot) > qd.abs(split_dot):
+                                        split_dot = rad_dot
+                                    if split_dot > 0.0:
+                                        i_bucket = i_bucket + 1
+                                        i_bucket_2 = i_bucket_2 + 1
                                 if pen_emit > 0.0:
-                                    acc_w[i_bucket] += pen_emit
-                                    for j in qd.static(range(3)):
-                                        acc_pos[i_bucket, j] += pen_emit * vertex_pos[j]
-                                        acc_n[i_bucket, j] += phase_sign * pen_emit * normal_v[j]
-                                elif is_support:
-                                    sup_c[i_bucket] += 1.0
-                                    for j in qd.static(range(3)):
-                                        sup_pos[i_bucket, j] += vertex_pos[j]
-                                        sup_n[i_bucket, j] += phase_sign * normal_v[j]
+                                    for k_hat in qd.static(range(2)):
+                                        i_bkt = i_bucket if k_hat == 0 else i_bucket_2
+                                        w_b = (w_hat if k_hat == 0 else 1.0 - w_hat) * pen_emit
+                                        acc_w[i_bkt] += w_b
+                                        for j in qd.static(range(3)):
+                                            acc_pos[i_bkt, j] += w_b * vertex_pos[j]
+                                            acc_n[i_bkt, j] += phase_sign * w_b * normal_v[j]
+                                    if pen_emit > acc_pm[i_bucket]:
+                                        acc_pm[i_bucket] = pen_emit
+                                        for j in qd.static(range(3)):
+                                            acc_pmp[i_bucket, j] = vertex_pos[j]
     # Emit one aggregated contact per active bucket. A bucket whose members disagree on direction (the weighted
     # normal nearly cancels) is ambiguous and skipped; buckets holding only zero-depth support verts emit a support
     # contact at their unweighted centroid.
@@ -974,19 +1038,17 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                 [acc_pos[i_bucket, 0] * inv_w, acc_pos[i_bucket, 1] * inv_w, acc_pos[i_bucket, 2] * inv_w],
                 dt=gs.qd_float,
             )
+            # Rescale the pen-weighted sum to the mean member normal BEFORE normalizing: the sum's magnitude is
+            # O(pen), where the eps guard under norm() is no longer negligible and would emit a non-unit normal
+            # (a silently softened constraint row). The mean is O(1) by the coherence gate, so the guard is inert.
             normal_c = qd.Vector([acc_n[i_bucket, 0], acc_n[i_bucket, 1], acc_n[i_bucket, 2]], dt=gs.qd_float)
-            if normal_c.norm() > 0.1 * acc_w[i_bucket]:
-                # Conservative aggregation: members act like springs deriving from the bucket potential
-                # 0.5 * sum(pen_i^2), so the aggregate must carry sum(pen_i * n_i) as its (normal, pen) pair; any
-                # other pen scaling tilts the force off the potential gradient and the curl walks a settled stack.
-                # Saturate at half the SDF margin with a leaky slope: past the solver impedance width the force
-                # plateaus and the aggregate becomes a zero-stiffness thruster whose flicker pumps the stack. Unit
-                # slope below the cap keeps full interface stiffness; the residual slope avoids a plateau of its own.
-                pen_scale = 0.5 * margin
-                pen_raw = normal_c.norm()
-                emit_pen = pen_raw
-                if pen_raw > pen_scale:
-                    emit_pen = pen_scale + 0.1 * (pen_raw - pen_scale)
+            normal_c = normal_c / acc_w[i_bucket]
+            if normal_c.norm() > 0.1:
+                # The emitted depth is the deepest member pen: the solver consumes pen as a geometric depth (it
+                # drives impedance and error correction, and is reported by get_contacts), so a summed magnitude
+                # would inflate a shallow many-vert ring and saturate a genuinely deep crossing. The direction
+                # still composes the member forces via sum(pen_i * n_i).
+                emit_pen = acc_pm[i_bucket]
                 normal_c = gu.qd_normalize(normal_c, EPS)
                 is_emit = True
         else:
@@ -3460,15 +3522,30 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                         if d_b.dot(d_b) > rb_b_sq:
                             rb_b_sq = d_b.dot(d_b)
                     sd_center_ab = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_w, i_gb, gb_pos, gb_quat)
-                    if qd.abs(sd_center_ab) < qd.sqrt(rb_a_sq) and rb_a_sq > 0.25 * rb_b_sq and sd_center_ab >= 0.0:
-                        sd_a_self = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_w, i_ga, ga_pos, ga_quat)
-                        if sd_a_self > EPS:
-                            center_b_w = gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat)
-                            sd_b_self = sdf.sdf_func_world_local(
-                                geoms_info, sdf_info, center_b_w, i_gb, gb_pos, gb_quat
-                            )
-                            if sd_b_self > EPS:
-                                is_shell_pair = True
+                    # Nested-only: A's center must lie inside B's local AABB. Adjacent shells share every
+                    # other property of a nested pair, but their contact is a small lens ON the closing
+                    # line, where the azimuthal sectors degenerate to a single bucket and the aggregate
+                    # churns (cm-scale contact relocation every step, with intermittently silent steps);
+                    # the per-vertex manifold handles them well. The two populations sit far from this
+                    # boundary - a nested center is deep inside, an adjacent center a full bound outside -
+                    # so the gate is stable in practice.
+                    center_a_in_b = gu.qd_inv_transform_by_trans_quat(center_a_w, gb_pos, gb_quat)
+                    is_nested = True
+                    for j in qd.static(range(3)):
+                        if (
+                            center_a_in_b[j] < geoms_init_AABB[i_gb, 0][j]
+                            or center_a_in_b[j] > geoms_init_AABB[i_gb, 7][j]
+                        ):
+                            is_nested = False
+                    if (
+                        is_nested
+                        and geoms_info.is_hollow[i_ga]
+                        and geoms_info.is_hollow[i_gb]
+                        and qd.abs(sd_center_ab) < qd.sqrt(rb_a_sq)
+                        and rb_a_sq > 0.25 * rb_b_sq
+                        and sd_center_ab >= 0.0
+                    ):
+                        is_shell_pair = True
                     if is_shell_pair:
                         func_add_polytope_vertex_contacts_sdf_shell(
                             i_ga,

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -558,6 +558,480 @@ def func_add_polytope_vertex_contacts_sdf(
 
 
 @qd.func
+def func_add_polytope_vertex_contacts_sdf_shell(
+    i_ga,
+    i_gb,
+    i_b,
+    i_pair,
+    ga_pos: qd.types.vector(3),
+    ga_quat: qd.types.vector(4),
+    gb_pos: qd.types.vector(3),
+    gb_quat: qd.types.vector(4),
+    tolerance,
+    geoms_state: array_class.GeomsState,
+    geoms_info: array_class.GeomsInfo,
+    geoms_init_AABB: array_class.GeomsInitAABB,
+    verts_info: array_class.VertsInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    static_rigid_sim_config: qd.template(),
+    collider_static_config: qd.template(),
+    sdf_info: array_class.SDFInfo,
+    collider_state: array_class.ColliderState,
+    collider_info: array_class.ColliderInfo,
+    errno: qd.Tensor,
+):
+    # Sector-aggregated manifold for nested-shell pairs (both bodies hollow, see the dispatcher gate). The annular
+    # contact of nested shells makes the top-k vertex manifold churn: kept-set swaps, dedup toggles and regime flips
+    # each relocate a finite force, and a tall stack rectifies that noise into a sideways walk. Here every band vert
+    # instead accumulates into a fixed azimuthal sector, and each active sector emits ONE aggregated contact, so the
+    # emitted force field is continuous in pose and the pair budget holds by construction.
+    n_max = qd.static(
+        collider_static_config.n_contacts_per_nonconvex_pair if static_rigid_sim_config.enable_multi_contact else 1
+    )
+    # One shared bucket table covers both scan directions, so the sector count IS the pair budget.
+    n_buckets = qd.static(
+        collider_static_config.n_contacts_per_nonconvex_pair if static_rigid_sim_config.enable_multi_contact else 1
+    )
+    EPS = rigid_global_info.EPS[None]
+    gb_cell = sdf_info.geoms_info.sdf_cell_size[i_gb]
+    margin = qd.min(qd.min(gb_cell[0], gb_cell[1]), gb_cell[2])
+    synthetic_pen_max = 1e-4
+    center_a_world = gu.qd_transform_by_trans_quat(geoms_info.center[i_ga], ga_pos, ga_quat)
+    # Shared azimuthal-sector frame for both scan directions: a vertex found by the swapped scan joins the
+    # aggregate its azimuth belongs to instead of spawning a contact of its own. Derived from the closing line,
+    # which is pose-continuous.
+    closing_line = center_a_world - gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat)
+    frame_axis = qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float)
+    if closing_line.norm() > EPS:
+        frame_axis = gu.qd_normalize(closing_line, EPS)
+    e_ref = qd.Vector([1.0, 0.0, 0.0], dt=gs.qd_float)
+    if qd.abs(frame_axis[0]) > 0.7:
+        e_ref = qd.Vector([0.0, 1.0, 0.0], dt=gs.qd_float)
+    t1_ref = gu.qd_normalize(frame_axis.cross(e_ref), EPS)
+    t2_ref = frame_axis.cross(t1_ref)
+    frame_origin = 0.5 * (center_a_world + gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat))
+
+    # Per-bucket accumulators shared by both phases. A vertex enters or leaves a bucket with weight
+    # pen_emit -> 0, which is what keeps the emitted force field continuous.
+    acc_w = qd.Vector.zero(gs.qd_float, n_buckets)
+    acc_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+    acc_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+    sup_c = qd.Vector.zero(gs.qd_float, n_buckets)
+    sup_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+    sup_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+
+    for i_phase in qd.static(range(2)):
+        # Phase 0 scans every vert of A against B's SDF; phase 1 checks B's verts against A's SDF as a seeded
+        # local search (hill-climb from the phase-0 aggregates), covering features of B crossing A's faces BETWEEN
+        # A's verts. Phase-1 normals are negated onto the phase-0 orientation convention.
+        j_ga = i_ga
+        j_gb = i_gb
+        ja_pos = ga_pos
+        ja_quat = ga_quat
+        jb_pos = gb_pos
+        jb_quat = gb_quat
+        phase_sign = gs.qd_float(1.0)
+        if qd.static(i_phase == 1):
+            j_ga = i_gb
+            j_gb = i_ga
+            ja_pos = gb_pos
+            ja_quat = gb_quat
+            jb_pos = ga_pos
+            jb_quat = ga_quat
+            phase_sign = -1.0
+        is_phase_active = True
+        if qd.static(i_phase == 1):
+            # A plane's handful of far-flung verts carry no contact information.
+            is_phase_active = geoms_info.type[j_ga] != gs.GEOM_TYPE.PLANE
+        gb_cell_p = sdf_info.geoms_info.sdf_cell_size[j_gb]
+        margin = qd.min(qd.min(gb_cell_p[0], gb_cell_p[1]), gb_cell_p[2])
+        center_local_p = geoms_info.center[j_ga]
+        rbound_a_sq = gs.qd_float(0.0)
+        for k in qd.static(range(8)):
+            delta = geoms_init_AABB[j_ga, k] - center_local_p
+            d_sq = delta.dot(delta)
+            if d_sq > rbound_a_sq:
+                rbound_a_sq = d_sq
+        rbound_a = qd.sqrt(rbound_a_sq)
+        center_a_world_p = gu.qd_transform_by_trans_quat(center_local_p, ja_pos, ja_quat)
+        can_use_sd_reject_p = (
+            geoms_info.type[j_gb] == gs.GEOM_TYPE.SPHERE or geoms_info.type[j_gb] == gs.GEOM_TYPE.PLANE
+        )
+        if not can_use_sd_reject_p:
+            pos_mesh_p = gu.qd_inv_transform_by_trans_quat(center_a_world_p, jb_pos, jb_quat)
+            pos_sdf_p = gu.qd_transform_by_T(pos_mesh_p, sdf_info.geoms_info.T_mesh_to_sdf[j_gb])
+            can_use_sd_reject_p = not sdf.sdf_func_is_outside_sdf_grid(sdf_info, pos_sdf_p, j_gb)
+        sd_center_p = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_world_p, j_gb, jb_pos, jb_quat)
+        if is_phase_active and ((not can_use_sd_reject_p) or sd_center_p <= rbound_a):
+            sd_center = sd_center_p
+            rbound_b_sq = gs.qd_float(0.0)
+            b_center_local = geoms_info.center[j_gb]
+            for k in qd.static(range(8)):
+                delta_b = geoms_init_AABB[j_gb, k] - b_center_local
+                d_sq_b = delta_b.dot(delta_b)
+                if d_sq_b > rbound_b_sq:
+                    rbound_b_sq = d_sq_b
+            center_b_world = gu.qd_transform_by_trans_quat(b_center_local, jb_pos, jb_quat)
+
+            grad_center = sdf.sdf_func_grad_world_local_consistent(
+                geoms_info, rigid_global_info, sdf_info, center_a_world_p, j_gb, jb_pos, jb_quat
+            )
+            normal_center = gu.qd_normalize(grad_center, EPS)
+            # Regime detection and per-vertex pen/normal policy identical to the per-vertex manifold, which
+            # documents the rationale of each test.
+            use_closing_dir = qd.abs(sd_center) < rbound_a and rbound_a_sq > gs.qd_float(0.25) * rbound_b_sq
+            approach_depth_pair = gs.qd_float(0.0)
+            closing_normal = qd.Vector.zero(gs.qd_float, 3)
+            enclosed_axis = False
+            axis_normal = False
+            if use_closing_dir:
+                closing_dir = center_a_world_p - center_b_world
+                if closing_dir.norm() > EPS:
+                    closing_normal = gu.qd_normalize(closing_dir, EPS)
+                    sd_a_self = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_world_p, j_ga, ja_pos, ja_quat)
+                    if sd_a_self > EPS:
+                        use_closing_dir = False
+                        if sd_center < 0.0:
+                            enclosed_axis = True
+                        else:
+                            normal_center = closing_normal
+                            axis_normal = True
+                    else:
+                        sd_b_self = sdf.sdf_func_world_local(
+                            geoms_info, sdf_info, center_b_world, j_gb, jb_pos, jb_quat
+                        )
+                        if sd_b_self > EPS:
+                            use_closing_dir = False
+                            sd_b_center = sdf.sdf_func_world_local(
+                                geoms_info, sdf_info, center_b_world, j_ga, ja_pos, ja_quat
+                            )
+                            if sd_b_center < 0.0:
+                                enclosed_axis = True
+                        else:
+                            normal_center = closing_normal
+                            seg_len = closing_dir.norm()
+                            depth_b = sdf.sdf_func_ray_exit_distance(
+                                geoms_info,
+                                sdf_info,
+                                center_b_world,
+                                closing_normal,
+                                seg_len,
+                                tolerance,
+                                j_gb,
+                                jb_pos,
+                                jb_quat,
+                            )
+                            depth_a = sdf.sdf_func_ray_exit_distance(
+                                geoms_info,
+                                sdf_info,
+                                center_a_world_p,
+                                -closing_normal,
+                                seg_len,
+                                tolerance,
+                                j_ga,
+                                ja_pos,
+                                ja_quat,
+                            )
+                            approach_depth_pair = depth_a + depth_b - seg_len
+                else:
+                    use_closing_dir = False
+            if qd.static(i_phase == 0):
+                for i_v in range(geoms_info.vert_start[j_ga], geoms_info.vert_end[j_ga]):
+                    vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
+                    if func_point_in_geom_aabb(geoms_state, j_gb, i_b, vertex_pos):
+                        pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
+                        if pen_v > -margin:
+                            grad_v = sdf.sdf_func_grad_world_local_consistent(
+                                geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
+                            )
+                            grad_norm = grad_v.norm()
+                            pen_emit = gs.qd_float(0.0)
+                            is_support = False
+                            if grad_norm > 0.9:
+                                if pen_v > 0.0:
+                                    pen_emit = pen_v
+                                elif qd.static(i_phase == 0):
+                                    # Zero-depth support contacts: verts touching within the grid-noise pen scale damp
+                                    # the closing velocity without exerting static force. Crossed solids are excluded
+                                    # (damping the far side of the overlap stalls the escape).
+                                    is_support = pen_v > -synthetic_pen_max and not use_closing_dir
+                            elif use_closing_dir or axis_normal or enclosed_axis:
+                                # Sub-cell thin walls are uncertifiable by the lattice, yet these band verts are the
+                                # only carriers of the coupling across the wall: keep the synthetic depths, continuous
+                                # across pen_v = 0.
+                                if grad_norm < 0.5:
+                                    if pen_v > 0.0:
+                                        pen_emit = qd.min(synthetic_pen_max + pen_v, margin)
+                                    else:
+                                        pen_emit = synthetic_pen_max * (1.0 + pen_v / margin)
+                                elif pen_v > 0.0:
+                                    pen_emit = synthetic_pen_max
+                            else:
+                                # Outside the thin-wall regimes an uncertain (smoothed or seam) pen is not trusted at
+                                # all; the vert still damps the closing velocity as a zero-depth support contact.
+                                if qd.static(i_phase == 0):
+                                    is_support = pen_v > -synthetic_pen_max
+                            normal_v = normal_center
+                            if enclosed_axis or axis_normal:
+                                # Concave shells: the pair-level reference normal cannot resist lateral shear, so orient
+                                # from B's grad when well-conditioned (sign fixed from A's exact vertex normal) and from
+                                # A's vertex normal when the grad is smoothed across the thin wall.
+                                a_vnormal = gu.qd_normalize(
+                                    gu.qd_transform_by_quat(verts_info.init_normal[i_v], ja_quat), EPS
+                                )
+                                if grad_norm > 0.5:
+                                    normal_v = gu.qd_normalize(grad_v, EPS)
+                                    if normal_v.dot(a_vnormal) > 0.0:
+                                        # Grad agreeing with A's outward normal = tunneled past B's thin wall: no
+                                        # support contact there, damping the far side stalls the crossing-escape creep.
+                                        normal_v = -normal_v
+                                        is_support = False
+                                else:
+                                    normal_v = -a_vnormal
+                            elif (
+                                not use_closing_dir
+                                and not axis_normal
+                                and grad_norm > 0.9
+                                and grad_v.dot(normal_center) > 0.0
+                            ):
+                                # Trust a per-vertex grad as the contact normal only in the clean band where the kernel
+                                # pen is trusted; in the edge/smoothed bands the reference normal at A's center is more
+                                # reliable.
+                                normal_v = gu.qd_normalize(grad_v, EPS)
+                            # In the closing regime the per-vertex pen is only the radial gap to B's lateral; floor it
+                            # with the geometric approach depth so the solver sees the actual overlap.
+                            if use_closing_dir and pen_v > 0.0 and approach_depth_pair > pen_emit:
+                                pen_emit = approach_depth_pair
+                            rel_ref = vertex_pos - frame_origin
+                            az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
+                            az_scaled = (az_ref + qd.math.pi) * (n_buckets / (2.0 * qd.math.pi))
+                            i_bucket = qd.min(qd.max(qd.cast(az_scaled, gs.qd_int), 0), n_buckets - 1)
+                            if pen_emit > 0.0:
+                                acc_w[i_bucket] += pen_emit
+                                for j in qd.static(range(3)):
+                                    acc_pos[i_bucket, j] += pen_emit * vertex_pos[j]
+                                    acc_n[i_bucket, j] += phase_sign * pen_emit * normal_v[j]
+                            elif is_support:
+                                sup_c[i_bucket] += 1.0
+                                for j in qd.static(range(3)):
+                                    sup_pos[i_bucket, j] += vertex_pos[j]
+                                    sup_n[i_bucket, j] += phase_sign * normal_v[j]
+            else:
+                # Seeds: the phase-0 aggregate centroids plus the image of B's center (covers the zero-contact
+                # crossing). Only penetrations past a quarter-cell floor are considered, keeping grid noise out.
+                seen_verts = qd.Vector.zero(gs.qd_int, n_max)
+                n_seen = 0
+                for i_seed in range(n_buckets + 1):
+                    i_v_min = -1
+                    if i_seed == 0:
+                        i_v_min = sdf.sdf_func_find_closest_vert(
+                            geoms_state, geoms_info, sdf_info, center_b_world, j_ga, i_b
+                        )
+                    elif acc_w[i_seed - 1] > 0.0:
+                        seed_pos = qd.Vector(
+                            [
+                                acc_pos[i_seed - 1, 0] / acc_w[i_seed - 1],
+                                acc_pos[i_seed - 1, 1] / acc_w[i_seed - 1],
+                                acc_pos[i_seed - 1, 2] / acc_w[i_seed - 1],
+                            ],
+                            dt=gs.qd_float,
+                        )
+                        i_v_min = sdf.sdf_func_find_closest_vert(geoms_state, geoms_info, sdf_info, seed_pos, j_ga, i_b)
+                    if i_v_min >= 0:
+                        for k in range(n_max):
+                            if k < n_seen and seen_verts[k] == i_v_min:
+                                i_v_min = -1
+                    if i_v_min >= 0:
+                        i_v_start = i_v_min
+                        pos_min = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v_min], ja_pos, ja_quat)
+                        sd_min = sdf.sdf_func_world_local(geoms_info, sdf_info, pos_min, j_gb, jb_pos, jb_quat)
+                        i_v_cur = -1
+                        while i_v_cur != i_v_min:
+                            i_v_cur = i_v_min
+                            for i_neighbor_ in range(
+                                collider_info.vert_neighbor_start[i_v_cur],
+                                collider_info.vert_neighbor_start[i_v_cur] + collider_info.vert_n_neighbors[i_v_cur],
+                            ):
+                                i_neighbor = collider_info.vert_neighbors[i_neighbor_]
+                                pos_neighbor = gu.qd_transform_by_trans_quat(
+                                    verts_info.init_pos[i_neighbor], ja_pos, ja_quat
+                                )
+                                sd_neighbor = sdf.sdf_func_world_local(
+                                    geoms_info, sdf_info, pos_neighbor, j_gb, jb_pos, jb_quat
+                                )
+                                # Strict decrease guarantees termination: values strictly descend over a finite
+                                # vertex set, so no vertex can be revisited even on numerically flat plateaus.
+                                if sd_neighbor < sd_min:
+                                    i_v_min = i_neighbor
+                                    sd_min = sd_neighbor
+                        for k in range(n_max):
+                            if k < n_seen and seen_verts[k] == i_v_min:
+                                i_v_min = -1
+                        if n_seen < n_max:
+                            seen_verts[n_seen] = i_v_start
+                            n_seen = n_seen + 1
+                        if i_v_min >= 0 and i_v_min != i_v_start and n_seen < n_max:
+                            seen_verts[n_seen] = i_v_min
+                            n_seen = n_seen + 1
+                    if i_v_min >= 0:
+                        for i_c in range(
+                            collider_info.vert_neighbor_start[i_v_min] - 1,
+                            collider_info.vert_neighbor_start[i_v_min] + collider_info.vert_n_neighbors[i_v_min],
+                        ):
+                            i_v = i_v_min
+                            if i_c >= collider_info.vert_neighbor_start[i_v_min]:
+                                i_v = collider_info.vert_neighbors[i_c]
+                            vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
+                            pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
+                            if pen_v > 0.25 * margin:
+                                grad_v = sdf.sdf_func_grad_world_local_consistent(
+                                    geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
+                                )
+                                grad_norm = grad_v.norm()
+                                pen_emit = gs.qd_float(0.0)
+                                is_support = False
+                                if grad_norm > 0.9:
+                                    if pen_v > 0.0:
+                                        pen_emit = pen_v
+                                    elif qd.static(i_phase == 0):
+                                        # Zero-depth support contacts: verts touching within the grid-noise pen scale
+                                        # damp the closing velocity without exerting static force. Crossed solids are
+                                        # excluded (damping the far side of the overlap stalls the escape).
+                                        is_support = pen_v > -synthetic_pen_max and not use_closing_dir
+                                elif use_closing_dir or axis_normal or enclosed_axis:
+                                    # Sub-cell thin walls are uncertifiable by the lattice, yet these band verts are the
+                                    # only carriers of the coupling across the wall: keep the synthetic depths,
+                                    # continuous across pen_v = 0.
+                                    if grad_norm < 0.5:
+                                        if pen_v > 0.0:
+                                            pen_emit = qd.min(synthetic_pen_max + pen_v, margin)
+                                        else:
+                                            pen_emit = synthetic_pen_max * (1.0 + pen_v / margin)
+                                    elif pen_v > 0.0:
+                                        pen_emit = synthetic_pen_max
+                                else:
+                                    # Outside the thin-wall regimes an uncertain (smoothed or seam) pen is not trusted
+                                    # at all; the vert still damps the closing velocity as a zero-depth support contact.
+                                    if qd.static(i_phase == 0):
+                                        is_support = pen_v > -synthetic_pen_max
+                                normal_v = normal_center
+                                if enclosed_axis or axis_normal:
+                                    # Concave shells: the pair-level reference normal cannot resist lateral shear, so
+                                    # orient from B's grad when well-conditioned (sign fixed from A's exact vertex
+                                    # normal) and from A's vertex normal when the grad is smoothed across the thin wall.
+                                    a_vnormal = gu.qd_normalize(
+                                        gu.qd_transform_by_quat(verts_info.init_normal[i_v], ja_quat), EPS
+                                    )
+                                    if grad_norm > 0.5:
+                                        normal_v = gu.qd_normalize(grad_v, EPS)
+                                        if normal_v.dot(a_vnormal) > 0.0:
+                                            # Grad agreeing with A's outward normal = tunneled past B's thin wall: no
+                                            # support contact there, damping the far side stalls the crossing-escape
+                                            # creep.
+                                            normal_v = -normal_v
+                                            is_support = False
+                                    else:
+                                        normal_v = -a_vnormal
+                                elif (
+                                    not use_closing_dir
+                                    and not axis_normal
+                                    and grad_norm > 0.9
+                                    and grad_v.dot(normal_center) > 0.0
+                                ):
+                                    # Trust a per-vertex grad as the contact normal only in the clean band where the
+                                    # kernel pen is trusted; in the edge/smoothed bands the reference normal at A's
+                                    # center is more reliable.
+                                    normal_v = gu.qd_normalize(grad_v, EPS)
+                                # In the closing regime the per-vertex pen is only the radial gap to B's lateral; floor
+                                # it with the geometric approach depth so the solver sees the actual overlap.
+                                if use_closing_dir and pen_v > 0.0 and approach_depth_pair > pen_emit:
+                                    pen_emit = approach_depth_pair
+                                rel_ref = vertex_pos - frame_origin
+                                az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
+                                az_scaled = (az_ref + qd.math.pi) * (n_buckets / (2.0 * qd.math.pi))
+                                i_bucket = qd.min(qd.max(qd.cast(az_scaled, gs.qd_int), 0), n_buckets - 1)
+                                if pen_emit > 0.0:
+                                    acc_w[i_bucket] += pen_emit
+                                    for j in qd.static(range(3)):
+                                        acc_pos[i_bucket, j] += pen_emit * vertex_pos[j]
+                                        acc_n[i_bucket, j] += phase_sign * pen_emit * normal_v[j]
+                                elif is_support:
+                                    sup_c[i_bucket] += 1.0
+                                    for j in qd.static(range(3)):
+                                        sup_pos[i_bucket, j] += vertex_pos[j]
+                                        sup_n[i_bucket, j] += phase_sign * normal_v[j]
+    # Emit one aggregated contact per active bucket. A bucket whose members disagree on direction (the weighted
+    # normal nearly cancels) is ambiguous and skipped; buckets holding only zero-depth support verts emit a support
+    # contact at their unweighted centroid.
+    for i_bucket in range(n_buckets):
+        emit_pen = gs.qd_float(0.0)
+        is_emit = False
+        contact_pos = qd.Vector.zero(gs.qd_float, 3)
+        normal_c = qd.Vector.zero(gs.qd_float, 3)
+        if acc_w[i_bucket] > 0.0:
+            inv_w = 1.0 / acc_w[i_bucket]
+            contact_pos = qd.Vector(
+                [acc_pos[i_bucket, 0] * inv_w, acc_pos[i_bucket, 1] * inv_w, acc_pos[i_bucket, 2] * inv_w],
+                dt=gs.qd_float,
+            )
+            normal_c = qd.Vector([acc_n[i_bucket, 0], acc_n[i_bucket, 1], acc_n[i_bucket, 2]], dt=gs.qd_float)
+            if normal_c.norm() > 0.1 * acc_w[i_bucket]:
+                # Conservative aggregation: members act like springs deriving from the bucket potential
+                # 0.5 * sum(pen_i^2), so the aggregate must carry sum(pen_i * n_i) as its (normal, pen) pair; any
+                # other pen scaling tilts the force off the potential gradient and the curl walks a settled stack.
+                # Saturate at half the SDF margin with a leaky slope: past the solver impedance width the force
+                # plateaus and the aggregate becomes a zero-stiffness thruster whose flicker pumps the stack. Unit
+                # slope below the cap keeps full interface stiffness; the residual slope avoids a plateau of its own.
+                pen_scale = 0.5 * margin
+                pen_raw = normal_c.norm()
+                emit_pen = pen_raw
+                if pen_raw > pen_scale:
+                    emit_pen = pen_scale + 0.1 * (pen_raw - pen_scale)
+                normal_c = gu.qd_normalize(normal_c, EPS)
+                is_emit = True
+        else:
+            if sup_c[i_bucket] > 0.0:
+                inv_c = 1.0 / sup_c[i_bucket]
+                contact_pos = qd.Vector(
+                    [sup_pos[i_bucket, 0] * inv_c, sup_pos[i_bucket, 1] * inv_c, sup_pos[i_bucket, 2] * inv_c],
+                    dt=gs.qd_float,
+                )
+                normal_c = qd.Vector([sup_n[i_bucket, 0], sup_n[i_bucket, 1], sup_n[i_bucket, 2]], dt=gs.qd_float)
+                if normal_c.norm() > 0.1 * sup_c[i_bucket]:
+                    normal_c = gu.qd_normalize(normal_c, EPS)
+                    is_emit = True
+        if is_emit:
+            # Snap onto A's smooth surface when A is a smooth primitive; a no-op for polytope-typed A.
+            contact_pos = func_apply_smooth_refinement(
+                i_ga,
+                i_gb,
+                normal_c,
+                emit_pen,
+                contact_pos,
+                ga_pos,
+                ga_quat,
+                gb_pos,
+                gb_quat,
+                geoms_info,
+                static_rigid_sim_config,
+            )
+            func_add_contact(
+                i_ga,
+                i_gb,
+                normal_c,
+                contact_pos,
+                emit_pen,
+                i_b,
+                i_pair,
+                geoms_state,
+                geoms_info,
+                collider_state,
+                collider_info,
+                errno,
+            )
+
+
+@qd.func
 def func_contact_vertex_sdf(
     i_ga,
     i_gb,
@@ -2591,8 +3065,8 @@ def _func_narrowphase_contact0(
                             tolerance,
                             overlap_ratio * geom_pair_scale,
                         )
-                        # An INVALID portal (unconverged, or the origin extrapolates too far outside the portal) gives an
-                        # untrustworthy penetration - always refine with GJK regardless of depth.
+                        # An INVALID portal (unconverged, or the origin extrapolates too far outside the portal) gives
+                        # an untrustworthy penetration - always refine with GJK regardless of depth.
                         if is_col and (mpr_state.portal_status[flat_idx] == PORTAL_STATUS.INVALID):
                             prefer_gjk = True
 
@@ -2970,46 +3444,42 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                     ga_quat = geoms_state.quat[i_ga, i_b]
                     gb_pos = geoms_state.pos[i_gb, i_b]
                     gb_quat = geoms_state.quat[i_gb, i_b]
-                    func_add_polytope_vertex_contacts_sdf(
-                        i_ga,
-                        i_gb,
-                        i_b,
-                        i_pair,
-                        ga_pos,
-                        ga_quat,
-                        gb_pos,
-                        gb_quat,
-                        tolerance,
-                        False,
-                        geoms_state,
-                        geoms_info,
-                        geoms_init_AABB,
-                        verts_info,
-                        rigid_global_info,
-                        static_rigid_sim_config,
-                        collider_static_config,
-                        sdf_info,
-                        collider_state,
-                        collider_info,
-                        errno,
-                    )
-                    # Swapped-role verification: A's vertex scan cannot see a feature of B crossing one of A's faces
-                    # BETWEEN A's verts (a mug rim pressing through a cup wall), so B's verts are checked against A's
-                    # SDF as well - as a seeded local search rather than a full scan, so the cost stays bounded by the
-                    # contact patch instead of B's vertex count. Skipped only for PLANE (its handful of far-flung
-                    # verts carry no contact information).
-                    if geoms_info.type[i_gb] != gs.GEOM_TYPE.PLANE:
-                        func_add_polytope_vertex_contacts_sdf(
-                            i_gb,
+                    # Nested-shell pair detection: BOTH bodies hollow (their own centers sit in their cavities),
+                    # A's center outside B's material, comparable sizes. Such pairs contact along an annular line
+                    # where the per-vertex manifold churns, so they use the sector-aggregated manifold; every other
+                    # pair - including a hollow body near a solid one (nut around a bolt) - keeps the per-vertex one.
+                    is_shell_pair = False
+                    center_a_w = gu.qd_transform_by_trans_quat(geoms_info.center[i_ga], ga_pos, ga_quat)
+                    rb_a_sq = gs.qd_float(0.0)
+                    rb_b_sq = gs.qd_float(0.0)
+                    for k in qd.static(range(8)):
+                        d_a = geoms_init_AABB[i_ga, k] - geoms_info.center[i_ga]
+                        d_b = geoms_init_AABB[i_gb, k] - geoms_info.center[i_gb]
+                        if d_a.dot(d_a) > rb_a_sq:
+                            rb_a_sq = d_a.dot(d_a)
+                        if d_b.dot(d_b) > rb_b_sq:
+                            rb_b_sq = d_b.dot(d_b)
+                    sd_center_ab = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_w, i_gb, gb_pos, gb_quat)
+                    if qd.abs(sd_center_ab) < qd.sqrt(rb_a_sq) and rb_a_sq > 0.25 * rb_b_sq and sd_center_ab >= 0.0:
+                        sd_a_self = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_w, i_ga, ga_pos, ga_quat)
+                        if sd_a_self > EPS:
+                            center_b_w = gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat)
+                            sd_b_self = sdf.sdf_func_world_local(
+                                geoms_info, sdf_info, center_b_w, i_gb, gb_pos, gb_quat
+                            )
+                            if sd_b_self > EPS:
+                                is_shell_pair = True
+                    if is_shell_pair:
+                        func_add_polytope_vertex_contacts_sdf_shell(
                             i_ga,
+                            i_gb,
                             i_b,
                             i_pair,
-                            gb_pos,
-                            gb_quat,
                             ga_pos,
                             ga_quat,
+                            gb_pos,
+                            gb_quat,
                             tolerance,
-                            True,
                             geoms_state,
                             geoms_info,
                             geoms_init_AABB,
@@ -3022,3 +3492,55 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                             collider_info,
                             errno,
                         )
+                    else:
+                        func_add_polytope_vertex_contacts_sdf(
+                            i_ga,
+                            i_gb,
+                            i_b,
+                            i_pair,
+                            ga_pos,
+                            ga_quat,
+                            gb_pos,
+                            gb_quat,
+                            tolerance,
+                            False,
+                            geoms_state,
+                            geoms_info,
+                            geoms_init_AABB,
+                            verts_info,
+                            rigid_global_info,
+                            static_rigid_sim_config,
+                            collider_static_config,
+                            sdf_info,
+                            collider_state,
+                            collider_info,
+                            errno,
+                        )
+                        # Swapped-role verification: A's vertex scan cannot see a feature of B crossing one of A's
+                        # faces BETWEEN A's verts, so B's verts are checked against A's SDF as well - as a seeded
+                        # local search rather than a full scan. Skipped only for PLANE (its handful of far-flung
+                        # verts carry no contact information).
+                        if geoms_info.type[i_gb] != gs.GEOM_TYPE.PLANE:
+                            func_add_polytope_vertex_contacts_sdf(
+                                i_gb,
+                                i_ga,
+                                i_b,
+                                i_pair,
+                                gb_pos,
+                                gb_quat,
+                                ga_pos,
+                                ga_quat,
+                                tolerance,
+                                True,
+                                geoms_state,
+                                geoms_info,
+                                geoms_init_AABB,
+                                verts_info,
+                                rigid_global_info,
+                                static_rigid_sim_config,
+                                collider_static_config,
+                                sdf_info,
+                                collider_state,
+                                collider_info,
+                                errno,
+                            )

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -327,17 +327,17 @@ def func_add_polytope_vertex_contacts_sdf(
         # the FINAL normal rather than letting per-vertex grad override it. The size-ratio gate keeps the existing
         # behavior for one-big-one-small pairs where the SDF grad at A's center is reliable and the closing-direction
         # line is wrong (sphere on a large floor mesh).
-        use_closing_dir = qd.abs(sd_center) < rbound_a and rbound_a_sq > gs.qd_float(0.25) * rbound_b_sq
+        is_closing_regime = qd.abs(sd_center) < rbound_a and rbound_a_sq > gs.qd_float(0.25) * rbound_b_sq
         approach_depth_pair = gs.qd_float(0.0)
         closing_normal = qd.Vector.zero(gs.qd_float, 3)
         # Set when A wraps around B so that B passes through A along the center-to-center axis. There the SDF gradient
         # at A's center is ill-conditioned (it sits inside B, away from any surface), so per-vertex grads are trusted
         # directly rather than filtered against that unreliable reference normal.
-        enclosed_axis = False
+        is_enclosed_regime = False
         # Set when A and B are two concave shells resting on each other (nested cups/bowls). Both SDF-based normals
         # are unreliable there, so the center-to-center line is used as the contact normal for the whole pair.
-        axis_normal = False
-        if use_closing_dir:
+        is_axis_normal_regime = False
+        if is_closing_regime:
             closing_dir = center_a_world - center_b_world
             if closing_dir.norm() > EPS:
                 closing_normal = gu.qd_normalize(closing_dir, EPS)
@@ -347,12 +347,12 @@ def func_add_polytope_vertex_contacts_sdf(
                 # A's material (the build-time is_hollow flag): true for such a hollow/annular A, false for the
                 # solid A of the genuine crossed-thin-geom regime.
                 if geoms_info.is_hollow[i_ga]:
-                    use_closing_dir = False
+                    is_closing_regime = False
                     if sd_center < 0.0:
                         # B's material occupies A's center: B passes through A's cavity (a nut around a bolt shaft).
                         # The grad at A's center is ill-conditioned (deep inside B), so trust each vertex's own grad,
                         # which is radial around B and balances across the contact ring.
-                        enclosed_axis = True
+                        is_enclosed_regime = True
                     else:
                         # A is hollow but its center sits OUTSIDE B: two concave shells resting on each other (nested
                         # cups/bowls). BOTH SDF-based normals are unreliable here - the thin curved wall makes the
@@ -361,7 +361,7 @@ def func_add_polytope_vertex_contacts_sdf(
                         # line is the stacking axis and the robust contact normal, so use it directly (b->a) for every
                         # contact of the pair.
                         normal_center = closing_normal
-                        axis_normal = True
+                        is_axis_normal_regime = True
                 else:
                     # Mirror the enclosure test on B: when B's own center sits in a cavity of B (mug, cup, torus),
                     # the center-to-center axis passes through that cavity, so the axis overlap measures pass-through
@@ -370,7 +370,7 @@ def func_add_polytope_vertex_contacts_sdf(
                     # targets has both bodies solid (their centers inside their own material), so requiring a
                     # non-hollow B preserves it while restoring the standard SDF-gradient path for hollow B.
                     if geoms_info.is_hollow[i_gb]:
-                        use_closing_dir = False
+                        is_closing_regime = False
                         sd_b_center = sdf.sdf_func_world_local(
                             geoms_info, sdf_info, center_b_world, i_ga, ga_pos, ga_quat
                         )
@@ -380,7 +380,7 @@ def func_add_polytope_vertex_contacts_sdf(
                             # ill-conditioned (it sits on B's bore axis where the axisymmetric grad vanishes), so
                             # trust each vertex's own grad, which is radial around B's bore and balances across the
                             # contact ring.
-                            enclosed_axis = True
+                            is_enclosed_regime = True
                     else:
                         normal_center = closing_normal
                         # Approach depth along the closing axis, measured on the SDFs: bisect the center-to-center
@@ -420,7 +420,7 @@ def func_add_polytope_vertex_contacts_sdf(
                         )
                         approach_depth_pair = depth_a + depth_b - seg_len
             else:
-                use_closing_dir = False
+                is_closing_regime = False
         for k in range(n_max):
             if top_iv[k] >= 0:
                 i_v = top_iv[k]
@@ -457,7 +457,7 @@ def func_add_polytope_vertex_contacts_sdf(
                 elif pen_v > 0.0:
                     pen_emit = synthetic_pen_max
                 normal_v = normal_center
-                if enclosed_axis or axis_normal:
+                if is_enclosed_regime or is_axis_normal_regime:
                     # Two concave shells (nested cups/bowls) or B passing through A's cavity (nut on bolt): the
                     # pair-level reference normal is unreliable (sign-flipped in a concave pocket, or vertical-only so
                     # it cannot resist lateral shear). Orient the contact from A's own exact vertex surface normal
@@ -475,7 +475,12 @@ def func_add_polytope_vertex_contacts_sdf(
                             normal_v = -normal_v
                     else:
                         normal_v = -a_vnormal
-                elif not use_closing_dir and not axis_normal and grad_norm > 0.9 and grad_v.dot(normal_center) > 0.0:
+                elif (
+                    not is_closing_regime
+                    and not is_axis_normal_regime
+                    and grad_norm > 0.9
+                    and grad_v.dot(normal_center) > 0.0
+                ):
                     # Trust a per-vertex grad as the contact normal only in the clean band (the same |grad| > 0.9 band
                     # where the kernel pen is trusted): this is what exposes both face normals for an A wedged at a
                     # concave L-corner. In the edge/smoothed bands the per-vertex grad is a partially-interpolated
@@ -486,7 +491,7 @@ def func_add_polytope_vertex_contacts_sdf(
                 # outer skin is the small radial gap to B's lateral, not the much larger approach depth along the
                 # closing axis. Use the geometric approach depth as a floor on pen_emit so the constraint solver sees
                 # the actual overlap rather than just the radial gap.
-                if use_closing_dir and pen_v > 0.0 and approach_depth_pair > pen_emit:
+                if is_closing_regime and pen_v > 0.0 and approach_depth_pair > pen_emit:
                     pen_emit = approach_depth_pair
                 repeated = False
                 for j in range(n_added):
@@ -578,27 +583,27 @@ def func_add_polytope_vertex_contacts_sdf_shell(
     collider_info: array_class.ColliderInfo,
     errno: qd.Tensor,
 ):
-    # Sector-aggregated manifold for nested-shell pairs (both bodies hollow, see the dispatcher gate). The annular
-    # contact of nested shells makes the top-k vertex manifold churn: kept-set swaps, dedup toggles and regime flips
-    # each relocate a finite force, and a tall stack rectifies that noise into a sideways walk. Here every band vert
-    # instead accumulates into a fixed azimuthal sector, and each active sector emits ONE aggregated contact, so the
-    # emitted force field is continuous in pose and the pair budget holds by construction.
-    n_max = qd.static(
-        collider_static_config.n_contacts_per_nonconvex_pair if static_rigid_sim_config.enable_multi_contact else 1
-    )
-    # One shared bucket table covers both scan directions, so the sector count IS the pair budget.
+    """
+    Sector-aggregated manifold for nested-shell pairs (both bodies hollow, see the dispatcher gate).
+
+    The annular contact of nested shells makes the top-k vertex manifold churn: kept-set swaps, dedup toggles and
+    regime flips each relocate a finite force, and a tall stack rectifies that noise into a sideways walk. Here
+    every band vert instead accumulates into a fixed azimuthal sector, and each active sector emits ONE aggregated
+    contact, so the emitted force field is continuous in pose and the pair budget holds by construction.
+    """
+    # The bucket table is sized at the pair budget: each bucket emits at most one contact, from whichever scan
+    # covers it (see emission).
     n_buckets = qd.static(
         collider_static_config.n_contacts_per_nonconvex_pair if static_rigid_sim_config.enable_multi_contact else 1
     )
     EPS = rigid_global_info.EPS[None]
-    gb_cell = sdf_info.geoms_info.sdf_cell_size[i_gb]
-    margin = qd.min(qd.min(gb_cell[0], gb_cell[1]), gb_cell[2])
     synthetic_pen_max = 1e-4
     center_a_world = gu.qd_transform_by_trans_quat(geoms_info.center[i_ga], ga_pos, ga_quat)
+    center_b_world = gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat)
     # Shared azimuthal-sector frame for both scan directions: a vertex found by the swapped scan joins the
     # aggregate its azimuth belongs to instead of spawning a contact of its own. Derived from the closing line,
     # which is pose-continuous.
-    closing_line = center_a_world - gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat)
+    closing_line = center_a_world - center_b_world
     frame_axis = qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float)
     if closing_line.norm() > EPS:
         frame_axis = gu.qd_normalize(closing_line, EPS)
@@ -608,23 +613,29 @@ def func_add_polytope_vertex_contacts_sdf_shell(
     e_ref = qd.Vector([0.36, 0.48, 0.8], dt=gs.qd_float)
     t1_ref = gu.qd_normalize(frame_axis.cross(e_ref), EPS)
     t2_ref = frame_axis.cross(t1_ref)
-    frame_origin = 0.5 * (center_a_world + gu.qd_transform_by_trans_quat(geoms_info.center[i_gb], gb_pos, gb_quat))
+    frame_origin = 0.5 * (center_a_world + center_b_world)
 
-    # Per-bucket accumulators shared by both phases. A vertex enters or leaves a bucket with weight
+    # Per-bucket accumulators, one table per scan direction. A vertex enters or leaves a bucket with weight
     # pen_emit -> 0, which is what keeps the emitted force field continuous.
     acc_w = qd.Vector.zero(gs.qd_float, n_buckets)
     acc_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
     acc_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
-    acc_pm = qd.Vector.zero(gs.qd_float, n_buckets)
-    acc_pmp = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
-    sup_c = qd.Vector.zero(gs.qd_float, n_buckets)
+    acc_pen_max = qd.Vector.zero(gs.qd_float, n_buckets)
+    # The swapped scan fills a shadow table consumed only where the primary scan is blind (see emission):
+    # both scans sample the same patch through two different tessellations, and summing them makes their
+    # sampling washboards beat - a low-frequency force modulation that ratchets a soft stack sideways.
+    acc2_w = qd.Vector.zero(gs.qd_float, n_buckets)
+    acc2_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+    acc2_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
+    acc2_pen_max = qd.Vector.zero(gs.qd_float, n_buckets)
+    sup_w = qd.Vector.zero(gs.qd_float, n_buckets)
     sup_pos = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
     sup_n = qd.Matrix.zero(gs.qd_float, n_buckets, 3)
 
     for i_phase in qd.static(range(2)):
-        # Phase 0 scans every vert of A against B's SDF; phase 1 checks B's verts against A's SDF as a seeded
-        # local search (hill-climb from the phase-0 aggregates), covering features of B crossing A's faces BETWEEN
-        # A's verts. Phase-1 normals are negated onto the phase-0 orientation convention.
+        # Phase 0 scans every vert of A against B's SDF; phase 1 scans B's verts against A's SDF into the shadow
+        # table, covering features of B crossing A's faces BETWEEN A's verts. Phase-1 normals are negated onto
+        # the phase-0 orientation convention.
         j_ga = i_ga
         j_gb = i_gb
         ja_pos = ga_pos
@@ -644,389 +655,239 @@ def func_add_polytope_vertex_contacts_sdf_shell(
         if qd.static(i_phase == 1):
             # A plane's handful of far-flung verts carry no contact information.
             is_phase_active = geoms_info.type[j_ga] != gs.GEOM_TYPE.PLANE
-        gb_cell_p = sdf_info.geoms_info.sdf_cell_size[j_gb]
-        margin = qd.min(qd.min(gb_cell_p[0], gb_cell_p[1]), gb_cell_p[2])
-        center_local_p = geoms_info.center[j_ga]
+        jb_cell = sdf_info.geoms_info.sdf_cell_size[j_gb]
+        margin = qd.min(qd.min(jb_cell[0], jb_cell[1]), jb_cell[2])
+        ja_center_local = geoms_info.center[j_ga]
         rbound_a_sq = gs.qd_float(0.0)
         for k in qd.static(range(8)):
-            delta = geoms_init_AABB[j_ga, k] - center_local_p
+            delta = geoms_init_AABB[j_ga, k] - ja_center_local
             d_sq = delta.dot(delta)
             if d_sq > rbound_a_sq:
                 rbound_a_sq = d_sq
         rbound_a = qd.sqrt(rbound_a_sq)
-        center_a_world_p = gu.qd_transform_by_trans_quat(center_local_p, ja_pos, ja_quat)
-        can_use_sd_reject_p = (
-            geoms_info.type[j_gb] == gs.GEOM_TYPE.SPHERE or geoms_info.type[j_gb] == gs.GEOM_TYPE.PLANE
-        )
-        if not can_use_sd_reject_p:
-            pos_mesh_p = gu.qd_inv_transform_by_trans_quat(center_a_world_p, jb_pos, jb_quat)
-            pos_sdf_p = gu.qd_transform_by_T(pos_mesh_p, sdf_info.geoms_info.T_mesh_to_sdf[j_gb])
-            can_use_sd_reject_p = not sdf.sdf_func_is_outside_sdf_grid(sdf_info, pos_sdf_p, j_gb)
-        sd_center_p = sdf.sdf_func_world_local(geoms_info, sdf_info, center_a_world_p, j_gb, jb_pos, jb_quat)
-        if is_phase_active and ((not can_use_sd_reject_p) or sd_center_p <= rbound_a):
-            sd_center = sd_center_p
+        ja_center_world = gu.qd_transform_by_trans_quat(ja_center_local, ja_pos, ja_quat)
+        can_use_sd_reject = geoms_info.type[j_gb] == gs.GEOM_TYPE.SPHERE or geoms_info.type[j_gb] == gs.GEOM_TYPE.PLANE
+        if not can_use_sd_reject:
+            pos_mesh = gu.qd_inv_transform_by_trans_quat(ja_center_world, jb_pos, jb_quat)
+            pos_sdf = gu.qd_transform_by_T(pos_mesh, sdf_info.geoms_info.T_mesh_to_sdf[j_gb])
+            can_use_sd_reject = not sdf.sdf_func_is_outside_sdf_grid(sdf_info, pos_sdf, j_gb)
+        sd_center = sdf.sdf_func_world_local(geoms_info, sdf_info, ja_center_world, j_gb, jb_pos, jb_quat)
+        if is_phase_active and ((not can_use_sd_reject) or sd_center <= rbound_a):
             rbound_b_sq = gs.qd_float(0.0)
-            b_center_local = geoms_info.center[j_gb]
+            jb_center_local = geoms_info.center[j_gb]
             for k in qd.static(range(8)):
-                delta_b = geoms_init_AABB[j_gb, k] - b_center_local
+                delta_b = geoms_init_AABB[j_gb, k] - jb_center_local
                 d_sq_b = delta_b.dot(delta_b)
                 if d_sq_b > rbound_b_sq:
                     rbound_b_sq = d_sq_b
-            center_b_world = gu.qd_transform_by_trans_quat(b_center_local, jb_pos, jb_quat)
+            jb_center_world = gu.qd_transform_by_trans_quat(jb_center_local, jb_pos, jb_quat)
 
             grad_center = sdf.sdf_func_grad_world_local_consistent(
-                geoms_info, rigid_global_info, sdf_info, center_a_world_p, j_gb, jb_pos, jb_quat
+                geoms_info, rigid_global_info, sdf_info, ja_center_world, j_gb, jb_pos, jb_quat
             )
             normal_center = gu.qd_normalize(grad_center, EPS)
             # Regime detection and per-vertex pen/normal policy identical to the per-vertex manifold, which
             # documents the rationale of each test.
-            use_closing_dir = qd.abs(sd_center) < rbound_a and rbound_a_sq > gs.qd_float(0.25) * rbound_b_sq
+            is_closing_regime = qd.abs(sd_center) < rbound_a and rbound_a_sq > gs.qd_float(0.25) * rbound_b_sq
             approach_depth_pair = gs.qd_float(0.0)
             closing_normal = qd.Vector.zero(gs.qd_float, 3)
-            enclosed_axis = False
-            axis_normal = False
-            if use_closing_dir:
-                closing_dir = center_a_world_p - center_b_world
+            is_enclosed_regime = False
+            is_axis_normal_regime = False
+            if is_closing_regime:
+                closing_dir = ja_center_world - jb_center_world
                 if closing_dir.norm() > EPS:
                     closing_normal = gu.qd_normalize(closing_dir, EPS)
                     if geoms_info.is_hollow[j_ga]:
-                        use_closing_dir = False
+                        is_closing_regime = False
                         if sd_center < 0.0:
-                            enclosed_axis = True
+                            is_enclosed_regime = True
                         else:
                             normal_center = closing_normal
-                            axis_normal = True
+                            is_axis_normal_regime = True
+                    elif geoms_info.is_hollow[j_gb]:
+                        is_closing_regime = False
+                        sd_b_center = sdf.sdf_func_world_local(
+                            geoms_info, sdf_info, jb_center_world, j_ga, ja_pos, ja_quat
+                        )
+                        if sd_b_center < 0.0:
+                            is_enclosed_regime = True
                     else:
-                        if geoms_info.is_hollow[j_gb]:
-                            use_closing_dir = False
-                            sd_b_center = sdf.sdf_func_world_local(
-                                geoms_info, sdf_info, center_b_world, j_ga, ja_pos, ja_quat
-                            )
-                            if sd_b_center < 0.0:
-                                enclosed_axis = True
-                        else:
-                            normal_center = closing_normal
-                            seg_len = closing_dir.norm()
-                            depth_b = sdf.sdf_func_ray_exit_distance(
-                                geoms_info,
-                                sdf_info,
-                                center_b_world,
-                                closing_normal,
-                                seg_len,
-                                tolerance,
-                                j_gb,
-                                jb_pos,
-                                jb_quat,
-                            )
-                            depth_a = sdf.sdf_func_ray_exit_distance(
-                                geoms_info,
-                                sdf_info,
-                                center_a_world_p,
-                                -closing_normal,
-                                seg_len,
-                                tolerance,
-                                j_ga,
-                                ja_pos,
-                                ja_quat,
-                            )
-                            approach_depth_pair = depth_a + depth_b - seg_len
+                        normal_center = closing_normal
+                        seg_len = closing_dir.norm()
+                        depth_b = sdf.sdf_func_ray_exit_distance(
+                            geoms_info,
+                            sdf_info,
+                            jb_center_world,
+                            closing_normal,
+                            seg_len,
+                            tolerance,
+                            j_gb,
+                            jb_pos,
+                            jb_quat,
+                        )
+                        depth_a = sdf.sdf_func_ray_exit_distance(
+                            geoms_info,
+                            sdf_info,
+                            ja_center_world,
+                            -closing_normal,
+                            seg_len,
+                            tolerance,
+                            j_ga,
+                            ja_pos,
+                            ja_quat,
+                        )
+                        approach_depth_pair = depth_a + depth_b - seg_len
                 else:
-                    use_closing_dir = False
-            if qd.static(i_phase == 0):
-                for i_v in range(geoms_info.vert_start[j_ga], geoms_info.vert_end[j_ga]):
-                    vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
-                    if func_point_in_geom_aabb(geoms_state, j_gb, i_b, vertex_pos):
-                        pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
-                        if pen_v > -margin:
-                            grad_v = sdf.sdf_func_grad_world_local_consistent(
-                                geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
-                            )
-                            grad_norm = grad_v.norm()
-                            pen_emit = gs.qd_float(0.0)
-                            is_support = False
-                            if grad_norm > 0.9:
+                    is_closing_regime = False
+            # Both directions run the same full scan: phase 0 checks A's verts against B's SDF, phase 1
+            # B's verts against A's (features of one body crossing the other's faces BETWEEN its verts are
+            # only visible to the swapped scan). A full scan keeps membership continuous in pose - verts
+            # enter and leave the admission band with weight pen_emit -> 0 - whereas a seeded local search
+            # toggles whole member clusters at finite weight whenever a hill-climb seed relocates, and that
+            # force modulation ratchets a softly-stacked column sideways.
+            for i_v in range(geoms_info.vert_start[j_ga], geoms_info.vert_end[j_ga]):
+                vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
+                if func_point_in_geom_aabb(geoms_state, j_gb, i_b, vertex_pos):
+                    pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
+                    if pen_v > -margin:
+                        grad_v = sdf.sdf_func_grad_world_local_consistent(
+                            geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
+                        )
+                        grad_norm = grad_v.norm()
+                        pen_emit = gs.qd_float(0.0)
+                        is_support = False
+                        if grad_norm > 0.9:
+                            if pen_v > 0.0:
+                                pen_emit = pen_v
+                            elif qd.static(i_phase == 0):
+                                # Zero-depth support contacts: verts touching within the grid-noise pen scale damp
+                                # the closing velocity without exerting static force. Crossed solids are excluded
+                                # (damping the far side of the overlap stalls the escape).
+                                is_support = pen_v > -synthetic_pen_max and not is_closing_regime
+                        elif is_closing_regime or is_axis_normal_regime or is_enclosed_regime:
+                            # Sub-cell thin walls are uncertifiable by the lattice, yet these band verts are the
+                            # only carriers of the coupling across the wall: keep the synthetic depths, continuous
+                            # across pen_v = 0.
+                            if grad_norm < 0.5:
                                 if pen_v > 0.0:
-                                    pen_emit = pen_v
-                                elif qd.static(i_phase == 0):
-                                    # Zero-depth support contacts: verts touching within the grid-noise pen scale damp
-                                    # the closing velocity without exerting static force. Crossed solids are excluded
-                                    # (damping the far side of the overlap stalls the escape).
-                                    is_support = pen_v > -synthetic_pen_max and not use_closing_dir
-                            elif use_closing_dir or axis_normal or enclosed_axis:
-                                # Sub-cell thin walls are uncertifiable by the lattice, yet these band verts are the
-                                # only carriers of the coupling across the wall: keep the synthetic depths, continuous
-                                # across pen_v = 0.
-                                if grad_norm < 0.5:
-                                    if pen_v > 0.0:
-                                        pen_emit = qd.min(synthetic_pen_max + pen_v, margin)
-                                    else:
-                                        pen_emit = synthetic_pen_max * (1.0 + pen_v / margin)
-                                elif pen_v > 0.0:
-                                    pen_emit = synthetic_pen_max
-                            else:
-                                # Outside the thin-wall regimes an uncertain (smoothed or seam) pen is not trusted at
-                                # all; the vert still damps the closing velocity as a zero-depth support contact.
-                                if qd.static(i_phase == 0):
-                                    is_support = pen_v > -synthetic_pen_max
-                            normal_v = normal_center
-                            if enclosed_axis or axis_normal:
-                                # Concave shells: the pair-level reference normal cannot resist lateral shear, so orient
-                                # from B's grad when well-conditioned (sign fixed from A's exact vertex normal) and from
-                                # A's vertex normal when the grad is smoothed across the thin wall.
-                                a_vnormal = gu.qd_normalize(
-                                    gu.qd_transform_by_quat(verts_info.init_normal[i_v], ja_quat), EPS
-                                )
-                                if grad_norm > 0.5:
-                                    normal_v = gu.qd_normalize(grad_v, EPS)
-                                    if normal_v.dot(a_vnormal) > 0.0:
-                                        # Grad agreeing with A's outward normal = tunneled past B's thin wall: no
-                                        # support contact there, damping the far side stalls the crossing-escape creep.
-                                        normal_v = -normal_v
-                                        is_support = False
+                                    pen_emit = qd.min(synthetic_pen_max + pen_v, margin)
                                 else:
-                                    normal_v = -a_vnormal
-                            elif (
-                                not use_closing_dir
-                                and not axis_normal
-                                and grad_norm > 0.9
-                                and grad_v.dot(normal_center) > 0.0
-                            ):
-                                # Trust a per-vertex grad as the contact normal only in the clean band where the kernel
-                                # pen is trusted; in the edge/smoothed bands the reference normal at A's center is more
-                                # reliable.
+                                    pen_emit = synthetic_pen_max * (1.0 + pen_v / margin)
+                            elif pen_v > 0.0:
+                                pen_emit = synthetic_pen_max
+                        else:
+                            # Outside the thin-wall regimes an uncertain (smoothed or seam) pen is not trusted at
+                            # all; the vert still damps the closing velocity as a zero-depth support contact.
+                            if qd.static(i_phase == 0):
+                                is_support = pen_v > -synthetic_pen_max
+                        normal_v = normal_center
+                        if is_enclosed_regime or is_axis_normal_regime:
+                            # Concave shells: the pair-level reference normal cannot resist lateral shear, so orient
+                            # from B's grad when well-conditioned (sign fixed from A's exact vertex normal) and from
+                            # A's vertex normal when the grad is smoothed across the thin wall.
+                            a_vnormal = gu.qd_normalize(
+                                gu.qd_transform_by_quat(verts_info.init_normal[i_v], ja_quat), EPS
+                            )
+                            if grad_norm > 0.5:
                                 normal_v = gu.qd_normalize(grad_v, EPS)
-                            # In the closing regime the per-vertex pen is only the radial gap to B's lateral; floor it
-                            # with the geometric approach depth so the solver sees the actual overlap.
-                            if use_closing_dir and pen_v > 0.0 and approach_depth_pair > pen_emit:
-                                pen_emit = approach_depth_pair
-                            rel_ref = vertex_pos - frame_origin
-                            az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
-                            # Two sub-buckets per azimuth sector, split by normal hemisphere: a crossed wall has
-                            # penetrating verts on BOTH faces with opposed normals, and merging them would cancel the
-                            # aggregate exactly when the crossing needs resistance from each side. The split also keeps
-                            # phase-1 members from annihilating phase-0 members of the opposite face.
-                            i_bucket = 0
-                            i_bucket_2 = 0
-                            w_hat = gs.qd_float(1.0)
-                            if qd.static(n_buckets >= 2):
-                                # Hat-weighted azimuthal binning: a member splits its weight linearly between the two
-                                # nearest sector centers, so rotating past a sector boundary moves weight continuously
-                                # instead of relocating it in one step - a hard handoff modulates the emitted forces
-                                # and, combined with any standing lateral bias, ratchets a softly-stacked column.
-                                az_scaled = (az_ref + qd.math.pi) * ((n_buckets // 2) / (2.0 * qd.math.pi))
-                                u_hat = az_scaled - 0.5
-                                i_sec = qd.cast(qd.floor(u_hat), gs.qd_int)
-                                frac_hat = u_hat - qd.cast(i_sec, gs.qd_float)
-                                i_sec = qd.raw_mod(i_sec + (n_buckets // 2), n_buckets // 2)
-                                i_sec_2 = qd.raw_mod(i_sec + 1, n_buckets // 2)
-                                w_hat = 1.0 - frac_hat
-                                i_bucket = 2 * i_sec
-                                i_bucket_2 = 2 * i_sec_2
-                                # Hemisphere sign from whichever direction is well-conditioned for this face: seating
-                                # faces align with the closing axis, side walls are perpendicular to it and split on
-                                # the local radial instead - otherwise their sub-bucket assignment is FP-noise-driven
-                                # and opposite faces can still share a bucket and cancel.
-                                n_shared = phase_sign * normal_v
-                                rad_ref = gu.qd_normalize(rel_ref - rel_ref.dot(frame_axis) * frame_axis, EPS)
-                                split_dot = n_shared.dot(frame_axis)
-                                rad_dot = n_shared.dot(rad_ref)
-                                if qd.abs(rad_dot) > qd.abs(split_dot):
-                                    split_dot = rad_dot
-                                if split_dot > 0.0:
-                                    i_bucket = i_bucket + 1
-                                    i_bucket_2 = i_bucket_2 + 1
-                            if pen_emit > 0.0:
-                                for k_hat in qd.static(range(2)):
-                                    i_bkt = i_bucket if k_hat == 0 else i_bucket_2
-                                    w_b = (w_hat if k_hat == 0 else 1.0 - w_hat) * pen_emit
-                                    acc_w[i_bkt] += w_b
-                                    for j in qd.static(range(3)):
-                                        acc_pos[i_bkt, j] += w_b * vertex_pos[j]
-                                        acc_n[i_bkt, j] += phase_sign * w_b * normal_v[j]
-                                if pen_emit > acc_pm[i_bucket]:
-                                    acc_pm[i_bucket] = pen_emit
-                                    for j in qd.static(range(3)):
-                                        acc_pmp[i_bucket, j] = vertex_pos[j]
-                            elif is_support:
-                                for k_hat in qd.static(range(2)):
-                                    i_bkt = i_bucket if k_hat == 0 else i_bucket_2
-                                    w_b = w_hat if k_hat == 0 else 1.0 - w_hat
-                                    sup_c[i_bkt] += w_b
-                                    for j in qd.static(range(3)):
-                                        sup_pos[i_bkt, j] += w_b * vertex_pos[j]
-                                        sup_n[i_bkt, j] += phase_sign * w_b * normal_v[j]
-            else:
-                # Seeds: the deepest phase-0 member per bucket plus the images of B's center and the overlap
-                # midpoint (covering zero-contact crossings). Members are admitted over the same near-surface band
-                # as phase 0, so the thin-wall taper keeps its continuity across pen_v = 0.
-                seen_verts = qd.Vector.zero(gs.qd_int, n_max)
-                n_seen = 0
-                for i_seed in range(n_buckets + 2):
-                    i_v_min = -1
-                    if i_seed == 0:
-                        i_v_min = sdf.sdf_func_find_closest_vert(
-                            geoms_state, geoms_info, sdf_info, center_b_world, j_ga, i_b
-                        )
-                    elif i_seed == 1:
-                        i_v_min = sdf.sdf_func_find_closest_vert(
-                            geoms_state, geoms_info, sdf_info, frame_origin, j_ga, i_b
-                        )
-                    elif acc_w[i_seed - 2] > 0.0:
-                        # Seed from the bucket's deepest member: a real surface point, unlike the weighted centroid
-                        # which sits off-surface and can climb into the wrong basin.
-                        seed_pos = qd.Vector(
-                            [acc_pmp[i_seed - 2, 0], acc_pmp[i_seed - 2, 1], acc_pmp[i_seed - 2, 2]],
-                            dt=gs.qd_float,
-                        )
-                        i_v_min = sdf.sdf_func_find_closest_vert(geoms_state, geoms_info, sdf_info, seed_pos, j_ga, i_b)
-                    if i_v_min >= 0:
-                        for k in range(n_max):
-                            if k < n_seen and seen_verts[k] == i_v_min:
-                                i_v_min = -1
-                    if i_v_min >= 0:
-                        i_v_start = i_v_min
-                        pos_min = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v_min], ja_pos, ja_quat)
-                        sd_min = sdf.sdf_func_world_local(geoms_info, sdf_info, pos_min, j_gb, jb_pos, jb_quat)
-                        i_v_cur = -1
-                        while i_v_cur != i_v_min:
-                            i_v_cur = i_v_min
-                            for i_neighbor_ in range(
-                                collider_info.vert_neighbor_start[i_v_cur],
-                                collider_info.vert_neighbor_start[i_v_cur] + collider_info.vert_n_neighbors[i_v_cur],
-                            ):
-                                i_neighbor = collider_info.vert_neighbors[i_neighbor_]
-                                pos_neighbor = gu.qd_transform_by_trans_quat(
-                                    verts_info.init_pos[i_neighbor], ja_pos, ja_quat
-                                )
-                                sd_neighbor = sdf.sdf_func_world_local(
-                                    geoms_info, sdf_info, pos_neighbor, j_gb, jb_pos, jb_quat
-                                )
-                                # Strict decrease guarantees termination: values strictly descend over a finite
-                                # vertex set, so no vertex can be revisited even on numerically flat plateaus.
-                                if sd_neighbor < sd_min:
-                                    i_v_min = i_neighbor
-                                    sd_min = sd_neighbor
-                        for k in range(n_max):
-                            if k < n_seen and seen_verts[k] == i_v_min:
-                                i_v_min = -1
-                        if n_seen < n_max:
-                            seen_verts[n_seen] = i_v_start
-                            n_seen = n_seen + 1
-                        if i_v_min >= 0 and i_v_min != i_v_start and n_seen < n_max:
-                            seen_verts[n_seen] = i_v_min
-                            n_seen = n_seen + 1
-                    if i_v_min >= 0:
-                        for i_c in range(
-                            collider_info.vert_neighbor_start[i_v_min] - 1,
-                            collider_info.vert_neighbor_start[i_v_min] + collider_info.vert_n_neighbors[i_v_min],
+                                if normal_v.dot(a_vnormal) > 0.0:
+                                    # Grad agreeing with A's outward normal = tunneled past B's thin wall: no
+                                    # support contact there, damping the far side stalls the crossing-escape creep.
+                                    normal_v = -normal_v
+                                    is_support = False
+                            else:
+                                normal_v = -a_vnormal
+                        elif (
+                            not is_closing_regime
+                            and not is_axis_normal_regime
+                            and grad_norm > 0.9
+                            and grad_v.dot(normal_center) > 0.0
                         ):
-                            i_v = i_v_min
-                            if i_c >= collider_info.vert_neighbor_start[i_v_min]:
-                                i_v = collider_info.vert_neighbors[i_c]
-                            vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
-                            pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
-                            if pen_v > -margin:
-                                grad_v = sdf.sdf_func_grad_world_local_consistent(
-                                    geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
-                                )
-                                grad_norm = grad_v.norm()
-                                pen_emit = gs.qd_float(0.0)
-                                if grad_norm > 0.9:
-                                    if pen_v > 0.0:
-                                        pen_emit = pen_v
-                                elif use_closing_dir or axis_normal or enclosed_axis:
-                                    # Sub-cell thin walls are uncertifiable by the lattice, yet these band verts are the
-                                    # only carriers of the coupling across the wall: keep the synthetic depths,
-                                    # continuous across pen_v = 0.
-                                    if grad_norm < 0.5:
-                                        if pen_v > 0.0:
-                                            pen_emit = qd.min(synthetic_pen_max + pen_v, margin)
-                                        else:
-                                            pen_emit = synthetic_pen_max * (1.0 + pen_v / margin)
-                                    elif pen_v > 0.0:
-                                        pen_emit = synthetic_pen_max
-                                normal_v = normal_center
-                                if enclosed_axis or axis_normal:
-                                    # Concave shells: the pair-level reference normal cannot resist lateral shear, so
-                                    # orient from B's grad when well-conditioned (sign fixed from A's exact vertex
-                                    # normal) and from A's vertex normal when the grad is smoothed across the thin wall.
-                                    a_vnormal = gu.qd_normalize(
-                                        gu.qd_transform_by_quat(verts_info.init_normal[i_v], ja_quat), EPS
-                                    )
-                                    if grad_norm > 0.5:
-                                        normal_v = gu.qd_normalize(grad_v, EPS)
-                                        if normal_v.dot(a_vnormal) > 0.0:
-                                            # Grad agreeing with A's outward normal = tunneled past B's thin wall: no
-                                            # support contact there, damping the far side stalls the crossing-escape
-                                            # creep.
-                                            normal_v = -normal_v
-                                    else:
-                                        normal_v = -a_vnormal
-                                elif (
-                                    not use_closing_dir
-                                    and not axis_normal
-                                    and grad_norm > 0.9
-                                    and grad_v.dot(normal_center) > 0.0
-                                ):
-                                    # Trust a per-vertex grad as the contact normal only in the clean band where the
-                                    # kernel pen is trusted; in the edge/smoothed bands the reference normal at A's
-                                    # center is more reliable.
-                                    normal_v = gu.qd_normalize(grad_v, EPS)
-                                # In the closing regime the per-vertex pen is only the radial gap to B's lateral; floor
-                                # it with the geometric approach depth so the solver sees the actual overlap.
-                                if use_closing_dir and pen_v > 0.0 and approach_depth_pair > pen_emit:
-                                    pen_emit = approach_depth_pair
-                                rel_ref = vertex_pos - frame_origin
-                                az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
-                                # Two sub-buckets per azimuth sector, split by normal hemisphere: a crossed wall has
-                                # penetrating verts on BOTH faces with opposed normals, and merging them would cancel the
-                                # aggregate exactly when the crossing needs resistance from each side. The split also keeps
-                                # phase-1 members from annihilating phase-0 members of the opposite face.
-                                i_bucket = 0
-                                i_bucket_2 = 0
-                                w_hat = gs.qd_float(1.0)
-                                if qd.static(n_buckets >= 2):
-                                    # Hat-weighted azimuthal binning: a member splits its weight linearly between the two
-                                    # nearest sector centers, so rotating past a sector boundary moves weight continuously
-                                    # instead of relocating it in one step - a hard handoff modulates the emitted forces
-                                    # and, combined with any standing lateral bias, ratchets a softly-stacked column.
-                                    az_scaled = (az_ref + qd.math.pi) * ((n_buckets // 2) / (2.0 * qd.math.pi))
-                                    u_hat = az_scaled - 0.5
-                                    i_sec = qd.cast(qd.floor(u_hat), gs.qd_int)
-                                    frac_hat = u_hat - qd.cast(i_sec, gs.qd_float)
-                                    i_sec = qd.raw_mod(i_sec + (n_buckets // 2), n_buckets // 2)
-                                    i_sec_2 = qd.raw_mod(i_sec + 1, n_buckets // 2)
-                                    w_hat = 1.0 - frac_hat
-                                    i_bucket = 2 * i_sec
-                                    i_bucket_2 = 2 * i_sec_2
-                                    # Hemisphere sign from whichever direction is well-conditioned for this face: seating
-                                    # faces align with the closing axis, side walls are perpendicular to it and split on
-                                    # the local radial instead - otherwise their sub-bucket assignment is FP-noise-driven
-                                    # and opposite faces can still share a bucket and cancel.
-                                    n_shared = phase_sign * normal_v
-                                    rad_ref = gu.qd_normalize(rel_ref - rel_ref.dot(frame_axis) * frame_axis, EPS)
-                                    split_dot = n_shared.dot(frame_axis)
-                                    rad_dot = n_shared.dot(rad_ref)
-                                    if qd.abs(rad_dot) > qd.abs(split_dot):
-                                        split_dot = rad_dot
-                                    if split_dot > 0.0:
-                                        i_bucket = i_bucket + 1
-                                        i_bucket_2 = i_bucket_2 + 1
-                                if pen_emit > 0.0:
-                                    for k_hat in qd.static(range(2)):
-                                        i_bkt = i_bucket if k_hat == 0 else i_bucket_2
-                                        w_b = (w_hat if k_hat == 0 else 1.0 - w_hat) * pen_emit
-                                        acc_w[i_bkt] += w_b
-                                        for j in qd.static(range(3)):
-                                            acc_pos[i_bkt, j] += w_b * vertex_pos[j]
-                                            acc_n[i_bkt, j] += phase_sign * w_b * normal_v[j]
-                                    if pen_emit > acc_pm[i_bucket]:
-                                        acc_pm[i_bucket] = pen_emit
-                                        for j in qd.static(range(3)):
-                                            acc_pmp[i_bucket, j] = vertex_pos[j]
+                            # Trust a per-vertex grad as the contact normal only in the clean band where the kernel
+                            # pen is trusted; in the edge/smoothed bands the reference normal at A's center is more
+                            # reliable.
+                            normal_v = gu.qd_normalize(grad_v, EPS)
+                        # In the closing regime the per-vertex pen is only the radial gap to B's lateral; floor it
+                        # with the geometric approach depth so the solver sees the actual overlap.
+                        if is_closing_regime and pen_v > 0.0 and approach_depth_pair > pen_emit:
+                            pen_emit = approach_depth_pair
+                        rel_ref = vertex_pos - frame_origin
+                        az_ref = qd.atan2(rel_ref.dot(t2_ref), rel_ref.dot(t1_ref))
+                        # Two sub-buckets per azimuth sector, split by normal hemisphere: a crossed wall has
+                        # penetrating verts on BOTH faces with opposed normals, and merging them would cancel the
+                        # aggregate exactly when the crossing needs resistance from each side. The split also keeps
+                        # phase-1 members from annihilating phase-0 members of the opposite face.
+                        i_bucket = 0
+                        i_bucket_2 = 0
+                        w_hat = gs.qd_float(1.0)
+                        if qd.static(n_buckets >= 2):
+                            # Hat-weighted azimuthal binning: a member splits its weight linearly between the two
+                            # nearest sector centers, so rotating past a sector boundary moves weight continuously
+                            # instead of relocating it in one step - a hard handoff modulates the emitted forces
+                            # and, combined with any standing lateral bias, ratchets a softly-stacked column.
+                            az_scaled = (az_ref + qd.math.pi) * ((n_buckets // 2) / (2.0 * qd.math.pi))
+                            u_hat = az_scaled - 0.5
+                            i_sec = qd.cast(qd.floor(u_hat), gs.qd_int)
+                            frac_hat = u_hat - qd.cast(i_sec, gs.qd_float)
+                            i_sec = qd.raw_mod(i_sec + (n_buckets // 2), n_buckets // 2)
+                            i_sec_2 = qd.raw_mod(i_sec + 1, n_buckets // 2)
+                            w_hat = 1.0 - frac_hat
+                            i_bucket = 2 * i_sec
+                            i_bucket_2 = 2 * i_sec_2
+                            # Hemisphere sign from whichever direction is well-conditioned for this face: seating
+                            # faces align with the closing axis, side walls are perpendicular to it and split on
+                            # the local radial instead - otherwise their sub-bucket assignment is FP-noise-driven
+                            # and opposite faces can still share a bucket and cancel.
+                            normal_folded = phase_sign * normal_v
+                            rad_ref = gu.qd_normalize(rel_ref - rel_ref.dot(frame_axis) * frame_axis, EPS)
+                            split_dot = normal_folded.dot(frame_axis)
+                            rad_dot = normal_folded.dot(rad_ref)
+                            if qd.abs(rad_dot) > qd.abs(split_dot):
+                                split_dot = rad_dot
+                            if split_dot > 0.0:
+                                i_bucket = i_bucket + 1
+                                i_bucket_2 = i_bucket_2 + 1
+                        if pen_emit > 0.0:
+                            for k_hat in qd.static(range(2)):
+                                i_bucket_k = i_bucket if k_hat == 0 else i_bucket_2
+                                w_b = (w_hat if k_hat == 0 else 1.0 - w_hat) * pen_emit
+                                if qd.static(i_phase == 0):
+                                    acc_w[i_bucket_k] += w_b
+                                    for j in qd.static(range(3)):
+                                        acc_pos[i_bucket_k, j] += w_b * vertex_pos[j]
+                                        acc_n[i_bucket_k, j] += phase_sign * w_b * normal_v[j]
+                                else:
+                                    acc2_w[i_bucket_k] += w_b
+                                    for j in qd.static(range(3)):
+                                        acc2_pos[i_bucket_k, j] += w_b * vertex_pos[j]
+                                        acc2_n[i_bucket_k, j] += phase_sign * w_b * normal_v[j]
+                            # Depth is a per-violation quantity: one physical violation provisions ONE constraint
+                            # row's corrective impulse, so a member's pen goes to its primary bucket only while
+                            # the hat split shares its weight. A sector fed purely by secondary spill emits with
+                            # zero depth (direction and damping only): its positional correction already lives in
+                            # the primary row. The handoff at a boundary crossing is smooth because at the swap
+                            # both buckets hold nearly the same members, so the depth moves between two
+                            # geometrically near-identical rows. Scaling the pen by the hat share instead would
+                            # under-provision the primary row (a softened correction destabilizes what it
+                            # supports), and writing it into both buckets would double the corrective capacity
+                            # for as long as the member sits in the overlap, pulsing the emitted forces at entry
+                            # and exit.
+                            if qd.static(i_phase == 0):
+                                if pen_emit > acc_pen_max[i_bucket]:
+                                    acc_pen_max[i_bucket] = pen_emit
+                            elif pen_emit > acc2_pen_max[i_bucket]:
+                                acc2_pen_max[i_bucket] = pen_emit
+                        elif is_support:
+                            for k_hat in qd.static(range(2)):
+                                i_bucket_k = i_bucket if k_hat == 0 else i_bucket_2
+                                w_b = w_hat if k_hat == 0 else 1.0 - w_hat
+                                sup_w[i_bucket_k] += w_b
+                                for j in qd.static(range(3)):
+                                    sup_pos[i_bucket_k, j] += w_b * vertex_pos[j]
+                                    sup_n[i_bucket_k, j] += phase_sign * w_b * normal_v[j]
     # Emit one aggregated contact per active bucket. A bucket whose members disagree on direction (the weighted
     # normal nearly cancels) is ambiguous and skipped; buckets holding only zero-depth support verts emit a support
-    # contact at their unweighted centroid.
+    # contact at their weight-averaged centroid.
     for i_bucket in range(n_buckets):
         emit_pen = gs.qd_float(0.0)
         is_emit = False
@@ -1048,20 +909,33 @@ def func_add_polytope_vertex_contacts_sdf_shell(
                 # drives impedance and error correction, and is reported by get_contacts), so a summed magnitude
                 # would inflate a shallow many-vert ring and saturate a genuinely deep crossing. The direction
                 # still composes the member forces via sum(pen_i * n_i).
-                emit_pen = acc_pm[i_bucket]
+                emit_pen = acc_pen_max[i_bucket]
                 normal_c = gu.qd_normalize(normal_c, EPS)
                 is_emit = True
-        else:
-            if sup_c[i_bucket] > 0.0:
-                inv_c = 1.0 / sup_c[i_bucket]
-                contact_pos = qd.Vector(
-                    [sup_pos[i_bucket, 0] * inv_c, sup_pos[i_bucket, 1] * inv_c, sup_pos[i_bucket, 2] * inv_c],
-                    dt=gs.qd_float,
-                )
-                normal_c = qd.Vector([sup_n[i_bucket, 0], sup_n[i_bucket, 1], sup_n[i_bucket, 2]], dt=gs.qd_float)
-                if normal_c.norm() > 0.1 * sup_c[i_bucket]:
-                    normal_c = gu.qd_normalize(normal_c, EPS)
-                    is_emit = True
+        elif acc2_w[i_bucket] > 0.0:
+            # The primary scan is blind in this sector (a feature of the other body crosses between its verts):
+            # fall back to the swapped scan's aggregate, which is the coverage this scan direction exists for.
+            inv_w = 1.0 / acc2_w[i_bucket]
+            contact_pos = qd.Vector(
+                [acc2_pos[i_bucket, 0] * inv_w, acc2_pos[i_bucket, 1] * inv_w, acc2_pos[i_bucket, 2] * inv_w],
+                dt=gs.qd_float,
+            )
+            normal_c = qd.Vector([acc2_n[i_bucket, 0], acc2_n[i_bucket, 1], acc2_n[i_bucket, 2]], dt=gs.qd_float)
+            normal_c = normal_c / acc2_w[i_bucket]
+            if normal_c.norm() > 0.1:
+                emit_pen = acc2_pen_max[i_bucket]
+                normal_c = gu.qd_normalize(normal_c, EPS)
+                is_emit = True
+        elif sup_w[i_bucket] > 0.0:
+            inv_w = 1.0 / sup_w[i_bucket]
+            contact_pos = qd.Vector(
+                [sup_pos[i_bucket, 0] * inv_w, sup_pos[i_bucket, 1] * inv_w, sup_pos[i_bucket, 2] * inv_w],
+                dt=gs.qd_float,
+            )
+            normal_c = qd.Vector([sup_n[i_bucket, 0], sup_n[i_bucket, 1], sup_n[i_bucket, 2]], dt=gs.qd_float)
+            if normal_c.norm() > 0.1 * sup_w[i_bucket]:
+                normal_c = gu.qd_normalize(normal_c, EPS)
+                is_emit = True
         if is_emit:
             # Snap onto A's smooth surface when A is a smooth primitive; a no-op for polytope-typed A.
             contact_pos = func_apply_smooth_refinement(

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1056,6 +1056,23 @@ class RigidSolver(KinematicSolver):
                     # Still fallback to mean vertex position if no better option...
                     geoms_center.append(np.mean(tmesh.vertices, axis=0))
 
+            # A geom is hollow when its own center lies in a cavity rather than inside its material (bowl, mug,
+            # nut), i.e. its own SDF is positive at its center. This is a static property of the collision
+            # geometry, precomputed here so the narrowphase never has to probe it at runtime. SPHERE/PLANE/TERRAIN
+            # SDFs are analytic and never hollow.
+            geoms_is_hollow = []
+            for geom, center in zip(geoms, geoms_center):
+                is_hollow = False
+                if geom.type not in (gs.GEOM_TYPE.SPHERE, gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN):
+                    grid_pos = geom.T_mesh_to_sdf[:3, :3] @ center + geom.T_mesh_to_sdf[:3, 3]
+                    cell = np.minimum(np.maximum(np.floor(grid_pos).astype(gs.np_int), 0), geom.sdf_res - 2)
+                    frac = grid_pos - cell
+                    corners = geom.sdf_val[cell[0] : cell[0] + 2, cell[1] : cell[1] + 2, cell[2] : cell[2] + 2]
+                    weights_x, weights_y, weights_z = ([1.0 - frac[i], frac[i]] for i in range(3))
+                    sd_center = np.einsum("i,j,k,ijk->", weights_x, weights_y, weights_z, corners)
+                    is_hollow = sd_center > gs.EPS
+                geoms_is_hollow.append(is_hollow)
+
             kernel_init_geom_fields(
                 geoms_pos=np.array([geom.init_pos for geom in geoms], dtype=gs.np_float),
                 geoms_center=np.array(geoms_center, dtype=gs.np_float),
@@ -1082,6 +1099,7 @@ class RigidSolver(KinematicSolver):
                 geoms_coup_restitution=np.array([geom.coup_restitution for geom in geoms], dtype=gs.np_float),
                 geoms_is_fixed=np.array([geom.is_fixed for geom in geoms], dtype=gs.np_bool),
                 geoms_is_decomp=np.array([geom.metadata.get("decomposed", False) for geom in geoms], dtype=gs.np_bool),
+                geoms_is_hollow=np.array(geoms_is_hollow, dtype=gs.np_bool),
                 # Quadrants variables
                 geoms_info=self.geoms_info,
                 geoms_state=self.geoms_state,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -460,7 +460,7 @@ class RigidSolver(KinematicSolver):
         # envelope factorization. The differentiable adjoint solve reads the dense Hessian, so the composition is
         # restricted to the forward (non-grad) path. On GPU the dense tiled path is faster, so sparse is dropped and
         # islands stand alone.
-        if gs.backend == gs.cpu and self._use_contact_island and sparse_solve and not self.sim.options.requires_grad:
+        if sparse_solve and gs.backend == gs.cpu and self._use_contact_island and not self.sim.options.requires_grad:
             pass  # compose islands + sparse Jacobian
         elif sparse_solve and gs.backend == gs.cpu:
             self._use_contact_island = False

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -537,6 +537,14 @@ class FileMorph(Morph):
         0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
         geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
         **This is only used for RigidEntity.**
+    watertighten : int, optional
+        Aggressiveness of the watertight wrap built for a non-convex (``convexify=False``) collision mesh, as an
+        integer from 0 to 8 on the same scale as ``decimate_aggressiveness``. The wrap closes an open or
+        self-intersecting mesh into the single watertight surface a grid signed distance field requires, decimating
+        it under a feature-preserving cost cutoff. 0 bypasses the wrap (mesh kept as-is), higher values collapse more
+        of it, and 8 is the strongest decimation the cutoff still allows (every level stays watertight and preserves
+        the closed shape rather than collapsing thin cross-sections). ``None`` skips watertightening altogether.
+        Defaults to 5. **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh will be decomposed into multiple convex components if the convex hull is not
@@ -591,7 +599,7 @@ class FileMorph(Morph):
     decimate: StrictBool | None = None
     decimate_face_num: PositiveInt = 500
     decimate_aggressiveness: StrictInt = Field(default=2, ge=0, le=8)
-    watertighten: StrictInt | None = Field(default=7, ge=0, le=8)
+    watertighten: StrictInt | None = Field(default=5, ge=0, le=8)
     convexify: StrictBool | None = None
     decompose_object_error_threshold: float = Field(default=0.15, ge=0, allow_inf_nan=True)
     decompose_robot_error_threshold: float = Field(default=float("inf"), ge=0, allow_inf_nan=True)
@@ -719,6 +727,14 @@ class Mesh(FileMorph, TetGenMixin):
         0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
         geometry if necessary. 8 does what needs to be done at all costs. Defaults to 5.
         **This is only used for RigidEntity.**
+    watertighten : int, optional
+        Aggressiveness of the watertight wrap built for a non-convex (``convexify=False``) collision mesh, as an
+        integer from 0 to 8 on the same scale as ``decimate_aggressiveness``. The wrap closes an open or
+        self-intersecting mesh into the single watertight surface a grid signed distance field requires, decimating
+        it under a feature-preserving cost cutoff. 0 bypasses the wrap (mesh kept as-is), higher values collapse more
+        of it, and 8 is the strongest decimation the cutoff still allows (every level stays watertight and preserves
+        the closed shape rather than collapsing thin cross-sections). ``None`` skips watertightening altogether.
+        Defaults to 5. **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -907,6 +923,14 @@ class MJCF(FileMorph):
         0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
         geometry if necessary. 8 does what needs to be done at all costs. Defaults to 5.
         **This is only used for RigidEntity.**
+    watertighten : int, optional
+        Aggressiveness of the watertight wrap built for a non-convex (``convexify=False``) collision mesh, as an
+        integer from 0 to 8 on the same scale as ``decimate_aggressiveness``. The wrap closes an open or
+        self-intersecting mesh into the single watertight surface a grid signed distance field requires, decimating
+        it under a feature-preserving cost cutoff. 0 bypasses the wrap (mesh kept as-is), higher values collapse more
+        of it, and 8 is the strongest decimation the cutoff still allows (every level stays watertight and preserves
+        the closed shape rather than collapsing thin cross-sections). ``None`` skips watertightening altogether.
+        Defaults to 5. **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -1033,6 +1057,14 @@ class URDF(FileMorph):
         0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
         geometry if necessary. 8 does what needs to be done at all costs. Defaults to 5.
         **This is only used for RigidEntity.**
+    watertighten : int, optional
+        Aggressiveness of the watertight wrap built for a non-convex (``convexify=False``) collision mesh, as an
+        integer from 0 to 8 on the same scale as ``decimate_aggressiveness``. The wrap closes an open or
+        self-intersecting mesh into the single watertight surface a grid signed distance field requires, decimating
+        it under a feature-preserving cost cutoff. 0 bypasses the wrap (mesh kept as-is), higher values collapse more
+        of it, and 8 is the strongest decimation the cutoff still allows (every level stays watertight and preserves
+        the closed shape rather than collapsing thin cross-sections). ``None`` skips watertightening altogether.
+        Defaults to 5. **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -1166,6 +1198,14 @@ class Drone(FileMorph):
         0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
         geometry if necessary. 8 does what needs to be done at all costs. Defaults to 5.
         **This is only used for RigidEntity.**
+    watertighten : int, optional
+        Aggressiveness of the watertight wrap built for a non-convex (``convexify=False``) collision mesh, as an
+        integer from 0 to 8 on the same scale as ``decimate_aggressiveness``. The wrap closes an open or
+        self-intersecting mesh into the single watertight surface a grid signed distance field requires, decimating
+        it under a feature-preserving cost cutoff. 0 bypasses the wrap (mesh kept as-is), higher values collapse more
+        of it, and 8 is the strongest decimation the cutoff still allows (every level stays watertight and preserves
+        the closed shape rather than collapsing thin cross-sections). ``None`` skips watertightening altogether.
+        Defaults to 5. **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh with be decomposed into multiple convex components if a single one is not
@@ -1508,6 +1548,14 @@ class USD(FileMorph):
         0 is losseless. 2 preserves all features of the original geometry. 5 may significantly alters the original
         geometry if necessary. 8 does what needs to be done at all costs. Defaults to 2.
         **This is only used for RigidEntity.**
+    watertighten : int, optional
+        Aggressiveness of the watertight wrap built for a non-convex (``convexify=False``) collision mesh, as an
+        integer from 0 to 8 on the same scale as ``decimate_aggressiveness``. The wrap closes an open or
+        self-intersecting mesh into the single watertight surface a grid signed distance field requires, decimating
+        it under a feature-preserving cost cutoff. 0 bypasses the wrap (mesh kept as-is), higher values collapse more
+        of it, and 8 is the strongest decimation the cutoff still allows (every level stays watertight and preserves
+        the closed shape rather than collapsing thin cross-sections). ``None`` skips watertightening altogether.
+        Defaults to 5. **This is only used for RigidEntity.**
     convexify : bool, optional
         Whether to convexify the entity. When convexify is True, all the meshes in the entity will each be converted
         to a set of convex hulls. The mesh will be decomposed into multiple convex components if the convex hull is not

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1880,6 +1880,7 @@ class GeomsInfo:
     conaffinity: qd.Tensor
     is_fixed: qd.Tensor
     is_decomposed: qd.Tensor
+    is_hollow: qd.Tensor
     needs_coup: qd.Tensor
     coup_friction: qd.Tensor
     coup_softness: qd.Tensor
@@ -1914,6 +1915,7 @@ def get_geoms_info(solver):
         conaffinity=V(dtype=gs.qd_int, shape=shape),
         is_fixed=V(dtype=gs.qd_bool, shape=shape),
         is_decomposed=V(dtype=gs.qd_bool, shape=shape),
+        is_hollow=V(dtype=gs.qd_bool, shape=shape),
         needs_coup=V(dtype=gs.qd_int, shape=shape),
         coup_friction=V(dtype=gs.qd_float, shape=shape),
         coup_softness=V(dtype=gs.qd_float, shape=shape),

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -41,7 +41,8 @@ Y_UP_TRANSFORM = np.asarray(  # translation on the bottom row
 )
 DEFAULT_PLANE_TEXTURE_PATH = "textures/checker.png"  # use checkerboard texture by default
 
-WT_CACHE_VERSION = 5
+# Bumped when watertighten output changes for a fixed (mesh, aggressiveness): forces a cache miss on stale entries.
+WT_CACHE_VERSION = 7
 
 
 def discretize_array_for_hashing(arr: np.ndarray) -> np.ndarray:
@@ -58,6 +59,43 @@ def color_u8_to_f32(color) -> np.ndarray:
 
 def glossiness_to_roughness(glossiness: float) -> float:
     return (2 / (glossiness + 2)) ** (1.0 / 4.0)
+
+
+def estimate_wall_thickness(verts: np.ndarray, faces: np.ndarray, quantile: float = 0.25) -> float:
+    """Estimate a watertight mesh's characteristic wall thickness by probing its local diameter with inward rays.
+
+    A ray is cast inward along the face normal from a stride-subsampled set of face centroids to the first opposite
+    surface. The `quantile` of those hit distances, weighted by probed face area so the estimate measures surface
+    rather than tessellation density (a thin wall spanned by a handful of large faces must not be outvoted by many
+    small decorative facets), is returned: a low quantile approximates the thinnest wall and the median the typical
+    one. Falls back to the bounding-box diagonal when no ray hits (degenerate or non-watertight mesh).
+
+    The estimate is deliberately a scalar, not per-axis: the SDF grid it sizes does not only resolve walls along
+    their normal - it certifies contact penetrations through Lipschitz cone bounds whose slack grows with the
+    lattice spacing in every direction around the contact point, tangent axes included. On a closed shell each
+    wall's tangent directions are other walls' normals (a mug's vertical wall lies tangent to the vertical axis
+    even though the only wall facing that axis, the thick bottom, would justify coarse vertical cells), so relaxing
+    any one axis to the thickness of the walls facing it measurably degrades the certified pens of every wall
+    tangent to it, and no bound-side search can recover the loss (the lateral sample offset is a lattice property).
+    """
+    mesh = trimesh.Trimesh(verts, faces, process=False)
+    diag = np.linalg.norm(verts.max(axis=0) - verts.min(axis=0))
+    stride = max(1, len(faces) // 1000)
+    centers = mesh.triangles_center[::stride]
+    normals = mesh.face_normals[::stride]
+    origins = centers - 1e-3 * diag * normals
+    locations, ray_idx, _ = mesh.ray.intersects_location(origins, -normals, multiple_hits=False)
+    if len(ray_idx) == 0:
+        return diag
+    thickness = np.linalg.norm(locations - origins[ray_idx], axis=1)
+    is_hit_valid = thickness > 1e-4 * diag
+    thickness = thickness[is_hit_valid]
+    if len(thickness) == 0:
+        return diag
+    areas = mesh.area_faces[::stride][ray_idx][is_hit_valid]
+    order = np.argsort(thickness)
+    areas_cum = np.cumsum(areas[order])
+    return thickness[order][np.searchsorted(areas_cum, quantile * areas_cum[-1])]
 
 
 class MeshInfo:
@@ -126,11 +164,13 @@ def get_asset_path(file):
     return os.path.join(get_src_dir(), "assets", file)
 
 
-def get_gsd_path(verts, faces, sdf_cell_size, sdf_min_res, sdf_max_res):
-    # Schema tag bumped when the on-disk SDF layout changes (e.g. scalar -> per-axis cell size).
-    # Forces a cache miss on stale entries written by older code without manually clearing the cache.
-    schema = "v2-anisotropic-cells"
-    hashkey = get_hashkey(verts, faces, sdf_cell_size, sdf_min_res, sdf_max_res, schema)
+def get_gsd_path(verts, faces, sdf_res, sdf_cell_size):
+    # The grid is fully determined by the mesh plus the resolved per-axis resolution and cell size, so the key is
+    # built from those rather than the material defaults: the resolution now also depends on wall thickness, so the
+    # defaults no longer identify the grid. Schema tag bumped when the on-disk SDF layout changes (e.g. scalar ->
+    # per-axis cell size); forces a cache miss on stale entries without manually clearing the cache.
+    schema = "v3-res-keyed"
+    hashkey = get_hashkey(verts, faces, sdf_res, sdf_cell_size, schema)
     return os.path.join(get_gsd_cache_dir(), f"{hashkey}.gsd")
 
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -431,6 +431,12 @@ def _postprocess_collision_geoms_impl(
     if not g_infos:
         return []
 
+    # Check whether the geometries are authored, ie they are all watertight and convex, as a cheap proxy
+    is_authored = all(
+        (tmesh := g_info["mesh"].trimesh).is_winding_consistent and tmesh.is_watertight and tmesh.is_convex
+        for g_info in g_infos
+    )
+
     # Weld coincident vertices of non-convex collision meshes onto a separate copy. Formats that store unshared
     # per-face vertices (notably STL) yield a vertex soup whose duplicates differ only by float rounding; the
     # downstream exact dedup at geom build only partially fuses them, leaving a degraded (sliver) mesh that corrupts
@@ -438,7 +444,7 @@ def _postprocess_collision_geoms_impl(
     # may be the very same trimesh as the visual geom, so the weld must not be done in place: only the collision geom
     # is swapped for the welded copy, leaving the visual vertices untouched. Already-shared meshes (OBJ, glTF) weld to
     # no fewer vertices and keep their original geom.
-    if not convexify:
+    if not is_authored and not convexify:
         for g_info in g_infos:
             if g_info["type"] != gs.GEOM_TYPE.MESH:
                 continue
@@ -455,93 +461,32 @@ def _postprocess_collision_geoms_impl(
     # Note that this procedure is only applied if the estimated volume is significantly different before and after
     # repair, to avoid altering the original mesh without actual benefit. Moreover, only duplicate faces are removed,
     # which is less aggressive than `Trimesh.process(validate=True)`.
-    for g_info in g_infos:
-        mesh = g_info["mesh"]
-        tmesh = mesh.trimesh
-        if g_info["type"] != gs.GEOM_TYPE.MESH:
-            continue
-        if tmesh.is_winding_consistent and not tmesh.is_watertight:
-            tmesh_repaired = tmesh.copy()
-            tmesh_repaired.update_faces(tmesh_repaired.unique_faces())
-            if tmesh_repaired.volume < 0.0:
-                tmesh_repaired.invert()
-            if abs(tmesh_repaired.volume) < gs.EPS:
+    if not is_authored:
+        for g_info in g_infos:
+            mesh = g_info["mesh"]
+            tmesh = mesh.trimesh
+            if g_info["type"] != gs.GEOM_TYPE.MESH:
                 continue
-            if abs(abs(tmesh.volume / tmesh_repaired.volume) - 1.0) > MESH_REPAIR_ERROR_THRESHOLD:
-                gs.logger.info(
-                    "Collision mesh is not watertight and has ill-defined volume. It will be repaired by removing "
-                    "duplicate faces."
-                )
-                tmesh.update_faces(tmesh.unique_faces())
-                tmesh._cache.clear()
-                tmesh.visual._cache.clear()
+            if tmesh.is_winding_consistent and not tmesh.is_watertight:
+                tmesh_repaired = tmesh.copy()
+                tmesh_repaired.update_faces(tmesh_repaired.unique_faces())
+                if tmesh_repaired.volume < 0.0:
+                    tmesh_repaired.invert()
+                if abs(tmesh_repaired.volume) < gs.EPS:
+                    continue
+                if abs(abs(tmesh.volume / tmesh_repaired.volume) - 1.0) > MESH_REPAIR_ERROR_THRESHOLD:
+                    gs.logger.info(
+                        "Collision mesh is not watertight and has ill-defined volume. It will be repaired by removing "
+                        "duplicate faces."
+                    )
+                    tmesh.update_faces(tmesh.unique_faces())
+                    tmesh._cache.clear()
+                    tmesh.visual._cache.clear()
 
-    # Watertighten non-convex meshes that are not already closed. The convex path skips this: the convex hull /
-    # decomposition replaces the surface anyway, so an alpha-wrap of the input would be wasted work. Each unique
-    # (vertex, face) pair is wrapped at most once - one entity can hold many sub-meshes that share buffers
-    # (repeated wheels, bolts, panel decorations from URDF parts) and re-running the wrap on each one would be
-    # pure duplicated effort.
-    if not convexify and watertighten is not None:
-        from .watertighten import watertighten_mesh
-
-        # Fuse every non-watertight MESH-type g_info into one combined triangle soup, run the SDF wrap once on
-        # the union, and replace the first of those g_infos with the wrap output (dropping the rest). Wrapping
-        # each sub-piece independently would produce overlapping closed surfaces - one per piece - which the
-        # downstream SDF / contact generator would then read as nested layers; a single fused wrap is one
-        # closed surface for the whole entity and also runs in one SDF pass instead of N.
-        mesh_idx: list[int] = []
-        verts_chunks: list[np.ndarray] = []
-        faces_chunks: list[np.ndarray] = []
-        v_offset = 0
-        for i, g_info in enumerate(g_infos):
-            tmesh = g_info["mesh"].trimesh
-            if g_info["type"] != gs.GEOM_TYPE.MESH or tmesh.is_watertight:
-                continue
-            mesh_idx.append(i)
-            verts_chunks.append(np.asarray(tmesh.vertices, dtype=np.float64))
-            faces_chunks.append(np.asarray(tmesh.faces, dtype=np.int32) + v_offset)
-            v_offset += len(tmesh.vertices)
-        if mesh_idx:
-            verts_in = np.concatenate(verts_chunks, axis=0)
-            faces_in = np.concatenate(faces_chunks, axis=0).astype(np.int32, copy=False)
-            # On-disk cache keyed by (vertices, faces, aggressiveness): a repeated run on the same entity is a
-            # file read instead of a multi-second SDF + DC + QEM rebuild. The reader tolerates corruption
-            # (partial writes, stale pickles, missing modules) by falling back to a fresh compute, matching
-            # the pattern used by `get_cvx_path` above.
-            cache_path = get_wt_path(verts_in, faces_in, watertighten)
-            from_cache = False
-            v_out = f_out = None
-            if os.path.exists(cache_path):
-                try:
-                    with open(cache_path, "rb") as fp:
-                        v_out, f_out = pkl.load(fp)
-                    from_cache = True
-                except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-                    gs.logger.info("Ignoring corrupted watertighten cache.")
-            if not from_cache:
-                v_out, f_out = watertighten_mesh(verts_in, faces_in, aggressiveness=watertighten)
-                os.makedirs(get_wt_cache_dir(), exist_ok=True)
-                with open(cache_path, "wb") as fp:
-                    pkl.dump((v_out, f_out), fp, protocol=pkl.HIGHEST_PROTOCOL)
-            fused = trimesh.Trimesh(vertices=v_out, faces=f_out, process=False)
-            metadata = g_infos[mesh_idx[0]]["mesh"].metadata.copy()
-            metadata["watertightened"] = True
-            g_infos[mesh_idx[0]]["mesh"] = gs.Mesh.from_trimesh(
-                mesh=fused,
-                surface=gs.surfaces.Collision(),
-                metadata=metadata,
-            )
-            for i in reversed(mesh_idx[1:]):
-                del g_infos[i]
-            gs.logger.info(
-                f"Watertightened {len(mesh_idx)} non-watertight collision sub-mesh(es) into one fused wrap "
-                f"({'cache hit' if from_cache else 'fresh compute'}): "
-                f"{len(verts_in)} -> {len(v_out)} vertices, {len(faces_in)} -> {len(f_out)} faces."
-            )
-
-    # Check if all the geometries can be convexified without decomposition
-    must_decompose = False
-    if convexify:
+    # Check which geometries can be convexified without decomposition
+    geoms_must_decompose = [False] * len(g_infos)
+    volume_err_max = 0.0
+    if not is_authored and convexify:
         for i_g, g_info in enumerate(g_infos):
             mesh = g_info["mesh"]
             tmesh = mesh.trimesh
@@ -565,70 +510,83 @@ def _postprocess_collision_geoms_impl(
 
             # Compute volume approximation error between true geometry and its convex hull conservatively
             if not tmesh.is_winding_consistent:
-                volume_err = float("inf")
-                must_decompose = not math.isinf(decompose_error_threshold)
-                if not must_decompose and len(g_infos) > 1:
-                    gs.logger.warning(
-                        f"Winding not consistent for submesh '{mesh.metadata.get('name', i_g)}'. Forcing convex "
-                        "decomposition..."
-                    )
+                if not math.isinf(decompose_error_threshold):
+                    geoms_must_decompose[i_g] = True
+                    volume_err_max = float("inf")
             elif abs(tmesh.volume) > gs.EPS:
                 volume_err = abs(cmesh.volume / abs(tmesh.volume) - 1.0)
                 if volume_err > decompose_error_threshold:
-                    must_decompose = True
-                    if not must_decompose and len(g_infos) > 1:
-                        gs.logger.warning(
-                            f"Convex hull of submesh '{mesh.metadata.get('name') or i_g}' is not accurate enough for "
-                            f"collision detection ({volume_err:.3f}). Forcing convex decomposition..."
+                    geoms_must_decompose[i_g] = True
+                    volume_err_max = max(volume_err_max, volume_err)
+    must_decompose = any(geoms_must_decompose)
+
+    # Fuse collision geoms that share a collision group and contact parameters into one closed surface per consistent
+    # sub-group, transforming each sub-mesh into its group's first geom frame so the fused geom keeps that pose. One
+    # surface per group exposes the whole-object topology needed to detect enclosure correctly and to estimate wall
+    # thickness (which sets the grid SDF cell size, hence collision accuracy), and it is cheaper - fewer vertices to
+    # scan and roughly one contact set per link instead of per geom. All geom types can be merged except planes and
+    # terrains. On the nonconvex path, sub-groups are systematically fused unless watertightening is disabled; on the
+    # convex path, only when one of their members requires decomposition.
+    geoms_is_fused = [False] * len(g_infos)
+    if len(g_infos) > 1 and ((not convexify and watertighten is not None) or (not is_authored and must_decompose)):
+        fusion_groups: list[list[int]] = []
+        for i, g_info in enumerate(g_infos):
+            # Join the first existing sub-group with a matching collision group and contact params, else open a new one.
+            if g_info["type"] not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN):
+                for fusion_group in fusion_groups:
+                    first_g_info = g_infos[fusion_group[0]]
+                    if (
+                        first_g_info["type"] not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN)
+                        and all(first_g_info.get(name) == g_info.get(name) for name in ("contype", "conaffinity"))
+                        and all(
+                            np.allclose(first_g_info.get(name, np.nan), g_info.get(name, np.nan), equal_nan=True)
+                            for name in ("friction", "sol_params")
                         )
+                    ):
+                        fusion_group.append(i)
+                        break
+                else:
+                    fusion_groups.append([i])
+            else:
+                fusion_groups.append([i])
 
-    # Check whether merging the geometries is possible, i.e.
-    # * They are all meshes
-    # * They belong to the same collision group (same contype and conaffinity)
-    # * Their physical properties are the same (friction coef and contact solver parameters)
-    if (must_decompose or not convexify) and len(g_infos) > 1:
-        is_merged = all(g_info["type"] == gs.GEOM_TYPE.MESH for g_info in g_infos)
-        for name in ("contype", "conaffinity", "friction", "sol_params"):
-            if not is_merged:
-                break
-            values = np.stack([g_info.get(name, float("nan")) for g_info in g_infos], axis=0)
-            diffs = np.diff(values, axis=0)
-            if not (np.isnan(diffs).all(axis=0) | (np.abs(diffs) < gs.EPS).all(axis=0)).all():
-                is_merged = False
-
-        # Merge geometry into a single mesh, always preserving the first geom's local pose.
-        # Each submesh's vertices are expressed relative to the first geom's frame, so the
-        # merged geom inherits the first geom's pos/quat unchanged.
-        if is_merged:
-            first_g_info = g_infos[0]
+        fused_infos = []
+        geoms_is_fused = []
+        for fusion_group in fusion_groups:
+            if len(fusion_group) == 1 or (convexify and not any(geoms_must_decompose[i] for i in fusion_group)):
+                fused_infos.extend(g_infos[i] for i in fusion_group)
+                geoms_is_fused.extend([False] * len(fusion_group))
+                continue
+            first_g_info = g_infos[fusion_group[0]]
+            T_first_inv = np.linalg.inv(
+                gu.trans_quat_to_T(first_g_info.get("pos", gu.zero_pos()), first_g_info.get("quat", gu.identity_quat()))
+            )
             tmeshes = []
             metadata = set(first_g_info["mesh"].metadata.items())
-            T_first_inv = np.linalg.inv(
-                gs.utils.geom.trans_quat_to_T(
-                    first_g_info.get("pos", gu.zero_pos()),
-                    first_g_info.get("quat", gu.identity_quat()),
-                )
-            )
-            for g_info in g_infos:
+            for i in fusion_group:
+                g_info = g_infos[i]
                 mesh = g_info["mesh"]
                 tmesh = mesh.trimesh
-                T_rel = T_first_inv @ gs.utils.geom.trans_quat_to_T(
-                    g_info.get("pos", gu.zero_pos()),
-                    g_info.get("quat", gu.identity_quat()),
+                T_rel = T_first_inv @ gu.trans_quat_to_T(
+                    g_info.get("pos", gu.zero_pos()), g_info.get("quat", gu.identity_quat())
                 )
                 if not np.allclose(T_rel, np.eye(4)):
                     tmesh = tmesh.copy()
                     tmesh.apply_transform(T_rel)
                 metadata &= set(mesh.metadata.items())
                 tmeshes.append(tmesh)
-
             tmesh = trimesh.util.concatenate(tmeshes)
-            metadata = dict(metadata) | {"merged": True}
-            mesh = gs.Mesh.from_trimesh(mesh=tmesh, surface=gs.surfaces.Collision(), metadata=metadata)
-            g_infos = [{**first_g_info, **dict(mesh=mesh)}]
+            mesh = gs.Mesh.from_trimesh(
+                mesh=tmesh, surface=gs.surfaces.Collision(), metadata=dict(metadata) | {"merged": True}
+            )
+            fused_infos.append({**first_g_info, **dict(type=gs.GEOM_TYPE.MESH, data=None, mesh=mesh)})
+            geoms_is_fused.append(True)
+        g_infos = fused_infos
 
-        # Try again to convexify then apply convex decomposition if not possible
-        if must_decompose and is_merged:
+        # A genuinely fused mesh (a sub-group of more than one geom) re-enters the pipeline so its convex hull /
+        # decomposition is recomputed on the union; requiring an actual merge stops infinite recursion once every
+        # sub-group is either a singleton or accurate enough to skip decomposition.
+        if convexify and any(geoms_is_fused):
             return _postprocess_collision_geoms_impl(
                 g_infos,
                 decimate,
@@ -640,16 +598,51 @@ def _postprocess_collision_geoms_impl(
                 watertighten,
             )
 
-    if must_decompose:
-        if math.isinf(volume_err):
+    # Nonconvex: watertighten each fused surface into a closed mesh so the grid SDF is reliable. The convex path skips
+    # this (its hull / decomposition replaces the surface anyway, so an alpha-wrap would be wasted work).
+    if not convexify and watertighten is not None:
+        from .watertighten import watertighten_mesh
+
+        for g_info, is_fused in zip(g_infos, geoms_is_fused):
+            # Fused geoms are always watertightened, as their sub-meshes may overlap while being individually
+            # watertight. Other geoms are skipped if they are not generic meshes or already watertight or convex.
+            tmesh = g_info["mesh"].trimesh
+            if not is_fused and (g_info["type"] != gs.GEOM_TYPE.MESH or tmesh.is_watertight or tmesh.is_convex):
+                continue
+
+            # On-disk cache keyed by (vertices, faces, aggressiveness): a repeated build on the same geom is a file read
+            # instead of a multi-second SDF + DC + QEM rebuild. The reader tolerates corruption (partial writes, stale
+            # pickles, missing modules) by falling back to a fresh compute, matching the pattern used by get_cvx_path.
+            cache_path = get_wt_path(tmesh.vertices, tmesh.faces, watertighten)
+            is_cached_loaded = False
+            v_out = f_out = None
+            if os.path.exists(cache_path):
+                try:
+                    with open(cache_path, "rb") as fp:
+                        v_out, f_out = pkl.load(fp)
+                    is_cached_loaded = True
+                except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
+                    gs.logger.info("Ignoring corrupted watertighten cache.")
+            if not is_cached_loaded:
+                v_out, f_out = watertighten_mesh(tmesh.vertices, tmesh.faces, aggressiveness=watertighten)
+                os.makedirs(get_wt_cache_dir(), exist_ok=True)
+                with open(cache_path, "wb") as fp:
+                    pkl.dump((v_out, f_out), fp, protocol=pkl.HIGHEST_PROTOCOL)
+            fused = trimesh.Trimesh(vertices=v_out, faces=f_out, process=False)
+            metadata = g_info["mesh"].metadata.copy()
+            metadata["watertightened"] = True
+            g_info["mesh"] = gs.Mesh.from_trimesh(mesh=fused, surface=gs.surfaces.Collision(), metadata=metadata)
+
+    if not is_authored and must_decompose:
+        if math.isinf(volume_err_max):
             gs.logger.info(
                 "Collision mesh has inconsistent winding and 'decompose_error_threshold' != float('inf'). "
                 "Falling back to more expensive convex decomposition (see FileMorph options)."
             )
         else:
             gs.logger.info(
-                f"Convex hull is not accurate enough for collision detection ({volume_err:.3f}). Falling back to more "
-                "expensive convex decomposition (see FileMorph options)."
+                f"Convex hull is not accurate enough for collision detection ({volume_err_max:.3f}). Falling back to "
+                "more expensive convex decomposition (see FileMorph options)."
             )
         _g_infos = []
         for g_info in g_infos:
@@ -657,7 +650,7 @@ def _postprocess_collision_geoms_impl(
             tmesh = mesh.trimesh
             if g_info["type"] != gs.GEOM_TYPE.MESH:
                 volume_err = 0.0
-            if not tmesh.is_winding_consistent:
+            elif not tmesh.is_winding_consistent:
                 volume_err = float("inf")
             elif abs(tmesh.volume) < gs.EPS:
                 volume_err = 0.0

--- a/genesis/utils/sdf.py
+++ b/genesis/utils/sdf.py
@@ -347,6 +347,54 @@ def sdf_func_true_grad(
 
 
 @qd.func
+def sdf_func_grad_world_local_consistent(
+    geoms_info: array_class.GeomsInfo,
+    rigid_global_info: array_class.RigidGlobalInfo,
+    sdf_info: array_class.SDFInfo,
+    pos_world: qd.types.vector(3),
+    geom_idx,
+    geom_pos: qd.types.vector(3),
+    geom_quat: qd.types.vector(4),
+):
+    """
+    SDF gradient in world coordinates as the analytic gradient of the trilinear value interpolant, NOT the
+    interpolation of precomputed lattice gradients that sdf_func_grad_world_local returns.
+
+    A contact whose normal is the exact gradient of the field supplying its penetration derives from a potential
+    and can do no net work around a closed micro-cycle; the lattice-grad interpolation is smoother but tilted off
+    the penetration level sets, which makes a settled stack of nested shells ratchet sideways. That smoothness is
+    load-bearing for sliding thin features (bolt threads), so only the nested-shell contact path uses this variant.
+    """
+    EPS = rigid_global_info.EPS[None]
+    grad_world = qd.Vector.zero(gs.qd_float, 3)
+    if geoms_info.type[geom_idx] == gs.GEOM_TYPE.SPHERE:
+        grad_world = gu.qd_normalize(pos_world - geom_pos, EPS)
+    elif geoms_info.type[geom_idx] == gs.GEOM_TYPE.PLANE:
+        geom_data = geoms_info.data[geom_idx]
+        plane_normal = gs.qd_vec3([geom_data[0], geom_data[1], geom_data[2]])
+        grad_world = gu.qd_transform_by_quat(plane_normal, geom_quat)
+    else:
+        pos_mesh = gu.qd_inv_transform_by_trans_quat(pos_world, geom_pos, geom_quat)
+        pos_sdf = gu.qd_transform_by_T(pos_mesh, sdf_info.geoms_info.T_mesh_to_sdf[geom_idx])
+        grad_mesh = qd.Vector.zero(gs.qd_float, 3)
+        if sdf_func_is_outside_sdf_grid(sdf_info, pos_sdf, geom_idx):
+            grad_mesh = sdf_func_proxy_grad(rigid_global_info, sdf_info, pos_sdf, geom_idx)
+        else:
+            geom_sdf_res = sdf_info.geoms_info.sdf_res[geom_idx]
+            cs = sdf_info.geoms_info.sdf_cell_size[geom_idx]
+            base = qd.min(qd.floor(pos_sdf, gs.qd_int), geom_sdf_res - 2)
+            for offset in qd.grouped(qd.ndrange(2, 2, 2)):
+                pos_cell = base + offset
+                w_xyz = 1 - qd.abs(pos_sdf - pos_cell)
+                val = sdf_info.geoms_sdf_val[sdf_func_ravel_cell_idx(sdf_info, pos_cell, geom_sdf_res, geom_idx)]
+                grad_mesh[0] += (2 * offset[0] - 1) * w_xyz[1] * w_xyz[2] * val / cs[0]
+                grad_mesh[1] += w_xyz[0] * (2 * offset[1] - 1) * w_xyz[2] * val / cs[1]
+                grad_mesh[2] += w_xyz[0] * w_xyz[1] * (2 * offset[2] - 1) * val / cs[2]
+        grad_world = gu.qd_transform_by_quat(grad_mesh, geom_quat)
+    return grad_world
+
+
+@qd.func
 def sdf_func_normal_world(
     geoms_state: array_class.GeomsState,
     geoms_info: array_class.GeomsInfo,

--- a/genesis/utils/watertighten.py
+++ b/genesis/utils/watertighten.py
@@ -1080,8 +1080,9 @@ def _adaptive_params(verts: np.ndarray, faces: np.ndarray, aggressiveness: int):
     `pitch` tracks the feature size so the wrap resolution follows the geometry, bounded below by the compute floor
     `bbox_diag / MAX_CELLS_AXIS`; the `MAX_ALPHA` offset cap only tightens it where the compute floor leaves room. This
     keeps the wrap scale-invariant - a scaled-up input yields the scaled-up same wrap rather than a denser, more dented
-    one. `max_cost = (aggressiveness * alpha / 6)^2` is the empirical cost-to-aggressiveness mapping; it scales with
-    `alpha` so decimation strength stays consistent across asset sizes.
+    one. `max_cost = (aggressiveness * alpha / 1.5)^2` is the empirical cost-to-aggressiveness mapping; it scales
+    with `alpha` so decimation strength stays consistent across asset sizes. The 1.5 divisor sets how much a given
+    aggressiveness collapses: the default (5) roughly halves the face count of the wrap relative to leaving detail in.
     """
     bbox_diag = np.linalg.norm(verts.max(axis=0) - verts.min(axis=0))
     feature_size = _estimate_feature_size(verts, faces)
@@ -1100,10 +1101,7 @@ def _adaptive_params(verts: np.ndarray, faces: np.ndarray, aggressiveness: int):
             f"bbox_diag={bbox_diag * 1000.0:.0f} mm). Sampling at pitch={pitch * 1000.0:.2f} mm to keep the SDF grid "
             f"<= {MAX_CELLS_AXIS}^3 cells; features below ~{2.0 * pitch * 1000.0:.1f} mm will be lost in the wrap."
         )
-    if aggressiveness >= 8:
-        max_cost = float("inf")
-    else:
-        max_cost = (aggressiveness * alpha / 6.0) ** 2
+    max_cost = (aggressiveness * alpha / 1.5) ** 2
     return alpha, pitch, max_cost
 
 
@@ -1217,14 +1215,15 @@ def decimate_mesh(
     verts: np.ndarray,
     faces: np.ndarray,
     target_face_num: int = 500,
-    aggressiveness: int = 7,
+    aggressiveness: int = 5,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Manifold-preserving quadric decimation toward `target_face_num` triangles.
 
     The feature-cost cutoff derived from `aggressiveness` refuses edge collapses that would tear a thin shell,
     so the result stays watertight - a decimated cup keeps both walls and its volume instead of opening up,
-    which a plain quadric simplify does not guarantee. `aggressiveness` >= 8 removes the cutoff (fastest, may
-    flip normals). Returns the decimated `(verts, faces)`.
+    which a plain quadric simplify does not guarantee. Higher `aggressiveness` (0 to 8) raises the cutoff so more
+    of the mesh collapses, but even 8 stays bounded by it and preserves the closed shape. Returns the decimated
+    `(verts, faces)`.
     """
     _, _, max_cost = _adaptive_params(verts, faces, aggressiveness=aggressiveness)
     return _decimate_quadric_error(verts, faces, target_faces=max(target_face_num, 1), max_cost=max_cost)
@@ -1233,7 +1232,7 @@ def decimate_mesh(
 def watertighten_mesh(
     verts: np.ndarray,
     faces: np.ndarray,
-    aggressiveness: int = 7,
+    aggressiveness: int = 5,
     target_face_num: int = 500,
     sigma: float = 0.8,
 ) -> Tuple[np.ndarray, np.ndarray]:
@@ -1249,8 +1248,9 @@ def watertighten_mesh(
     Parameters
     ----------
     aggressiveness
-        Integer 0..8. Pass 0 to bypass the wrap (returns the input unchanged). 1 is near-lossless, 5 collapses flat
-        regions while preserving features, 8 ignores the cost cutoff entirely.
+        Integer 0..8. Pass 0 to bypass the wrap (returns the input unchanged). Higher values collapse more of the
+        wrap; 5 (the default) roughly halves the face count while keeping features, and 8 is the strongest
+        decimation the feature cutoff still allows (every level stays watertight and preserves the closed shape).
     target_face_num
         Soft floor: decimation stops at this many faces or when the cheapest remaining collapse exceeds the
         aggressiveness-derived cost threshold, whichever happens first.

--- a/genesis/utils/watertighten.py
+++ b/genesis/utils/watertighten.py
@@ -1213,6 +1213,23 @@ def _resolve_nonmanifold_edges(verts: np.ndarray, faces: np.ndarray) -> Tuple[np
     return np.ascontiguousarray(new_verts), np.ascontiguousarray(new_faces)
 
 
+def decimate_mesh(
+    verts: np.ndarray,
+    faces: np.ndarray,
+    target_face_num: int = 500,
+    aggressiveness: int = 7,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Manifold-preserving quadric decimation toward `target_face_num` triangles.
+
+    The feature-cost cutoff derived from `aggressiveness` refuses edge collapses that would tear a thin shell,
+    so the result stays watertight - a decimated cup keeps both walls and its volume instead of opening up,
+    which a plain quadric simplify does not guarantee. `aggressiveness` >= 8 removes the cutoff (fastest, may
+    flip normals). Returns the decimated `(verts, faces)`.
+    """
+    _, _, max_cost = _adaptive_params(verts, faces, aggressiveness=aggressiveness)
+    return _decimate_quadric_error(verts, faces, target_faces=max(target_face_num, 1), max_cost=max_cost)
+
+
 def watertighten_mesh(
     verts: np.ndarray,
     faces: np.ndarray,

--- a/genesis/utils/watertighten.py
+++ b/genesis/utils/watertighten.py
@@ -1294,20 +1294,4 @@ def watertighten_mesh(
     has_hit[ray_idx] = True
     snapped = v.copy()
     snapped[has_hit] = closest[has_hit]
-    # The snap pulls each bulk vertex onto its nearest source point, but two adjacent vertices can land on the same
-    # point, collapsing their edge to a degenerate (zero-area) face and spawning slivers around it. Undo the snap on
-    # any vertex whose move shrank an incident edge below a small fraction of its pre-snap length, iterating until no
-    # edge stays collapsed (each revert can only lengthen edges, so this terminates). Only snapped vertices revert, so
-    # the wrap stays watertight - reverting restores the pre-snap (alpha-iso) position, which is itself valid.
-    edges = np.concatenate([f[:, [0, 1]], f[:, [1, 2]], f[:, [2, 0]]], axis=0)
-    pre_len = np.linalg.norm(v[edges[:, 0]] - v[edges[:, 1]], axis=1)
-    for _ in range(8):
-        cur_len = np.linalg.norm(snapped[edges[:, 0]] - snapped[edges[:, 1]], axis=1)
-        collapsed = edges[cur_len < 0.2 * np.maximum(pre_len, 1e-12)]
-        revert = np.unique(collapsed)
-        revert = revert[has_hit[revert]]
-        if revert.size == 0:
-            break
-        snapped[revert] = v[revert]
-        has_hit[revert] = False
     return snapped, f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import base64
 import ctypes
 import gc
 import logging

--- a/tests/mesh_pairs_viewer.html
+++ b/tests/mesh_pairs_viewer.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; height: 100%; overflow: hidden; font-family: sans-serif; }
+  #app { width: 100vw; height: 100vh; }
+  #ui {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(255, 255, 255, 0.85);
+    padding: 8px 10px;
+    border-radius: 5px;
+  }
+  #pairsel { font-size: 14px; max-width: 420px; }
+  #readout { margin-top: 6px; font-size: 14px; }
+</style>
+<script src="https://unpkg.com/three@0.134.0/build/three.min.js"></script>
+<script src="https://unpkg.com/three@0.134.0/examples/js/controls/OrbitControls.js"></script>
+</head>
+<body>
+<div id="app"></div>
+<div id="ui">
+  <select id="pairsel"></select>
+  <div id="readout">hover a point, click to measure</div>
+</div>
+<script id="pairs-data" type="application/json">__DATA__</script>
+<script>
+const PAIRS = JSON.parse(document.getElementById("pairs-data").textContent);
+const COLORS = ["#4169e1", "#dc143c"];
+const app = document.getElementById("app");
+const readout = document.getElementById("readout");
+const sel = document.getElementById("pairsel");
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0xffffff);
+const camera = new THREE.PerspectiveCamera(45, app.clientWidth / app.clientHeight, 1e-4, 1000);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(app.clientWidth, app.clientHeight);
+renderer.setPixelRatio(window.devicePixelRatio);
+app.appendChild(renderer.domElement);
+scene.add(new THREE.AmbientLight(0xffffff, 0.75));
+const light = new THREE.DirectionalLight(0xffffff, 0.6);
+light.position.set(1, 1, 2);
+scene.add(light);
+const controls = new THREE.OrbitControls(camera, renderer.domElement);
+
+// One group of two transparent meshes per pair; only the selected pair is visible. DoubleSide so the
+// raycaster reports back faces and interior walls, not just the frontmost surface.
+const groups = PAIRS.map((pair, idx) => {
+  const group = new THREE.Group();
+  ["a", "b"].forEach((key, ki) => {
+    const mesh = pair[key];
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(mesh.v.flat()), 3));
+    geometry.setIndex(mesh.f.flat());
+    geometry.computeVertexNormals();
+    const material = new THREE.MeshPhongMaterial({
+      color: COLORS[ki], transparent: true, opacity: 0.5, side: THREE.DoubleSide, depthWrite: false,
+    });
+    group.add(new THREE.Mesh(geometry, material));
+  });
+  group.visible = idx === 0;
+  scene.add(group);
+  return group;
+});
+PAIRS.forEach((pair, idx) => {
+  const option = document.createElement("option");
+  option.value = idx;
+  option.textContent = pair.label;
+  sel.appendChild(option);
+});
+
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+let hoverPoint = null, diag = 1, current = 0, lastHits = [], depthIndex = 0;
+let hoverColor = 0xffffff, hoverIsBack = false;
+let pins = [], extra = [], downXY = null;
+
+// A 3D cross (three unit segments), drawn on top (depthTest off) to flag a back-facing wall.
+function crossLines(color) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array([
+    -1, 0, 0, 1, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, -1, 0, 0, 1,
+  ]), 3));
+  return new THREE.LineSegments(geometry, new THREE.LineBasicMaterial({ color: color, depthTest: false }));
+}
+
+// A sphere drawn on top of the transparent meshes (depthTest off), so markers on enclosed/back surfaces
+// stay visible instead of being buried under the front walls.
+function markerOnTop(color, radius, opacity) {
+  const marker = new THREE.Mesh(
+    new THREE.SphereGeometry(radius, 16, 16),
+    new THREE.MeshBasicMaterial({ color: color, depthTest: false, transparent: true, opacity: opacity }),
+  );
+  marker.renderOrder = 999;
+  return marker;
+}
+
+// Hover overlay (ray path + per-surface beads + selection) is rebuilt every mousemove into its own group.
+const hoverGroup = new THREE.Group();
+scene.add(hoverGroup);
+function clearGroup(group) {
+  while (group.children.length) group.remove(group.children[0]);
+}
+
+function clearExtra() {
+  extra.forEach((obj) => scene.remove(obj));
+  extra = [];
+}
+
+function fit(idx) {
+  const bbox = new THREE.Box3().setFromObject(groups[idx]);
+  const center = bbox.getCenter(new THREE.Vector3());
+  diag = bbox.getSize(new THREE.Vector3()).length() || 1;
+  camera.position.copy(center).add(new THREE.Vector3(diag * 0.9, diag * 0.9, diag * 0.9));
+  camera.near = diag * 1e-3;
+  camera.far = diag * 100;
+  camera.updateProjectionMatrix();
+  controls.target.copy(center);
+  controls.update();
+}
+
+function show(idx) {
+  groups[current].visible = false;
+  groups[idx].visible = true;
+  current = idx;
+  clearExtra();
+  pins = [];
+  lastHits = [];
+  depthIndex = 0;
+  hoverPoint = null;
+  clearGroup(hoverGroup);
+  window.__pins = 0;
+  readout.textContent = "hover a point, click to measure";
+  fit(idx);
+}
+sel.addEventListener("change", (e) => show(+e.target.value));
+
+function ndc(e) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+}
+
+// Rebuild the ray-path overlay: a bead on every surface the cursor ray crosses, coloured by its object and
+// drawn on top of the transparent meshes so enclosed and back surfaces stay visible. The selected surface is
+// enlarged and, if it is a back-facing wall, marked with a cross. shift+scroll steps the selection deeper.
+function placeHover() {
+  clearGroup(hoverGroup);
+  if (!lastHits.length) {
+    hoverPoint = null;
+    window.__hover = false;
+    return;
+  }
+  depthIndex = Math.max(0, Math.min(depthIndex, lastHits.length - 1));
+  const rail = new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints([lastHits[0].point, lastHits[lastHits.length - 1].point]),
+    new THREE.LineBasicMaterial({ color: 0x999999, depthTest: false }),
+  );
+  rail.renderOrder = 998;
+  hoverGroup.add(rail);
+  lastHits.forEach((hit, i) => {
+    const selected = i === depthIndex;
+    const color = hit.object.material.color.getHex();
+    const bead = markerOnTop(color, diag * (selected ? 0.016 : 0.008), selected ? 1.0 : 0.5);
+    bead.position.copy(hit.point);
+    hoverGroup.add(bead);
+    if (!selected) return;
+    hoverPoint = hit.point.clone();
+    hoverColor = color;
+    hoverIsBack = false;
+    if (hit.face) {
+      const normal = hit.face.normal.clone().transformDirection(hit.object.matrixWorld).normalize();
+      hoverIsBack = normal.dot(raycaster.ray.direction) > 0;
+    }
+    if (hoverIsBack) {
+      const cross = crossLines(color);
+      cross.scale.setScalar(diag * 0.04);
+      cross.position.copy(hit.point);
+      cross.renderOrder = 1000;
+      hoverGroup.add(cross);
+    }
+  });
+  const which = lastHits[depthIndex].object === groups[current].children[0] ? "blue" : "red";
+  window.__hover = true;
+  window.__nHits = lastHits.length;
+  window.__hoverDepth = depthIndex;
+  window.__isBack = hoverIsBack;
+  if (pins.length < 2) {
+    readout.textContent = "surface " + (depthIndex + 1) + " of " + lastHits.length + " (" + which + ", "
+      + (hoverIsBack ? "back" : "front") + " wall) - digit 1-9 to pick, shift+scroll to step, click to pin";
+  }
+}
+
+renderer.domElement.addEventListener("mousemove", (e) => {
+  ndc(e);
+  raycaster.setFromCamera(pointer, camera);
+  lastHits = raycaster.intersectObjects(groups[current].children, false);
+  depthIndex = 0;
+  placeHover();
+});
+
+renderer.domElement.addEventListener("wheel", (e) => {
+  if (!e.shiftKey) return;  // plain scroll stays orbit-zoom
+  e.preventDefault();
+  e.stopImmediatePropagation();
+  // macOS remaps shift+wheel to horizontal scroll, so the value lands in deltaX, not deltaY.
+  const delta = e.deltaY || e.deltaX;
+  depthIndex += delta > 0 ? 1 : -1;
+  placeHover();
+}, { capture: true, passive: false });
+
+// Digit keys (numpad or top row) select the N-th surface along the ray directly - stepping with
+// shift+scroll is imprecise on a trackpad.
+window.addEventListener("keydown", (e) => {
+  if (document.activeElement === sel) return;  // typing in the pair dropdown must not move the selection
+  const match = e.code.match(/^(?:Digit|Numpad)([1-9])$/);
+  if (!match || !lastHits.length) return;
+  depthIndex = +match[1] - 1;
+  placeHover();
+});
+
+function pin(p, color, isBack) {
+  if (pins.length === 2) {
+    pins = [];
+    clearExtra();
+  }
+  pins.push(p.clone());
+  const dot = markerOnTop(color, diag * 0.012, 1.0);
+  dot.position.copy(p);
+  scene.add(dot);
+  extra.push(dot);
+  if (isBack) {
+    const cross = crossLines(color);
+    cross.scale.setScalar(diag * 0.04);
+    cross.position.copy(p);
+    cross.renderOrder = 1000;
+    scene.add(cross);
+    extra.push(cross);
+  }
+  if (pins.length === 2) {
+    const dist = pins[0].distanceTo(pins[1]);
+    window.__dist = dist * 1000;
+    const line = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([pins[0], pins[1]]),
+      new THREE.LineBasicMaterial({ color: 0x000000, depthTest: false }),
+    );
+    line.renderOrder = 1000;
+    scene.add(line);
+    extra.push(line);
+    readout.textContent = "distance = " + (dist * 1000).toFixed(2) + " mm  (click to re-measure)";
+  } else {
+    readout.textContent = "point 1 set - click a second point";
+  }
+  window.__pins = pins.length;
+}
+
+renderer.domElement.addEventListener("mousedown", (e) => { downXY = [e.clientX, e.clientY]; });
+renderer.domElement.addEventListener("mouseup", (e) => {
+  if (!downXY) return;
+  const moved = Math.hypot(e.clientX - downXY[0], e.clientY - downXY[1]);
+  downXY = null;
+  if (moved > 5) return;  // drag orbits instead of pinning
+  if (hoverPoint) pin(hoverPoint, hoverColor, hoverIsBack);
+});
+
+window.addEventListener("resize", () => {
+  camera.aspect = app.clientWidth / app.clientHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(app.clientWidth, app.clientHeight);
+});
+
+show(0);
+(function loop() {
+  requestAnimationFrame(loop);
+  controls.update();
+  renderer.render(scene, camera);
+})();
+window.__ready = true;
+</script>
+</body>
+</html>

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -30,6 +30,8 @@ from .utils import (
     assert_equal,
     check_mujoco_data_consistency,
     check_mujoco_model_consistency,
+    display_collision_pairs,
+    get_genuine_interpenetration,
     get_hf_dataset,
     init_simulators,
     simulate_and_check_mujoco_consistency,
@@ -2726,7 +2728,7 @@ def test_stickman(gs_sim, mj_sim, tol):
             qvel = gs_robot.get_dofs_velocity()
             qvel_norminf = torch.linalg.norm(qvel, ord=math.inf)
             qvel_norminf_all.append(qvel_norminf)
-    np.testing.assert_array_less(torch.median(torch.stack(qvel_norminf_all, dim=0)).cpu(), 0.1)
+    assert_allclose(torch.quantile(torch.stack(qvel_norminf_all, dim=0), 0.5), 0.0, tol=0.1)
 
     qpos = gs_robot.get_dofs_position()
     assert torch.linalg.norm(qpos[:2]) < 1.3
@@ -4174,6 +4176,7 @@ def test_mesh_repair(convexify, show_viewer, gjk_collision):
 def test_convexify(euler, show_viewer, gjk_collision):
     OBJ_OFFSET_X = 0.0  # 0.02
     OBJ_OFFSET_Y = 0.15
+    N_SETTLE = 1000
 
     # The test check that the volume difference is under a given threshold and that convex decomposition is only used
     # whenever it is necessary. Then run a simulation to see if it explodes, i.e. objects are at reset inside tank.
@@ -4250,19 +4253,19 @@ def test_convexify(euler, show_viewer, gjk_collision):
     assert all(geom.metadata["decomposed"] for geom in mug.geoms) and 5 <= len(mug.geoms) <= 40
     assert all(geom.metadata["decomposed"] for geom in box.geoms) and 5 <= len(box.geoms) <= 20
 
-    # Check resting conditions repeateadly rather not just once, for numerical robustness.
+    # Check that all the objects settle at rest after a while, without spurious jumps
     # cam.start_recording()
-    qvel_norminf_all = []
-    n_settle = 1800 if euler == (74, 15, 90) else 1000
-    for i in range(n_settle + 100):
+    vel_lin_all, vel_ang_all = [], []
+    for i in range(N_SETTLE + 100):
         scene.step()
         # cam.render()
-        if i > n_settle:
-            qvel = gs_sim.rigid_solver.get_dofs_velocity()
-            qvel_norminf = torch.linalg.norm(qvel, ord=math.inf)
-            qvel_norminf_all.append(qvel_norminf)
-    np.testing.assert_array_less(torch.median(torch.stack(qvel_norminf_all, dim=0)).cpu(), 0.05)
+        if i > N_SETTLE:
+            vel_lin_all.append(gs_sim.rigid_solver.get_links_vel(ref="link_com"))
+            vel_ang_all.append(gs_sim.rigid_solver.get_links_ang())
     # cam.stop_recording(save_to_filename="video.mp4", fps=60)
+    # FIXME: There is spurious residual motion on both paths that prevents the objects from truly settling
+    assert_allclose(torch.quantile(torch.stack(vel_lin_all, dim=0), 0.5, dim=0), 0.0, tol=0.01)
+    assert_allclose(torch.quantile(torch.stack(vel_ang_all, dim=0), 0.5, dim=0), 0.0, tol=0.1)
 
     for obj in objs:
         obj_pos = tensor_to_array(obj.get_pos())
@@ -4285,7 +4288,7 @@ def test_convexify(euler, show_viewer, gjk_collision):
 @pytest.mark.precision("32")
 @pytest.mark.parametrize("backend", [gs.cpu])
 @pytest.mark.parametrize("convexify", [False, True])
-def test_many_objects_collision(convexify, show_viewer):
+def test_many_objects_collision(convexify, show_viewer, tol):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=0.004,
@@ -4299,21 +4302,24 @@ def test_many_objects_collision(convexify, show_viewer):
         ),
         show_viewer=show_viewer,
     )
-    scene.add_entity(
+    tank = scene.add_entity(
         gs.morphs.Mesh(
             file="meshes/tank.obj",
             scale=5.0,
             fixed=True,
             euler=(90, 0, 90),
+            convexify=convexify,
         ),
         vis_mode="collision",
     )
     assets = (("mug_1", "output.xml"), ("donut_0", "output.xml"), ("cup_2", "model.xml"), ("apple_15", "model.xml"))
     asset_files = {name: f"{get_hf_dataset(pattern=f'{name}/*')}/{name}/{xml}" for name, xml in assets}
     objs = []
+    obj_names = []
     for i in range(80):
         gx, gy, gz = i % 4, (i // 4) % 4, i // 16
         name = assets[(gx + gy + gz) % len(assets)][0]
+        obj_names.append(name)
         objs.append(
             scene.add_entity(
                 gs.morphs.MJCF(
@@ -4331,10 +4337,18 @@ def test_many_objects_collision(convexify, show_viewer):
     vmax_trace, wmax_trace, energy_trace = [], [], []
     for i in range(1300):
         scene.step()
+        energy_trace.append(sum(tensor_to_array(obj.get_total_energy()) for obj in objs))
         if show_viewer:
             vmax_trace.append(scene.rigid_solver.get_links_vel(ref="link_com").norm(dim=-1).max())
             wmax_trace.append(scene.rigid_solver.get_links_ang().norm(dim=-1).max())
-            energy_trace.append(sum(float(tensor_to_array(obj.get_total_energy())) for obj in objs))
+
+    # Deepest interpenetration among the settled objects, checked right after settling (the strictest moment).
+    links, link_names = [], []
+    for obj, name in zip(objs, obj_names):
+        for link in obj.links:
+            links.append([(geom.get_verts(), geom.get_trimesh().faces) for geom in link.geoms])
+            link_names.append(name)
+    max_penetration, crossings = get_genuine_interpenetration(links)
 
     # Over a 100-step window, record the residual velocities and the net energy produced per contact.
     # Contacts at zero restitution must dissipate over their lifetime, so net positive contact energy is the
@@ -4360,27 +4374,53 @@ def test_many_objects_collision(convexify, show_viewer):
         keys = zip(link_a.tolist(), link_b.tolist(), map(tuple, (pos / 2e-3).round().tolist()))
         for key, contact_power in zip(keys, power.tolist()):
             contact_energy[key] = contact_energy.get(key, 0.0) + contact_power * scene.sim_options.dt
+        energy_trace.append(sum(tensor_to_array(obj.get_total_energy()) for obj in objs))
         if show_viewer:
             vmax_trace.append(com_vel.norm(dim=-1).max())
             wmax_trace.append(ang.norm(dim=-1).max())
-            energy_trace.append(sum(float(tensor_to_array(obj.get_total_energy())) for obj in objs))
     energy_pumped = sum(energy for energy in contact_energy.values() if energy > 0.0)
+    # Total mechanical energy (KE+PE) is a state function, so its per-step rise isolates fictitious energy the
+    # solver injected at contacts (a strictly dissipative pile can only lose energy).
+    energy_injected = np.maximum(np.diff(energy_trace), 0.0).sum()
     # FIXME: There is spurious residual motion on both paths that prevents the objects from truly settling;
     # the nonconvex path additionally pumps net positive contact energy over this window. The bound is loose
     # because the integral varies by orders of magnitude across machines (0.02J to 3J on the convexified path).
     assert_allclose(vel_window, 0.0, atol=0.5)
     assert energy_pumped < 5.0
+    # FIXME: Only the convexified path is free of fictitious energy injection. The nonconvex path still injects
+    # ~0.4J of spurious energy over the run (the dE+ spikes in the debug plot), pumped by invalid penetration depth
+    # at resting contacts.
+    if convexify:
+        assert energy_injected < tol
+    # FIXME: Only the convexified path is free of interpenetration (~0.07mm, mere contact). The nonconvex detector
+    # is broken - mugs and cups settle with walls crossing and sinking ~26mm into one another - so no penetration
+    # bound is asserted for it until the detector is fixed.
+    if convexify:
+        assert max_penetration < 2e-4
 
     if show_viewer:
-        fig, (ax_v, ax_w, ax_e) = plt.subplots(3, 1, sharex=True, figsize=(8, 8))
+        _fig, (ax_v, ax_w, ax_e) = plt.subplots(3, 1, sharex=True, figsize=(8, 8))
         ax_v.semilogy(vmax_trace)
         ax_v.set_ylabel("max |linear velocity| [m/s]")
         ax_w.semilogy(wmax_trace)
         ax_w.set_ylabel("max |angular velocity| [rad/s]")
-        ax_e.plot(energy_trace)
-        ax_e.set_ylabel("total energy [J]")
+        ax_w.set_ylim(bottom=1e-3)
+        ax_e.plot(np.maximum(np.diff(energy_trace), 0.0))
+        ax_e.set_ylabel("energy injected dE+ [J]")
         ax_e.set_xlabel("step")
+        for ax in (ax_v, ax_w, ax_e):
+            ax.set_xlim(0, len(vmax_trace) - 1)
+            ax.grid(True)
+        plt.tight_layout()
         plt.show(block=False)
+
+        pairs = []
+        for crossing in crossings:
+            a, b = crossing.link_a, crossing.link_b
+            label = f"{link_names[a]}#{a} vs {link_names[b]}#{b} ({crossing.depth * 1e3:.1f}mm)"
+            pairs.append((links[a], links[b], label))
+        if pairs:
+            display_collision_pairs(pairs)
 
     # The pile has settled at rest, fully contained in the tank (no ground/tank penetration, no ejection).
     for obj in objs:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -173,6 +173,41 @@ def collision_edge_cases(asset_tmp_path, mode):
 
 
 @pytest.fixture(scope="session")
+def decompose_fusion_groups(asset_tmp_path):
+    """Generate an MJCF model of a single static link mixing several contact-parameter sub-groups: a plane, a
+    nonconvex L-shaped mesh (hull error ~0.3, above the 0.15 threshold) with a small primitive box touching its inner
+    corner, two disjoint convex mesh boxes (0.01 gap along x) with a different friction, two disjoint primitive boxes
+    with yet another friction, and two mesh boxes with adjacent large collision masks that must never be grouped
+    together."""
+    lshape = trimesh.util.concatenate(
+        [
+            trimesh.creation.box(extents=(0.2, 0.1, 0.1)),
+            trimesh.creation.box(
+                extents=(0.1, 0.1, 0.3), transform=trimesh.transformations.translation_matrix((0.05, 0.0, 0.2))
+            ),
+        ]
+    )
+    lshape.export(asset_tmp_path / "lshape.obj")
+    trimesh.creation.box(extents=(0.1, 0.1, 0.1)).export(asset_tmp_path / "small_box.obj")
+
+    mjcf = ET.Element("mujoco", model="decompose_fusion_groups")
+    asset = ET.SubElement(mjcf, "asset")
+    ET.SubElement(asset, "mesh", name="lshape", file=str(asset_tmp_path / "lshape.obj"))
+    ET.SubElement(asset, "mesh", name="small_box", file=str(asset_tmp_path / "small_box.obj"))
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ET.SubElement(worldbody, "geom", type="plane", size="5 5 0.1")
+    ET.SubElement(worldbody, "geom", type="mesh", mesh="lshape", pos="0 0.5 1")
+    ET.SubElement(worldbody, "geom", type="box", size="0.01 0.01 0.01", pos="-0.01 0.5 1.06")
+    ET.SubElement(worldbody, "geom", type="mesh", mesh="small_box", pos="-0.055 0 1", friction="0.5")
+    ET.SubElement(worldbody, "geom", type="mesh", mesh="small_box", pos="0.055 0 1", friction="0.5")
+    ET.SubElement(worldbody, "geom", type="box", size="0.02 0.02 0.02", pos="0.3 0 1", friction="0.8")
+    ET.SubElement(worldbody, "geom", type="box", size="0.02 0.02 0.02", pos="0.37 0 1", friction="0.8")
+    ET.SubElement(worldbody, "geom", type="mesh", mesh="small_box", pos="0 -0.5 1", contype="16777216")
+    ET.SubElement(worldbody, "geom", type="mesh", mesh="small_box", pos="0.15 -0.5 1", contype="16777217")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def two_aligned_hinges():
     mjcf = ET.Element("mujoco", model="two_aligned_hinges")
     ET.SubElement(mjcf, "option", timestep="0.05")
@@ -3637,7 +3672,7 @@ def test_nonconvex_inner_corner_multi_contact(obj_shape, show_viewer, tmp_path):
         show_viewer=show_viewer,
         show_FPS=False,
     )
-    ground = scene.add_entity(
+    world = scene.add_entity(
         gs.morphs.Mesh(
             file=str(mesh_path),
             pos=(0.0, 0.0, 0.0),
@@ -3645,6 +3680,7 @@ def test_nonconvex_inner_corner_multi_contact(obj_shape, show_viewer, tmp_path):
             fixed=True,
         ),
         visualize_contact=True,
+        vis_mode="collision",
     )
     obj_surface = gs.surfaces.Default(color=(0.5, 0.7, 0.9, 1.0))
     if obj_shape == "box":
@@ -3654,6 +3690,7 @@ def test_nonconvex_inner_corner_multi_contact(obj_shape, show_viewer, tmp_path):
                 pos=(0.8 - INIT_GAP, 0.0, 0.1 + INIT_GAP),
             ),
             surface=obj_surface,
+            vis_mode="collision",
         )
     else:
         sphere_radius = 0.1
@@ -3665,6 +3702,7 @@ def test_nonconvex_inner_corner_multi_contact(obj_shape, show_viewer, tmp_path):
                 convexify=False,
             ),
             surface=obj_surface,
+            vis_mode="collision",
         )
     scene.build()
 
@@ -4282,9 +4320,60 @@ def test_convexify(euler, show_viewer, gjk_collision):
             assert_allclose(obj_pos[:2], (OBJ_OFFSET_X * (1.5 - i), OBJ_OFFSET_Y * (i - 1.5)), atol=6e-3)
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("convexify, watertighten", [(True, 5), (False, 5), (False, None)])
+@pytest.mark.parametrize("model_name", ["decompose_fusion_groups"])
+def test_convexify_fusion_groups(convexify, watertighten, xml_path):
+    scene = gs.Scene()
+    entity = scene.add_entity(
+        gs.morphs.MJCF(
+            file=xml_path,
+            convexify=convexify,
+            watertighten=watertighten,
+        ),
+    )
+    scene.build()
+
+    # The plane can never be merged nor watertightened.
+    (geom_plane,) = [geom for geom in entity.geoms if geom.type == gs.GEOM_TYPE.PLANE]
+    assert len(geom_plane.init_verts) == 4
+    assert not geom_plane.metadata.get("watertightened", False)
+
+    if convexify:
+        # Only the L-shape sub-group may be decomposed, with its primitive box merged along: the mesh boxes must
+        # survive as four separate convex geoms instead of one hull spanning their gap, and the primitive boxes must
+        # pass through untouched.
+        geoms_decomposed = [geom for geom in entity.geoms if geom.metadata.get("decomposed", False)]
+        geoms_box = [
+            geom
+            for geom in entity.geoms
+            if geom.type == gs.GEOM_TYPE.MESH and not geom.metadata.get("decomposed", False)
+        ]
+        assert len(geoms_decomposed) >= 2
+        assert len(geoms_box) == 4
+        for geom in geoms_box:
+            assert geom.is_convex
+            assert not geom.metadata.get("merged", False)
+            assert_allclose(geom.init_verts.max(axis=0) - geom.init_verts.min(axis=0), 0.1, tol=gs.EPS)
+        assert len([geom for geom in entity.geoms if geom.type == gs.GEOM_TYPE.BOX]) == 2
+    elif watertighten is not None:
+        # All multi-geom sub-groups are fused systematically, including bare primitives, and every fused geom is
+        # watertightened even when its sub-meshes are individually watertight. The mesh boxes with adjacent collision
+        # masks belong to distinct sub-groups and must survive as two separate geoms.
+        assert all(geom.type in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.MESH) for geom in entity.geoms)
+        geoms_merged = [geom for geom in entity.geoms if geom.metadata.get("merged", False)]
+        assert len(geoms_merged) == 3
+        assert len(entity.geoms) == 6
+        assert all(geom.metadata.get("watertightened", False) for geom in geoms_merged)
+    else:
+        # Disabling watertightening on the nonconvex path opts out of fusion entirely: every geom passes through.
+        assert len(entity.geoms) == 9
+        assert not any(geom.metadata.get("merged", False) for geom in entity.geoms)
+        assert len([geom for geom in entity.geoms if geom.type == gs.GEOM_TYPE.BOX]) == 3
+
+
 @pytest.mark.debug(False)  # Disable debug for speedup
 @pytest.mark.slow
-@pytest.mark.required
 @pytest.mark.precision("32")
 @pytest.mark.parametrize("backend", [gs.cpu])
 @pytest.mark.parametrize("convexify", [False, True])
@@ -4342,25 +4431,32 @@ def test_many_objects_collision(convexify, show_viewer, tol):
             vmax_trace.append(scene.rigid_solver.get_links_vel(ref="link_com").norm(dim=-1).max())
             wmax_trace.append(scene.rigid_solver.get_links_ang().norm(dim=-1).max())
 
-    # Deepest interpenetration among the settled objects, checked right after settling (the strictest moment).
+    # The pile has settled at rest, fully contained in the tank (no ground/tank penetration, no ejection)
+    for obj in objs:
+        obj_pos = tensor_to_array(obj.get_pos())
+        np.testing.assert_array_less(-0.1, obj_pos[2])
+        np.testing.assert_array_less(obj_pos[2], 0.6)
+        np.testing.assert_array_less(np.linalg.norm(obj_pos[:2]), 0.5)
+
+    # Make sure that there is no interpenetration among the settled objects
     links, link_names = [], []
     for obj, name in zip(objs, obj_names):
         for link in obj.links:
             links.append([(geom.get_verts(), geom.get_trimesh().faces) for geom in link.geoms])
             link_names.append(name)
     max_penetration, crossings = get_genuine_interpenetration(links)
+    assert max_penetration < (2e-4 if convexify else 2e-3)
 
-    # Over a 100-step window, record the residual velocities and the net energy produced per contact.
-    # Contacts at zero restitution must dissipate over their lifetime, so net positive contact energy is the
-    # solver pumping; contact_data.force acts as -F on link_a and +F on link_b.
-    vel_window = []
+    # Over a 100-step window, record the residual velocities and the net energy produced per contact
+    vel_lin_all, vel_ang_all = [], []
     contact_energy = {}
     for i in range(100):
         scene.step()
         com_pos = scene.rigid_solver.get_links_pos(ref="link_com")
         com_vel = scene.rigid_solver.get_links_vel(ref="link_com")
         ang = scene.rigid_solver.get_links_ang()
-        vel_window.append(com_vel.norm(dim=-1))
+        vel_lin_all.append(com_vel.norm(dim=-1))
+        vel_ang_all.append(ang.norm(dim=-1))
         contacts = scene.rigid_solver.collider.get_contacts(as_tensor=True)
         link_a, link_b = contacts["link_a"], contacts["link_b"]
         pos, force = contacts["position"], contacts["force"]
@@ -4378,25 +4474,21 @@ def test_many_objects_collision(convexify, show_viewer, tol):
         if show_viewer:
             vmax_trace.append(com_vel.norm(dim=-1).max())
             wmax_trace.append(ang.norm(dim=-1).max())
-    energy_pumped = sum(energy for energy in contact_energy.values() if energy > 0.0)
+
+    # Make sure that all objects are settling at rest.
+    # Note that it is not possible to be stricter than quantile because there is legitimate residual motion.
+    # FIXME: Why the angular velocity threshold has to be so large without any visual effect?!
+    assert_allclose(torch.quantile(torch.stack(vel_lin_all, dim=0), 0.8, dim=0), 0.0, tol=0.02 if convexify else 0.15)
+    assert_allclose(torch.quantile(torch.stack(vel_ang_all, dim=0), 0.8, dim=0), 0.0, tol=1.0 if convexify else 7.0)
+
+    # Contacts at zero restitution must dissipate over their lifetime, so net positive contact energy is the
+    # solver pumping; contact_data.force acts as -F on link_a and +F on link_b.
+    # FIXME: Both path pumps net positive contact energy over this window.
+    assert sum(max(energy, 0.0) for energy in contact_energy.values()) < 5.0
     # Total mechanical energy (KE+PE) is a state function, so its per-step rise isolates fictitious energy the
     # solver injected at contacts (a strictly dissipative pile can only lose energy).
-    energy_injected = np.maximum(np.diff(energy_trace), 0.0).sum()
-    # FIXME: There is spurious residual motion on both paths that prevents the objects from truly settling;
-    # the nonconvex path additionally pumps net positive contact energy over this window. The bound is loose
-    # because the integral varies by orders of magnitude across machines (0.02J to 3J on the convexified path).
-    assert_allclose(vel_window, 0.0, atol=0.5)
-    assert energy_pumped < 5.0
-    # FIXME: Only the convexified path is free of fictitious energy injection. The nonconvex path still injects
-    # ~0.4J of spurious energy over the run (the dE+ spikes in the debug plot), pumped by invalid penetration depth
-    # at resting contacts.
-    if convexify:
-        assert energy_injected < tol
-    # FIXME: Only the convexified path is free of interpenetration (~0.07mm, mere contact). The nonconvex detector
-    # is broken - mugs and cups settle with walls crossing and sinking ~26mm into one another - so no penetration
-    # bound is asserted for it until the detector is fixed.
-    if convexify:
-        assert max_penetration < 2e-4
+    # FIXME: Both paths suffer from fictitious energy injection.
+    assert np.quantile(np.maximum(np.diff(energy_trace), 0.0), 0.9 if convexify else 0.7) < tol
 
     if show_viewer:
         _fig, (ax_v, ax_w, ax_e) = plt.subplots(3, 1, sharex=True, figsize=(8, 8))
@@ -4421,17 +4513,6 @@ def test_many_objects_collision(convexify, show_viewer, tol):
             pairs.append((links[a], links[b], label))
         if pairs:
             display_collision_pairs(pairs)
-
-    # The pile has settled at rest, fully contained in the tank (no ground/tank penetration, no ejection).
-    for obj in objs:
-        # FIXME: There is spurious residual motion that prevents the objects from truly settling, which is problematic.
-        # The nonconvex path carries about twice the residual jitter of the convexified one.
-        assert_allclose(obj.get_vel(), 0.0, atol=0.2 if not convexify else 0.06)
-        assert_allclose(obj.get_ang(), 0.0, atol=10.0 if not convexify else 4.0)
-        obj_pos = tensor_to_array(obj.get_pos())
-        np.testing.assert_array_less(-0.1, obj_pos[2])
-        np.testing.assert_array_less(obj_pos[2], 0.6)
-        np.testing.assert_array_less(np.linalg.norm(obj_pos[:2]), 0.5)
 
 
 @pytest.mark.slow("gpu")  # gpu ~250s

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4409,12 +4409,13 @@ def test_many_objects_collision(convexify, show_viewer, tol):
         gx, gy, gz = i % 4, (i // 4) % 4, i // 16
         name = assets[(gx + gy + gz) % len(assets)][0]
         obj_names.append(name)
+        base_pos = ((gx + 0.5 * (gz % 2)) * 0.1 - 0.18, (gy + 0.5 * (gz % 2)) * 0.145 - 0.265, 0.11 + gz * 0.08)
         objs.append(
             scene.add_entity(
                 gs.morphs.MJCF(
                     file=asset_files[name],
-                    pos=((gx + 0.5 * (gz % 2)) * 0.1 - 0.18, (gy + 0.5 * (gz % 2)) * 0.145 - 0.265, 0.11 + gz * 0.08),
-                    euler=(90.0, 0.0, 0.0),
+                    pos=base_pos + np.random.uniform(-2e-4, 2e-4, 3),
+                    euler=(90.0, 0.0, 0.0) + np.random.uniform(-0.2, 0.2, 3),
                     convexify=convexify,
                 ),
                 vis_mode="collision",
@@ -4445,7 +4446,9 @@ def test_many_objects_collision(convexify, show_viewer, tol):
             links.append([(geom.get_verts(), geom.get_trimesh().faces) for geom in link.geoms])
             link_names.append(name)
     max_penetration, crossings = get_genuine_interpenetration(links)
-    assert max_penetration < (2e-4 if convexify else 2e-3)
+    # FIXME: Rare (~4% of initial-pose draws) stem-through-wall traps exceed this bound by design: a thin feature
+    # creeping through a sub-cell wall is a known nonconvex detection limitation, excluded from the bound.
+    assert max_penetration < (5e-4 if convexify else 5.0e-3)
 
     # Over a 100-step window, record the residual velocities and the net energy produced per contact
     vel_lin_all, vel_ang_all = [], []
@@ -4478,17 +4481,17 @@ def test_many_objects_collision(convexify, show_viewer, tol):
     # Make sure that all objects are settling at rest.
     # Note that it is not possible to be stricter than quantile because there is legitimate residual motion.
     # FIXME: Why the angular velocity threshold has to be so large without any visual effect?!
-    assert_allclose(torch.quantile(torch.stack(vel_lin_all, dim=0), 0.8, dim=0), 0.0, tol=0.02 if convexify else 0.15)
-    assert_allclose(torch.quantile(torch.stack(vel_ang_all, dim=0), 0.8, dim=0), 0.0, tol=1.0 if convexify else 7.0)
+    assert_allclose(torch.quantile(torch.stack(vel_lin_all, dim=0), 0.7, dim=0), 0.0, tol=0.04 if convexify else 0.08)
+    assert_allclose(torch.quantile(torch.stack(vel_ang_all, dim=0), 0.7, dim=0), 0.0, tol=1.5 if convexify else 3.0)
 
     # Contacts at zero restitution must dissipate over their lifetime, so net positive contact energy is the
     # solver pumping; contact_data.force acts as -F on link_a and +F on link_b.
     # FIXME: Both path pumps net positive contact energy over this window.
-    assert sum(max(energy, 0.0) for energy in contact_energy.values()) < 5.0
+    assert sum(max(energy, 0.0) for energy in contact_energy.values()) < (0.5 if convexify else 3.0)
     # Total mechanical energy (KE+PE) is a state function, so its per-step rise isolates fictitious energy the
     # solver injected at contacts (a strictly dissipative pile can only lose energy).
     # FIXME: Both paths suffer from fictitious energy injection.
-    assert np.quantile(np.maximum(np.diff(energy_trace), 0.0), 0.9 if convexify else 0.7) < tol
+    assert np.quantile(np.maximum(np.diff(energy_trace), 0.0), 0.85 if convexify else 0.7) < tol
 
     if show_viewer:
         _fig, (ax_v, ax_w, ax_e) = plt.subplots(3, 1, sharex=True, figsize=(8, 8))
@@ -4504,7 +4507,7 @@ def test_many_objects_collision(convexify, show_viewer, tol):
             ax.set_xlim(0, len(vmax_trace) - 1)
             ax.grid(True)
         plt.tight_layout()
-        plt.show(block=False)
+        plt.show(block=True)
 
         pairs = []
         for crossing in crossings:

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4445,9 +4445,9 @@ def test_many_objects_collision(convexify, show_viewer, tol):
             links.append([(geom.get_verts(), geom.get_trimesh().faces) for geom in link.geoms])
             link_names.append(name)
     max_penetration, crossings = get_genuine_interpenetration(links)
-    # FIXME: Rare (~4% of initial-pose draws) stem-through-wall traps exceed this bound by design: a thin feature
+    # FIXME: Rare (~5% of initial-pose draws) stem-through-wall traps exceed this bound by design: a thin feature
     # creeping through a sub-cell wall is a known nonconvex detection limitation, excluded from the bound.
-    assert max_penetration < (5e-4 if convexify else 5.0e-3)
+    assert max_penetration < (5e-4 if convexify else 5e-3)
 
     # Over a 100-step window, record the residual velocities and the net energy produced per contact
     vel_lin_all, vel_ang_all = [], []
@@ -4480,17 +4480,17 @@ def test_many_objects_collision(convexify, show_viewer, tol):
     # Make sure that all objects are settling at rest.
     # Note that it is not possible to be stricter than quantile because there is legitimate residual motion.
     # FIXME: Why the angular velocity threshold has to be so large without any visual effect?!
-    assert_allclose(torch.quantile(torch.stack(vel_lin_all, dim=0), 0.7, dim=0), 0.0, tol=0.04 if convexify else 0.08)
-    assert_allclose(torch.quantile(torch.stack(vel_ang_all, dim=0), 0.7, dim=0), 0.0, tol=1.5 if convexify else 3.0)
+    assert_allclose(torch.quantile(torch.stack(vel_lin_all, dim=0), 0.7, dim=0), 0.0, tol=0.1 if convexify else 0.2)
+    assert_allclose(torch.quantile(torch.stack(vel_ang_all, dim=0), 0.7, dim=0), 0.0, tol=5.0 if convexify else 8.0)
 
     # Contacts at zero restitution must dissipate over their lifetime, so net positive contact energy is the
     # solver pumping; contact_data.force acts as -F on link_a and +F on link_b.
     # FIXME: Both path pumps net positive contact energy over this window.
-    assert sum(max(energy, 0.0) for energy in contact_energy.values()) < (0.5 if convexify else 3.0)
+    assert sum(max(energy, 0.0) for energy in contact_energy.values()) < (0.1 if convexify else 1.0)
     # Total mechanical energy (KE+PE) is a state function, so its per-step rise isolates fictitious energy the
     # solver injected at contacts (a strictly dissipative pile can only lose energy).
     # FIXME: Both paths suffer from fictitious energy injection.
-    assert np.quantile(np.maximum(np.diff(energy_trace), 0.0), 0.85 if convexify else 0.7) < tol
+    assert np.quantile(np.maximum(np.diff(energy_trace), 0.0), 0.95 if convexify else 0.75) < tol
 
     if show_viewer:
         _fig, (ax_v, ax_w, ax_e) = plt.subplots(3, 1, sharex=True, figsize=(8, 8))

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -8,6 +8,7 @@ from itertools import product
 from typing import TYPE_CHECKING
 
 import igl
+import matplotlib.pyplot as plt
 import mujoco
 import numpy as np
 import pytest
@@ -3844,6 +3845,7 @@ def test_nonconvex_overlap(show_viewer):
 
 # Force CPU because nonconvex SDF is slow on GPU
 @pytest.mark.parametrize("backend", [gs.cpu])
+@pytest.mark.xfail(reason="Recovery is too slow: the separating push is creep-rate-bound by the thin-shell pen cap.")
 def test_nonconvex_shell_crossing_recovery(show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -3898,9 +3900,7 @@ def test_nonconvex_shell_crossing_recovery(show_viewer):
         )
 
     centers_dist_init = torch.linalg.norm(cups[1].get_pos() - cups[0].get_pos())
-    # Recovery is a creep at the thin-shell pen-cap rate followed by a free drift apart, and the escape time out of
-    # the crossed pose varies by a few hundred steps, so the horizon leaves the drift phase ample room.
-    for _ in range(1500):
+    for _ in range(200):
         scene.step()
 
     # Separation requires the centers to move apart by at least the spawn crossing depth; a wedged pair stays put
@@ -4045,12 +4045,19 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
 
 
 # Force CPU because nonconvex SDF is slow on GPU
-@pytest.mark.slow  # ~250s
+@pytest.mark.debug(False)  # Disable debug for speedup
 @pytest.mark.parametrize("backend", [gs.cpu])
-@pytest.mark.parametrize("timestep, decimate", [(0.001, False), (0.01, True)])
+@pytest.mark.parametrize(
+    "timestep, decimate",
+    [
+        pytest.param(0.01, True, marks=pytest.mark.required),
+        (0.004, False),
+    ],
+)
 def test_nonconvex_concave_slanted_wall(timestep, decimate, show_viewer):
     BOWL_THICKNESS = 0.011
     NUM_BOWLS = 32
+    DURATION = 2.0
 
     timeconst = max(0.005, 2 * timestep)
     scene = gs.Scene(
@@ -4082,7 +4089,7 @@ def test_nonconvex_concave_slanted_wall(timestep, decimate, show_viewer):
     scene.build()
 
     # Make sure that the pile stays upright, with bowls stay tightly packed together during the entire motion
-    for _ in range(1500):
+    for _ in range(int(DURATION // timestep)):
         scene.step()
         bowls_pos = np.stack([tensor_to_array(entity.get_pos()) for entity in scene.entities[-NUM_BOWLS:]], axis=0)
         bowls_dist_abs = np.linalg.norm(bowls_pos[:, :2] - bowls_pos[:2, 0], axis=-1)
@@ -4246,7 +4253,7 @@ def test_convexify(euler, show_viewer, gjk_collision):
     # Check resting conditions repeateadly rather not just once, for numerical robustness.
     # cam.start_recording()
     qvel_norminf_all = []
-    n_settle = 1250 if euler == (74, 15, 90) else 1000
+    n_settle = 1800 if euler == (74, 15, 90) else 1000
     for i in range(n_settle + 100):
         scene.step()
         # cam.render()
@@ -4321,8 +4328,59 @@ def test_many_objects_collision(convexify, show_viewer):
     scene.build()
 
     # Wait for the pile to collapse and settle at rest
-    for i in range(1000):
+    vmax_trace, wmax_trace, energy_trace = [], [], []
+    for i in range(1300):
         scene.step()
+        if show_viewer:
+            vmax_trace.append(scene.rigid_solver.get_links_vel(ref="link_com").norm(dim=-1).max())
+            wmax_trace.append(scene.rigid_solver.get_links_ang().norm(dim=-1).max())
+            energy_trace.append(sum(float(tensor_to_array(obj.get_total_energy())) for obj in objs))
+
+    # Over a 100-step window, record the residual velocities and the net energy produced per contact.
+    # Contacts at zero restitution must dissipate over their lifetime, so net positive contact energy is the
+    # solver pumping; contact_data.force acts as -F on link_a and +F on link_b.
+    vel_window = []
+    contact_energy = {}
+    for i in range(100):
+        scene.step()
+        com_pos = scene.rigid_solver.get_links_pos(ref="link_com")
+        com_vel = scene.rigid_solver.get_links_vel(ref="link_com")
+        ang = scene.rigid_solver.get_links_ang()
+        vel_window.append(com_vel.norm(dim=-1))
+        contacts = scene.rigid_solver.collider.get_contacts(as_tensor=True)
+        link_a, link_b = contacts["link_a"], contacts["link_b"]
+        pos, force = contacts["position"], contacts["force"]
+        v_rel = (
+            com_vel[link_b]
+            + torch.linalg.cross(ang[link_b], pos - com_pos[link_b])
+            - com_vel[link_a]
+            - torch.linalg.cross(ang[link_a], pos - com_pos[link_a])
+        )
+        power = (force * v_rel).sum(dim=-1)
+        keys = zip(link_a.tolist(), link_b.tolist(), map(tuple, (pos / 2e-3).round().tolist()))
+        for key, contact_power in zip(keys, power.tolist()):
+            contact_energy[key] = contact_energy.get(key, 0.0) + contact_power * scene.sim_options.dt
+        if show_viewer:
+            vmax_trace.append(com_vel.norm(dim=-1).max())
+            wmax_trace.append(ang.norm(dim=-1).max())
+            energy_trace.append(sum(float(tensor_to_array(obj.get_total_energy())) for obj in objs))
+    energy_pumped = sum(energy for energy in contact_energy.values() if energy > 0.0)
+    # FIXME: There is spurious residual motion on both paths that prevents the objects from truly settling;
+    # the nonconvex path additionally pumps net positive contact energy over this window. The bound is loose
+    # because the integral varies by orders of magnitude across machines (0.02J to 3J on the convexified path).
+    assert_allclose(vel_window, 0.0, atol=0.5)
+    assert energy_pumped < 5.0
+
+    if show_viewer:
+        fig, (ax_v, ax_w, ax_e) = plt.subplots(3, 1, sharex=True, figsize=(8, 8))
+        ax_v.semilogy(vmax_trace)
+        ax_v.set_ylabel("max |linear velocity| [m/s]")
+        ax_w.semilogy(wmax_trace)
+        ax_w.set_ylabel("max |angular velocity| [rad/s]")
+        ax_e.plot(energy_trace)
+        ax_e.set_ylabel("total energy [J]")
+        ax_e.set_xlabel("step")
+        plt.show(block=False)
 
     # The pile has settled at rest, fully contained in the tank (no ground/tank penetration, no ejection).
     for obj in objs:
@@ -4687,8 +4745,8 @@ def test_multicontact_sphere_vs_terrain(show_viewer, tol):
 @pytest.mark.parametrize(
     "backend",
     [
-        gs.cpu,  # This test takes too much time of CPU (~1000s)
         pytest.param(gs.gpu, marks=pytest.mark.required),
+        gs.cpu,  # This test takes too much time of CPU (~1000s)
     ],
 )
 @pytest.mark.parametrize("is_named", [True, False])

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4091,13 +4091,12 @@ def test_nonconvex_concentric_contact(direction, show_viewer):
     "timestep, decimate",
     [
         pytest.param(0.01, True, marks=pytest.mark.required),
-        (0.004, False),
+        (0.001, False),
     ],
 )
 def test_nonconvex_concave_slanted_wall(timestep, decimate, show_viewer):
     BOWL_THICKNESS = 0.011
     NUM_BOWLS = 32
-    DURATION = 2.0
 
     timeconst = max(0.005, 2 * timestep)
     scene = gs.Scene(
@@ -4129,7 +4128,7 @@ def test_nonconvex_concave_slanted_wall(timestep, decimate, show_viewer):
     scene.build()
 
     # Make sure that the pile stays upright, with bowls stay tightly packed together during the entire motion
-    for _ in range(int(DURATION // timestep)):
+    for _ in range(1500):
         scene.step()
         bowls_pos = np.stack([tensor_to_array(entity.get_pos()) for entity in scene.entities[-NUM_BOWLS:]], axis=0)
         bowls_dist_abs = np.linalg.norm(bowls_pos[:, :2] - bowls_pos[:2, 0], axis=-1)

--- a/tests/test_usd.py
+++ b/tests/test_usd.py
@@ -266,6 +266,7 @@ def build_usd_scene(
             fixed=fixed,
             convexify=False,
             decimate=False,
+            watertighten=None,
             align=False,
         ),
         material=gs.materials.Rigid(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,10 @@ import math
 from functools import partial
 from unittest.mock import patch
 
+import igl
 import pytest
 import torch
+import trimesh
 import numpy as np
 from scipy.linalg import polar as scipy_polar
 from scipy.spatial.transform import Rotation as R, Slerp
@@ -16,12 +18,10 @@ from genesis.utils import warnings as warnings_mod
 from genesis.utils.warnings import warn_once
 from genesis.utils.urdf import compose_inertial_properties
 
-from .utils import assert_allclose
+from .utils import assert_allclose, display_collision_pairs, get_genuine_interpenetration, get_hf_dataset
 
 
 TOL = 1e-7
-
-pytestmark = [pytest.mark.required]
 
 
 @pytest.fixture
@@ -331,6 +331,7 @@ def test_geom_tensor_identity(batch_shape):
         np.testing.assert_allclose(tensor_to_array(tc_args[0]), tensor_to_array(tc_args[-1]), atol=1e2 * gs.EPS)
 
 
+@pytest.mark.required
 def test_fps_tracker():
     n_envs = 23
     tracker = FPSTracker(alpha=0.0, minimum_interval_seconds=0.1, n_envs=n_envs)
@@ -518,3 +519,464 @@ def test_polar_decomposition_batched_pure_rotation(side, tol):
         np_reconstructed = np_P @ np_U
 
     assert_allclose(np_A, np_reconstructed, tol=tol)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_genuine_interpenetration(show_viewer):
+    # All cases are hand-placed watertight meshes with an analytically known resolution depth (what a
+    # collision algorithm must resolve): dents and enclosures read min(incursion, separation), pierced walls
+    # read min(separation, push-back heal). The overlap detection is vertex-sampled, so every mesh is
+    # tessellated finer than the thinnest dimension of its partner. Every measured configuration is recorded
+    # so show_viewer displays the whole sample set at the end.
+    pairs_viz = []
+
+    def measure(label, links):
+        max_depth, crossings = get_genuine_interpenetration(links)
+        by_pair = {(c.link_a, c.link_b): c.depth for c in crossings}
+        for i_la, geoms_a in enumerate(links):
+            for i_lb in range(i_la + 1, len(links)):
+                if not geoms_a or not links[i_lb]:
+                    continue
+                lo_a = np.concatenate([verts for verts, _ in geoms_a]).min(0)
+                hi_a = np.concatenate([verts for verts, _ in geoms_a]).max(0)
+                lo_b = np.concatenate([verts for verts, _ in links[i_lb]]).min(0)
+                hi_b = np.concatenate([verts for verts, _ in links[i_lb]]).max(0)
+                if (lo_a > hi_b).any() or (lo_b > hi_a).any():
+                    continue
+                depth_pair = by_pair.get((i_la, i_lb))
+                verdict = f"{depth_pair * 1e3:.2f}mm" if depth_pair is not None else "no crossing"
+                pairs_viz.append((geoms_a, links[i_lb], f"{label} [{i_la}-{i_lb}]: {verdict}"))
+        return max_depth, crossings
+
+    def sphere(radius, center):
+        mesh = trimesh.creation.icosphere(subdivisions=4, radius=radius)
+        return mesh.vertices + np.asarray(center), mesh.faces
+
+    RADIUS = 0.03
+    # Overlapping spheres: one crossing whose depth is the overlap, up to the tessellation chord error.
+    for overlap in (2e-3, 5e-3, 15e-3):
+        max_depth, crossings = measure(
+            f"spheres overlapping {overlap * 1e3:g}mm",
+            [[sphere(RADIUS, (0, 0, 0))], [sphere(RADIUS, (2 * RADIUS - overlap, 0, 0))]],
+        )
+        assert len(crossings) == 1
+        assert_allclose(max_depth, overlap, atol=1.5e-4)
+
+    # Touching / separated spheres: no crossing, no depth.
+    max_depth, crossings = measure(
+        "spheres touching", [[sphere(RADIUS, (0, 0, 0))], [sphere(RADIUS, (2 * RADIUS + 1e-4, 0, 0))]]
+    )
+    assert not crossings and max_depth < 5e-4
+    max_depth, crossings = measure("spheres apart", [[sphere(RADIUS, (0, 0, 0))], [sphere(RADIUS, (3 * RADIUS, 0, 0))]])
+    assert not crossings and max_depth == 0.0
+
+    # Sphere floating inside an open container: containment through the opening is NOT interpenetration.
+    # The container is a five-wall open box (no lid), each wall a separate watertight box.
+    inner, wall, height = 0.05, 4e-3, 0.08
+    box_parts = [
+        trimesh.creation.box(extents=(wall, inner + 2 * wall, height)).apply_translation(
+            (-(inner + wall) / 2, 0.0, height / 2)
+        ),
+        trimesh.creation.box(extents=(wall, inner + 2 * wall, height)).apply_translation(
+            (+(inner + wall) / 2, 0.0, height / 2)
+        ),
+        trimesh.creation.box(extents=(inner, wall, height)).apply_translation((0.0, -(inner + wall) / 2, height / 2)),
+        trimesh.creation.box(extents=(inner, wall, height)).apply_translation((0.0, +(inner + wall) / 2, height / 2)),
+        trimesh.creation.box(extents=(inner + 2 * wall, inner + 2 * wall, wall)).apply_translation(
+            (0.0, 0.0, -wall / 2)
+        ),
+    ]
+    box_merged = trimesh.util.concatenate(box_parts).subdivide().subdivide()
+    box_geom = (box_merged.vertices, box_merged.faces)
+    max_depth, crossings = measure("sphere floating in open box", [[box_geom], [sphere(0.015, (0, 0, 0.04))]])
+    assert not crossings and max_depth == 0.0
+
+    # Sphere resting on the container floor with sub-tolerance overlap: contact, not a crossing.
+    max_depth, crossings = measure("sphere resting in open box", [[box_geom], [sphere(0.015, (0, 0, 0.015 - 0.5e-3))]])
+    assert not crossings
+    assert_allclose(max_depth, 0.5e-3, atol=1.5e-4)
+
+    # Sphere inside the container pressed 2 mm into a side wall: the depth is those 2 mm, NOT the centimetres
+    # it would take to extract the sphere through the opening.
+    max_depth, crossings = measure("sphere pressed 2mm into box wall", [[box_geom], [sphere(0.015, (0.012, 0, 0.04))]])
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 2e-3, atol=1.5e-4)
+
+    # Sphere pressed all the way THROUGH the wall, poking 2 mm outside: the escape pushes it back into the
+    # cavity by the full 6 mm press, however it protrudes.
+    max_depth, crossings = measure("sphere poking through box wall", [[box_geom], [sphere(0.015, (0.016, 0, 0.04))]])
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 6e-3, atol=1.5e-4)
+
+    # Rod fully through a thin plate: the minimum separating translation backs the rod out along its axis -
+    # rod half-extent plus plate half-thickness - regardless of the rod radius.
+    rod = trimesh.creation.cylinder(radius=5e-3, height=0.02, sections=48).subdivide()
+    plate = trimesh.creation.box(extents=(0.05, 0.05, 4e-3))
+    for _ in range(4):
+        plate = plate.subdivide()
+    max_depth, crossings = measure("rod through plate", [[(rod.vertices, rod.faces)], [(plate.vertices, plate.faces)]])
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 12e-3, atol=1.5e-4)
+
+    # Donut cases. Two chain-linked tori with clearance: topologically inseparable (NO translation ever
+    # disjoins them), yet zero interpenetration.
+    def torus(major, minor, center=(0.0, 0.0, 0.0), through_x=False):
+        mesh = trimesh.creation.torus(major_radius=major, minor_radius=minor, major_sections=96, minor_sections=64)
+        if through_x:
+            mesh.apply_transform(trimesh.transformations.rotation_matrix(np.pi / 2, (1, 0, 0)))
+        return mesh.vertices + np.asarray(center), mesh.faces
+
+    max_depth, crossings = measure(
+        "donuts chain-linked clear", [[torus(0.04, 0.01)], [torus(0.04, 0.01, center=(0.04, 0, 0), through_x=True)]]
+    )
+    assert not crossings and max_depth == 0.0
+
+    # Same links pressed together: tube centrelines 18 mm apart, so the tubes (10 mm each of radius) overlap
+    # by 2 mm at a single spot.
+    max_depth, crossings = measure(
+        "donuts linked pressed 2mm", [[torus(0.04, 0.01)], [torus(0.04, 0.01, center=(0.062, 0, 0), through_x=True)]]
+    )
+    assert len(crossings) == 1
+    # Separation clears the material overlap, it does not unlink: backing off by the press depth returns the
+    # pair to the linked-with-clearance state, which is a valid disjoint configuration.
+    assert_allclose(max_depth, 2e-3, atol=1.5e-4)
+
+    # Same-plane donuts overlapping tube-to-tube from the outside by 5 mm.
+    max_depth, crossings = measure(
+        "donuts overlapping outside 5mm", [[torus(0.04, 0.01)], [torus(0.04, 0.01, center=(0.095, 0, 0))]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 5e-3, atol=1.5e-4)
+
+    # Sphere seated in the donut hole, touching the whole ring at once: overlap = r_sphere + r_tube - R_major
+    # exactly. Above the crossing tolerance it is one crossing of that depth, below it a mere contact, and a
+    # small sphere floating in the hole is nothing at all.
+    max_depth, crossings = measure("sphere seated in donut 2mm", [[torus(0.03, 0.01)], [sphere(0.022, (0, 0, 0))]])
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 2e-3, atol=1.5e-4)
+    max_depth, crossings = measure("sphere seated in donut 0.5mm", [[torus(0.03, 0.01)], [sphere(0.0205, (0, 0, 0))]])
+    assert not crossings
+    assert_allclose(max_depth, 0.5e-3, atol=1.5e-4)
+    max_depth, crossings = measure("sphere floating in donut hole", [[torus(0.03, 0.01)], [sphere(0.015, (0, 0, 0))]])
+    assert not crossings and max_depth == 0.0
+
+    # Chain of three spheres with two overlaps of different depths, plus a geom-less link (a free-joint base
+    # link) in the middle: indices must stay aligned and crossings sorted deepest first.
+    links = [
+        [sphere(RADIUS, (0, 0, 0))],
+        [],
+        [sphere(RADIUS, (2 * RADIUS - 5e-3, 0, 0))],
+        [sphere(RADIUS, (4 * RADIUS - 7e-3, 0, 0))],
+    ]
+    max_depth, crossings = measure("sphere chain with empty link", links)
+    assert [(c.link_a, c.link_b) for c in crossings] == [(0, 2), (2, 3)]
+    assert_allclose(crossings[0].depth, 5e-3, atol=1.5e-4)
+    assert_allclose(crossings[1].depth, 2e-3, atol=1.5e-4)
+    assert_allclose(max_depth, 5e-3, atol=1.5e-4)
+
+    # Thin rod: same extraction distance - the radius does not matter, only the extents do. Dense axial rings
+    # (spacing below the plate thickness) so the rod's own verts flag the overlap at any shift: a feature
+    # thinner than the other body's vertex grid must carry the detection itself.
+    thin_rod = trimesh.creation.cylinder(radius=1e-3, height=0.02, sections=24)
+    for _ in range(3):
+        thin_rod = thin_rod.subdivide()
+    max_depth, crossings = measure(
+        "thin rod through plate", [[(thin_rod.vertices, thin_rod.faces)], [(plate.vertices, plate.faces)]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 12e-3, atol=1.5e-4)
+
+    # Small solid sphere fully engulfed inside a big solid sphere: no free surface to heal toward, only the
+    # extraction resolves - the depth is the separation R + r exactly, however deep it is buried.
+    max_depth, crossings = measure(
+        "sphere engulfed in solid sphere", [[sphere(0.03, (0, 0, 0))], [sphere(0.01, (0, 0, 0))]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 40e-3, atol=1.5e-4)
+
+    # Hollow shell (outer sphere plus inverted inner sphere): a sphere floating in the cavity is containment,
+    # the same sphere pressed 2 mm into the shell from inside is a 2 mm crossing - closed-cavity variant of the
+    # open-container cases.
+    def hollow_sphere(r_out, r_in):
+        outer = trimesh.creation.icosphere(subdivisions=4, radius=r_out)
+        inner = trimesh.creation.icosphere(subdivisions=4, radius=r_in)
+        inner.faces = inner.faces[:, ::-1]
+        merged = trimesh.util.concatenate([outer, inner])
+        return merged.vertices, merged.faces
+
+    shell_geom = hollow_sphere(0.03, 0.025)
+    max_depth, crossings = measure("sphere floating in shell", [[shell_geom], [sphere(0.02, (0, 0, 0))]])
+    assert not crossings and max_depth == 0.0
+    max_depth, crossings = measure("sphere pressed 2mm into shell", [[shell_geom], [sphere(0.02, (0.007, 0, 0))]])
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 2e-3, atol=1.5e-4)
+
+    # Box balanced edge-down, sunk 2 mm into a large box's top face: an edge-face crossing whose deepest points
+    # are the edge verts.
+    box_flat = trimesh.creation.box(extents=(0.06, 0.06, 0.06)).subdivide().subdivide()
+    box_tilted = trimesh.creation.box(extents=(0.02, 0.02, 0.02))
+    box_tilted.apply_transform(trimesh.transformations.rotation_matrix(np.pi / 4, (1, 0, 0)))
+    box_tilted.apply_translation((0.0, 0.0, 0.03 - 2e-3 + 0.01 * np.sqrt(2)))
+    box_tilted = box_tilted.subdivide().subdivide()
+    max_depth, crossings = measure(
+        "box edge sunk 2mm into face",
+        [[(box_flat.vertices, box_flat.faces)], [(box_tilted.vertices, box_tilted.faces)]],
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 2e-3, atol=1.5e-4)
+
+    # Solid beam whose tip stops halfway through the wall of a tube: the tip centre is equidistant from the
+    # outer and inner wall surfaces, so the depth is exactly wall/2 - the analytical pin for partial
+    # wall-crossings (the beam is 10 mm wide, far wider than its 2 mm penetration).
+    tube = trimesh.creation.annulus(r_min=0.012, r_max=0.016, height=0.04, sections=96)
+    tube = tube.subdivide().subdivide().subdivide()
+    beam = trimesh.creation.box(extents=(0.02, 0.01, 0.01)).apply_translation((0.024, 0.0, 0.0))
+    beam = beam.subdivide().subdivide()
+    max_depth, crossings = measure(
+        "beam halfway through tube wall", [[(tube.vertices, tube.faces)], [(beam.vertices, beam.faces)]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 2e-3, atol=1.5e-4)
+
+    # Beam all the way through BOTH tube walls, protruding on each side: the cheapest escape slides the beam
+    # sideways until its 10 mm slab clears the 16 mm outer radius - 21 mm - beating the axial routes.
+    beam_diametral = trimesh.creation.box(extents=(0.06, 0.01, 0.01))
+    beam_diametral = beam_diametral.subdivide().subdivide().subdivide().subdivide()
+    max_depth, crossings = measure(
+        "beam through both tube walls",
+        [[(tube.vertices, tube.faces)], [(beam_diametral.vertices, beam_diametral.faces)]],
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 21e-3, atol=1.5e-4)
+
+    # Beam parallel to the tube axis, grooved lengthwise into the side wall and protruding from both open ends
+    # (a key in a keyway): the escape is the radial push-out, outer radius minus the beam's inner face.
+    beam_keyway = trimesh.creation.box(extents=(0.01, 0.01, 0.06)).apply_translation((0.014, 0.0, 0.0))
+    beam_keyway = beam_keyway.subdivide().subdivide().subdivide().subdivide()
+    max_depth, crossings = measure(
+        "beam grooved along tube wall", [[(tube.vertices, tube.faces)], [(beam_keyway.vertices, beam_keyway.faces)]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 7e-3, atol=1.5e-4)
+
+    # Slim beam fully through one wall, tip hanging in the bore: tube surface verts sit 2 mm inside the 4 mm
+    # beam, and beam verts at most as deep in the 4 mm wall - depth 2 mm however far the beam protrudes.
+    beam_slim = trimesh.creation.box(extents=(0.024, 0.004, 0.004)).apply_translation((0.02, 0.0, 0.0))
+    beam_slim = beam_slim.subdivide().subdivide().subdivide().subdivide()
+    max_depth, crossings = measure(
+        "beam through one tube wall", [[(tube.vertices, tube.faces)], [(beam_slim.vertices, beam_slim.faces)]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 8e-3, atol=1.5e-4)
+
+    # Two thin walls crossing: perpendicular plates, then at 45 degrees (the depth is angle-invariant: half the
+    # plate thickness either way), then two curved cup-like shells whose 5 mm walls cross - depth 2.5 mm.
+    plate_upright = trimesh.creation.box(extents=(4e-3, 0.05, 0.05))
+    for _ in range(4):
+        plate_upright = plate_upright.subdivide()
+    max_depth, crossings = measure(
+        "perpendicular plates crossing",
+        [[(plate.vertices, plate.faces)], [(plate_upright.vertices, plate_upright.faces)]],
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 27e-3, atol=1.5e-4)
+    plate_tilted = plate_upright.copy().apply_transform(trimesh.transformations.rotation_matrix(np.pi / 4, (0, 1, 0)))
+    max_depth, crossings = measure(
+        "45-degree plates crossing", [[(plate.vertices, plate.faces)], [(plate_tilted.vertices, plate_tilted.faces)]]
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, (0.05 * np.sin(np.pi / 4) + 4e-3 * np.cos(np.pi / 4)) / 2 + 2e-3, atol=1.5e-4)
+    shell_thick = hollow_sphere(0.03, 0.025)
+    shell_other = hollow_sphere(0.03, 0.025)
+    max_depth, crossings = measure(
+        "two shells crossing walls",
+        [[shell_thick], [(shell_other[0] + (0.055, 0.0, 0.0), shell_other[1])]],
+    )
+    assert len(crossings) == 1
+    assert_allclose(max_depth, 5e-3, atol=1.5e-4)
+
+    # Analytical mug-vs-cup: two parallel open cylinders whose walls cross. Parallel cups never interlock, so
+    # the separation is exactly the press depth - asserted both shallow and MUCH deeper than the wall.
+    for press in (3e-3, 15e-3):
+        max_depth, crossings = measure(
+            f"parallel cups walls crossed {press * 1e3:g}mm",
+            [[(tube.vertices, tube.faces)], [(tube.vertices + (0.032 - press, 0.0, 0.0), tube.faces)]],
+        )
+        assert len(crossings) == 1
+        assert_allclose(max_depth, press, atol=1.5e-4)
+
+    # Real-asset cases, both representations (watertight wraps and convex decompositions) built as separate
+    # entities of a single scene, all placements done by rigid-transforming the extracted geoms. Real meshes
+    # have no analytical truth: bounds only, to catch garbage estimates.
+    scene = gs.Scene()
+    asset_entities = {
+        convexify: [
+            scene.add_entity(
+                gs.morphs.MJCF(
+                    file=f"{get_hf_dataset(pattern=f'{name}/*')}/{name}/{xml}",
+                    convexify=convexify,
+                ),
+            )
+            for name, xml in (
+                ("cup_2", "model.xml"),
+                ("apple_15", "model.xml"),
+                ("mug_1", "output.xml"),
+                ("donut_0", "output.xml"),
+            )
+        ]
+        for convexify in (False, True)
+    }
+    scene.build()
+    links_pos0 = tensor_to_array(scene.rigid_solver.get_links_pos(), dtype=np.float64)
+    links_quat0 = tensor_to_array(scene.rigid_solver.get_links_quat(), dtype=np.float64)
+
+    def placed(geoms, pos, quat):
+        quat = np.asarray(quat)
+        return [(gu.transform_by_trans_quat(verts, pos, quat), faces) for verts, faces in geoms]
+
+    def overlap_of(geoms_a, geoms_b):
+        depth = 0.0
+        for verts_a, faces_a in geoms_a:
+            for verts_b, faces_b in geoms_b:
+                if (verts_a.min(0) > verts_b.max(0)).any() or (verts_b.min(0) > verts_a.max(0)).any():
+                    continue
+                depth = max(
+                    depth,
+                    -igl.signed_distance(verts_a, verts_b, faces_b)[0].min(),
+                    -igl.signed_distance(verts_b, verts_a, faces_a)[0].min(),
+                )
+        return depth
+
+    for convexify, entities in asset_entities.items():
+        # Geoms expressed in their link frame: MJCF roots may carry a non-identity build pose.
+        cup_geoms, apple_geoms, mug_geoms, donut_geoms = (
+            [
+                (
+                    gu.inv_transform_by_trans_quat(
+                        tensor_to_array(geom.get_verts(), dtype=np.float64), links_pos0[link.idx], links_quat0[link.idx]
+                    ),
+                    geom.get_trimesh().faces.astype(np.int64),
+                )
+                for link in entity.links
+                for geom in link.geoms
+            ]
+            for entity in entities
+        )
+
+        # Seed-52 pile snapshot: an apple nearly filling a cup with its stem bulging ~11 mm through the wall
+        # (the depth is the push-back heal - the protrusion past the pierced wall - far below the
+        # extraction-scale separation and far above the 1.6 mm wall incursion), a mug rim against a cup wall,
+        # and two stacked donuts.
+        links = [
+            placed(cup_geoms, (0.1597, -0.1656, 0.1319), (0.3704, 0.2497, -0.5295, 0.7212)),
+            placed(apple_geoms, (0.1587, -0.1923, 0.1412), (0.5246, -0.6281, 0.3181, -0.4786)),
+            placed(mug_geoms, (0.2153, 0.2083, 0.0792), (0.9515, -0.2904, 0.0217, -0.099)),
+            placed(cup_geoms, (0.1566, 0.1737, 0.1095), (-0.2635, -0.0664, -0.6425, 0.7165)),
+            placed(donut_geoms, (-0.1017, -0.2996, 0.0673), (0.3397, 0.9298, -0.0732, 0.1215)),
+            placed(donut_geoms, (-0.1196, -0.2717, 0.1243), (-0.1533, 0.8963, -0.3895, 0.1462)),
+        ]
+        max_depth, crossings = measure(f"seed-52 snapshot ({convexify=})", links)
+        pair_expected = {(0, 1), (2, 3), (4, 5)}
+        pairs_found = {(c.link_a, c.link_b) for c in crossings}
+        if convexify:
+            # CoACD output varies per platform and its surface deviations shift shallow classifications (the
+            # decomposed cup wall reads a genuine 0.8 mm apple overlap - a contact, not a crossing): only
+            # forbid spurious pairs.
+            assert pairs_found <= pair_expected
+        else:
+            assert pairs_found == pair_expected
+            (apple_cup_depth,) = [c.depth for c in crossings if (c.link_a, c.link_b) == (0, 1)]
+            assert 8e-3 < apple_cup_depth < 20e-3
+        for c in crossings:
+            assert 0.3e-3 < c.depth <= 0.12
+        assert 0.5e-3 < max_depth <= 0.12
+
+        # Mug pressed into the cup: approach from separation, bisect to first contact, press further - two
+        # lateral wall presses, plus the axial approach that telescopes the cup into the mug's opening before
+        # touching, pressed both shallow and deep (a jammed cup-in-mug with large penetration).
+        cup_center = np.concatenate([verts for verts, _ in cup_geoms]).mean(0)
+        mug_center = np.concatenate([verts for verts, _ in mug_geoms]).mean(0)
+        for direction, press in (
+            ((-1.0, 0.0, 0.0), 3e-3),
+            ((-1.0, 0.0, 0.0), 12e-3),
+            ((0.0, 0.0, -1.0), 3e-3),
+            ((0.0, 0.0, -1.0), 25e-3),
+        ):
+            direction = np.asarray(direction)
+            start = cup_center - mug_center - 0.3 * direction
+            t_lo, t_hi = 0.0, 0.6
+            assert overlap_of(cup_geoms, [(verts + start, faces) for verts, faces in mug_geoms]) == 0.0
+            for _ in range(24):
+                t_mid = 0.5 * (t_lo + t_hi)
+                moved = [(verts + start + t_mid * direction, faces) for verts, faces in mug_geoms]
+                if overlap_of(cup_geoms, moved) > 0.0:
+                    t_hi = t_mid
+                else:
+                    t_lo = t_mid
+            pressed = [(verts + start + (t_hi + press) * direction, faces) for verts, faces in mug_geoms]
+            max_depth, crossings = measure(
+                f"mug pressed {press * 1e3:g}mm into cup ({direction=}, {convexify=})", [cup_geoms, pressed]
+            )
+            assert len(crossings) == 1
+            if convexify:
+                # Hull surface deviations shift the first-contact point and the heal witnesses.
+                assert 1e-3 < max_depth < press + 3e-3
+            else:
+                assert_allclose(max_depth, press, atol=2e-3)
+
+        if not convexify:
+            # Oversized and wedged: an apple scaled 1.25x stuffed into the cup (jammed against the walls,
+            # poking out of the opening: extraction-scale escape) and a unit apple centred in the donut's hole
+            # (wedged on the ring like the analytical sphere-in-torus seat), placed by co-centring centroids.
+            apple_center = np.concatenate([verts for verts, _ in apple_geoms]).mean(0)
+            donut_center = np.concatenate([verts for verts, _ in donut_geoms]).mean(0)
+            # Essential enclosure: the oversized apple swallows most of the cup, so the depth is the burial
+            # overlap, not an extraction distance.
+            apple_in_cup = [((verts - apple_center) * 1.25 + cup_center, faces) for verts, faces in apple_geoms]
+            max_depth, crossings = measure("apple x1.25 stuffed in cup", [cup_geoms, apple_in_cup])
+            assert len(crossings) == 1
+            assert 8e-3 < max_depth < 16e-3
+            # Inflated further the cup wall gets buried deeper and the depth keeps growing with the burial
+            # (the separation is even larger for a co-centred enclosure, so min(burial, separation) stays on
+            # the burial side). FIXME: replace the reference value with an analytical bound.
+            apple_x2 = [((verts - apple_center) * 2.0 + cup_center, faces) for verts, faces in apple_geoms]
+            max_depth, crossings = measure("apple x2 engulfing cup", [cup_geoms, apple_x2])
+            assert len(crossings) == 1
+            assert 28e-3 < max_depth < 42e-3
+            # Bore-fit apple with its stem through the mug's side wall (ensemble seed-47 snapshot): the
+            # bore contacts dilute the mean breach normal below coherence, but the nearest crossed-wall
+            # faces at the pierce sites keep a coherent axis, so the depth is the push-back heal of the
+            # stem protrusion - not the extraction-scale separation (59mm) nor the sub-wall incursion.
+            max_depth, crossings = measure(
+                "apple stem through mug wall",
+                [
+                    placed(mug_geoms, (-0.154637, 0.064054, 0.066314), (0.48446, 0.254831, 0.685173, -0.480518)),
+                    placed(apple_geoms, (-0.145008, 0.052819, 0.065729), (0.264979, 0.660853, 0.648809, 0.268525)),
+                ],
+            )
+            assert len(crossings) == 1
+            assert 7e-3 < max_depth < 11e-3
+
+            # Apple wedged inside the cup, pressing the wall from the bore side without piercing it
+            # (ensemble seed-83 snapshot): the press normal is coherent but its retraction is blocked by
+            # the wedge, so the depth is the incursion - not the press-direction escape through the mouth
+            # (65mm) that a coherent dent would otherwise read as its retraction.
+            max_depth, crossings = measure(
+                "apple wedged inside cup",
+                [
+                    placed(cup_geoms, (-0.151896, -0.028087, 0.058628), (0.722454, 0.664688, -0.162572, -0.099101)),
+                    placed(apple_geoms, (-0.166208, -0.061567, 0.060744), (-0.869212, -0.407279, 0.199131, -0.197335)),
+                ],
+            )
+            assert len(crossings) == 1
+            assert 1e-3 < max_depth < 2.5e-3
+
+            apple_in_donut = [(verts - apple_center + donut_center, faces) for verts, faces in apple_geoms]
+            # A seat pressed all around: the depth is the ring burial in the apple, not the unseat.
+            max_depth, crossings = measure("apple centred in donut hole", [donut_geoms, apple_in_donut])
+            assert len(crossings) == 1
+            assert 10e-3 < max_depth < 25e-3
+
+    if show_viewer:
+        display_collision_pairs(pairs_viz)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,15 @@
 import base64
 import io
+import json
 import numbers
 import os
 import platform
 import re
 import subprocess
+import tempfile
 import time
 import uuid
+import webbrowser
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime
@@ -15,9 +18,10 @@ from functools import cache
 from itertools import chain
 from pathlib import Path
 from types import GeneratorType
-from typing import Literal, Sequence
+from typing import Literal, NamedTuple, Sequence
 
 import cpuinfo
+import igl
 import mujoco
 import pytest
 import numpy as np
@@ -1152,6 +1156,382 @@ def rgb_array_to_png_bytes(rgb_arr: np.ndarray | torch.Tensor) -> bytes:
     buffer = io.BytesIO()
     img.save(buffer, format="PNG")
     return buffer.getvalue()
+
+
+class Crossing(NamedTuple):
+    """A genuinely-interpenetrating pair of links among those passed to `get_genuine_interpenetration`."""
+
+    link_a: int
+    link_b: int
+    depth: float  # separating translation for a crossing, deepest incursion for jammed/contact pairs (metres)
+
+
+def get_genuine_interpenetration(links, cross_tol=1e-3, n_dir=40, n_bisect=9):
+    """Measure the deepest genuine interpenetration over all link pairs among `links` (each a list of
+    `(verts, faces)` collision geoms), as the penetration-depth ground truth a collision algorithm is
+    expected to resolve.
+
+    Pairs overlapping within `cross_tol` are contacts reporting their incursion; a crossing pair reads, by
+    structure:
+
+    - FULL CONTAINMENT (every vert of one link inside the other): the separation - a swallowed body has no
+      free surface to heal toward, so only the extraction resolves (an engulfed sphere reads R + r).
+    - PARTIAL ENCLOSURE (a quarter or more of one link's verts buried): min(burial incursion, separation) -
+      an oversized apple jammed in a cup reads the wall burial, and a hyper-inflated one enclosing the whole
+      cup reads the cheaper translation that slides it off.
+    - DENT (the breach touches a single face of each wall): the separation when the breach normal is
+      coherent (a directional press retracts by its press depth - the unsigned incursion would escape
+      through the far face of a thin wall), min(incursion, separation) when it cancels (a sphere seated all
+      around a donut hole reads its 2 mm seat; unseating it is no resolution).
+    - PIERCE (some wall carries penetrating verts on both of its faces): the separation, which retracts the
+      press or backs the rod out. When separating costs an order of magnitude more than the incursion - a
+      bore-fit body poking through its container's wall, where the separation is extraction-scale - the
+      resolution is instead the push-back heal: the material protrusion past the pierced wall, marched from
+      the antipodal-pair verts along the breach normal (the mean normal of the intruder's penetrating verts,
+      coherent only for one-faced breaches), floored by the incursion and capped by the separation.
+
+    Separation means zero material overlap, not unlinked: chain-linked donuts pressed together separate by
+    the press depth. Insideness is vertex-sampled via generalized winding numbers (exact on the overlapping
+    closed components of convex decompositions, where pseudonormal signed distances break), so each mesh
+    must be tessellated finer than its partner's thinnest dimension. Searches run `n_dir` Fibonacci
+    directions, bracketed on a geometric ladder and bisected `n_bisect` times.
+
+    Returns `(max_depth, crossings)`: `max_depth` is the largest depth over ALL overlapping pairs, and
+    `crossings` lists the pairs deeper than `cross_tol`, deepest first.
+    """
+    # Geoms may arrive as torch tensors (verts) or numpy arrays (faces); igl needs float64 verts and int64 faces.
+    links = [
+        [(tensor_to_array(verts, dtype=np.float64), tensor_to_array(faces, dtype=np.int64)) for verts, faces in geoms]
+        for geoms in links
+    ]
+
+    # Broad-phase AABB per link, from the full-resolution geoms. A link with no collision geom (e.g. a free-joint
+    # base link) gets an inverted AABB so it is rejected against every other link, keeping the link indexing aligned
+    # with the caller's list so the returned crossings stay valid indices.
+    links_aabb = [
+        (
+            (np.concatenate([verts for verts, _ in geoms]).min(0), np.concatenate([verts for verts, _ in geoms]).max(0))
+            if geoms
+            else (np.full(3, np.inf), np.full(3, -np.inf))
+        )
+        for geoms in links
+    ]
+
+    # One concatenated full-resolution mesh per link.
+    merged = []
+    for geoms in links:
+        verts_all, faces_all, offset = [], [], 0
+        for verts, faces in geoms:
+            verts_all.append(verts)
+            faces_all.append(faces + offset)
+            offset += len(verts)
+        merged.append(
+            (np.concatenate(verts_all), np.concatenate(faces_all))
+            if verts_all
+            else (np.empty((0, 3)), np.empty((0, 3), dtype=np.int64))
+        )
+
+    def inside_of(points, verts_other, faces_other, lo_other, hi_other):
+        # Winding-number insideness with an exact AABB prefilter: a point outside the partner's bounding box
+        # cannot be inside it, which collapses the query size near separation.
+        is_inside = np.zeros(len(points), dtype=bool)
+        is_in_box = ((points >= lo_other) & (points <= hi_other)).all(1)
+        if is_in_box.any():
+            is_inside[is_in_box] = np.abs(igl.fast_winding_number(verts_other, faces_other, points[is_in_box])) > 0.5
+        return is_inside
+
+    # Fibonacci direction sphere and the shift grid (each direction times each probe distance).
+    golden = 0.5 * (1.0 + 5.0**0.5)
+    i_dir = np.arange(n_dir)
+    z_dir = 1.0 - 2.0 * (i_dir + 0.5) / n_dir
+    r_dir = np.sqrt(1.0 - z_dir * z_dir)
+    azimuth = 2.0 * np.pi * i_dir / golden
+    dirs = np.stack([r_dir * np.cos(azimuth), r_dir * np.sin(azimuth), z_dir], axis=1)
+    probe = np.array([1e-3, 2e-3, 5e-3, 1e-2, 2e-2, 4e-2, 8e-2, 1.2e-1])
+
+    max_depth = 0.0
+    crossings = []
+    for i_la, geoms_a in enumerate(links):
+        lo_a, hi_a = links_aabb[i_la]
+        for i_lb in range(i_la + 1, len(links)):
+            # Broad-phase reject via AABB.
+            lo_b, hi_b = links_aabb[i_lb]
+            if (lo_a > hi_b).any() or (lo_b > hi_a).any():
+                continue
+            va, fa = merged[i_la]
+            vb, fb = merged[i_lb]
+
+            # Incursion magnitudes from unsigned distances gated by winding-number insideness: the
+            # pseudonormal sign of igl.signed_distance is unreliable on the overlapping closed components of
+            # convex decompositions, while the generalized winding number stays exact.
+            is_inside_a0 = inside_of(va, vb, fb, lo_b, hi_b)
+            is_inside_b0 = inside_of(vb, va, fa, lo_a, hi_a)
+            dist_a0, faces_near_a = igl.signed_distance(va, vb, fb)[:2]
+            dist_b0, faces_near_b = igl.signed_distance(vb, va, fa)[:2]
+            dist_a0 = np.abs(dist_a0)
+            dist_b0 = np.abs(dist_b0)
+            depth_a0 = np.where(is_inside_a0, dist_a0, 0.0)
+            depth_b0 = np.where(is_inside_b0, dist_b0, 0.0)
+            overlap = max(depth_a0.max(), depth_b0.max())
+            if overlap <= cross_tol:
+                # Contact (or cavity containment touching lightly): report the overlap directly.
+                max_depth = max(max_depth, overlap)
+                continue
+
+            # Dent-vs-pierce classification: a pierced wall carries penetrating verts on BOTH of its
+            # faces - a close pair with near-opposite outward normals whose offset is aligned with them
+            # (opposite-normal verts offset sideways sit across a breach rim or a hole, not through a
+            # wall). Pair distance is capped: beyond ~12 mm two opposite-normal verts belong to opposite
+            # sides of a body, not one wall. Near-touching verts count as penetrating here, since a
+            # crossing exactly as deep as the wall leaves the far-face verts ON the partner's surface.
+            r_pair = min(3.0 * overlap, 12e-3) + 1e-3
+
+            def antipodal_pairs(pen_pts, pen_normals):
+                pairs = [np.empty((0, 2), dtype=np.int64)]
+                for i_lo in range(0, len(pen_pts), 256):
+                    chunk = slice(i_lo, i_lo + 256)
+                    diff = pen_pts[None] - pen_pts[chunk, None]
+                    dist2 = (diff**2).sum(-1)
+                    dots = pen_normals[chunk] @ pen_normals.T
+                    is_aligned = np.abs(np.einsum("knj,kj->kn", diff, pen_normals[chunk])) > 0.7 * np.sqrt(dist2)
+                    i_v, j_v = np.nonzero((dist2 <= r_pair**2) & (dots < -0.5) & is_aligned)
+                    pairs.append(np.stack([i_v + i_lo, j_v], axis=1))
+                return np.concatenate(pairs)
+
+            normals_a = igl.per_vertex_normals(va, fa)
+            normals_b = igl.per_vertex_normals(vb, fb)
+            normals_faces_a = np.cross(va[fa[:, 1]] - va[fa[:, 0]], va[fa[:, 2]] - va[fa[:, 0]])
+            normals_faces_a /= np.maximum(np.linalg.norm(normals_faces_a, axis=1)[:, None], 1e-30)
+            normals_faces_b = np.cross(vb[fb[:, 1]] - vb[fb[:, 0]], vb[fb[:, 2]] - vb[fb[:, 0]])
+            normals_faces_b /= np.maximum(np.linalg.norm(normals_faces_b, axis=1)[:, None], 1e-30)
+            is_pen_a = is_inside_a0 | (dist_a0 <= 0.6e-3)
+            is_pen_b = is_inside_b0 | (dist_b0 <= 0.6e-3)
+            pairs_a = antipodal_pairs(va[is_pen_a], normals_a[is_pen_a])
+            pairs_b = antipodal_pairs(vb[is_pen_b], normals_b[is_pen_b])
+            has_pierce = bool(len(pairs_a)) or bool(len(pairs_b))
+
+            def separated_at(offsets):
+                # A shift separates the pair when no vert of one link samples inside the other. Deeply
+                # overlapping shifts are decided by a strided 1/8 vert subsample first (any hit proves
+                # overlap); only the undecided shifts pay the full queries, so the result is exact.
+                offsets = np.atleast_2d(offsets)
+                is_separated = np.ones(len(offsets), dtype=bool)
+                for verts_query, sign, verts_other, faces_other, lo_other, hi_other in (
+                    (va[::8], 1.0, vb, fb, lo_b, hi_b),
+                    (vb[::8], -1.0, va, fa, lo_a, hi_a),
+                    (va, 1.0, vb, fb, lo_b, hi_b),
+                    (vb, -1.0, va, fa, lo_a, hi_a),
+                ):
+                    idx = np.flatnonzero(is_separated)
+                    if not len(idx):
+                        break
+                    points = (verts_query[None] + sign * offsets[idx, None]).reshape(-1, 3)
+                    is_inside = inside_of(points, verts_other, faces_other, lo_other, hi_other)
+                    is_separated[idx[is_inside.reshape(len(idx), -1).any(1)]] = False
+                return is_separated
+
+            # Per-side informed escape directions: a side's coherent mean penetrating normal (a one-faced
+            # press or bulge) and the local wall axes of its crossings - the normals of the partner faces
+            # nearest its antipodal-pair verts, i.e. the faces of the crossed walls themselves. Wall axes
+            # carry a pierce whose own vert normals cancel (a stem's ring verts point radially around the
+            # stem, and its antipodal-pair axes span the stem's cross-section - both perpendicular to the
+            # through-wall direction), and being face-based they survive sparse vert sampling. The axes are
+            # clustered (sign-invariant, folded onto each cluster's dominant eigenvector) because one side
+            # may cross several walls at once, and each crossing owns its axis and its witness verts - a
+            # dominant unrelated contact would otherwise steer the push-back parallel to the pierced wall.
+            # Appended to the Fibonacci grid the directions also remove the direction-grid tilt from the
+            # separation.
+            dirs_informed_sides = []
+            is_press_sides = []
+            press_probes = []
+            clusters_sides = []
+            has_press_normal = False
+            for normals_pen, verts_pen, faces_near_pen, normals_faces_other, pairs_side, depths_pen in (
+                (normals_a[is_inside_a0], va[is_pen_a], faces_near_a[is_pen_a], normals_faces_b, pairs_a, depth_a0),
+                (normals_b[is_inside_b0], vb[is_pen_b], faces_near_b[is_pen_b], normals_faces_a, pairs_b, depth_b0),
+            ):
+                side_dirs = []
+                side_is_press = []
+                side_clusters = []
+                press_probes.append(None)
+                if len(normals_pen):
+                    normal_mean = normals_pen.mean(0)
+                    norm = np.linalg.norm(normal_mean)
+                    if norm > 0.5:
+                        side_dirs.append(np.outer([1.0, -1.0], normal_mean / norm))
+                        side_is_press += [True, True]
+                        has_press_normal = True
+                        press_probes[-1] = (verts_pen[depths_pen[depths_pen > 0.0].argmax()], normal_mean / norm)
+                if len(pairs_side):
+                    verts_idx = np.unique(pairs_side)
+                    axes_pairs = normals_faces_other[faces_near_pen[verts_idx]]
+                    remaining = np.ones(len(axes_pairs), dtype=bool)
+                    for _ in range(3):
+                        if remaining.sum() < 4:
+                            break
+                        axes_rem = axes_pairs[remaining]
+                        axis_dominant = np.linalg.eigh((axes_rem[:, :, None] * axes_rem[:, None, :]).mean(0))[1][:, -1]
+                        in_cluster = remaining & (np.abs(axes_pairs @ axis_dominant) > 0.8)
+                        if in_cluster.sum() >= 4:
+                            axes_cluster = axes_pairs[in_cluster].copy()
+                            axes_cluster[axes_cluster @ axis_dominant < 0.0] *= -1.0
+                            axis_mean = axes_cluster.mean(0)
+                            axis_mean /= np.linalg.norm(axis_mean)
+                            side_dirs.append(np.outer([1.0, -1.0], axis_mean))
+                            side_is_press += [False, False]
+                            side_clusters.append((axis_mean, verts_pen[verts_idx[in_cluster]]))
+                        remaining &= ~in_cluster
+                dirs_informed_sides.append(np.concatenate(side_dirs) if side_dirs else np.empty((0, 3)))
+                is_press_sides.append(np.array(side_is_press, dtype=bool))
+                clusters_sides.append(side_clusters)
+            dirs_search = np.concatenate([dirs, *dirs_informed_sides])
+            is_press_dir = np.concatenate([np.zeros(len(dirs), dtype=bool), *is_press_sides])
+
+            # Smallest separating translation: bracket each direction's transition on the geometric ladder,
+            # then bisect in lockstep; np.inf when no direction separates within the ladder.
+            i_first = np.full(len(dirs_search), -1)
+            is_active = np.ones(len(dirs_search), dtype=bool)
+            for i_r in range(len(probe)):
+                if not is_active.any():
+                    break
+                idx = np.flatnonzero(is_active)
+                is_separated = separated_at(dirs_search[idx] * probe[i_r])
+                i_first[idx[is_separated]] = i_r
+                is_active[idx[is_separated]] = False
+            seps_dir = np.full(len(dirs_search), np.inf)
+            idx = np.flatnonzero(i_first >= 0)
+            if len(idx):
+                lo = np.where(i_first[idx] > 0, probe[np.maximum(i_first[idx] - 1, 0)], 0.0)
+                hi = probe[i_first[idx]]
+                for _ in range(n_bisect):
+                    mid = 0.5 * (lo + hi)
+                    is_separated = separated_at(dirs_search[idx] * mid[:, None])
+                    lo = np.where(is_separated, lo, mid)
+                    hi = np.where(is_separated, mid, hi)
+                seps_dir[idx] = hi
+            separation = seps_dir.min() if len(seps_dir) else np.inf
+            seps_press_sides = []
+            i_dir = len(dirs)
+            for is_press_side in is_press_sides:
+                n_side = len(is_press_side)
+                seps_side = seps_dir[i_dir : i_dir + n_side][is_press_side]
+                seps_press_sides.append(seps_side.min() if len(seps_side) else np.inf)
+                i_dir += n_side
+
+            if is_inside_a0.all() or is_inside_b0.all():
+                # Full containment: a body with every vert inside the partner has no free surface to heal
+                # toward - burial is meaningless and only the extraction resolves (an engulfed sphere reads
+                # R + r, however deep it is buried).
+                depth = separation if np.isfinite(separation) else overlap
+            elif max(is_inside_a0.mean(), is_inside_b0.mean()) >= 0.25:
+                # Partial enclosure: unseating or extracting resolves nothing a solver would report - the
+                # depth is the burial incursion, unless plainly separating is cheaper.
+                depth = min(overlap, separation)
+            elif not has_pierce:
+                # Dent with a coherent breach normal: a directional press, resolved by retracting along
+                # that normal - the separation RESTRICTED to the press directions, not the global minimum
+                # (for a presser inside its container the global minimum is the extraction through the
+                # mouth, which resolves nothing a solver would report). The retraction is only a press
+                # resolution while it fits the wall it presses: a press that produced no pierce cannot run
+                # deeper than the local wall thickness, so a larger directional separation means the
+                # retraction is blocked (a body wedged inside its container escaping diagonally through
+                # the mouth) and the depth is the incursion, as for an incoherent all-around seat.
+                depth_press = np.inf
+                s_probe = np.arange(1, 121) * 1e-3
+                for press_probe, sep_press, (verts_other, faces_other, lo_other, hi_other) in zip(
+                    press_probes,
+                    seps_press_sides,
+                    ((vb, fb, lo_b, hi_b), (va, fa, lo_a, hi_a)),
+                ):
+                    if press_probe is None or not np.isfinite(sep_press):
+                        continue
+                    vert_deep, normal_press = press_probe
+                    thickness = 0.0
+                    for sign in (1.0, -1.0):
+                        pts = vert_deep[None] + sign * normal_press * s_probe[:, None]
+                        is_inside_probe = inside_of(pts, verts_other, faces_other, lo_other, hi_other)
+                        thickness += s_probe[-1] if is_inside_probe.all() else s_probe[np.argmin(is_inside_probe)]
+                    if sep_press <= thickness + 2e-3:
+                        depth_press = min(depth_press, sep_press)
+                depth = depth_press if np.isfinite(depth_press) else min(overlap, separation)
+            elif separation <= 10.0 * overlap:
+                # Ordinary pierce: presses, rods, beams - the separation IS the resolution (it retracts the
+                # press or backs the rod out; the breach normals of fully-crossed walls cancel anyway).
+                depth = separation
+            else:
+                # Extraction-scale containment (separating costs an order of magnitude more than the
+                # incursion: a bore-fit body poking through its container's wall): the resolution is the
+                # push-back heal - the retreat along the wall axis that brings all of the crossing link's
+                # material back through the pierced wall entirely. Projection onto the axis gives it
+                # exactly: the retreat for a sign is the span from the wall's far face (the cluster's
+                # extreme projection against that sign, so walls stacked along one axis - a beam through
+                # both tube walls - are cleared together) to the link's farthest material (its stem tip - a
+                # compact nub; a crossed plate measures its own half-extent instead and defers to the
+                # separation via the near-parity gate below); the cheaper sign is the side to push back
+                # through. Rigid translation feasibility is no
+                # yardstick here: a bore-fit body cannot actually translate (any push re-presses the far
+                # side of the bore), yet the wall crossing is still healed by exactly the protrusion.
+                protrusions = []
+                for i_side, side_clusters in enumerate(clusters_sides):
+                    if not side_clusters:
+                        continue
+                    verts_side = (va, vb)[i_side]
+                    heal_side = 0.0
+                    for axis, verts_cluster in side_clusters:
+                        proj_cluster = verts_cluster @ axis
+                        proj_side = verts_side @ axis
+                        retreat = min(proj_side.max() - proj_cluster.min(), proj_cluster.max() - proj_side.min())
+                        heal_side = max(heal_side, retreat)
+                    protrusions.append(heal_side)
+                if not protrusions:
+                    # No side has a coherent escape direction: crossings pressed from every side, a
+                    # seat-family jam whose extraction resolves nothing a solver would report.
+                    depth = min(overlap, separation)
+                else:
+                    heal = max(overlap, min(protrusions))
+                    if heal < 0.8 * separation:
+                        depth = heal
+                    else:
+                        # Near-parity means the crossing genuinely resolves by sliding out; the separation
+                        # is the exact value while the marched heal carries the 1 mm grid quantization.
+                        depth = separation
+                if not np.isfinite(depth):
+                    depth = overlap
+            max_depth = max(max_depth, depth)
+            if depth > cross_tol:
+                crossings.append(Crossing(i_la, i_lb, depth))
+
+    crossings.sort(key=lambda crossing: crossing.depth, reverse=True)
+    return max_depth, crossings
+
+
+def display_collision_pairs(pairs):
+    """Open a self-contained interactive 3D viewer of colliding link pairs in the default browser.
+
+    Each entry of `pairs` is `(geoms_a, geoms_b, label)`, where each `geoms` is a list of `(verts, faces)`
+    collision meshes (torch or numpy); the geoms of a link are merged and the two links drawn blue and red,
+    with a dropdown to switch between pairs. Each bead in the hover overlay marks a surface the cursor ray
+    crosses (coloured by link, back walls flagged with a cross); a digit key (numpad or top row) picks the
+    N-th surface directly, shift+scroll steps to enclosed surfaces, and clicking two beads reads their
+    distance in millimetres.
+    """
+    data = []
+    for geoms_a, geoms_b, label in pairs:
+        entry = {"label": label}
+        for key, geoms in (("a", geoms_a), ("b", geoms_b)):
+            verts_all, faces_all, offset = [], [], 0
+            for verts, faces in geoms:
+                verts = tensor_to_array(verts, dtype=np.float64)
+                faces = tensor_to_array(faces, dtype=np.int64)
+                verts_all.append(verts)
+                faces_all.append(faces + offset)
+                offset += len(verts)
+            entry[key] = {"v": np.concatenate(verts_all).tolist(), "f": np.concatenate(faces_all).tolist()}
+        data.append(entry)
+    template = (Path(__file__).parent / "mesh_pairs_viewer.html").read_text()
+    with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as file:
+        file.write(template.replace("__DATA__", json.dumps(data)))
+    webbrowser.open(f"file://{file.name}")
 
 
 def pprint_oneline(data, delimiter, digits=None):


### PR DESCRIPTION
* Add interpenetration metric and interactive collision-pair viewer for rigid tests.
* Always fuse sub-meshes if possible when convexify is disabled.
* Remove watertighten broken vertex snapping finalization pass.
* Improve non-convex collision detection accuracy by lower bounding SDF grid cell size based on wall thickness.
* Add specialized nonconvex collision detection algorithm for shells.