### PR TITLE
[MISC] Fix flaky unit test.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -531,8 +531,8 @@ def test_genuine_interpenetration(show_viewer):
     # so show_viewer displays the whole sample set at the end.
     pairs_viz = []
 
-    def measure(label, links):
-        max_depth, crossings = get_genuine_interpenetration(links)
+    def measure(label, links, is_exact=True):
+        max_depth, crossings = get_genuine_interpenetration(links, is_exact=is_exact)
         by_pair = {(c.link_a, c.link_b): c.depth for c in crossings}
         for i_la, geoms_a in enumerate(links):
             for i_lb in range(i_la + 1, len(links)):
@@ -554,14 +554,17 @@ def test_genuine_interpenetration(show_viewer):
         return mesh.vertices + np.asarray(center), mesh.faces
 
     RADIUS = 0.03
-    # Overlapping spheres: one crossing whose depth is the overlap, up to the tessellation chord error.
+    # Overlapping spheres: one crossing whose depth is the overlap, up to the tessellation chord error. The
+    # deepest incursion vertex sits well inside its partner, so it is not a borderline winding-number query:
+    # the fast approximation (is_exact=False) agrees with the exact path here, just at a looser bound.
     for overlap in (2e-3, 5e-3, 15e-3):
-        max_depth, crossings = measure(
-            f"spheres overlapping {overlap * 1e3:g}mm",
-            [[sphere(RADIUS, (0, 0, 0))], [sphere(RADIUS, (2 * RADIUS - overlap, 0, 0))]],
-        )
+        pair = [[sphere(RADIUS, (0, 0, 0))], [sphere(RADIUS, (2 * RADIUS - overlap, 0, 0))]]
+        max_depth, crossings = measure(f"spheres overlapping {overlap * 1e3:g}mm", pair)
         assert len(crossings) == 1
         assert_allclose(max_depth, overlap, atol=1.5e-4)
+        max_depth_fast, crossings_fast = measure(f"spheres overlapping {overlap * 1e3:g}mm fast", pair, is_exact=False)
+        assert len(crossings_fast) == 1
+        assert_allclose(max_depth_fast, overlap, atol=5e-4)
 
     # Touching / separated spheres: no crossing, no depth.
     max_depth, crossings = measure(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -554,9 +554,7 @@ def test_genuine_interpenetration(show_viewer):
         return mesh.vertices + np.asarray(center), mesh.faces
 
     RADIUS = 0.03
-    # Overlapping spheres: one crossing whose depth is the overlap, up to the tessellation chord error. The
-    # deepest incursion vertex sits well inside its partner, so it is not a borderline winding-number query:
-    # the fast approximation (is_exact=False) agrees with the exact path here, just at a looser bound.
+    # Overlapping spheres: one crossing whose depth is the overlap, up to the tessellation chord error.
     for overlap in (2e-3, 5e-3, 15e-3):
         pair = [[sphere(RADIUS, (0, 0, 0))], [sphere(RADIUS, (2 * RADIUS - overlap, 0, 0))]]
         max_depth, crossings = measure(f"spheres overlapping {overlap * 1e3:g}mm", pair)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1166,7 +1166,7 @@ class Crossing(NamedTuple):
     depth: float  # separating translation for a crossing, deepest incursion for jammed/contact pairs (metres)
 
 
-def get_genuine_interpenetration(links, cross_tol=1e-3, n_dir=40, n_bisect=9):
+def get_genuine_interpenetration(links, cross_tol=1e-3, n_dir=40, n_bisect=9, is_exact=True):
     """Measure the deepest genuine interpenetration over all link pairs among `links` (each a list of
     `(verts, faces)` collision geoms), as the penetration-depth ground truth a collision algorithm is
     expected to resolve.
@@ -1198,6 +1198,10 @@ def get_genuine_interpenetration(links, cross_tol=1e-3, n_dir=40, n_bisect=9):
 
     Returns `(max_depth, crossings)`: `max_depth` is the largest depth over ALL overlapping pairs, and
     `crossings` lists the pairs deeper than `cross_tol`, deepest first.
+
+    `is_exact` gates the insideness of the ground-truth `overlap` on the exact `igl.winding_number`; set it
+    False to use the faster tree approximation, whose platform-dependent error can shift `overlap` on
+    borderline geometry (see `inside_of`).
     """
     # Geoms may arrive as torch tensors (verts) or numpy arrays (faces); igl needs float64 verts and int64 faces.
     links = [
@@ -1231,13 +1235,17 @@ def get_genuine_interpenetration(links, cross_tol=1e-3, n_dir=40, n_bisect=9):
             else (np.empty((0, 3)), np.empty((0, 3), dtype=np.int64))
         )
 
-    def inside_of(points, verts_other, faces_other, lo_other, hi_other):
-        # Winding-number insideness with an exact AABB prefilter: a point outside the partner's bounding box
-        # cannot be inside it, which collapses the query size near separation.
+    def inside_of(points, verts_other, faces_other, lo_other, hi_other, is_exact=False):
+        # Winding-number insideness with an AABB prefilter: a point outside the partner's box can't be inside.
+        # `igl.fast_winding_number` is a tree approximation whose error is platform-dependent (BLAS order),
+        # not float noise, so it can flip a vertex's insideness across platforms. `is_exact` uses the exact
+        # `igl.winding_number` for the one-shot calls that set `overlap`'s ground truth; the hot `separated_at`
+        # search keeps the fast one, where a wrong result only costs an extra bisection step.
         is_inside = np.zeros(len(points), dtype=bool)
         is_in_box = ((points >= lo_other) & (points <= hi_other)).all(1)
         if is_in_box.any():
-            is_inside[is_in_box] = np.abs(igl.fast_winding_number(verts_other, faces_other, points[is_in_box])) > 0.5
+            winding_number = igl.winding_number if is_exact else igl.fast_winding_number
+            is_inside[is_in_box] = np.abs(winding_number(verts_other, faces_other, points[is_in_box])) > 0.5
         return is_inside
 
     # Fibonacci direction sphere and the shift grid (each direction times each probe distance).
@@ -1264,8 +1272,8 @@ def get_genuine_interpenetration(links, cross_tol=1e-3, n_dir=40, n_bisect=9):
             # Incursion magnitudes from unsigned distances gated by winding-number insideness: the
             # pseudonormal sign of igl.signed_distance is unreliable on the overlapping closed components of
             # convex decompositions, while the generalized winding number stays exact.
-            is_inside_a0 = inside_of(va, vb, fb, lo_b, hi_b)
-            is_inside_b0 = inside_of(vb, va, fa, lo_a, hi_a)
+            is_inside_a0 = inside_of(va, vb, fb, lo_b, hi_b, is_exact=is_exact)
+            is_inside_b0 = inside_of(vb, va, fa, lo_a, hi_a, is_exact=is_exact)
             dist_a0, faces_near_a = igl.signed_distance(va, vb, fb)[:2]
             dist_b0, faces_near_b = igl.signed_distance(vb, va, fa)[:2]
             dist_a0 = np.abs(dist_a0)


### PR DESCRIPTION
## Description

Fix the flaky `tests/test_utils.py::test_genuine_interpenetration` unit test added in #3020
```
tests/test_utils.py:657: AssertionError
>       assert_allclose(max_depth, 2e-3, atol=1.5e-4)
E       Not equal to tolerance rtol=0, atol=0.00015
E        ACTUAL: array(0.003663)
E        DESIRED: array(0.002)
```
- Added is_exact flag 

## Related Issue

saw CI failing in unrelated PR https://github.com/Genesis-Embodied-AI/genesis-world/actions/runs/29126420548/job/86473270572?pr=2813

## Motivation and Context

The test helper get_genuine_interpenetration() computes a ground-truth penetration depth by asking, for each vertex, "is this point inside the other mesh?" computed with igl.fast_winding_number, but the surrounding code assumes the answer is exact.

Why it only fails on macOS: That approximation's error depends on floating-point/BLAS math order, which differs across platforms. So a vertex can be confidently classified outside on Linux but flip to inside on macOS, not because it's a borderline case, just because the two machines' math rounds differently.

The reported depth is a max over all vertices flagged inside. So a single vertex wrongly flagged inside injects a spurious, larger value that overrides the correct one. Concretely: a sphere seated symmetrically in a donut hole should read ~2mm; on macOS one misclassified rim vertex (~3.7mm from the surface) pushed it to 3.66mm — 18x over the test's tolerance.

Fix: Use the exact igl.winding_number for the two calls that set the ground-truth depth and keep the fast approximation in the hot direction-search loop.

## How Has This Been / Can This Be Tested?

- `python -m pytest tests/test_utils.py::test_genuine_interpenetration -x -q` passes.
- Full `tests/test_utils.py` (30 cases: spheres, box dent/pierce, rod-through-plate, chain-linked donuts, real-asset cup/apple/mug/donut scenarios, etc.) passes with unchanged tolerances.
- The overlapping-sphere cases are additionally run with `is_exact=False` (a non-borderline configuration where fast and exact agree) at a looser bound, so both winding-number branches are exercised.
- `tests/test_rigid_physics.py::test_many_objects_collision` (the other consumer of `get_genuine_interpenetration`, 80 real-asset objects settling into a pile) passes.
- `pre-commit run --files tests/utils.py tests/test_utils.py` passes (ruff check + format).

## Screenshots (if appropriate):

N/A

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.