### PR TITLE
[FEATURE] Add MJCF skip_root_plane option for worldbody floors

### DIFF
--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -991,12 +991,18 @@ class MJCF(FileMorph):
     default_armature : float, optional
         Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
         actuated. None to disable. Default to 0.1.
+    skip_root_plane : bool, optional
+        If True, skip plane geoms attached to the MJCF worldbody (body id 0) when loading the entity. Many MJCF robot
+        models ship with an embedded ground plane that is inconvenient when the scene already has its own floor, or
+        when the robot is placed so that its links would otherwise penetrate that plane. This is opt-in: planes that
+        are part of the MJCF file are kept by default. Defaults to False.
     """
 
     pos: Vec3FType | None = None
     quat: UnitVec4FType | None = None
     requires_jac_and_IK: StrictBool = True
     default_armature: float | None = Field(default=0.1, ge=0)
+    skip_root_plane: StrictBool = False
 
     @model_validator(mode="before")
     @classmethod

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -217,7 +217,13 @@ def parse_xml(morph, surface):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
+    links_g_infos = parse_geoms(
+        mj,
+        morph.scale,
+        surface,
+        morph.file,
+        skip_root_plane=getattr(morph, "skip_root_plane", False),
+    )
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -628,13 +634,22 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, scale, surface, xml_path):
+def parse_geoms(mj, scale, surface, xml_path, *, skip_root_plane=False):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
     is_any_col = False
     for i_g in range(mj.ngeom):
         if mj.geom_bodyid[i_g] < 0:
+            continue
+
+        # Opt-in: drop plane geoms on the MJCF worldbody so robot models that embed a floor can be loaded into a
+        # scene that already provides its own ground (or when the embedded plane would penetrate the robot).
+        if (
+            skip_root_plane
+            and mj.geom_bodyid[i_g] == 0
+            and mj.geom_type[i_g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ):
             continue
 
         # try parsing a given geometry

--- a/tests/core/test_misc.py
+++ b/tests/core/test_misc.py
@@ -237,6 +237,26 @@ def test_urdf_mjcf_names_from_file():
 
 
 @pytest.mark.required
+def test_mjcf_skip_root_plane():
+    # ant.xml embeds a worldbody floor plane. Default loading keeps it; skip_root_plane drops only that plane.
+    ant_file = "xml/ant.xml"
+
+    scene_default = gs.Scene(show_viewer=False)
+    ant_default = scene_default.add_entity(gs.morphs.MJCF(file=ant_file))
+    scene_default.build()
+    n_planes_default = sum(1 for geom in ant_default.geoms if geom.type == gs.GEOM_TYPE.PLANE)
+    assert n_planes_default >= 1
+
+    scene_skip = gs.Scene(show_viewer=False)
+    ant_skip = scene_skip.add_entity(gs.morphs.MJCF(file=ant_file, skip_root_plane=True))
+    scene_skip.build()
+    n_planes_skip = sum(1 for geom in ant_skip.geoms if geom.type == gs.GEOM_TYPE.PLANE)
+    assert n_planes_skip == n_planes_default - 1
+    # Non-plane geoms are preserved (visual/collision copies may inflate counts; compare plane drop only).
+    assert len(ant_skip.geoms) < len(ant_default.geoms)
+
+
+@pytest.mark.required
 def test_surface_shortcut_resolution():
     # Plastic family: color resolves to diffuse_texture; the Rough subclass roughness default (1.0) feeds
     # roughness_texture and default_roughness.


### PR DESCRIPTION
## Description
Adds an opt-in `skip_root_plane` flag on `gs.morphs.MJCF` that skips plane geoms attached to the MJCF worldbody (body id 0) when loading an entity.

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#2782

## Motivation and Context
Many MJCF robot models (e.g. `xml/ant.xml`) embed a ground plane in the worldbody. Loading them as a single entity into a scene that already has a floor, or placing the robot such that links penetrate that embedded plane, is awkward. Maintainer guidance on the issue was to keep MJCF planes by default and offer an explicit morph option rather than silently stripping them.

Default remains `False` so existing behavior is unchanged.

## How Has This Been / Can This Be Tested?
- Unit test `tests/core/test_misc.py::test_mjcf_skip_root_plane` loads `xml/ant.xml` with and without `skip_root_plane=True` and asserts exactly one fewer plane geom when the flag is set.
- Filter logic was also checked against MuJoCo's geom body/type arrays for ant.xml (one root plane at body id 0).

Example:

```python
import genesis as gs

scene = gs.Scene(show_viewer=False)
scene.add_entity(gs.morphs.Plane())
# drop ant's embedded floor so only the scene plane is used
ant = scene.add_entity(gs.morphs.MJCF(file="xml/ant.xml", skip_root_plane=True))
scene.build()
```

## Screenshots (if appropriate):

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.