### PR TITLE
[MISC] Speed up nonconvex collision detection with vert spatial grid and coarse SDF lower bound.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -139,11 +139,17 @@ class RigidGeom(RBC):
         # below still bounds it to [sdf_min_res, sdf_max_res]. The shrink applies to all three axes, not just the
         # wall's normal axis: the certified penetration bounds that hold shell contacts apart need lattice points
         # near the contact in every direction, so a wall must be finely sampled along its tangent axes too (see
-        # estimate_wall_thickness).
+        # get_wall_thickness).
         cell_size_target = self._material.sdf_cell_size
         if not self._is_convex:
-            wall_thickness = mu.estimate_wall_thickness(self._sdf_verts, self._sdf_faces)
-            cell_size_target = min(cell_size_target, wall_thickness / 2.0)
+            # The wall-thickness probe only makes sense on a closed surface: on an open mesh the inward rays escape
+            # through the holes, so keep the material target there. The sdf mesh probed by 'get_wall_thickness' is a
+            # proxy for this collision mesh and must share its watertightness, hence it raises if that does not hold.
+            if self._mesh.is_watertight:
+                wall_thickness = mu.get_wall_thickness(self._sdf_verts, self._sdf_faces)
+                cell_size_target = min(cell_size_target, wall_thickness / 2.0)
+            else:
+                gs.logger.warning(f"Geom idx {self._idx} is not watertight; skipping wall-thickness SDF refinement.")
         self._sdf_cell_size = gs.EPS + np.clip(cell_size_target, per_axis_lower, per_axis_upper)
         self._sdf_res = np.ceil(grid_size / self._sdf_cell_size).astype(gs.np_int) + 1
         # Constant once the SDF resolution is fixed. Cached because the solver re-reads it for every geom on each

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -595,8 +595,15 @@ class Mesh(RBC):
         if "convexified" in self.metadata:
             return self.metadata["convexified"]
         if self._is_convex is None:
-            self._is_convex = bool(self._mesh.is_convex)
+            self._is_convex = self._mesh.is_convex
         return self._is_convex
+
+    @property
+    def is_watertight(self) -> bool:
+        """
+        Whether the mesh is a closed manifold surface.
+        """
+        return self._mesh.is_watertight
 
     @property
     def metadata(self):

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -271,6 +271,7 @@ class Collider:
         self._init_collision_pair_idx(self._collision_pair_idx)
         self._init_valid_pairs()
         self._init_verts_connectivity(vert_neighbors, vert_neighbor_start, vert_n_neighbors)
+        self._init_verts_spatial_grid()
         self._init_max_contacts(self._n_possible_pairs, self._large_contact_pair_mask)
         self._init_terrain_state()
 
@@ -614,6 +615,54 @@ class Collider:
             vert_n_neighbors = np.concatenate(vert_n_neighbors, dtype=gs.np_int)
 
         return vert_neighbors, vert_neighbor_start, vert_n_neighbors
+
+    def _init_verts_spatial_grid(self):
+        """
+        Sort each geom's collision verts into a fixed 8x8x8 grid over its local AABB, as a permutation of vert
+        indices ordered by grid cell (z fastest) plus per-cell vert ranges.
+
+        The nonconvex narrowphase visits only the cells overlapping the other geom's pulled-back AABB, skipping far
+        verts wholesale. Binning uses the same single-precision cell mapping as the kernel side; that mapping is
+        monotone, so a vert inside a (padded) query box always lands inside the visited cell range.
+        """
+        if self._solver.n_verts == 0:
+            return
+        n_geoms = len(self._solver.geoms)
+        verts_idx = []
+        verts_pos = []
+        cells_vert_start = []
+        geoms_origin = np.zeros((n_geoms, 3), dtype=gs.np_float)
+        geoms_inv_cell_size = np.zeros((n_geoms, 3), dtype=gs.np_float)
+        offset_vert = 0
+        for i_g, geom in enumerate(self._solver.geoms):
+            verts = geom.init_verts.astype(gs.np_float)
+            if len(verts) == 0:
+                verts_idx.append(np.zeros(0, dtype=gs.np_int))
+                verts_pos.append(np.zeros((0, 3), dtype=gs.np_float))
+                cells_vert_start.append(np.full(8**3 + 1, offset_vert, dtype=gs.np_int))
+                continue
+            origin = verts.min(axis=0)
+            extent = verts.max(axis=0) - origin
+            inv_cell_size = np.where(extent > 0.0, 8 / np.maximum(extent, gs.EPS), 0.0).astype(gs.np_float)
+            verts_cell = np.clip(np.floor((verts - origin) * inv_cell_size), 0, 7).astype(gs.np_int)
+            verts_cell_flat = (verts_cell[:, 0] * 8 + verts_cell[:, 1]) * 8 + verts_cell[:, 2]
+            order = np.argsort(verts_cell_flat, kind="stable")
+            verts_idx.append(order + geom.vert_start)
+            # The positions themselves are duplicated in spatial order: the scan streams them sequentially, where
+            # gathering through the permutation would defeat the prefetcher on the hot path.
+            verts_pos.append(verts[order])
+            counts = np.bincount(verts_cell_flat, minlength=8**3)
+            cells_vert_start.append(np.concatenate(([0], counts.cumsum())) + offset_vert)
+            geoms_origin[i_g] = origin
+            geoms_inv_cell_size[i_g] = inv_cell_size
+            offset_vert = offset_vert + len(verts)
+
+        verts_spatial_grid = self._collider_info.verts_spatial_grid
+        verts_spatial_grid.verts_idx.from_numpy(np.concatenate(verts_idx, dtype=gs.np_int))
+        verts_spatial_grid.verts_pos.from_numpy(np.concatenate(verts_pos, dtype=gs.np_float))
+        verts_spatial_grid.cells_vert_start.from_numpy(np.concatenate(cells_vert_start, dtype=gs.np_int))
+        verts_spatial_grid.geoms_origin.from_numpy(geoms_origin)
+        verts_spatial_grid.geoms_inv_cell_size.from_numpy(geoms_inv_cell_size)
 
     def _init_collision_pair_idx(self, collision_pair_idx):
         if self._n_possible_pairs == 0:

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -89,7 +89,6 @@ def func_add_polytope_vertex_contacts_sdf(
     gb_pos: qd.types.vector(3),
     gb_quat: qd.types.vector(4),
     tolerance,
-    seeded: qd.template(),
     geoms_state: array_class.GeomsState,
     geoms_info: array_class.GeomsInfo,
     geoms_init_AABB: array_class.GeomsInitAABB,
@@ -101,6 +100,7 @@ def func_add_polytope_vertex_contacts_sdf(
     collider_state: array_class.ColliderState,
     collider_info: array_class.ColliderInfo,
     errno: qd.Tensor,
+    seeded: qd.template(),
 ):
     # Emit up to n_max contacts at the deepest spatially-diverse vertices of A penetrating (or near-touching) B's
     # surface. Pass 1 scans every vertex of A, evaluates B's grid SDF at each, and keeps the n_max deepest in a small
@@ -185,31 +185,72 @@ def func_add_polytope_vertex_contacts_sdf(
             top_pen[k] = -gs.qd_float(1e30)
             top_iv[k] = -1
         if qd.static(not seeded):
-            for i_v in range(geoms_info.vert_start[i_ga], geoms_info.vert_end[i_ga]):
-                vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ga_pos, ga_quat)
-                if func_point_in_geom_aabb(geoms_state, i_gb, i_b, vertex_pos):
-                    pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, i_gb, gb_pos, gb_quat)
-                    if pen_v > -margin:
-                        close_idx = -1
-                        for k in range(n_max):
-                            if close_idx < 0 and top_iv[k] >= 0:
-                                other_pos = gu.qd_transform_by_trans_quat(
-                                    verts_info.init_pos[top_iv[k]], ga_pos, ga_quat
+            # Pull B's world AABB back into A's local frame (its exact enclosing box, padded to absorb the
+            # rounding of the two transform paths) and walk only the spatial cells of A overlapping it: a vert
+            # outside B's AABB contributes nothing, so far cells are skipped wholesale, without per-vertex work.
+            # The exact world-AABB gate below is unchanged, and the cell binning shares the kernel's monotone
+            # single-precision cell mapping, so every vert that can pass the gate lies in a visited cell.
+            aabb_center = 0.5 * (geoms_state.aabb_min[i_gb, i_b] + geoms_state.aabb_max[i_gb, i_b])
+            aabb_half_size = 0.5 * (geoms_state.aabb_max[i_gb, i_b] - geoms_state.aabb_min[i_gb, i_b])
+            box_center = gu.qd_inv_transform_by_trans_quat(aabb_center, ga_pos, ga_quat)
+            box_half_size = qd.abs(gu.qd_quat_to_R(ga_quat, EPS)).transpose() @ aabb_half_size
+            box_min = box_center - box_half_size
+            box_max = box_center + box_half_size
+            box_pad = 1e-6 * (1.0 + box_min.norm() + box_max.norm())
+            n_cells_per_axis = 8
+            spatial_origin = collider_info.verts_spatial_grid.geoms_origin[i_ga]
+            spatial_inv_cell_size = collider_info.verts_spatial_grid.geoms_inv_cell_size[i_ga]
+            cell_min = qd.floor((box_min - box_pad - spatial_origin) * spatial_inv_cell_size, gs.qd_int)
+            cell_max = qd.floor((box_max + box_pad - spatial_origin) * spatial_inv_cell_size, gs.qd_int)
+            # The box overlaps the grid only where its cell interval meets [0, n_cells_per_axis - 1] on every
+            # axis; a broadphase pair whose pulled-back box clears the grid on some axis (common for rotated
+            # meshes) scans nothing. Clamping is applied only inside this guard, so indexing stays within the
+            # geom's own cell-range block.
+            if (cell_max >= 0).all() and (cell_min <= n_cells_per_axis - 1).all():
+                cell_min = qd.max(cell_min, 0)
+                cell_max = qd.min(cell_max, n_cells_per_axis - 1)
+                for i_cx in range(cell_min[0], cell_max[0] + 1):
+                    for i_cy in range(cell_min[1], cell_max[1] + 1):
+                        # Cells along z are contiguous in the cell-range layout, so the whole z-run is one vert range.
+                        i_cell = (
+                            i_ga * (n_cells_per_axis**3 + 1)
+                            + (i_cx * n_cells_per_axis + i_cy) * n_cells_per_axis
+                            + cell_min[2]
+                        )
+                        for i_sv in range(
+                            collider_info.verts_spatial_grid.cells_vert_start[i_cell],
+                            collider_info.verts_spatial_grid.cells_vert_start[i_cell + cell_max[2] - cell_min[2] + 1],
+                        ):
+                            vertex_pos = gu.qd_transform_by_trans_quat(
+                                collider_info.verts_spatial_grid.verts_pos[i_sv], ga_pos, ga_quat
+                            )
+                            if func_point_in_geom_aabb(geoms_state, i_gb, i_b, vertex_pos):
+                                is_in_band, sd_v = sdf.sdf_func_world_local_banded(
+                                    geoms_info, sdf_info, vertex_pos, i_gb, gb_pos, gb_quat, margin
                                 )
-                                if (vertex_pos - other_pos).norm() < diversity_radius:
-                                    close_idx = k
-                        if close_idx >= 0:
-                            if pen_v > top_pen[close_idx]:
-                                top_pen[close_idx] = pen_v
-                                top_iv[close_idx] = i_v
-                        else:
-                            weakest_idx = 0
-                            for k in range(1, n_max):
-                                if top_pen[k] < top_pen[weakest_idx]:
-                                    weakest_idx = k
-                            if pen_v > top_pen[weakest_idx]:
-                                top_pen[weakest_idx] = pen_v
-                                top_iv[weakest_idx] = i_v
+                                pen_v = -sd_v
+                                if is_in_band:
+                                    i_v = collider_info.verts_spatial_grid.verts_idx[i_sv]
+                                    close_idx = -1
+                                    for k in range(n_max):
+                                        if close_idx < 0 and top_iv[k] >= 0:
+                                            other_pos = gu.qd_transform_by_trans_quat(
+                                                verts_info.init_pos[top_iv[k]], ga_pos, ga_quat
+                                            )
+                                            if (vertex_pos - other_pos).norm() < diversity_radius:
+                                                close_idx = k
+                                    if close_idx >= 0:
+                                        if pen_v > top_pen[close_idx]:
+                                            top_pen[close_idx] = pen_v
+                                            top_iv[close_idx] = i_v
+                                    else:
+                                        weakest_idx = 0
+                                        for k in range(1, n_max):
+                                            if top_pen[k] < top_pen[weakest_idx]:
+                                                weakest_idx = k
+                                        if pen_v > top_pen[weakest_idx]:
+                                            top_pen[weakest_idx] = pen_v
+                                            top_iv[weakest_idx] = i_v
         else:
             # Seeded verification: what the pair's first scan cannot see is a feature of A (rim, edge) crossing one
             # of B's faces BETWEEN B's verts; any such feature lies in B's near-surface band, connected on A's vertex
@@ -327,7 +368,7 @@ def func_add_polytope_vertex_contacts_sdf(
         # the FINAL normal rather than letting per-vertex grad override it. The size-ratio gate keeps the existing
         # behavior for one-big-one-small pairs where the SDF grad at A's center is reliable and the closing-direction
         # line is wrong (sphere on a large floor mesh).
-        is_closing_regime = qd.abs(sd_center) < rbound_a and rbound_a_sq > gs.qd_float(0.25) * rbound_b_sq
+        is_closing_regime = qd.abs(sd_center) < rbound_a and rbound_a_sq > 0.25 * rbound_b_sq
         approach_depth_pair = gs.qd_float(0.0)
         closing_normal = qd.Vector.zero(gs.qd_float, 3)
         # Set when A wraps around B so that B passes through A along the center-to-center axis. There the SDF gradient
@@ -748,8 +789,11 @@ def func_add_polytope_vertex_contacts_sdf_shell(
             for i_v in range(geoms_info.vert_start[j_ga], geoms_info.vert_end[j_ga]):
                 vertex_pos = gu.qd_transform_by_trans_quat(verts_info.init_pos[i_v], ja_pos, ja_quat)
                 if func_point_in_geom_aabb(geoms_state, j_gb, i_b, vertex_pos):
-                    pen_v = -sdf.sdf_func_world_local(geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat)
-                    if pen_v > -margin:
+                    is_in_band, sd_v = sdf.sdf_func_world_local_banded(
+                        geoms_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat, margin
+                    )
+                    pen_v = -sd_v
+                    if is_in_band:
                         grad_v = sdf.sdf_func_grad_world_local_consistent(
                             geoms_info, rigid_global_info, sdf_info, vertex_pos, j_gb, jb_pos, jb_quat
                         )
@@ -3454,7 +3498,6 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                             gb_pos,
                             gb_quat,
                             tolerance,
-                            False,
                             geoms_state,
                             geoms_info,
                             geoms_init_AABB,
@@ -3466,6 +3509,7 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                             collider_state,
                             collider_info,
                             errno,
+                            seeded=False,
                         )
                         # Swapped-role verification: A's vertex scan cannot see a feature of B crossing one of A's
                         # faces BETWEEN A's verts, so B's verts are checked against A's SDF as well - as a seeded
@@ -3482,7 +3526,6 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                 ga_pos,
                                 ga_quat,
                                 tolerance,
-                                True,
                                 geoms_state,
                                 geoms_info,
                                 geoms_init_AABB,
@@ -3494,4 +3537,5 @@ def func_narrow_phase_nonconvex_vs_nonterrain(
                                 collider_state,
                                 collider_info,
                                 errno,
+                                seeded=True,
                             )

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -3175,6 +3175,50 @@ class RigidSolver(KinematicSolver):
 
         return tensor
 
+    def get_total_energy(self, envs_idx=None):
+        """Get the total mechanical energy of all entities in Joules [J] (kinetic + potential).
+
+        Kinetic energy is computed using the joint-space mass matrix: ``KE = 0.5 * dq^T * M(q) * dq``. When the
+        ``approximate_implicitfast`` integrator is used, the mass matrix is recomputed once to exclude implicit
+        damping terms added during integration. Potential energy is the sum over all links:
+        ``PE = -sum_i(m_i * g^T * p_i)``, where ``p_i`` is the center-of-mass position of link *i*.
+
+        Parameters
+        ----------
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        total_energy : torch.Tensor, shape () or (n_envs,)
+        """
+        if self._static_rigid_sim_config.integrator == gs.integrator.approximate_implicitfast:
+            kernel_compute_mass_matrix(
+                links_state=self.links_state,
+                links_info=self.links_info,
+                dofs_state=self.dofs_state,
+                dofs_info=self.dofs_info,
+                entities_info=self.entities_info,
+                rigid_global_info=self._rigid_global_info,
+                static_rigid_sim_config=self._static_rigid_sim_config,
+                decompose=False,
+            )
+        mass_mat = self.get_mass_mat(envs_idx=envs_idx)
+        dofs_vel = self.get_dofs_velocity(envs_idx=envs_idx)
+        Mv = torch.matmul(mass_mat, dofs_vel.unsqueeze(-1)).squeeze(-1)
+        kinetic_energy = 0.5 * torch.sum(dofs_vel * Mv, dim=-1)
+
+        gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
+        links_pos = self.get_links_pos(envs_idx=envs_idx, ref="link_com")  # (..., n_links, 3)
+        links_mass = self.get_links_inertial_mass(envs_idx=envs_idx)  # (n_links,), or (n_envs, n_links) if batched
+
+        # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
+        # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)
+        g_dot_p = torch.sum(gravity.unsqueeze(-2) * links_pos, dim=-1)  # (..., n_links)
+        potential_energy = -torch.sum(links_mass * g_dot_p, dim=-1)
+
+        return kinetic_energy + potential_energy
+
     def get_geoms_friction(self, geoms_idx=None):
         return qd_to_torch(self.geoms_info.friction, geoms_idx, copy=True)
 

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -888,10 +888,34 @@ def get_collider_state(
 
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class VertsSpatialGrid:
+    # Per-geom 8x8x8 grid over collision verts in the local AABB: a permutation of vert indices sorted by grid
+    # cell (z fastest), the matching vert positions duplicated in that order for sequential streaming, and per-cell
+    # vert ranges (8^3 + 1 entries per geom), so a scan visits only the cells overlapping a query box. The cell
+    # mapping is anchored by geoms_origin / geoms_inv_cell_size in the geom frame.
+    verts_idx: qd.Tensor
+    verts_pos: qd.Tensor
+    cells_vert_start: qd.Tensor
+    geoms_origin: qd.Tensor
+    geoms_inv_cell_size: qd.Tensor
+
+
+def get_verts_spatial_grid(solver):
+    return VertsSpatialGrid(
+        verts_idx=V(dtype=gs.qd_int, shape=(solver.n_verts_,)),
+        verts_pos=V_VEC(3, dtype=gs.qd_float, shape=(solver.n_verts_,)),
+        cells_vert_start=V(dtype=gs.qd_int, shape=(max(solver.n_geoms * (8**3 + 1), 1),)),
+        geoms_origin=V_VEC(3, dtype=gs.qd_float, shape=(solver.n_geoms_,)),
+        geoms_inv_cell_size=V_VEC(3, dtype=gs.qd_float, shape=(solver.n_geoms_,)),
+    )
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ColliderInfo:
     vert_neighbors: qd.Tensor
     vert_neighbor_start: qd.Tensor
     vert_n_neighbors: qd.Tensor
+    verts_spatial_grid: VertsSpatialGrid
     # (i_ga, i_gb) -> dense pair index, or -1 if invalid. Used by SAP broadphase, narrowphase, and contact cache.
     collision_pair_idx: qd.Tensor
     max_possible_pairs: qd.Tensor
@@ -936,6 +960,7 @@ def get_collider_info(solver, n_vert_neighbors, n_valid_pairs, collider_static_c
         vert_neighbors=V(dtype=gs.qd_int, shape=(max(n_vert_neighbors, 1),)),
         vert_neighbor_start=V(dtype=gs.qd_int, shape=(solver.n_verts_,)),
         vert_n_neighbors=V(dtype=gs.qd_int, shape=(solver.n_verts_,)),
+        verts_spatial_grid=get_verts_spatial_grid(solver),
         collision_pair_idx=V(dtype=gs.qd_int, shape=(solver.n_geoms_, solver.n_geoms_)),
         max_possible_pairs=V(dtype=gs.qd_int, shape=()),
         max_collision_pairs=V(dtype=gs.qd_int, shape=()),
@@ -1494,6 +1519,9 @@ class SDFGeomInfo:
     sdf_max: qd.Tensor
     sdf_cell_size: qd.Tensor
     sdf_cell_start: qd.Tensor
+    # Coarse min-grid companion: per-block minima over grid nodes, a certified lower bound of the trilinear sd.
+    sdf_coarse_res: qd.Tensor
+    sdf_coarse_cell_start: qd.Tensor
 
 
 def get_sdf_geom_info(n_geoms):
@@ -1503,6 +1531,8 @@ def get_sdf_geom_info(n_geoms):
         sdf_max=V(dtype=gs.qd_float, shape=(n_geoms,)),
         sdf_cell_size=V_VEC(3, dtype=gs.qd_float, shape=(n_geoms,)),
         sdf_cell_start=V(dtype=gs.qd_int, shape=(n_geoms,)),
+        sdf_coarse_res=V_VEC(3, dtype=gs.qd_int, shape=(n_geoms,)),
+        sdf_coarse_cell_start=V(dtype=gs.qd_int, shape=(n_geoms,)),
     )
 
 
@@ -1513,9 +1543,10 @@ class SDFInfo:
     geoms_sdf_val: qd.Tensor
     geoms_sdf_grad: qd.Tensor
     geoms_sdf_closest_vert: qd.Tensor
+    geoms_sdf_coarse_val: qd.Tensor
 
 
-def get_sdf_info(n_geoms, n_cells):
+def get_sdf_info(n_geoms, n_cells, n_coarse_cells):
     if math.prod((n_cells, 3)) > np.iinfo(np.int32).max:
         gs.raise_exception(
             f"SDF Gradient shape (n_cells={n_cells}, 3) is too large. Consider manually setting larger "
@@ -1528,6 +1559,7 @@ def get_sdf_info(n_geoms, n_cells):
         geoms_sdf_val=V(dtype=gs.qd_float, shape=(max(n_cells, 1),)),
         geoms_sdf_grad=V_VEC(3, dtype=gs.qd_float, shape=(max(n_cells, 1),)),
         geoms_sdf_closest_vert=V(dtype=gs.qd_int, shape=(max(n_cells, 1),)),
+        geoms_sdf_coarse_val=V(dtype=gs.qd_float, shape=(max(n_coarse_cells, 1),)),
     )
 
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -32,6 +32,7 @@ from .misc import (
     get_tet_cache_dir,
     get_usd_cache_dir,
     get_wt_cache_dir,
+    get_wth_cache_dir,
 )
 
 MESH_REPAIR_ERROR_THRESHOLD = 0.01
@@ -43,6 +44,8 @@ DEFAULT_PLANE_TEXTURE_PATH = "textures/checker.png"  # use checkerboard texture 
 
 # Bumped when watertighten output changes for a fixed (mesh, aggressiveness): forces a cache miss on stale entries.
 WT_CACHE_VERSION = 7
+# Bumped when the wall-thickness estimate changes for a fixed (mesh, quantile): forces a cache miss on stale entries.
+WTH_CACHE_VERSION = 1
 
 
 def discretize_array_for_hashing(arr: np.ndarray) -> np.ndarray:
@@ -61,14 +64,15 @@ def glossiness_to_roughness(glossiness: float) -> float:
     return (2 / (glossiness + 2)) ** (1.0 / 4.0)
 
 
-def estimate_wall_thickness(verts: np.ndarray, faces: np.ndarray, quantile: float = 0.25) -> float:
+def get_wall_thickness(verts: np.ndarray, faces: np.ndarray, quantile: float = 0.25) -> float:
     """Estimate a watertight mesh's characteristic wall thickness by probing its local diameter with inward rays.
 
     A ray is cast inward along the face normal from a stride-subsampled set of face centroids to the first opposite
     surface. The `quantile` of those hit distances, weighted by probed face area so the estimate measures surface
     rather than tessellation density (a thin wall spanned by a handful of large faces must not be outvoted by many
     small decorative facets), is returned: a low quantile approximates the thinnest wall and the median the typical
-    one. Falls back to the bounding-box diagonal when no ray hits (degenerate or non-watertight mesh).
+    one. The mesh must be watertight: inward rays escape through holes of an open surface, so the estimate is
+    meaningless there and an exception is raised (the caller is expected to skip the probe for non-watertight meshes).
 
     The estimate is deliberately a scalar, not per-axis: the SDF grid it sizes does not only resolve walls along
     their normal - it certifies contact penetrations through Lipschitz cone bounds whose slack grows with the
@@ -78,24 +82,36 @@ def estimate_wall_thickness(verts: np.ndarray, faces: np.ndarray, quantile: floa
     any one axis to the thickness of the walls facing it measurably degrades the certified pens of every wall
     tangent to it, and no bound-side search can recover the loss (the lateral sample offset is a lattice property).
     """
+    cache_path = get_wth_path(verts, faces, quantile)
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "rb") as file:
+                return pkl.load(file)
+        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
+            gs.logger.info("Ignoring corrupted wall-thickness cache.")
+
     mesh = trimesh.Trimesh(verts, faces, process=False)
+    if not mesh.is_watertight:
+        gs.raise_exception("Wall-thickness estimation requires a watertight mesh.")
     diag = np.linalg.norm(verts.max(axis=0) - verts.min(axis=0))
     stride = max(1, len(faces) // 1000)
     centers = mesh.triangles_center[::stride]
     normals = mesh.face_normals[::stride]
     origins = centers - 1e-3 * diag * normals
     locations, ray_idx, _ = mesh.ray.intersects_location(origins, -normals, multiple_hits=False)
-    if len(ray_idx) == 0:
-        return diag
     thickness = np.linalg.norm(locations - origins[ray_idx], axis=1)
+    # A hit at the ray origin's own face reads as zero thickness; drop those self-hits before taking the quantile.
     is_hit_valid = thickness > 1e-4 * diag
     thickness = thickness[is_hit_valid]
-    if len(thickness) == 0:
-        return diag
     areas = mesh.area_faces[::stride][ray_idx][is_hit_valid]
     order = np.argsort(thickness)
     areas_cum = np.cumsum(areas[order])
-    return thickness[order][np.searchsorted(areas_cum, quantile * areas_cum[-1])]
+    wall_thickness = thickness[order][np.searchsorted(areas_cum, quantile * areas_cum[-1])]
+
+    os.makedirs(get_wth_cache_dir(), exist_ok=True)
+    with open(cache_path, "wb") as file:
+        pkl.dump(wall_thickness, file, protocol=pkl.HIGHEST_PROTOCOL)
+    return wall_thickness
 
 
 class MeshInfo:
@@ -202,6 +218,11 @@ def get_remesh_path(verts, faces, edge_len_abs, edge_len_ratio, fix):
 def get_wt_path(verts, faces, aggressiveness):
     hashkey = get_hashkey(verts, faces, aggressiveness, WT_CACHE_VERSION)
     return os.path.join(get_wt_cache_dir(), f"{hashkey}.wt")
+
+
+def get_wth_path(verts, faces, quantile):
+    hashkey = get_hashkey(verts, faces, quantile, WTH_CACHE_VERSION)
+    return os.path.join(get_wth_cache_dir(), f"{hashkey}.wth")
 
 
 def get_exr_path(file_path):

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -296,6 +296,10 @@ def get_wt_cache_dir():
     return os.path.join(get_cache_dir(), "wt")
 
 
+def get_wth_cache_dir():
+    return os.path.join(get_cache_dir(), "wth")
+
+
 def get_exr_cache_dir():
     return os.path.join(get_cache_dir(), "exr")
 

--- a/genesis/utils/sdf.py
+++ b/genesis/utils/sdf.py
@@ -9,7 +9,11 @@ import genesis.utils.array_class as array_class
 class SDF:
     def __init__(self, rigid_solver):
         self.solver = rigid_solver
-        self._sdf_info = array_class.get_sdf_info(self.solver.n_geoms, self.solver.n_cells)
+        self._geoms_sdf_coarse_res = np.array(
+            [(geom.sdf_res - 2) // 4 + 1 for geom in rigid_solver.geoms], dtype=gs.np_int
+        ).reshape((-1, 3))
+        n_coarse_cells = int(self._geoms_sdf_coarse_res.prod(axis=-1).sum())
+        self._sdf_info = array_class.get_sdf_info(self.solver.n_geoms, self.solver.n_cells, n_coarse_cells)
         self._is_active = False
 
     def activate(self):
@@ -18,6 +22,18 @@ class SDF:
 
         if self.solver.n_geoms > 0:
             geoms = self.solver.geoms
+            # Coarse min-grid companion of each SDF: block minima over the grid nodes, with blocks overlapping by
+            # one node so that every interpolation cell's 8 nodes lie inside the block of its coarse cell. Derived
+            # from the loaded grids, so the preprocessing cache is untouched.
+            geoms_sdf_coarse_val = []
+            for geom, coarse_res in zip(geoms, self._geoms_sdf_coarse_res):
+                coarse_val = geom.sdf_val
+                for axis in range(3):
+                    windows = np.minimum(
+                        4 * np.arange(coarse_res[axis])[:, None] + np.arange(5), coarse_val.shape[axis] - 1
+                    )
+                    coarse_val = np.take(coarse_val, windows, axis=axis).min(axis=axis + 1)
+                geoms_sdf_coarse_val.append(coarse_val.reshape((-1,)))
             sdf_kernel_init_geom_fields(
                 geoms_T_mesh_to_sdf=np.array([geom.T_mesh_to_sdf for geom in geoms], dtype=gs.np_float),
                 geoms_sdf_res=np.array([geom.sdf_res for geom in geoms], dtype=gs.np_int),
@@ -32,6 +48,11 @@ class SDF:
                 geoms_sdf_closest_vert=np.concatenate(
                     [geom.sdf_closest_vert_flattened for geom in geoms], dtype=gs.np_int
                 ),
+                geoms_sdf_coarse_res=self._geoms_sdf_coarse_res,
+                geoms_sdf_coarse_cell_start=np.concatenate(
+                    ([0], self._geoms_sdf_coarse_res.prod(axis=-1).cumsum()[:-1]), dtype=gs.np_int
+                ),
+                geoms_sdf_coarse_val=np.concatenate(geoms_sdf_coarse_val, dtype=gs.np_float),
                 static_rigid_sim_config=self.solver._static_rigid_sim_config,
                 sdf_info=self._sdf_info,
             )
@@ -53,11 +74,15 @@ def sdf_kernel_init_geom_fields(
     geoms_sdf_max: qd.types.ndarray(),
     geoms_sdf_cell_size: qd.types.ndarray(),
     geoms_sdf_closest_vert: qd.types.ndarray(),
+    geoms_sdf_coarse_res: qd.types.ndarray(),
+    geoms_sdf_coarse_cell_start: qd.types.ndarray(),
+    geoms_sdf_coarse_val: qd.types.ndarray(),
     static_rigid_sim_config: qd.template(),
     sdf_info: array_class.SDFInfo,
 ):
     n_geoms = sdf_info.geoms_sdf_start.shape[0]
     n_cells = sdf_info.geoms_sdf_val.shape[0]
+    n_coarse_cells = sdf_info.geoms_sdf_coarse_val.shape[0]
 
     qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
     for i in range(n_geoms):
@@ -71,12 +96,18 @@ def sdf_kernel_init_geom_fields(
         sdf_info.geoms_info.sdf_max[i] = geoms_sdf_max[i]
         for j in qd.static(range(3)):
             sdf_info.geoms_info.sdf_cell_size[i][j] = geoms_sdf_cell_size[i, j]
+        sdf_info.geoms_info.sdf_coarse_cell_start[i] = geoms_sdf_coarse_cell_start[i]
+        for j in qd.static(range(3)):
+            sdf_info.geoms_info.sdf_coarse_res[i][j] = geoms_sdf_coarse_res[i, j]
 
     for i in range(n_cells):
         sdf_info.geoms_sdf_val[i] = geoms_sdf_val[i]
         sdf_info.geoms_sdf_closest_vert[i] = geoms_sdf_closest_vert[i]
         for j in qd.static(range(3)):
             sdf_info.geoms_sdf_grad[i][j] = geoms_sdf_grad[i, j]
+
+    for i in range(n_coarse_cells):
+        sdf_info.geoms_sdf_coarse_val[i] = geoms_sdf_coarse_val[i]
 
 
 @qd.func
@@ -135,6 +166,73 @@ def sdf_func_world_local(
         sd = sdf_func_sdf(sdf_info, pos_sdf, geom_idx)
 
     return sd
+
+
+@qd.func
+def sdf_func_coarse_sd_lower_bound(sdf_info: array_class.SDFInfo, pos_sdf, geom_idx):
+    """
+    Certified lower bound on the trilinear sd at an in-grid point: the minimum node value over the 4^3-cell node
+    block containing its interpolation cell. Exact by convexity - the interpolant only combines nodes of that
+    block - at the cost of a single load instead of the 8-node gather.
+    """
+    res = sdf_info.geoms_info.sdf_res[geom_idx]
+    base = qd.min(qd.floor(pos_sdf, gs.qd_int), res - 2)
+    coarse_cell = base // 4
+    coarse_res = sdf_info.geoms_info.sdf_coarse_res[geom_idx]
+    return sdf_info.geoms_sdf_coarse_val[
+        sdf_info.geoms_info.sdf_coarse_cell_start[geom_idx]
+        + (coarse_cell[0] * coarse_res[1] + coarse_cell[1]) * coarse_res[2]
+        + coarse_cell[2]
+    ]
+
+
+@qd.func
+def sdf_func_world_local_banded(
+    geoms_info: array_class.GeomsInfo,
+    sdf_info: array_class.SDFInfo,
+    pos_world: qd.types.vector(3),
+    geom_idx,
+    geom_pos: qd.types.vector(3),
+    geom_quat: qd.types.vector(4),
+    band,
+):
+    """
+    Band-gated variant of sdf_func_world_local, returning (is_in_band, sd).
+
+    is_in_band == (sd < band) for exactly the sd sdf_func_world_local would return, but sd itself is only computed
+    (and meaningful) when in band: an in-grid query whose coarse block minimum already clears the band skips the
+    8-node gather for a single coarse load.
+    """
+    is_in_band = False
+    sd = gs.qd_float(0.0)
+
+    if geoms_info.type[geom_idx] == gs.GEOM_TYPE.SPHERE:
+        sd = (pos_world - geom_pos).norm() - geoms_info.data[geom_idx][0]
+        is_in_band = sd < band
+
+    elif geoms_info.type[geom_idx] == gs.GEOM_TYPE.PLANE:
+        pos_mesh = gu.qd_inv_transform_by_trans_quat(pos_world, geom_pos, geom_quat)
+        geom_data = geoms_info.data[geom_idx]
+        plane_normal = gs.qd_vec3([geom_data[0], geom_data[1], geom_data[2]])
+        sd = pos_mesh.dot(plane_normal)
+        is_in_band = sd < band
+
+    else:
+        pos_mesh = gu.qd_inv_transform_by_trans_quat(pos_world, geom_pos, geom_quat)
+        pos_sdf = gu.qd_transform_by_T(pos_mesh, sdf_info.geoms_info.T_mesh_to_sdf[geom_idx])
+        if sdf_func_is_outside_sdf_grid(sdf_info, pos_sdf, geom_idx):
+            sd = sdf_func_proxy_sdf(sdf_info, pos_sdf, geom_idx)
+            is_in_band = sd < band
+        else:
+            coarse_lower_bound = sdf_func_coarse_sd_lower_bound(sdf_info, pos_sdf, geom_idx)
+            # The bound holds in exact arithmetic, but the floating-point evaluation of the trilinear sum can
+            # round below the block minimum; the relative guard keeps a vertex whose exact interpolant clears the
+            # band from being misclassified when its rounded value dips just inside.
+            if not (coarse_lower_bound - 1e-6 * (1.0 + qd.abs(coarse_lower_bound)) >= band):
+                sd = sdf_func_true_sdf(sdf_info, pos_sdf, geom_idx)
+                is_in_band = sd < band
+
+    return is_in_band, sd
 
 
 @qd.func

--- a/tests/test_rigid_physics.py
+++ b/tests/test_rigid_physics.py
@@ -4128,9 +4128,10 @@ def test_nonconvex_concave_slanted_wall(timestep, decimate, show_viewer):
     scene.build()
 
     # Make sure that the pile stays upright, with bowls stay tightly packed together during the entire motion
+    bowls_link_idx = [entity.base_link_idx for entity in scene.entities[-NUM_BOWLS:]]
     for _ in range(1500):
         scene.step()
-        bowls_pos = np.stack([tensor_to_array(entity.get_pos()) for entity in scene.entities[-NUM_BOWLS:]], axis=0)
+        bowls_pos = tensor_to_array(scene.rigid_solver.get_links_pos(bowls_link_idx, relative=True))
         bowls_dist_abs = np.linalg.norm(bowls_pos[:, :2] - bowls_pos[:2, 0], axis=-1)
         assert (bowls_dist_abs < 0.1).all()
         bowls_dist_rel = np.linalg.norm(np.diff(bowls_pos, axis=0), axis=-1)
@@ -4426,7 +4427,7 @@ def test_many_objects_collision(convexify, show_viewer, tol):
     vmax_trace, wmax_trace, energy_trace = [], [], []
     for i in range(1300):
         scene.step()
-        energy_trace.append(sum(tensor_to_array(obj.get_total_energy()) for obj in objs))
+        energy_trace.append(tensor_to_array(scene.rigid_solver.get_total_energy()))
         if show_viewer:
             vmax_trace.append(scene.rigid_solver.get_links_vel(ref="link_com").norm(dim=-1).max())
             wmax_trace.append(scene.rigid_solver.get_links_ang().norm(dim=-1).max())
@@ -4472,7 +4473,7 @@ def test_many_objects_collision(convexify, show_viewer, tol):
         keys = zip(link_a.tolist(), link_b.tolist(), map(tuple, (pos / 2e-3).round().tolist()))
         for key, contact_power in zip(keys, power.tolist()):
             contact_energy[key] = contact_energy.get(key, 0.0) + contact_power * scene.sim_options.dt
-        energy_trace.append(sum(tensor_to_array(obj.get_total_energy()) for obj in objs))
+        energy_trace.append(tensor_to_array(scene.rigid_solver.get_total_energy()))
         if show_viewer:
             vmax_trace.append(com_vel.norm(dim=-1).max())
             wmax_trace.append(ang.norm(dim=-1).max())


### PR DESCRIPTION
## Description

Speed up the nonconvex vertex-scan narrowphase, which profiles as ~90% pure vertex iteration on mesh piles (74-79% of the step on the two heaviest test scenes):

1. **Per-geom vert spatial grid** (built at init): the scan walks only the cells overlapping the other geom's pulled-back AABB, skipping far verts wholesale. Every vert that can pass the unchanged world-AABB gate provably lies in a visited cell.
2. **Coarse min-SDF grid** (4^3-block node minima): certifies a vert as outside the contact-emission band with one load instead of the 8-node trilinear gather.

Also adds a vectorized `RigidSolver.get_total_energy()` and batches the per-step getters of the two stress tests.

FPS on the scenes of `test_many_objects_collision[False]` / `test_nonconvex_concave_slanted_wall[0.001-False]`: **+27% / +31-46%** (CPU, interleaved A/B vs main).

## How Has This Been / Can This Be Tested?

With fast-math disabled, forcing the walk to visit every cell is bitwise-identical to the skipping version over 300 steps of both scenes: skipped verts provably contribute nothing, and the only difference vs main is the vertex visitation order (floating-point-level trajectory reshuffling). The full nonconvex test battery passes.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.