### PR TITLE
[AMDGPU] Perf: cache repeated Jaref lookup in func_update_constraint_batch

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -4416,8 +4416,12 @@ def func_update_constraint_batch(
     cost_i = gs.qd_float(0.0)
     gauss_i = gs.qd_float(0.0)
 
-    # Beware 'active' does not refer to whether a constraint is active, but rather whether its quadratic cost is active
+    # Beware 'active' does not refer to whether a constraint is active, but rather whether its quadratic cost is active.
+    # `Jaref[i_c, i_b]` is read up to 6 times in the original loop body; the DSL cannot
+    # safely CSE these reads across the intervening writes to `active`. Hoisting the
+    # value into a local makes it a single global load per iter.
     for i_c in range(constraint_state.n_constraints[i_b]):
+        Jaref_c = constraint_state.Jaref[i_c, i_b]
         if qd.static(static_rigid_sim_config.solver_type == gs.constraint_solver.Newton):
             constraint_state.prev_active[i_c, i_b] = constraint_state.active[i_c, i_b]
         constraint_state.active[i_c, i_b] = True
@@ -4427,18 +4431,18 @@ def func_update_constraint_batch(
             f = constraint_state.efc_frictionloss[i_c, i_b]
             r = constraint_state.diag[i_c, i_b]
             rf = r * f
-            linear_neg = constraint_state.Jaref[i_c, i_b] <= -rf
-            linear_pos = constraint_state.Jaref[i_c, i_b] >= rf
+            linear_neg = Jaref_c <= -rf
+            linear_pos = Jaref_c >= rf
             constraint_state.active[i_c, i_b] = not (linear_neg or linear_pos)
             floss_force = linear_neg * f + linear_pos * -f
-            floss_cost_local = linear_neg * f * (-0.5 * rf - constraint_state.Jaref[i_c, i_b])
-            floss_cost_local = floss_cost_local + linear_pos * f * (-0.5 * rf + constraint_state.Jaref[i_c, i_b])
+            floss_cost_local = linear_neg * f * (-0.5 * rf - Jaref_c)
+            floss_cost_local = floss_cost_local + linear_pos * f * (-0.5 * rf + Jaref_c)
             cost_i = cost_i + floss_cost_local
         elif nef <= i_c:  # Contact constraints
-            constraint_state.active[i_c, i_b] = constraint_state.Jaref[i_c, i_b] < 0
+            constraint_state.active[i_c, i_b] = Jaref_c < 0
 
         constraint_state.efc_force[i_c, i_b] = floss_force + (
-            -constraint_state.Jaref[i_c, i_b] * constraint_state.efc_D[i_c, i_b] * constraint_state.active[i_c, i_b]
+            -Jaref_c * constraint_state.efc_D[i_c, i_b] * constraint_state.active[i_c, i_b]
         )
 
     # qfrc_constraint = J^T @ efc_force. Sparse scatter over each constraint's coupled DOFs (jac_dofs_idx) when that


### PR DESCRIPTION
## Summary

`func_update_constraint_batch` reads `constraint_state.Jaref[i_c, i_b]` several times
within the same iteration. This hoists the element into a local variable so it is loaded
once and reused, removing redundant global-memory reads in a hot constraint-solver loop.
This is pure common-subexpression elimination: the computed values are identical and only
the number of memory loads is reduced. No correctness change. Backend-agnostic (benefits
all backends), motivated by AMD/ROCm performance profiling on MI300X.

Verified with the rigid-physics `required` test set, run with and without this change:
- AMD MI300X (VF slice, `-n 8 --backend gpu`): identical results — 281 passed / 5 xfailed,
  a byte-identical pass/fail set versus baseline (zero behavioral delta).
- AMD MI325X (baremetal, Docker/theRock, `-n 8`, gpu-only): 0 GPU failures.

Ported from AMD ROCm/Genesis integration work.
