### PR TITLE
[BUG FIX] Preserve PBR base color in packed RGBA

### DIFF
--- a/genesis/options/surfaces.py
+++ b/genesis/options/surfaces.py
@@ -641,7 +641,9 @@ class BSDF(Surface):
         )
 
     def get_rgba(self, batch: bool = False) -> BatchTexture | Texture:
-        color = self.emissive_texture if self.emissive_texture is not None else self.diffuse_texture
+        color = self.diffuse_texture
+        if (color is None or color.is_black) and self.emissive_texture is not None:
+            color = self.emissive_texture
         return _make_rgba(color, self.opacity_texture, batch)
 
     @model_validator(mode="after")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -235,6 +235,40 @@ def test_surface_shortcut_resolution():
 
 
 @pytest.mark.required
+def test_bsdf_rgba_prefers_base_color_over_emissive_texture():
+    diffuse = gs.textures.ImageTexture(image_array=np.full((4, 4, 3), (201, 166, 105), dtype=np.uint8))
+    opacity = gs.textures.ImageTexture(image_array=np.full((4, 4), 255, dtype=np.uint8))
+    emissive = gs.textures.ImageTexture(image_array=np.full((2, 2, 3), 9, dtype=np.uint8))
+
+    rgba = gs.surfaces.BSDF(
+        diffuse_texture=diffuse,
+        opacity_texture=opacity,
+        emissive_texture=emissive,
+    ).get_rgba()
+
+    assert rgba.image_array.shape == (4, 4, 4)
+    assert np.array_equal(rgba.image_array[..., :3], diffuse.image_array)
+    assert np.array_equal(rgba.image_array[..., 3], opacity.image_array)
+
+    black_diffuse = gs.textures.ImageTexture(
+        image_array=np.full((2, 2, 3), (201, 166, 105), dtype=np.uint8),
+        image_color=(0.0, 0.0, 0.0),
+    )
+    emissive_terrain = gs.textures.ImageTexture(image_array=np.full((2, 2, 3), (76, 122, 64), dtype=np.uint8))
+    rgba = gs.surfaces.BSDF(
+        diffuse_texture=black_diffuse,
+        opacity_texture=gs.textures.ImageTexture(image_array=np.full((2, 2), 255, dtype=np.uint8)),
+        emissive_texture=emissive_terrain,
+    ).get_rgba()
+
+    assert np.array_equal(rgba.image_array[..., :3], emissive_terrain.image_array)
+
+    rgba = gs.surfaces.BSDF(color=(0.0, 0.0, 0.0)).get_rgba()
+
+    assert rgba.color == (0.0, 0.0, 0.0, 1.0)
+
+
+@pytest.mark.required
 def test_fps_algorithm_core():
     # Shape, dtype, determinism, anchor-on-no-seed, and invalid n_samples all in one test.
     points = np.random.default_rng(1).random((50, 3))


### PR DESCRIPTION
## Why

Some GLBs, including HLOD tiles, use a zero base-color factor while putting their imagery in an emissive texture. The previous packed-RGBA path treated the mere presence of a diffuse texture as authoritative, producing black terrain. Conversely, preferring emissive whenever present loses the intended PBR base color of ordinary assets such as vehicles.

## What changed

- Prefer a nonblack PBR diffuse texture when creating packed RGBA.
- Fall back to emissive when diffuse is absent or intentionally black.
- Cover both the normal PBR and zero-base-factor HLOD cases.

## Impact / safety properties

This only affects the packed RGBA representation consumed by renderers; it leaves the original material textures and shading inputs intact.

## Validation

Constructed both material shapes under Genesis initialization and verified the selected RGBA pixels.

Fixes #3046.
