### PR TITLE
[BUG FIX] Honour system scroll direction in viewer plugins.

### DIFF
--- a/genesis/ext/pyrender/overlay/plugin.py
+++ b/genesis/ext/pyrender/overlay/plugin.py
@@ -413,8 +413,9 @@ class ImGuiOverlayPlugin(ViewerPlugin):
 
     def on_mouse_scroll(self, x, y, dx, dy) -> EVENT_HANDLE_STATE:
         if self._available:
-            # imgui backend expects: on_mouse_scroll(x, y, mods, scroll)
-            self._impl.on_mouse_scroll(x, y, 0, dy)
+            # Pyglet's deltas already reflect the system's scrolling preference. Forward them directly because the
+            # imgui-bundle Pyglet backend negates the vertical delta, which reverses the configured direction.
+            self._io.add_mouse_wheel_event(dx, dy)
         return EVENT_HANDLED if self._is_capturing() else None
 
     def on_mouse_motion(self, x, y, dx, dy) -> EVENT_HANDLE_STATE:

--- a/tests/test_imgui_overlay.py
+++ b/tests/test_imgui_overlay.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from unittest.mock import Mock
 
 import numpy as np
 import pytest

--- a/tests/test_imgui_overlay.py
+++ b/tests/test_imgui_overlay.py
@@ -60,18 +60,6 @@ def test_imgui_overlay_capture_pending_entities_preserves_heterogeneous_morphs()
     assert heterogeneous_kwargs["visualize_contact"] is True
 
 
-@pytest.mark.required
-def test_imgui_overlay_mouse_scroll_preserves_pyglet_direction():
-    plugin = ImGuiOverlayPlugin.__new__(ImGuiOverlayPlugin)
-    plugin._available = True
-    plugin._io = Mock()
-    plugin._is_capturing = Mock(return_value=False)
-
-    plugin.on_mouse_scroll(10, 20, -2, 3)
-
-    plugin._io.add_mouse_wheel_event.assert_called_once_with(-2, 3)
-
-
 def _apply_deterministic_imgui_overrides(monkeypatch):
     """Make ImGui rendering and timing pixel-identical across renderers for snapshot tests."""
     from imgui_bundle import imgui

--- a/tests/test_imgui_overlay.py
+++ b/tests/test_imgui_overlay.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -57,6 +58,18 @@ def test_imgui_overlay_capture_pending_entities_preserves_heterogeneous_morphs()
     assert heterogeneous_kwargs["material"] is heterogeneous_entity.material
     assert heterogeneous_kwargs["surface"] is heterogeneous_entity.surface
     assert heterogeneous_kwargs["visualize_contact"] is True
+
+
+@pytest.mark.required
+def test_imgui_overlay_mouse_scroll_preserves_pyglet_direction():
+    plugin = ImGuiOverlayPlugin.__new__(ImGuiOverlayPlugin)
+    plugin._available = True
+    plugin._io = Mock()
+    plugin._is_capturing = Mock(return_value=False)
+
+    plugin.on_mouse_scroll(10, 20, -2, 3)
+
+    plugin._io.add_mouse_wheel_event.assert_called_once_with(-2, 3)
 
 
 def _apply_deterministic_imgui_overrides(monkeypatch):


### PR DESCRIPTION
## Description

Forward Pyglet's horizontal and vertical scroll deltas directly to Dear ImGui so the operating system's scrolling preference is preserved. The imgui-bundle Pyglet backend negates the vertical delta, which made Genesis's overlay reverse the configured direction.

This also preserves horizontal scrolling, which the previous call dropped.

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/genesis-world/issues/2943

## Motivation and Context

Pyglet already reports scroll deltas using the user's configured direction. Passing the vertical delta through `PygletRenderer.on_mouse_scroll` negates it a second time, so natural scrolling behaves opposite to the system preference. Sending both deltas to the ImGui IO API avoids that backend transformation.

## How Has This Been / Can This Be Tested?

- `uv run pytest -n 0 --snapshot-warn-unused tests/test_imgui_overlay.py -p no:pytest-retry -p no:rerunfailures` — 6 passed, 1 skipped.
- `uv run pre-commit run --files genesis/ext/pyrender/overlay/plugin.py tests/test_imgui_overlay.py` — Ruff check and Ruff format passed.
- `uv run pytest --snapshot-warn-unused -m required tests/ -p no:pytest-retry -p no:rerunfailures` — 600 passed, 37 skipped, 6 xfailed; four unrelated snapshot tests failed identically on the untouched base commit `2585e540208ad58da46d03af3281ba6aa4ad99d1`:
  - `tests/test_render.py::test_sensors_draw_debug[RASTERIZER-0]`
  - `tests/test_recorders.py::test_plotter`
  - `tests/test_render.py::test_rasterizer_env_separate[True-RASTERIZER]`
  - `tests/test_recorders.py::test_vector_field_plotter_subplots`

## Screenshots (if appropriate):

Not applicable; this changes input-event handling only.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
