### PR TITLE
[FEATURE] Support explicit mounting transform in RigidEntity.attach.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2,7 +2,7 @@ import inspect
 import math
 import os
 from itertools import chain
-from typing import TYPE_CHECKING, Literal, Any, Sequence
+from typing import TYPE_CHECKING, Literal, Any
 from functools import wraps
 
 import quadrants as qd
@@ -22,6 +22,7 @@ from genesis.utils import mjcf as mju
 from genesis.utils import terrain as tu
 from genesis.utils import urdf as uu
 from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_numpy, qd_to_torch
+from genesis.typing import UnitVec4FType, Vec3FType
 from genesis.engine.states.entities import RigidEntityState
 
 from ..base_entity import Entity
@@ -1396,8 +1397,8 @@ class KinematicEntity(Entity):
         self,
         parent_entity,
         parent_link_name: str | None = None,
-        pos: Sequence[float] | None = None,
-        quat: Sequence[float] | None = None,
+        pos: Vec3FType | None = None,
+        quat: UnitVec4FType | None = None,
     ):
         """
         Merge two entities to act as single one, by attaching the base link of this entity as a child of a given link of
@@ -1426,14 +1427,17 @@ class KinematicEntity(Entity):
         if self._is_attached:
             gs.raise_exception("Entity already attached.")
 
-        if pos is not None or quat is not None:
+        is_mounting = pos is not None or quat is not None
+        if is_mounting:
             mount_pos = gu.zero_pos() if pos is None else np.asarray(pos, dtype=gs.np_float)
             mount_quat = gu.identity_quat() if quat is None else np.asarray(quat, dtype=gs.np_float)
             if mount_pos.shape != (3,):
                 gs.raise_exception(f"Mounting 'pos' must have shape (3,), got {mount_pos.shape}.")
             if mount_quat.shape != (4,):
                 gs.raise_exception(f"Mounting 'quat' must have shape (4,) (w, x, y, z), got {mount_quat.shape}.")
-            mount_quat = mount_quat / np.linalg.norm(mount_quat)
+            if np.linalg.norm(mount_quat) < gs.EPS:
+                gs.raise_exception("Mounting 'quat' cannot be a zero-length quaternion.")
+            mount_quat = gu.normalize(mount_quat)
 
         if not isinstance(parent_entity, KinematicEntity):
             gs.raise_exception("Parent entity must derive from 'KinematicEntity'.")
@@ -1443,6 +1447,11 @@ class KinematicEntity(Entity):
 
         if parent_entity.idx > self.idx:
             gs.raise_exception("Parent entity must be instantiated before child entity.")
+
+        # Attaching reshapes the kinematic tree, but the post-build pass that anchors each heterogeneous variant's
+        # inertia and frame runs per free root and cannot follow a reparented (or absorbed) base link.
+        if self._enable_heterogeneous or parent_entity._enable_heterogeneous:
+            gs.raise_exception("Attaching heterogeneous entities is not supported.")
 
         # Check if base link was fixed but no longer is
         base_link = self.links[0]
@@ -1530,7 +1539,7 @@ class KinematicEntity(Entity):
         # its (new) parent link, so overwriting it here mounts the entity at (pos, quat) in the parent link frame.
         # Compose with the morph frame offset exactly as '_align_link' does for the morph pose at load time, so the
         # relative pose getters keep stripping the offset correctly.
-        if pos is not None or quat is not None:
+        if is_mounting:
             base_link._pos, base_link._quat = gu.transform_pos_quat_by_trans_quat(
                 self._offset_pos, self._offset_quat, mount_pos, mount_quat
             )

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1392,7 +1392,13 @@ class KinematicEntity(Entity):
         self._links_offset_quat[link_idx - self._link_start] = offset_quat
 
     @gs.assert_unbuilt
-    def attach(self, parent_entity, parent_link_name: str | None = None):
+    def attach(
+        self,
+        parent_entity,
+        parent_link_name: str | None = None,
+        pos: Sequence[float] | None = None,
+        quat: Sequence[float] | None = None,
+    ):
         """
         Merge two entities to act as single one, by attaching the base link of this entity as a child of a given link of
         another entity.
@@ -1408,9 +1414,26 @@ class KinematicEntity(Entity):
         parent_link_name : str
             The name of the link in the parent entity to be linked. Default to the latest link the parent kinematic
             tree.
+        pos : array_like, shape (3,), optional
+            Mounting position of this entity's base link relative to the parent link frame. If neither `pos` nor
+            `quat` is provided, the base link keeps its current local pose, i.e. the morph `pos` / `quat` this entity
+            was created with acts as the mounting transform. If only `quat` is provided, defaults to (0, 0, 0).
+        quat : array_like, shape (4,), optional
+            Mounting orientation (w, x, y, z) of this entity's base link relative to the parent link frame. If only
+            `pos` is provided, defaults to the identity quaternion. Providing `pos` and/or `quat` overrides the pose
+            inherited from the morph.
         """
         if self._is_attached:
             gs.raise_exception("Entity already attached.")
+
+        if pos is not None or quat is not None:
+            mount_pos = gu.zero_pos() if pos is None else np.asarray(pos, dtype=gs.np_float)
+            mount_quat = gu.identity_quat() if quat is None else np.asarray(quat, dtype=gs.np_float)
+            if mount_pos.shape != (3,):
+                gs.raise_exception(f"Mounting 'pos' must have shape (3,), got {mount_pos.shape}.")
+            if mount_quat.shape != (4,):
+                gs.raise_exception(f"Mounting 'quat' must have shape (4,) (w, x, y, z), got {mount_quat.shape}.")
+            mount_quat = mount_quat / np.linalg.norm(mount_quat)
 
         if not isinstance(parent_entity, KinematicEntity):
             gs.raise_exception("Parent entity must derive from 'KinematicEntity'.")
@@ -1502,6 +1525,15 @@ class KinematicEntity(Entity):
                 link._root_idx = parent_link.root_idx
                 link._is_fixed &= parent_link.is_fixed
                 link._invweight = None
+
+        # Apply the explicit mounting transform. Forward kinematics interprets the base link's local pose relative to
+        # its (new) parent link, so overwriting it here mounts the entity at (pos, quat) in the parent link frame.
+        # Compose with the morph frame offset exactly as '_align_link' does for the morph pose at load time, so the
+        # relative pose getters keep stripping the offset correctly.
+        if pos is not None or quat is not None:
+            base_link._pos, base_link._quat = gu.transform_pos_quat_by_trans_quat(
+                self._offset_pos, self._offset_quat, mount_pos, mount_quat
+            )
 
         self._is_attached = True
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -1567,3 +1567,71 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
         assert_allclose(torch.linalg.norm(hand.links[-1].get_pos() - attach_link.get_pos(), dim=-1), 0.105, tol=tol)
 
     assert_allclose(tool.get_pos(), hand.get_link("right_finger").get_pos(), tol=gs.EPS)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("is_fixed", [False, True])
+def test_attach_mounting_transform(is_fixed, show_viewer, tol):
+    """Explicit 'pos' / 'quat' passed to 'attach' mount the child at that transform in the parent link frame,
+    overriding the pose inherited from the child's morph."""
+    MOUNT_POS = (0.10, 0.20, 0.30)
+    MOUNT_QUAT = (math.cos(math.pi / 8), 0.0, math.sin(math.pi / 8), 0.0)  # 45 deg about y
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=0.01,
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    franka = scene.add_entity(
+        gs.morphs.URDF(
+            file="urdf/panda_bullet/panda_nohand.urdf",
+            merge_fixed_links=False,
+            fixed=True,
+        ),
+    )
+    hand = scene.add_entity(
+        gs.morphs.URDF(
+            file="urdf/panda_bullet/hand.urdf",
+            # A conflicting morph pose: the explicit mounting transform must override it.
+            pos=(1.0, -2.0, 3.0),
+            euler=(0, 0, 45),
+            fixed=is_fixed,
+            batch_fixed_verts=is_fixed,
+        ),
+    )
+    tool = scene.add_entity(
+        gs.morphs.Sphere(radius=0.005),
+    )
+
+    with pytest.raises(gs.GenesisException):
+        hand.attach(franka, "attachment", pos=(0.0, 0.0))
+    with pytest.raises(gs.GenesisException):
+        hand.attach(franka, "attachment", quat=(1.0, 0.0, 0.0))
+
+    hand.attach(franka, "attachment", pos=MOUNT_POS, quat=MOUNT_QUAT)
+    # 'pos' only: 'quat' defaults to identity.
+    tool.attach(hand, "right_finger", pos=(0.0, 0.0, 0.05))
+    scene.build()
+
+    franka.control_dofs_position([-1, 0.8, 1, -2, 1, 0.5, -0.5])
+    for _ in range(10):
+        scene.step()
+
+    attach_link = franka.get_link("attachment")
+    expected_pos = attach_link.get_pos() + gu.transform_by_quat(
+        torch.tensor(MOUNT_POS, dtype=gs.tc_float, device=gs.device), attach_link.get_quat()
+    )
+    expected_quat = gu.transform_quat_by_quat(
+        torch.tensor(MOUNT_QUAT, dtype=gs.tc_float, device=gs.device), attach_link.get_quat()
+    )
+    assert_allclose(hand.links[0].get_pos(), expected_pos, tol=tol)
+    assert_allclose(hand.links[0].get_quat(), expected_quat, tol=tol)
+
+    finger_link = hand.get_link("right_finger")
+    expected_tool_pos = finger_link.get_pos() + gu.transform_by_quat(
+        torch.tensor((0.0, 0.0, 0.05), dtype=gs.tc_float, device=gs.device), finger_link.get_quat()
+    )
+    assert_allclose(tool.get_pos(), expected_tool_pos, tol=tol)
+    assert_allclose(tool.get_quat(), finger_link.get_quat(), tol=tol)

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -1479,6 +1479,8 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
         monkeypatch.setenv("QD_NUM_THREADS", "3")
 
     EULER_OFFSET = (0, 0, 45)
+    TOOL_MOUNT_POS = (0.0, 0.0, 0.05)
+    TOOL_MOUNT_QUAT = (math.cos(math.pi / 8), math.sin(math.pi / 8), 0.0, 0.0)  # 45 deg about x
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -1519,6 +1521,8 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
     tool = scene.add_entity(
         gs.morphs.Sphere(
             radius=0.005,
+            # A conflicting morph pose: the explicit mounting transform below must override it.
+            pos=(1.0, -2.0, 3.0),
         ),
     )
     box = scene.add_entity(
@@ -1529,8 +1533,17 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
     )
     with pytest.raises(gs.GenesisException):
         franka.attach(hand, "right_finger")
+    # Omitting the mounting transform keeps the child's morph pose acting as the mount.
     hand.attach(franka, "attachment")
-    tool.attach(hand, "right_finger")
+    # Malformed mounting transforms (wrong shape, or a zero-length quaternion) raise before any kinematic-tree
+    # mutation, leaving the entity attachable.
+    with pytest.raises(gs.GenesisException):
+        tool.attach(hand, "right_finger", pos=(0.0, 0.0))
+    with pytest.raises(gs.GenesisException):
+        tool.attach(hand, "right_finger", quat=(1.0, 0.0, 0.0))
+    with pytest.raises(gs.GenesisException):
+        tool.attach(hand, "right_finger", quat=(0.0, 0.0, 0.0, 0.0))
+    tool.attach(hand, "right_finger", pos=TOOL_MOUNT_POS, quat=TOOL_MOUNT_QUAT)
     scene.build()
     with pytest.raises(gs.GenesisException):
         box.attach(hand, "right_finger")
@@ -1566,72 +1579,14 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
     if not merge_fixed_links:
         assert_allclose(torch.linalg.norm(hand.links[-1].get_pos() - attach_link.get_pos(), dim=-1), 0.105, tol=tol)
 
-    assert_allclose(tool.get_pos(), hand.get_link("right_finger").get_pos(), tol=gs.EPS)
-
-
-@pytest.mark.required
-@pytest.mark.parametrize("is_fixed", [False, True])
-def test_attach_mounting_transform(is_fixed, show_viewer, tol):
-    """Explicit 'pos' / 'quat' passed to 'attach' mount the child at that transform in the parent link frame,
-    overriding the pose inherited from the child's morph."""
-    MOUNT_POS = (0.10, 0.20, 0.30)
-    MOUNT_QUAT = (math.cos(math.pi / 8), 0.0, math.sin(math.pi / 8), 0.0)  # 45 deg about y
-
-    scene = gs.Scene(
-        sim_options=gs.options.SimOptions(
-            dt=0.01,
-        ),
-        show_viewer=show_viewer,
-    )
-    scene.add_entity(gs.morphs.Plane())
-    franka = scene.add_entity(
-        gs.morphs.URDF(
-            file="urdf/panda_bullet/panda_nohand.urdf",
-            merge_fixed_links=False,
-            fixed=True,
-        ),
-    )
-    hand = scene.add_entity(
-        gs.morphs.URDF(
-            file="urdf/panda_bullet/hand.urdf",
-            # A conflicting morph pose: the explicit mounting transform must override it.
-            pos=(1.0, -2.0, 3.0),
-            euler=(0, 0, 45),
-            fixed=is_fixed,
-            batch_fixed_verts=is_fixed,
-        ),
-    )
-    tool = scene.add_entity(
-        gs.morphs.Sphere(radius=0.005),
-    )
-
-    with pytest.raises(gs.GenesisException):
-        hand.attach(franka, "attachment", pos=(0.0, 0.0))
-    with pytest.raises(gs.GenesisException):
-        hand.attach(franka, "attachment", quat=(1.0, 0.0, 0.0))
-
-    hand.attach(franka, "attachment", pos=MOUNT_POS, quat=MOUNT_QUAT)
-    # 'pos' only: 'quat' defaults to identity.
-    tool.attach(hand, "right_finger", pos=(0.0, 0.0, 0.05))
-    scene.build()
-
-    franka.control_dofs_position([-1, 0.8, 1, -2, 1, 0.5, -0.5])
-    for _ in range(10):
-        scene.step()
-
-    attach_link = franka.get_link("attachment")
-    expected_pos = attach_link.get_pos() + gu.transform_by_quat(
-        torch.tensor(MOUNT_POS, dtype=gs.tc_float, device=gs.device), attach_link.get_quat()
-    )
-    expected_quat = gu.transform_quat_by_quat(
-        torch.tensor(MOUNT_QUAT, dtype=gs.tc_float, device=gs.device), attach_link.get_quat()
-    )
-    assert_allclose(hand.links[0].get_pos(), expected_pos, tol=tol)
-    assert_allclose(hand.links[0].get_quat(), expected_quat, tol=tol)
-
+    # The tool's explicit mounting transform overrides its conflicting morph pose: it sits at (pos, quat) in the
+    # right-finger frame rather than at the finger origin.
     finger_link = hand.get_link("right_finger")
     expected_tool_pos = finger_link.get_pos() + gu.transform_by_quat(
-        torch.tensor((0.0, 0.0, 0.05), dtype=gs.tc_float, device=gs.device), finger_link.get_quat()
+        torch.tensor(TOOL_MOUNT_POS, dtype=gs.tc_float, device=gs.device), finger_link.get_quat()
+    )
+    expected_tool_quat = gu.transform_quat_by_quat(
+        torch.tensor(TOOL_MOUNT_QUAT, dtype=gs.tc_float, device=gs.device), finger_link.get_quat()
     )
     assert_allclose(tool.get_pos(), expected_tool_pos, tol=tol)
-    assert_allclose(tool.get_quat(), finger_link.get_quat(), tol=tol)
+    assert_allclose(tool.get_quat(), expected_tool_quat, tol=tol)

--- a/tests/rigid/test_heterogeneous.py
+++ b/tests/rigid/test_heterogeneous.py
@@ -298,6 +298,9 @@ def test_morph_property_raises():
         morph=kinematic_morphs_heterogeneous,
         material=gs.materials.Kinematic(),
     )
+    tool = scene.add_entity(
+        morph=gs.morphs.Box(size=(0.05, 0.05, 0.05)),
+    )
 
     assert single_obj.morph is single_morph
     assert rigid_obj.main_morph is rigid_morphs_heterogeneous[0]
@@ -310,6 +313,12 @@ def test_morph_property_raises():
     assert list(kinematic_obj.morphs) == list(kinematic_morphs_heterogeneous)
     with pytest.raises(gs.GenesisException, match=r"Heterogeneous.*\.morphs"):
         _ = kinematic_obj.morph
+
+    # Attaching is unsupported both from a heterogeneous entity (as the reparented child) and onto one (as parent).
+    with pytest.raises(gs.GenesisException, match="[Hh]eterogeneous"):
+        rigid_obj.attach(single_obj)
+    with pytest.raises(gs.GenesisException, match="[Hh]eterogeneous"):
+        tool.attach(rigid_obj)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

Add optional `pos` / `quat` arguments to `RigidEntity.attach`, specifying the mounting transform of the attached entity's base link relative to the parent link frame:

```python
gripper.attach(arm, "attachment", pos=(0.0, 0.0, 0.107), quat=(0.7071068, 0.0, 0.0, 0.7071068))
```

When both arguments are omitted, behavior is unchanged: the base link keeps its current local pose, i.e. the morph `pos` / `quat` the entity was created with keeps acting as the mounting transform. When provided, the mounting pose overrides the pose inherited from the morph, and composes with the morph frame offset (`offset_pos` / `offset_quat`) exactly as `_align_link` composes the morph pose at load time, so the relative pose getters keep stripping the offset correctly. Invalid shapes raise a `GenesisException` before any kinematic-tree mutation.

Attaching a heterogeneous entity (created from a list of morphs), either as the child or as the parent, now raises a `GenesisException`. The post-build pass that anchors each variant's inertia and frame runs per free root and cannot follow a base link that `attach` reparents or absorbs into the parent, so the combination was never correctly supported.

## Related Issue

None - small additive API. Attaching a tool/gripper entity to an arm at a specified tool frame is a common composition workflow.

## Motivation and Context

`attach` reparents the child base link without touching its local pose, so forward kinematics silently reinterprets the child morph's world-frame `pos` / `quat` as the parent-link-relative mounting transform. This works, but it is implicit and undocumented: the mounting pose must be decided at `add_entity` time (where it masquerades as a world pose), and code that wants a different mount per attachment has to bake it into the morph or the asset file. This PR makes the mounting transform an explicit, documented part of the attach API.

## How Has This Been / Can This Be Tested?

Coverage lives in `tests/rigid/test_asset_loading.py::test_merge_entities`, parametrized over fixed / floating-base children and merged / unmerged fixed links:

- the floating-base `hand` attaches with no mounting transform, so its morph pose keeps acting as the mount (unchanged legacy path);
- the `tool` attaches with an explicit `pos` / `quat` that overrides a deliberately conflicting morph pose (`pos=(1, -2, 3)`); after actuating the arm, the tool base link's world pose equals `finger_link_pose * (pos, quat)`;
- malformed `pos` / `quat` shapes raise `GenesisException` before the kinematic tree is mutated.

`tests/rigid/test_heterogeneous.py::test_morph_property_raises` additionally checks that attaching from and onto a heterogeneous entity raises.

```
pytest tests/rigid/test_asset_loading.py -k test_merge_entities
pytest tests/rigid/test_heterogeneous.py -k test_morph_property_raises
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
