### PR TITLE
[FEATURE] Add optional MJCF ground plane exclusion.

### DIFF
--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -992,8 +992,10 @@ class MJCF(FileMorph):
         Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
         actuated. None to disable. Default to 0.1.
     is_ground_plane_included : bool, optional
-        Whether to include plane geometries authored directly under the MJCF world body. Keep this enabled to preserve
-        the authored ground, or disable it when the Genesis scene supplies its own ground. Defaults to True.
+        Whether to keep plane geometries authored directly under the MJCF worldbody. Enabled by default so the model
+        keeps its embedded floor. Disable it when the scene already provides a ground, to avoid a duplicated
+        overlapping plane; the scene must then supply its own floor, otherwise the model has nothing to rest on.
+        Defaults to True.
     """
 
     pos: Vec3FType | None = None

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -991,12 +991,16 @@ class MJCF(FileMorph):
     default_armature : float, optional
         Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
         actuated. None to disable. Default to 0.1.
+    is_ground_plane_included : bool, optional
+        Whether to include plane geometries authored directly under the MJCF world body. Keep this enabled to preserve
+        the authored ground, or disable it when the Genesis scene supplies its own ground. Defaults to True.
     """
 
     pos: Vec3FType | None = None
     quat: UnitVec4FType | None = None
     requires_jac_and_IK: StrictBool = True
     default_armature: float | None = Field(default=0.1, ge=0)
+    is_ground_plane_included: StrictBool = True
 
     @model_validator(mode="before")
     @classmethod

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -991,18 +991,15 @@ class MJCF(FileMorph):
     default_armature : float, optional
         Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
         actuated. None to disable. Default to 0.1.
-    is_ground_plane_included : bool, optional
-        Whether to keep plane geometries authored directly under the MJCF worldbody. Enabled by default so the model
-        keeps its embedded floor. Disable it when the scene already provides a ground, to avoid a duplicated
-        overlapping plane; the scene must then supply its own floor, otherwise the model has nothing to rest on.
-        Defaults to True.
+    exclude_ground_plane : bool, optional
+        Whether to exclude plane geometries authored directly under the MJCF worldbody if any. Defaults to False.
     """
 
     pos: Vec3FType | None = None
     quat: UnitVec4FType | None = None
     requires_jac_and_IK: StrictBool = True
     default_armature: float | None = Field(default=0.1, ge=0)
-    is_ground_plane_included: StrictBool = True
+    exclude_ground_plane: StrictBool = False
 
     @model_validator(mode="before")
     @classmethod

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -61,7 +61,16 @@ def get_model_name(file_path):
     return None
 
 
-def build_model(xml, discard_visual, default_armature=None, merge_fixed_links=False, links_to_keep=()):
+def build_model(
+    xml,
+    discard_visual,
+    default_armature=None,
+    merge_fixed_links=False,
+    links_to_keep=(),
+    is_ground_plane_included=True,
+):
+    worldbody_geom_names = set()
+    unnamed_worldbody_geom_names = set()
     if isinstance(xml, (str, Path, urdfpy.URDF)):
         if isinstance(xml, urdfpy.URDF):
             is_urdf_file = True
@@ -103,6 +112,22 @@ def build_model(xml, discard_visual, default_armature=None, merge_fixed_links=Fa
                     mjcf.append(child)
                 mjcf.remove(elem)
                 root_parent_stack.append((include_root, include_path))
+
+        if not is_urdf_file and not is_ground_plane_included:
+            geom_names = {geom.attrib["name"] for geom in mjcf.iter("geom") if "name" in geom.attrib}
+            i_g = 0
+            for worldbody_elem in mjcf.findall("worldbody"):
+                for geom in worldbody_elem.findall("geom"):
+                    geom_name = geom.attrib.get("name")
+                    if geom_name is None:
+                        geom_name = f"genesis_worldbody_geom_{i_g}"
+                        while geom_name in geom_names:
+                            i_g += 1
+                            geom_name = f"genesis_worldbody_geom_{i_g}"
+                        geom.attrib["name"] = geom_name
+                        unnamed_worldbody_geom_names.add(geom_name)
+                    geom_names.add(geom_name)
+                    worldbody_geom_names.add(geom_name)
 
         # Make sure compiler options are defined
         compiler = mjcf.find("compiler")
@@ -179,6 +204,16 @@ def build_model(xml, discard_visual, default_armature=None, merge_fixed_links=Fa
             data = ET.tostring(root, encoding="utf8")
             mj = mujoco.MjModel.from_xml_string(data)
 
+            # Compiled link assignments lose source placement when fixed links are fused, so names preserve it.
+            empty_name_address = mj.names.find(b"\x00")
+            for geom_name in worldbody_geom_names:
+                i_g = mujoco.mj_name2id(mj, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+                if geom_name in unnamed_worldbody_geom_names:
+                    mj.name_geomadr[i_g] = empty_name_address
+                if mj.geom_type[i_g] == mujoco.mjtGeom.mjGEOM_PLANE:
+                    # A negative link assignment keeps excluded source geoms out of the Genesis model.
+                    mj.geom_bodyid[i_g] = -1
+
             # Special treatment for URDF
             if is_urdf_file:
                 # Discard placeholder inertias that were used to avoid parsing failure
@@ -208,8 +243,17 @@ def parse_xml(morph, surface):
         merge_fixed_links = morph.merge_fixed_links
         links_to_keep = morph.links_to_keep
 
+    is_ground_plane_included = not isinstance(morph, gs.morphs.MJCF) or morph.is_ground_plane_included
+
     # Build model from XML (either URDF or MJCF)
-    mj = build_model(morph.file, not morph.visualization, morph.default_armature, merge_fixed_links, links_to_keep)
+    mj = build_model(
+        morph.file,
+        not morph.visualization,
+        morph.default_armature,
+        merge_fixed_links,
+        links_to_keep,
+        is_ground_plane_included,
+    )
 
     # We have another more informative warning later so we suppress this one
     # gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_info['name']}`")
@@ -217,13 +261,7 @@ def parse_xml(morph, surface):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(
-        mj,
-        morph.scale,
-        surface,
-        morph.file,
-        is_ground_plane_included=not isinstance(morph, gs.morphs.MJCF) or morph.is_ground_plane_included,
-    )
+    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -634,7 +672,7 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, scale, surface, xml_path, is_ground_plane_included):
+def parse_geoms(mj, scale, surface, xml_path):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
@@ -642,13 +680,6 @@ def parse_geoms(mj, scale, surface, xml_path, is_ground_plane_included):
     for i_g in range(mj.ngeom):
         if mj.geom_bodyid[i_g] < 0:
             continue
-        if (
-            not is_ground_plane_included
-            and mj.geom_bodyid[i_g] == 0
-            and mj.geom_type[i_g] == mujoco.mjtGeom.mjGEOM_PLANE
-        ):
-            continue
-
         # try parsing a given geometry
         g_info = parse_geom(mj, i_g, scale, surface, xml_path)
         if g_info is None:

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -69,8 +69,6 @@ def build_model(
     links_to_keep=(),
     is_ground_plane_included=True,
 ):
-    worldbody_geom_names = set()
-    unnamed_worldbody_geom_names = set()
     if isinstance(xml, (str, Path, urdfpy.URDF)):
         if isinstance(xml, urdfpy.URDF):
             is_urdf_file = True
@@ -113,21 +111,14 @@ def build_model(
                 mjcf.remove(elem)
                 root_parent_stack.append((include_root, include_path))
 
+        # Drop ground planes authored directly under the worldbody so a model that embeds its own floor can be
+        # loaded into a scene that already provides a ground. Removing the source geoms before compilation leaves
+        # planes authored under child bodies untouched, even when the compiler fuses them into the worldbody.
         if not is_urdf_file and not is_ground_plane_included:
-            geom_names = {geom.attrib["name"] for geom in mjcf.iter("geom") if "name" in geom.attrib}
-            i_g = 0
-            for worldbody_elem in mjcf.findall("worldbody"):
-                for geom in worldbody_elem.findall("geom"):
-                    geom_name = geom.attrib.get("name")
-                    if geom_name is None:
-                        geom_name = f"genesis_worldbody_geom_{i_g}"
-                        while geom_name in geom_names:
-                            i_g += 1
-                            geom_name = f"genesis_worldbody_geom_{i_g}"
-                        geom.attrib["name"] = geom_name
-                        unnamed_worldbody_geom_names.add(geom_name)
-                    geom_names.add(geom_name)
-                    worldbody_geom_names.add(geom_name)
+            for worldbody in mjcf.findall("worldbody"):
+                for geom in tuple(worldbody.findall("geom")):
+                    if geom.attrib.get("type") == "plane":
+                        worldbody.remove(geom)
 
         # Make sure compiler options are defined
         compiler = mjcf.find("compiler")
@@ -203,16 +194,6 @@ def build_model(
             # Parse updated URDF file as a string
             data = ET.tostring(root, encoding="utf8")
             mj = mujoco.MjModel.from_xml_string(data)
-
-            # Compiled link assignments lose source placement when fixed links are fused, so names preserve it.
-            empty_name_address = mj.names.find(b"\x00")
-            for geom_name in worldbody_geom_names:
-                i_g = mujoco.mj_name2id(mj, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
-                if geom_name in unnamed_worldbody_geom_names:
-                    mj.name_geomadr[i_g] = empty_name_address
-                if mj.geom_type[i_g] == mujoco.mjtGeom.mjGEOM_PLANE:
-                    # A negative link assignment keeps excluded source geoms out of the Genesis model.
-                    mj.geom_bodyid[i_g] = -1
 
             # Special treatment for URDF
             if is_urdf_file:
@@ -680,6 +661,7 @@ def parse_geoms(mj, scale, surface, xml_path):
     for i_g in range(mj.ngeom):
         if mj.geom_bodyid[i_g] < 0:
             continue
+
         # try parsing a given geometry
         g_info = parse_geom(mj, i_g, scale, surface, xml_path)
         if g_info is None:

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -217,7 +217,13 @@ def parse_xml(morph, surface):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
+    links_g_infos = parse_geoms(
+        mj,
+        morph.scale,
+        surface,
+        morph.file,
+        is_ground_plane_included=not isinstance(morph, gs.morphs.MJCF) or morph.is_ground_plane_included,
+    )
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -628,13 +634,19 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, scale, surface, xml_path):
+def parse_geoms(mj, scale, surface, xml_path, is_ground_plane_included):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
     is_any_col = False
     for i_g in range(mj.ngeom):
         if mj.geom_bodyid[i_g] < 0:
+            continue
+        if (
+            not is_ground_plane_included
+            and mj.geom_bodyid[i_g] == 0
+            and mj.geom_type[i_g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ):
             continue
 
         # try parsing a given geometry

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -66,8 +66,8 @@ def build_model(
     discard_visual,
     default_armature=None,
     merge_fixed_links=False,
+    exclude_ground_plane=False,
     links_to_keep=(),
-    is_ground_plane_included=True,
 ):
     if isinstance(xml, (str, Path, urdfpy.URDF)):
         if isinstance(xml, urdfpy.URDF):
@@ -114,7 +114,7 @@ def build_model(
         # Drop ground planes authored directly under the worldbody so a model that embeds its own floor can be
         # loaded into a scene that already provides a ground. Removing the source geoms before compilation leaves
         # planes authored under child bodies untouched, even when the compiler fuses them into the worldbody.
-        if not is_urdf_file and not is_ground_plane_included:
+        if not is_urdf_file and exclude_ground_plane:
             for worldbody in mjcf.findall("worldbody"):
                 for geom in tuple(worldbody.findall("geom")):
                     if geom.attrib.get("type") == "plane":
@@ -224,16 +224,15 @@ def parse_xml(morph, surface):
         merge_fixed_links = morph.merge_fixed_links
         links_to_keep = morph.links_to_keep
 
-    is_ground_plane_included = not isinstance(morph, gs.morphs.MJCF) or morph.is_ground_plane_included
-
     # Build model from XML (either URDF or MJCF)
+    exclude_ground_plane = isinstance(morph, gs.morphs.MJCF) and morph.exclude_ground_plane
     mj = build_model(
         morph.file,
         not morph.visualization,
         morph.default_armature,
         merge_fixed_links,
+        exclude_ground_plane,
         links_to_keep,
-        is_ground_plane_included,
     )
 
     # We have another more informative warning later so we suppress this one

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -34,15 +34,6 @@ def box_plan():
 
 
 @pytest.fixture(scope="session")
-def box_plan_with_static_plane(box_plan):
-    mjcf = ET.fromstring(ET.tostring(box_plan))
-    mjcf.insert(0, ET.Element("compiler", fusestatic="true"))
-    fixed_link = ET.SubElement(mjcf.find("worldbody"), "body", name="fixed_plane_link", pos="0 0 -1")
-    ET.SubElement(fixed_link, "geom", type="plane", name="fixed_plane", size="1 1 0.1")
-    return mjcf
-
-
-@pytest.fixture(scope="session")
 def mimic_hinges():
     mjcf = ET.Element("mujoco", model="mimic_hinges")
     ET.SubElement(mjcf, "compiler", angle="degree")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -34,6 +34,15 @@ def box_plan():
 
 
 @pytest.fixture(scope="session")
+def box_plan_with_static_plane(box_plan):
+    mjcf = ET.fromstring(ET.tostring(box_plan))
+    mjcf.insert(0, ET.Element("compiler", fusestatic="true"))
+    fixed_link = ET.SubElement(mjcf.find("worldbody"), "body", name="fixed_plane_link", pos="0 0 -1")
+    ET.SubElement(fixed_link, "geom", type="plane", name="fixed_plane", size="1 1 0.1")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def mimic_hinges():
     mjcf = ET.Element("mujoco", model="mimic_hinges")
     ET.SubElement(mjcf, "compiler", angle="degree")

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -58,32 +58,21 @@ def test_mjcf_parsing_with_include():
     assert_allclose(robot1.get_qpos(), robot3.get_qpos(), tol=gs.EPS)
 
 
-def test_ground_plane_inclusion(box_plan_with_static_plane):
-    mjcf = ET.tostring(box_plan_with_static_plane, encoding="unicode")
+@pytest.mark.required
+def test_ground_plane_inclusion(box_plan):
+    mjcf = ET.tostring(box_plan, encoding="unicode")
     scene = gs.Scene()
-    entity_with_ground = scene.add_entity(
-        morph=gs.morphs.MJCF(
-            file=mjcf,
-        ),
-        vis_mode="collision",
-    )
+    entity_with_ground = scene.add_entity(gs.morphs.MJCF(file=mjcf))
     entity_without_ground = scene.add_entity(
-        morph=gs.morphs.MJCF(
+        gs.morphs.MJCF(
             file=mjcf,
             is_ground_plane_included=False,
-        ),
-        vis_mode="collision",
+        )
     )
-    scene.build(n_envs=0)
+    scene.build()
 
-    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_with_ground.geoms), 2)
-    assert_equal(
-        sum(
-            geom.type == gs.GEOM_TYPE.PLANE and geom.metadata["name"] == "fixed_plane"
-            for geom in entity_without_ground.geoms
-        ),
-        1,
-    )
+    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_with_ground.geoms), 1)
+    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_without_ground.geoms), 0)
     assert_equal(sum(geom.type == gs.GEOM_TYPE.BOX for geom in entity_without_ground.geoms), 1)
 
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -58,6 +58,29 @@ def test_mjcf_parsing_with_include():
     assert_allclose(robot1.get_qpos(), robot3.get_qpos(), tol=gs.EPS)
 
 
+def test_ground_plane_inclusion(box_plan):
+    mjcf = ET.tostring(box_plan, encoding="unicode")
+    scene = gs.Scene()
+    entity_with_ground = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=mjcf,
+        ),
+        vis_mode="collision",
+    )
+    entity_without_ground = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=mjcf,
+            is_ground_plane_included=False,
+        ),
+        vis_mode="collision",
+    )
+    scene.build(n_envs=0)
+
+    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_with_ground.geoms), 1)
+    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_without_ground.geoms), 0)
+    assert_equal(sum(geom.type == gs.GEOM_TYPE.BOX for geom in entity_without_ground.geoms), 1)
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_urdf_parsing(show_viewer, tol):

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -59,14 +59,19 @@ def test_mjcf_parsing_with_include():
 
 
 @pytest.mark.required
-def test_ground_plane_inclusion(box_plan):
+def test_ground_plane_preservation(box_plan):
     mjcf = ET.tostring(box_plan, encoding="unicode")
+
     scene = gs.Scene()
-    entity_with_ground = scene.add_entity(gs.morphs.MJCF(file=mjcf))
+    entity_with_ground = scene.add_entity(
+        gs.morphs.MJCF(
+            file=mjcf,
+        )
+    )
     entity_without_ground = scene.add_entity(
         gs.morphs.MJCF(
             file=mjcf,
-            is_ground_plane_included=False,
+            exclude_ground_plane=True,
         )
     )
     scene.build()

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -58,8 +58,8 @@ def test_mjcf_parsing_with_include():
     assert_allclose(robot1.get_qpos(), robot3.get_qpos(), tol=gs.EPS)
 
 
-def test_ground_plane_inclusion(box_plan):
-    mjcf = ET.tostring(box_plan, encoding="unicode")
+def test_ground_plane_inclusion(box_plan_with_static_plane):
+    mjcf = ET.tostring(box_plan_with_static_plane, encoding="unicode")
     scene = gs.Scene()
     entity_with_ground = scene.add_entity(
         morph=gs.morphs.MJCF(
@@ -76,8 +76,14 @@ def test_ground_plane_inclusion(box_plan):
     )
     scene.build(n_envs=0)
 
-    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_with_ground.geoms), 1)
-    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_without_ground.geoms), 0)
+    assert_equal(sum(geom.type == gs.GEOM_TYPE.PLANE for geom in entity_with_ground.geoms), 2)
+    assert_equal(
+        sum(
+            geom.type == gs.GEOM_TYPE.PLANE and geom.metadata["name"] == "fixed_plane"
+            for geom in entity_without_ground.geoms
+        ),
+        1,
+    )
     assert_equal(sum(geom.type == gs.GEOM_TYPE.BOX for geom in entity_without_ground.geoms), 1)
 
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -66,6 +66,7 @@ def test_ground_plane_preservation(box_plan):
     entity_with_ground = scene.add_entity(
         gs.morphs.MJCF(
             file=mjcf,
+            exclude_ground_plane=False,
         )
     )
     entity_without_ground = scene.add_entity(


### PR DESCRIPTION
## Description

Adds an `exclude_ground_plane` option to `gs.morphs.MJCF`, defaulting to `False` so existing loading behavior is unchanged. When set to `True`, plane geometries authored directly under the MJCF worldbody are dropped when loading the entity.

The planes are removed from the source XML before compilation, so planes authored under child bodies are left untouched even when the compiler fuses them into the worldbody.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#2782

## Motivation and Context

Many MJCF models embed a ground plane in their worldbody. Loading such a model into a scene that already provides its own floor is awkward and produces overlapping-plane contact artifacts. This option lets the user drop the embedded plane without editing the source MJCF file.

## How Has This Been Tested?

`tests/rigid/test_asset_loading.py::test_ground_plane_preservation` loads a box-on-plane MJCF with and without `exclude_ground_plane`, asserting the worldbody plane is dropped only when the option is set while the box geom is preserved.

## Checklist

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
