### PR TITLE
[BUG FIX] Fix mass matrix for attached entities.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -805,9 +805,8 @@ class KinematicEntity(Entity):
             links_j_infos[0] = [j_info]
 
             # The base link is now moving, which merges every kinematic tree connected to it into a single tree rooted
-            # at it. Parser-provided root indices assume a base welded to the world (one tree per child of the base),
-            # so recompute them by propagating each parent's root: parents precede children in the depth-first link
-            # ordering, and links with no parent (free bodies) root their own tree.
+            # at it. Parser-provided root indices assume a base welded to the world, so recompute them by propagating
+            # each parent's root (parents precede children); links with no parent root their own tree.
             for i_l, l_info in enumerate(l_infos):
                 if "root_idx" in l_info:
                     parent_idx = l_info["parent_idx"]
@@ -1468,11 +1467,9 @@ class KinematicEntity(Entity):
                     "Attaching fixed-based entity to parent link requires setting Morph option 'batch_fixed_verts=True'."
                 )
 
-        # The merged kinematic tree must keep contiguous DOFs (the mass-matrix assemble/factor/solve process each block
-        # as one contiguous interval), so every DOF-carrying link numbered between the target tree's root and this
-        # entity must already belong to that tree. Each violation gets its own actionable error: the foreign tree either
-        # lives in the same file as the target tree's root (an extra tree declared after it - passive, or already
-        # extended across entities by an earlier attach) or belongs to entities created in between.
+        # The merged kinematic tree must keep contiguous DOFs (each mass block is processed as one interval), so every
+        # DOF-carrying link numbered between the target tree's root and this entity must already belong to that tree.
+        # Each violation cause gets its own actionable error.
         root_link = self._solver.links[parent_link.root_idx]
         for link in self._solver.links[root_link.idx + 1 : self.link_start]:
             if link.n_dofs == 0 or link.root_idx == root_link.idx:
@@ -1534,10 +1531,9 @@ class KinematicEntity(Entity):
         # Overwrite parent link
         base_link._parent_idx = parent_link.idx
 
-        # Re-root the whole tree hanging from this entity's base link into the parent's tree - scene-wide, because
-        # entities previously attached into this one already share its root and must follow it (chained attaches may run
-        # in any order). This entity's links belonging to other trees (e.g. free bodies declared in the same file) keep
-        # their own root. The fixed flag and invweight follow the new root for every re-rooted link.
+        # Re-root the whole tree hanging from this entity's base link - scene-wide, because entities previously
+        # attached into this one already share its root and must follow it (chained attaches may run in any order);
+        # links of other trees declared in the same file keep their own root, as do the fixed flag and invweight.
         for link in self._solver.links:
             if link.root_idx == base_link.idx:
                 link._root_idx = parent_link.root_idx

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1435,10 +1435,9 @@ class KinematicEntity(Entity):
         Merge two entities to act as single one, by attaching the base link of this entity as a child of a given link of
         another entity.
 
-        The merged pair is simulated as one kinematic tree, so its dynamics cost scales with the range of degrees of
-        freedom spanning both entities, including any entity created in between. Instantiating attached entities
-        consecutively keeps that range tight; entities in between are still simulated correctly but inflate the cost
-        of the merged pair.
+        The merged pair is simulated as one kinematic tree, whose degrees of freedom must form one contiguous range.
+        This method enforces it: instantiate attached entities consecutively, attach onto the last kinematic tree of a
+        multi-tree parent, and attach all children of an entity onto the same tree.
 
         Parameters
         ----------
@@ -1468,6 +1467,36 @@ class KinematicEntity(Entity):
                 gs.raise_exception(
                     "Attaching fixed-based entity to parent link requires setting Morph option 'batch_fixed_verts=True'."
                 )
+
+        # The merged kinematic tree must keep contiguous DOFs (the mass-matrix assemble/factor/solve process each block
+        # as one contiguous interval), so every DOF-carrying link numbered between the target tree's root and this
+        # entity must already belong to that tree. Each violation gets its own actionable error: the foreign tree either
+        # lives in the same file as the target tree's root (an extra tree declared after it - passive, or already
+        # extended across entities by an earlier attach) or belongs to entities created in between.
+        root_link = self._solver.links[parent_link.root_idx]
+        for link in self._solver.links[root_link.idx + 1 : self.link_start]:
+            if link.n_dofs == 0 or link.root_idx == root_link.idx:
+                continue
+            foreign_root_link = self._solver.links[link.root_idx]
+            if foreign_root_link.entity is root_link.entity:
+                is_foreign_tree_merged = any(
+                    other_link.root_idx == link.root_idx and other_link.entity is not foreign_root_link.entity
+                    for other_link in self._solver.links[link.root_idx :]
+                )
+                if is_foreign_tree_merged:
+                    gs.raise_exception(
+                        "Attaching entities onto different kinematic trees of the same parent entity is not "
+                        "supported. Load the parent's trees as separate entities."
+                    )
+                gs.raise_exception(
+                    "Attaching an entity onto a kinematic tree that is not the last one declared in its file is not "
+                    "supported. Declare the attached-onto tree last, or load the file's other trees as separate "
+                    "entities."
+                )
+            gs.raise_exception(
+                "Creating entities between attached entities is not supported. Instantiate attached entities "
+                "consecutively."
+            )
 
         # Remove all root joints if necessary.
         # The requires shifting joint and dof indices of all subsequent entities.
@@ -1506,9 +1535,9 @@ class KinematicEntity(Entity):
         base_link._parent_idx = parent_link.idx
 
         # Re-root the whole tree hanging from this entity's base link into the parent's tree - scene-wide, because
-        # entities previously attached into this one already share its root and must follow it (chained attaches may
-        # run in any order). This entity's links belonging to other trees (e.g. free bodies declared in the same file)
-        # keep their own root. The fixed flag and invweight follow the new root for every re-rooted link.
+        # entities previously attached into this one already share its root and must follow it (chained attaches may run
+        # in any order). This entity's links belonging to other trees (e.g. free bodies declared in the same file) keep
+        # their own root. The fixed flag and invweight follow the new root for every re-rooted link.
         for link in self._solver.links:
             if link.root_idx == base_link.idx:
                 link._root_idx = parent_link.root_idx

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -804,11 +804,14 @@ class KinematicEntity(Entity):
             j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (6, 1))
             links_j_infos[0] = [j_info]
 
-            # Shift root idx for all child links and replace root if no longer fixed wrt world
-            for i_l in range(len(l_infos)):
-                l_info = l_infos[i_l]
-                if "root_idx" in l_info and l_info["root_idx"] in (1, i_l):
-                    l_info["root_idx"] = 0
+            # The base link is now moving, which merges every kinematic tree connected to it into a single tree rooted
+            # at it. Parser-provided root indices assume a base welded to the world (one tree per child of the base),
+            # so recompute them by propagating each parent's root: parents precede children in the depth-first link
+            # ordering, and links with no parent (free bodies) root their own tree.
+            for i_l, l_info in enumerate(l_infos):
+                if "root_idx" in l_info:
+                    parent_idx = l_info["parent_idx"]
+                    l_info["root_idx"] = l_infos[parent_idx]["root_idx"] if parent_idx != -1 else i_l
 
             # Must invalidate invweight for all child links and joints because the root joint was fixed when it was
             # initially computed. Re-initialize it to some strictly negative value to trigger recomputation in solver.

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1435,6 +1435,11 @@ class KinematicEntity(Entity):
         Merge two entities to act as single one, by attaching the base link of this entity as a child of a given link of
         another entity.
 
+        The merged pair is simulated as one kinematic tree, so its dynamics cost scales with the range of degrees of
+        freedom spanning both entities, including any entity created in between. Instantiating attached entities
+        consecutively keeps that range tight; entities in between are still simulated correctly but inflate the cost
+        of the merged pair.
+
         Parameters
         ----------
         parent_entity : genesis.Entity
@@ -1500,20 +1505,15 @@ class KinematicEntity(Entity):
         # Overwrite parent link
         base_link._parent_idx = parent_link.idx
 
-        for link in self.links:
-            # Break as soon as the root idx is -1, because the following links correspond to a different kinematic tree
-            if link.root_idx == -1:
-                break
-
-            # Override root idx for child links
-            assert link.root_idx == base_link.idx
-            link._root_idx = parent_link.root_idx
-
-            # Update fixed link flag
-            link._is_fixed &= parent_link.is_fixed
-
-            # Must invalidate invweight for all child links and joints
-            link._invweight = None
+        # Re-root the whole tree hanging from this entity's base link into the parent's tree - scene-wide, because
+        # entities previously attached into this one already share its root and must follow it (chained attaches may
+        # run in any order). This entity's links belonging to other trees (e.g. free bodies declared in the same file)
+        # keep their own root. The fixed flag and invweight follow the new root for every re-rooted link.
+        for link in self._solver.links:
+            if link.root_idx == base_link.idx:
+                link._root_idx = parent_link.root_idx
+                link._is_fixed &= parent_link.is_fixed
+                link._invweight = None
 
         self._is_attached = True
 

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -468,7 +468,14 @@ def func_compute_mass_matrix(
                         else i_0
                     )
 
-                    for i_d in range(entities_info.dof_start[i_e], entities_info.dof_end[i_e]):
+                    # Assemble each mass block rooted in this entity over its full range (see
+                    # entities_mass_block_dof_start in array_class.py): the mirror pass reads rows of the whole block,
+                    # so the block-root entity must write them all itself - mirroring per entity would copy a merged
+                    # child's rows before the child's own iteration has written them, leaving the cross-entity
+                    # couplings one recompute stale.
+                    blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
+                    blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
+                    for i_d in range(blocks_dof_start, blocks_dof_end):
                         for j_d in range(
                             rigid_global_info.dofs_mass_block_start[i_d], rigid_global_info.dofs_mass_block_end[i_d]
                         ):
@@ -477,7 +484,7 @@ def func_compute_mass_matrix(
                                 + dofs_state.f_vel[i_d, i_b].dot(dofs_state.cdof_vel[j_d, i_b])
                             ) * rigid_global_info.mass_parent_mask[i_d, j_d]
 
-                    for i_d in range(entities_info.dof_start[i_e], entities_info.dof_end[i_e]):
+                    for i_d in range(blocks_dof_start, blocks_dof_end):
                         for j_d in range(i_d + 1, rigid_global_info.dofs_mass_block_end[i_d]):
                             rigid_global_info.mass_mat[i_d, j_d, i_b] = rigid_global_info.mass_mat[j_d, i_d, i_b]
 

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -317,17 +317,10 @@ def func_compute_mass_matrix(
                 links_state.crb_quat[i_l, i_b] = links_state.cinr_quat[i_l, i_b]
                 links_state.crb_mass[i_l, i_b] = links_state.cinr_mass[i_l, i_b]
 
-    # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each tree
-    # is reduced by one thread rooted at its root link (root_idx == itself), over its precomputed link span [i_l_root,
-    # links_tree_end[i_l_root]), iterated high-index-to-low so a child folds into its parent before the parent
-    # propagates further. attach() can interleave other trees' links inside the span (only 0-DOF entities; see
-    # links_tree_end in array_class.py), so each link is gated on the thread's root: interleaved links are folded by
-    # their own tree's thread, race-free since the threads touch disjoint links. A tree spans merged entities (a merged
-    # child's links share the parent tree's root_idx; see attach) and, conversely, a single entity holding several free
-    # bodies (e.g. dominos) splits into one tree per body - so this exposes far more parallelism than the per-entity
-    # fold on multi-tree entities. A tree's top link may fold into a fixed (0-DOF) anchor of another tree (e.g. a world
-    # link); that anchor carries no DOF so its crb is unused, making the cross-tree write harmless even if several trees
-    # share it. Mirrors the root_idx tree walk in func_update_cartesian_space.
+    # crb: composite-rigid-body inertia, folded leaf-to-root, one thread per kinematic tree (root_idx == itself) over
+    # its link span in descending order so children fold before their parent propagates, gating each link on the
+    # thread's root (see links_tree_end in array_class.py). A tree's top link may fold into a fixed 0-DOF anchor of
+    # another tree, whose crb is unused. Mirrors the root_idx tree walk in func_update_cartesian_space.
     qd.loop_config(name="crb", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_0, i_b in (
         qd.ndrange(1, links_state.pos.shape[1])
@@ -414,11 +407,9 @@ def func_compute_mass_matrix(
             i_e = i_eb % n_entities
             i_b = i_eb // n_entities
 
-            # Assemble each mass block whose root DOF lies in this entity, over its full [block_start, block_end) lower
-            # triangle. When two entities are merged (see attach) the child's DOFs belong to a block rooted in the
-            # parent, so the parent assembles the whole coupled block (its columns extend past the entity into the
-            # child) and the child assembles nothing; iterating only the entity's own DOF range would drop the
-            # parent-child coupling. mass_parent_mask zeroes the within-block ancestor gaps.
+            # Assemble each mass block whose root DOF lies in this entity over its full lower triangle: a merged child
+            # owns no root and assembles nothing, while the parent assembles the whole coupled block (its columns
+            # extend past the entity). mass_parent_mask zeroes the within-block ancestor gaps.
             entity_dof_start = entities_info.dof_start[i_e]
             entity_dof_end = entities_info.dof_end[i_e]
             block_start = entity_dof_start
@@ -429,10 +420,9 @@ def func_compute_mass_matrix(
                     n_lower_tri = n_block_dofs * (n_block_dofs + 1) // 2
                     i_pair = tid
                     while i_pair < n_lower_tri:
-                        # Compressed lower-tri-inclusive index (matches tiled func_factor_mass): i_pair = i_d_ * (i_d_ +
-                        # 1) / 2 + j_d_, with j_d_ in [0, i_d_]. The fast-math-robust inversion is required here: a raw
-                        # sqrt drops the j=0 entry of every perfect-square row on GPU, leaving M missing long-range
-                        # coupling -> indefinite.
+                        # Compressed lower-tri-inclusive index: i_pair = i_d_ * (i_d_ + 1) / 2 + j_d_, with j_d_ in
+                        # [0, i_d_]. The fast-math-robust inversion is required: a raw sqrt drops the j=0 entry of
+                        # every perfect-square row on GPU, leaving M indefinite.
                         i_d_, j_d_ = linear_to_lower_tri(i_pair)
                         i_d = block_start + i_d_
                         j_d = block_start + j_d_
@@ -470,9 +460,7 @@ def func_compute_mass_matrix(
 
                     # Assemble each mass block rooted in this entity over its full range (see
                     # entities_mass_block_dof_start in array_class.py): the mirror pass reads rows of the whole block,
-                    # so the block-root entity must write them all itself - mirroring per entity would copy a merged
-                    # child's rows before the child's own iteration has written them, leaving the cross-entity
-                    # couplings one recompute stale.
+                    # so the block-root entity must write them all itself before mirroring.
                     blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
                     blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
                     for i_d in range(blocks_dof_start, blocks_dof_end):
@@ -566,12 +554,9 @@ def func_factor_mass_tiled(
         if not rigid_global_info.mass_mat_mask[i_e, i_b]:
             continue
 
-        # Factor each mass block whose root DOF lies in this entity, over its full [block_start, block_end) range. A
-        # single-block entity (the common case) has one block spanning it; a multi-block entity has several. When two
-        # entities are merged (see attach) the child's DOFs belong to a block rooted in the parent, so the child owns
-        # no root and factors nothing while the parent factors the whole coupled block (whose range extends past the
-        # entity). Each block owns its own scratch region [block_start, block_end); distinct blocks (across entities
-        # too) are disjoint, so the scatter stays race-free.
+        # Factor each mass block whose root DOF lies in this entity over its full range: a merged child owns no root
+        # and factors nothing, while the parent factors the whole coupled block. Each block owns its own scratch
+        # region [block_start, block_end), disjoint across entities too, so the scatter stays race-free.
         entity_dof_start = entities_info.dof_start[i_e]
         entity_dof_end = entities_info.dof_end[i_e]
         block_start = entity_dof_start
@@ -731,10 +716,8 @@ def func_factor_mass(
 
                     pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK,), gs.qd_float)
 
-                    # Factor each mass block rooted in this entity in-place in global memory over its full
-                    # [block_start, block_end) range, block-relative so shared indices are >= 0. When two entities are
-                    # merged (see attach) the child's DOFs belong to a block rooted in the parent; the child owns no
-                    # root and factors nothing while the parent factors the whole coupled block.
+                    # Factor each mass block rooted in this entity in-place in global memory over its full range,
+                    # block-relative so shared indices stay >= 0; a merged child owns no root and factors nothing.
                     block_start = entity_dof_start
                     while block_start < entity_dof_end:
                         block_end = rigid_global_info.dofs_mass_block_end[block_start]
@@ -815,11 +798,8 @@ def func_factor_mass(
                     i_e = rigid_global_info.awake_entities[i_slot, i_b]
                 if rigid_global_info.mass_mat_mask[i_e, i_b]:
                     # Factor each mass block rooted in this entity, iterated flat over the rooted range with per-DOF
-                    # block bounds (see entities_mass_block_dof_start in array_class.py): each elimination step only
-                    # touches rows of its own block, so interleaving independent blocks in one descending scan is exact.
-                    # When two entities are merged (see attach) the child owns no root and factors nothing; the parent
-                    # factors the whole coupled block. Blocks are disjoint per root, so distinct entities never write
-                    # the same rows.
+                    # block bounds (see entities_mass_block_dof_start in array_class.py): elimination never leaves a
+                    # block, so interleaving independent blocks in one descending scan is exact.
                     blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
                     blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
                     for i_d in range(blocks_dof_start, blocks_dof_end):
@@ -881,11 +861,9 @@ def func_factor_mass(
 
                     mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK, MAX_DOFS_PER_BLOCK + 1), gs.qd_float)
 
-                    # Factor each mass block rooted in this entity in shared memory, indexed block-relative so shared
-                    # indices are always >= 0. When two entities are merged (see attach) the child's DOFs belong to a
-                    # block rooted in the parent; using entity_dof_start as the origin would make the child's
-                    # block-local indices negative. The child entity owns no root and factors nothing; the parent
-                    # factors the whole coupled block, whose range extends past entity_dof_end.
+                    # Factor each mass block rooted in this entity in shared memory, indexed block-relative so
+                    # shared indices stay >= 0 (a merged child's block starts before its entity); the child owns no
+                    # root and factors nothing, while the parent factors the whole coupled block.
                     block_start = entity_dof_start
                     while block_start < entity_dof_end:
                         block_end = rigid_global_info.dofs_mass_block_end[block_start]
@@ -967,10 +945,8 @@ def func_factor_mass(
             if rigid_global_info.mass_mat_mask[i_e, i_b]:
                 EPS = rigid_global_info.EPS[None]
 
-                # Factor each mass block rooted in this entity, iterated flat over the rooted range with per-DOF block
-                # bounds (see entities_mass_block_dof_start in array_class.py and the forward scalar arm); the
-                # per-block index reversal this AD-safe factor uses maps each block onto itself, so the perturbed
-                # indices stay within the DOF's own block.
+                # Factor each mass block rooted in this entity, iterated flat like the forward scalar arm; the
+                # per-block index reversal this AD-safe factor uses maps each block onto itself.
                 blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
                 blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
                 for i_d in range(blocks_dof_start, blocks_dof_end):
@@ -1052,10 +1028,8 @@ def func_solve_mass_entity(
 
     if rigid_global_info.mass_mat_mask[i_e, i_b]:
         # Solve M x = y for each mass block rooted in this entity, iterated flat over the rooted range with per-DOF
-        # block bounds (see entities_mass_block_dof_start in array_class.py); the triangular substitutions never cross
-        # block boundaries, so interleaving independent blocks in one scan is exact. When two entities are merged (see
-        # attach) the child owns no root and solves nothing; the parent solves the whole coupled block, as splitting the
-        # substitutions at the entity boundary would break them.
+        # block bounds (see entities_mass_block_dof_start in array_class.py); the substitutions never cross block
+        # boundaries, and a merged child owns no root and solves nothing.
         blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
         blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
 
@@ -1865,9 +1839,8 @@ def func_implicit_damping(
         qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
         for i_e, i_b in qd.ndrange(n_entities, _B):
             # Set the mask over the mass blocks ROOTED in this entity (see entities_mass_block_dof_start in
-            # array_class.py). The block-root entity factors the whole coupled block (which for a merged pair extends
-            # into the child), so the refactor must be triggered by damping/act_bias anywhere in that range - including
-            # a merged child whose own DOFs live in a later entity.
+            # array_class.py): the block-root entity factors the whole coupled block, so damping/act_bias anywhere in
+            # it - including a merged child - must trigger the refactor.
             blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
             blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
             for i_d in range(blocks_dof_start, blocks_dof_end):

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -317,16 +317,16 @@ def func_compute_mass_matrix(
                 links_state.crb_quat[i_l, i_b] = links_state.cinr_quat[i_l, i_b]
                 links_state.crb_mass[i_l, i_b] = links_state.cinr_mass[i_l, i_b]
 
-    # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each
-    # tree is reduced by one thread rooted at its root link (root_idx == itself), over its precomputed link span
-    # [i_l_root, links_tree_end[i_l_root]), iterated high-index-to-low so a child folds into its parent before the
-    # parent propagates further. attach() can interleave other trees' links inside the span (see links_tree_end in
-    # array_class.py), so each link is gated on the thread's root: interleaved links are folded by their own tree's
-    # thread, race-free since the threads touch disjoint links. A tree spans merged entities (a merged child's links
-    # share the parent tree's root_idx; see attach) and, conversely, a single entity holding several free bodies (e.g.
-    # dominos) splits into one tree per body - so this exposes far more parallelism than the per-entity fold on
-    # multi-tree entities. A tree's top link may fold into a fixed (0-DOF) anchor of another tree (e.g. a world link);
-    # that anchor carries no DOF so its crb is unused, making the cross-tree write harmless even if several trees
+    # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each tree
+    # is reduced by one thread rooted at its root link (root_idx == itself), over its precomputed link span [i_l_root,
+    # links_tree_end[i_l_root]), iterated high-index-to-low so a child folds into its parent before the parent
+    # propagates further. attach() can interleave other trees' links inside the span (only 0-DOF entities; see
+    # links_tree_end in array_class.py), so each link is gated on the thread's root: interleaved links are folded by
+    # their own tree's thread, race-free since the threads touch disjoint links. A tree spans merged entities (a merged
+    # child's links share the parent tree's root_idx; see attach) and, conversely, a single entity holding several free
+    # bodies (e.g. dominos) splits into one tree per body - so this exposes far more parallelism than the per-entity
+    # fold on multi-tree entities. A tree's top link may fold into a fixed (0-DOF) anchor of another tree (e.g. a world
+    # link); that anchor carries no DOF so its crb is unused, making the cross-tree write harmless even if several trees
     # share it. Mirrors the root_idx tree walk in func_update_cartesian_space.
     qd.loop_config(name="crb", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_0, i_b in (
@@ -414,9 +414,9 @@ def func_compute_mass_matrix(
             i_e = i_eb % n_entities
             i_b = i_eb // n_entities
 
-            # Assemble each mass block whose root DOF lies in this entity, over its full [block_start, block_end)
-            # lower triangle. When two entities are merged (see attach) the child's DOFs belong to a block rooted in
-            # the parent, so the parent assembles the whole coupled block (its columns extend past the entity into the
+            # Assemble each mass block whose root DOF lies in this entity, over its full [block_start, block_end) lower
+            # triangle. When two entities are merged (see attach) the child's DOFs belong to a block rooted in the
+            # parent, so the parent assembles the whole coupled block (its columns extend past the entity into the
             # child) and the child assembles nothing; iterating only the entity's own DOF range would drop the
             # parent-child coupling. mass_parent_mask zeroes the within-block ancestor gaps.
             entity_dof_start = entities_info.dof_start[i_e]
@@ -742,8 +742,8 @@ def func_factor_mass(
                             n_block_dofs = block_end - block_start
 
                             # Copy the block's lower triangle into mass_mat_L (+ implicit damping on the diagonal),
-                            # cooperatively. Restricting to the block makes the factorization cost the sum of
-                            # per-block cubes instead of the whole (possibly multi-block) entity cube.
+                            # cooperatively. Restricting to the block makes the factorization cost the sum of per-block
+                            # cubes instead of the whole (possibly multi-block) entity cube.
                             i_d_ = tid
                             while i_d_ < n_block_dofs:
                                 i_d = block_start + i_d_
@@ -816,10 +816,10 @@ def func_factor_mass(
                 if rigid_global_info.mass_mat_mask[i_e, i_b]:
                     # Factor each mass block rooted in this entity, iterated flat over the rooted range with per-DOF
                     # block bounds (see entities_mass_block_dof_start in array_class.py): each elimination step only
-                    # touches rows of its own block, so interleaving independent blocks in one descending scan is
-                    # exact. When two entities are merged (see attach) the child owns no root and factors nothing; the
-                    # parent factors the whole coupled block. Blocks are disjoint per root, so distinct entities never
-                    # write the same rows.
+                    # touches rows of its own block, so interleaving independent blocks in one descending scan is exact.
+                    # When two entities are merged (see attach) the child owns no root and factors nothing; the parent
+                    # factors the whole coupled block. Blocks are disjoint per root, so distinct entities never write
+                    # the same rows.
                     blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
                     blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
                     for i_d in range(blocks_dof_start, blocks_dof_end):
@@ -995,8 +995,8 @@ def func_factor_mass(
                                     -dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None],
                                 )
 
-                # Cholesky-Banachiewicz algorithm (in the perturbed indices), access pattern is safe for
-                # autodiff https://en.wikipedia.org/wiki/Cholesky_decomposition
+                # Cholesky-Banachiewicz algorithm (in the perturbed indices), access pattern is safe for autodiff
+                # https://en.wikipedia.org/wiki/Cholesky_decomposition
                 for i_pr in range(blocks_dof_start, blocks_dof_end):
                     block_start = rigid_global_info.dofs_mass_block_start[i_pr]
                     for j_pr in range(block_start, i_pr + 1):
@@ -1054,8 +1054,8 @@ def func_solve_mass_entity(
         # Solve M x = y for each mass block rooted in this entity, iterated flat over the rooted range with per-DOF
         # block bounds (see entities_mass_block_dof_start in array_class.py); the triangular substitutions never cross
         # block boundaries, so interleaving independent blocks in one scan is exact. When two entities are merged (see
-        # attach) the child owns no root and solves nothing; the parent solves the whole coupled block, as splitting
-        # the substitutions at the entity boundary would break them.
+        # attach) the child owns no root and solves nothing; the parent solves the whole coupled block, as splitting the
+        # substitutions at the entity boundary would break them.
         blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
         blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
 

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -317,15 +317,17 @@ def func_compute_mass_matrix(
                 links_state.crb_quat[i_l, i_b] = links_state.cinr_quat[i_l, i_b]
                 links_state.crb_mass[i_l, i_b] = links_state.cinr_mass[i_l, i_b]
 
-    # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each tree
-    # is reduced by one thread rooted at its root link (root_idx == itself), over its precomputed contiguous link run
-    # [i_l_root, links_tree_end[i_l_root]), iterated high-index-to-low so a child folds into its parent before
-    # the parent propagates further. A tree spans merged entities (a merged child's links share the parent tree's
-    # root_idx; see attach) and, conversely, a single entity holding several free bodies (e.g. dominos) splits into one
-    # tree per body - so this exposes far more parallelism than the per-entity fold on multi-tree entities. A tree's
-    # top link may fold into a fixed (0-DOF) anchor of another tree (e.g. a world link); that anchor carries no DOF so
-    # its crb is unused, making the cross-tree write harmless even if several trees share it. Mirrors the root_idx tree
-    # walk in func_update_cartesian_space.
+    # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each
+    # tree is reduced by one thread rooted at its root link (root_idx == itself), over its precomputed link span
+    # [i_l_root, links_tree_end[i_l_root]), iterated high-index-to-low so a child folds into its parent before the
+    # parent propagates further. attach() can interleave other trees' links inside the span (see links_tree_end in
+    # array_class.py), so each link is gated on the thread's root: interleaved links are folded by their own tree's
+    # thread, race-free since the threads touch disjoint links. A tree spans merged entities (a merged child's links
+    # share the parent tree's root_idx; see attach) and, conversely, a single entity holding several free bodies (e.g.
+    # dominos) splits into one tree per body - so this exposes far more parallelism than the per-entity fold on
+    # multi-tree entities. A tree's top link may fold into a fixed (0-DOF) anchor of another tree (e.g. a world link);
+    # that anchor carries no DOF so its crb is unused, making the cross-tree write harmless even if several trees
+    # share it. Mirrors the root_idx tree walk in func_update_cartesian_space.
     qd.loop_config(name="crb", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_0, i_b in (
         qd.ndrange(1, links_state.pos.shape[1])
@@ -354,7 +356,7 @@ def func_compute_mass_matrix(
                         i_p = links_info.parent_idx[I_l]
                         I_p = [i_p, i_b]
 
-                        if i_p != -1:
+                        if links_info.root_idx[I_l] == i_l_root and i_p != -1:
                             func_add_safe_backward(
                                 links_state.crb_inertial, I_p, links_state.crb_inertial[i_l, i_b], BW
                             )
@@ -700,7 +702,7 @@ def func_factor_mass(
             # trailing submatrix, so the parallel per-row updates only READ the pivot row (from shared) -- race-free
             # regardless of scheduling. Numerically identical to the scalar branch below; only parallelization differs.
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_TREE = qd.static(static_rigid_sim_config.tiled_n_dofs_per_tree)
+            MAX_DOFS_PER_BLOCK = qd.static(static_rigid_sim_config.tiled_n_dofs_per_block)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
             for i in range(n_entities * _B * BLOCK_DIM):
@@ -720,7 +722,7 @@ def func_factor_mass(
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
 
-                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_TREE,), gs.qd_float)
+                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK,), gs.qd_float)
 
                     # Factor each mass block rooted in this entity in-place in global memory over its full
                     # [block_start, block_end) range, block-relative so shared indices are >= 0. When two entities are
@@ -849,7 +851,7 @@ def func_factor_mass(
                         rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
         else:
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_TREE = qd.static(static_rigid_sim_config.tiled_n_dofs_per_tree)
+            MAX_DOFS_PER_BLOCK = qd.static(static_rigid_sim_config.tiled_n_dofs_per_block)
             WARP_SIZE = qd.static(32)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
@@ -870,7 +872,7 @@ def func_factor_mass(
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
 
-                    mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_TREE, MAX_DOFS_PER_TREE + 1), gs.qd_float)
+                    mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK, MAX_DOFS_PER_BLOCK + 1), gs.qd_float)
 
                     # Factor each mass block rooted in this entity in shared memory, indexed block-relative so shared
                     # indices are always >= 0. When two entities are merged (see attach) the child's DOFs belong to a

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -28,7 +28,7 @@ from .misc import (
 
 # Block size (warp width) for the cooperative mass_mat_assemble path. Used only when
 # enable_cooperative_constraint_kernels=True (and not use_hibernation). One warp per (entity, env); lanes stride i_d_
-# within the entity dof block to coalesce the flipped mass_mat writes.
+# within the entity dof range to coalesce the flipped mass_mat writes.
 _MASS_MAT_BLOCK = 32
 
 
@@ -318,13 +318,14 @@ def func_compute_mass_matrix(
                 links_state.crb_mass[i_l, i_b] = links_state.cinr_mass[i_l, i_b]
 
     # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each tree
-    # is reduced by one thread rooted at its root link (root_idx == itself), over the contiguous run of links sharing
-    # that root_idx, iterated high-index-to-low so a child folds into its parent before the parent propagates further. A
-    # tree spans merged entities (a merged child's links share the parent tree's root_idx; see attach) and, conversely,
-    # a single entity holding several free bodies (e.g. dominos) splits into one tree per body - so this exposes far more
-    # parallelism than the per-entity fold on multi-tree entities. A tree's top link may fold into a fixed (0-DOF) anchor
-    # of another tree (e.g. a world link); that anchor carries no DOF so its crb is unused, making the cross-tree write
-    # harmless even if several trees share it. Mirrors the root_idx tree walk in func_update_cartesian_space.
+    # is reduced by one thread rooted at its root link (root_idx == itself), over its precomputed contiguous link run
+    # [i_l_root, links_tree_end[i_l_root]), iterated high-index-to-low so a child folds into its parent before
+    # the parent propagates further. A tree spans merged entities (a merged child's links share the parent tree's
+    # root_idx; see attach) and, conversely, a single entity holding several free bodies (e.g. dominos) splits into one
+    # tree per body - so this exposes far more parallelism than the per-entity fold on multi-tree entities. A tree's
+    # top link may fold into a fixed (0-DOF) anchor of another tree (e.g. a world link); that anchor carries no DOF so
+    # its crb is unused, making the cross-tree write harmless even if several trees share it. Mirrors the root_idx tree
+    # walk in func_update_cartesian_space.
     qd.loop_config(name="crb", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_0, i_b in (
         qd.ndrange(1, links_state.pos.shape[1])
@@ -346,14 +347,7 @@ def func_compute_mass_matrix(
                 )
                 I_l_root = [i_l_root, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l_root
                 if links_info.root_idx[I_l_root] == i_l_root:
-                    n_links_total = links_state.pos.shape[0]
-                    tree_end = i_l_root + 1
-                    while tree_end < n_links_total:
-                        I_l_next = [tree_end, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else tree_end
-                        if links_info.root_idx[I_l_next] != i_l_root:
-                            break
-                        tree_end = tree_end + 1
-
+                    tree_end = rigid_global_info.links_tree_end[i_l_root]
                     for k in range(tree_end - i_l_root):
                         i_l = tree_end - 1 - k
                         I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
@@ -418,19 +412,19 @@ def func_compute_mass_matrix(
             i_e = i_eb % n_entities
             i_b = i_eb // n_entities
 
-            # Assemble each mass block (kinematic tree) whose root DOF lies in this entity, over its full
-            # [block_start, block_end) lower triangle. When two entities are merged (see attach) the child's DOFs
-            # belong to a block rooted in the parent, so the parent assembles the whole coupled block (its columns
-            # extend past the entity into the child) and the child assembles nothing; iterating only the entity's own
-            # DOF range would drop the parent-child coupling. mass_parent_mask zeroes the within-block ancestor gaps.
+            # Assemble each mass block whose root DOF lies in this entity, over its full [block_start, block_end)
+            # lower triangle. When two entities are merged (see attach) the child's DOFs belong to a block rooted in
+            # the parent, so the parent assembles the whole coupled block (its columns extend past the entity into the
+            # child) and the child assembles nothing; iterating only the entity's own DOF range would drop the
+            # parent-child coupling. mass_parent_mask zeroes the within-block ancestor gaps.
             entity_dof_start = entities_info.dof_start[i_e]
             entity_dof_end = entities_info.dof_end[i_e]
             block_start = entity_dof_start
             while block_start < entity_dof_end:
                 block_end = rigid_global_info.dofs_mass_block_end[block_start]
                 if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                    n_blk = block_end - block_start
-                    n_lower_tri = n_blk * (n_blk + 1) // 2
+                    n_block_dofs = block_end - block_start
+                    n_lower_tri = n_block_dofs * (n_block_dofs + 1) // 2
                     i_pair = tid
                     while i_pair < n_lower_tri:
                         # Compressed lower-tri-inclusive index (matches tiled func_factor_mass): i_pair = i_d_ * (i_d_ +
@@ -520,24 +514,25 @@ def func_factor_mass_tiled(
     """Register-streaming tiled per-entity mass factor for the >shared-cap branch (GPU forward only).
 
     Replaces the shared-pivot cooperative LDL^T when an entity's mass submatrix exceeds GPU shared memory. M is
-    block-diagonal per kinematic tree, so one warp of T lanes factors each of the entity's mass blocks independently
-    (a single-tree entity has just one block spanning it) via the same qd.simt.TileNxN blocked Cholesky as the
-    constraint Hessian.
+    block-diagonal per mass block (see dofs_mass_block_start in array_class.py), so one warp of T lanes factors each
+    of the entity's blocks independently (a single-block entity has just one block spanning it) via the same
+    qd.simt.TileNxN blocked Cholesky as the constraint Hessian.
 
     func_solve_mass consumes the LTDL form M = L^T D L (L unit-lower), produced by eliminating DOFs last-to-first, not
     the standard L D L^T. The tile primitive does forward Cholesky M = G G^T, so each block's reverse-indexed matrix
-    M_rev[a, b] = M[n-1-a, n-1-b] (n the block size) is factored and its factor mapped back to the block's LTDL factor:
+    M_rev[a, b] = M[n-1-a, n-1-b] (n the block's DOF count) is factored and its factor mapped back to the block's LTDL
+    factor:
       L[i,j] = G_rev[n-1-j, n-1-i] / G_rev[n-1-i, n-1-i]  (i > j),  D_inv[i] = 1 / G_rev[n-1-i, n-1-i]^2,  diag(L) = 1.
 
     The qd.simt tile ops are batch-first while mass_mat_L is canonical batch-last (n_dofs, n_dofs, _B), so the
-    factorization runs in each mass block's region of the batch-first scratch
+    factorization runs in each block's region of the batch-first scratch
     rigid_global_info.mass_mat_tiled_scratch and is scattered into mass_mat_L / mass_mat_D_inv. To avoid a dedicated
     allocation, that scratch aliases the constraint Hessian buffer nt_H (same shape, and free at mass-factor time since
     the constraint solve only populates it later in the step); see get_constraint_state. The scratch and mass_mat_L are
     distinct buffers, so the scatter is race-free. Backward keeps its own branch in func_factor_mass.
     """
     # Reuse the Hessian's tile width; TileCls is dispatched to match it at the call site, so T and the tile class stay
-    # consistent for either value. In practice this path only runs for per-entity blocks exceeding shared memory (total
+    # consistent for either value. In practice this path only runs for mass blocks exceeding shared memory (total
     # n_dofs > 48), where the rule lands on 32.
     T = qd.static(static_rigid_sim_config.cholesky_tile_size)
     EPS = rigid_global_info.EPS[None]
@@ -562,12 +557,12 @@ def func_factor_mass_tiled(
         if not rigid_global_info.mass_mat_mask[i_e, i_b]:
             continue
 
-        # Factor each mass block (kinematic tree) whose root DOF lies in this entity, over its full [block_start,
-        # block_end) range. A single-tree entity (the common case) has one block spanning it; a multi-tree entity has
-        # several. When two entities are merged (see attach) the child's DOFs belong to a block rooted in the parent, so
-        # the child owns no root and factors nothing while the parent factors the whole coupled block (whose range
-        # extends past the entity). Each block owns its own scratch region [block_start, block_end); distinct blocks
-        # (across entities too) are disjoint, so the scatter stays race-free.
+        # Factor each mass block whose root DOF lies in this entity, over its full [block_start, block_end) range. A
+        # single-block entity (the common case) has one block spanning it; a multi-block entity has several. When two
+        # entities are merged (see attach) the child's DOFs belong to a block rooted in the parent, so the child owns
+        # no root and factors nothing while the parent factors the whole coupled block (whose range extends past the
+        # entity). Each block owns its own scratch region [block_start, block_end); distinct blocks (across entities
+        # too) are disjoint, so the scatter stays race-free.
         entity_dof_start = entities_info.dof_start[i_e]
         entity_dof_end = entities_info.dof_end[i_e]
         block_start = entity_dof_start
@@ -705,7 +700,7 @@ def func_factor_mass(
             # trailing submatrix, so the parallel per-row updates only READ the pivot row (from shared) -- race-free
             # regardless of scheduling. Numerically identical to the scalar branch below; only parallelization differs.
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_BLOCK = qd.static(static_rigid_sim_config.tiled_n_dofs_per_block)
+            MAX_DOFS_PER_TREE = qd.static(static_rigid_sim_config.tiled_n_dofs_per_tree)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
             for i in range(n_entities * _B * BLOCK_DIM):
@@ -725,23 +720,23 @@ def func_factor_mass(
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
 
-                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK,), gs.qd_float)
+                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_TREE,), gs.qd_float)
 
-                    # Factor each mass block (kinematic tree) rooted in this entity in-place in global memory over its
-                    # full [block_start, block_end) range, block-relative so shared indices are >= 0. When two entities
-                    # are merged (see attach) the child's DOFs belong to a block rooted in the parent; the child owns no
+                    # Factor each mass block rooted in this entity in-place in global memory over its full
+                    # [block_start, block_end) range, block-relative so shared indices are >= 0. When two entities are
+                    # merged (see attach) the child's DOFs belong to a block rooted in the parent; the child owns no
                     # root and factors nothing while the parent factors the whole coupled block.
                     block_start = entity_dof_start
                     while block_start < entity_dof_end:
                         block_end = rigid_global_info.dofs_mass_block_end[block_start]
                         if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                            n_blk = block_end - block_start
+                            n_block_dofs = block_end - block_start
 
-                            # Copy the lower triangle of the block into mass_mat_L (+ implicit damping on the diagonal),
-                            # cooperatively. Restricting to the block makes the factorization cost the sum of per-tree
-                            # cubes instead of the whole (possibly multi-body) entity cube.
+                            # Copy the block's lower triangle into mass_mat_L (+ implicit damping on the diagonal),
+                            # cooperatively. Restricting to the block makes the factorization cost the sum of
+                            # per-block cubes instead of the whole (possibly multi-block) entity cube.
                             i_d_ = tid
-                            while i_d_ < n_blk:
+                            while i_d_ < n_block_dofs:
                                 i_d = block_start + i_d_
                                 for j_d in range(block_start, i_d + 1):
                                     rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[
@@ -763,7 +758,7 @@ def func_factor_mass(
                             qd.simt.block.sync()
 
                             # In-place LDL^T, eliminating dofs from last to first (matches the scalar branch).
-                            for j in range(n_blk):
+                            for j in range(n_block_dofs):
                                 i_d = block_end - j - 1
                                 i_d_local = i_d - block_start
                                 D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
@@ -810,57 +805,51 @@ def func_factor_mass(
                         continue
                     i_e = rigid_global_info.awake_entities[i_slot, i_b]
                 if rigid_global_info.mass_mat_mask[i_e, i_b]:
-                    entity_dof_start = entities_info.dof_start[i_e]
-                    entity_dof_end = entities_info.dof_end[i_e]
-
-                    # Factor each mass block (kinematic tree) whose root DOF lies in this entity, over its full
-                    # [block_start, block_end) range. When two entities are merged (see attach), the child's DOFs
-                    # belong to a block rooted in the parent, so the child owns no root and factors nothing while the
+                    # Factor each mass block rooted in this entity, iterated flat over the rooted range with per-DOF
+                    # block bounds (see entities_mass_block_dof_start in array_class.py): each elimination step only
+                    # touches rows of its own block, so interleaving independent blocks in one descending scan is
+                    # exact. When two entities are merged (see attach) the child owns no root and factors nothing; the
                     # parent factors the whole coupled block. Blocks are disjoint per root, so distinct entities never
-                    # write the same rows. block_end may extend past entity_dof_end into a merged child.
-                    block_start = entity_dof_start
-                    while block_start < entity_dof_end:
-                        block_end = rigid_global_info.dofs_mass_block_end[block_start]
-                        if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                            for i_d in range(block_start, block_end):
-                                for j_d in range(block_start, i_d + 1):
-                                    rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[
-                                        i_d, j_d, i_b
-                                    ]
+                    # write the same rows.
+                    blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
+                    blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
+                    for i_d in range(blocks_dof_start, blocks_dof_end):
+                        for j_d in range(rigid_global_info.dofs_mass_block_start[i_d], i_d + 1):
+                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
 
-                                if qd.static(implicit_damping):
-                                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                        if qd.static(implicit_damping):
+                            I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
+                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
+                            )
+                            if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                                if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
                                     rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
                                         rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                        + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
+                                        - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
                                     )
-                                    if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                                        if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
-                                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
-                                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                                - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
-                                            )
 
-                            for i_d_ in range(block_end - block_start):
-                                i_d = block_end - i_d_ - 1
-                                D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
+                    for i_d_ in range(blocks_dof_end - blocks_dof_start):
+                        i_d = blocks_dof_end - i_d_ - 1
+                        block_start = rigid_global_info.dofs_mass_block_start[i_d]
+                        D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                        rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
 
-                                for j_d_ in range(i_d - block_start):
-                                    j_d = i_d - j_d_ - 1
-                                    a = rigid_global_info.mass_mat_L[i_d, j_d, i_b] * D_inv
-                                    for k_d in range(block_start, j_d + 1):
-                                        rigid_global_info.mass_mat_L[j_d, k_d, i_b] -= (
-                                            a * rigid_global_info.mass_mat_L[i_d, k_d, i_b]
-                                        )
-                                    rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
+                        for j_d_ in range(i_d - block_start):
+                            j_d = i_d - j_d_ - 1
+                            a = rigid_global_info.mass_mat_L[i_d, j_d, i_b] * D_inv
+                            for k_d in range(block_start, j_d + 1):
+                                rigid_global_info.mass_mat_L[j_d, k_d, i_b] -= (
+                                    a * rigid_global_info.mass_mat_L[i_d, k_d, i_b]
+                                )
+                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
 
-                                # FIXME: Diagonal coeffs of L are ignored in computations, so no need to update them.
-                                rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
-                        block_start = block_end
+                        # FIXME: Diagonal coeffs of L are ignored in computations, so no need to update them.
+                        rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
         else:
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_BLOCK = qd.static(static_rigid_sim_config.tiled_n_dofs_per_block)
+            MAX_DOFS_PER_TREE = qd.static(static_rigid_sim_config.tiled_n_dofs_per_tree)
             WARP_SIZE = qd.static(32)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
@@ -881,19 +870,19 @@ def func_factor_mass(
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
 
-                    mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK, MAX_DOFS_PER_BLOCK + 1), gs.qd_float)
+                    mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_TREE, MAX_DOFS_PER_TREE + 1), gs.qd_float)
 
-                    # Factor each mass block (kinematic tree) rooted in this entity in shared memory, indexed
-                    # block-relative so shared indices are always >= 0. When two entities are merged (see attach) the
-                    # child's DOFs belong to a block rooted in the parent; using entity_dof_start as the origin would
-                    # make the child's block-local indices negative. The child entity owns no root and factors nothing;
-                    # the parent factors the whole coupled block, whose range extends past entity_dof_end.
+                    # Factor each mass block rooted in this entity in shared memory, indexed block-relative so shared
+                    # indices are always >= 0. When two entities are merged (see attach) the child's DOFs belong to a
+                    # block rooted in the parent; using entity_dof_start as the origin would make the child's
+                    # block-local indices negative. The child entity owns no root and factors nothing; the parent
+                    # factors the whole coupled block, whose range extends past entity_dof_end.
                     block_start = entity_dof_start
                     while block_start < entity_dof_end:
                         block_end = rigid_global_info.dofs_mass_block_end[block_start]
                         if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                            n_blk = block_end - block_start
-                            n_lower_tri = n_blk * (n_blk + 1) // 2
+                            n_block_dofs = block_end - block_start
+                            n_lower_tri = n_block_dofs * (n_block_dofs + 1) // 2
 
                             i_pair = tid
                             while i_pair < n_lower_tri:
@@ -906,7 +895,7 @@ def func_factor_mass(
 
                             if qd.static(implicit_damping):
                                 i_d_ = tid
-                                while i_d_ < n_blk:
+                                while i_d_ < n_block_dofs:
                                     i_d = block_start + i_d_
                                     I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
                                     mass_mat[i_d_, i_d_] = (
@@ -922,8 +911,8 @@ def func_factor_mass(
                                     i_d_ = i_d_ + BLOCK_DIM
                                 qd.simt.block.sync()
 
-                            for j in range(n_blk):
-                                i_d_ = n_blk - j - 1
+                            for j in range(n_block_dofs):
+                                i_d_ = n_block_dofs - j - 1
                                 i_d = block_end - j - 1
 
                                 D_inv = 1.0 / mass_mat[i_d_, i_d_]
@@ -948,7 +937,7 @@ def func_factor_mass(
                                     qd.simt.block.sync()
 
                             i_pair = tid
-                            n_strict_lower_tri = n_blk * (n_blk - 1) // 2
+                            n_strict_lower_tri = n_block_dofs * (n_block_dofs - 1) // 2
                             while i_pair < n_strict_lower_tri:
                                 i_d_, j_d_ = linear_to_lower_tri(i_pair, strict=True)
                                 rigid_global_info.mass_mat_L[block_start + i_d_, block_start + j_d_, i_b] = mass_mat[
@@ -969,92 +958,73 @@ def func_factor_mass(
             if rigid_global_info.mass_mat_mask[i_e, i_b]:
                 EPS = rigid_global_info.EPS[None]
 
-                entity_dof_start = entities_info.dof_start[i_e]
-                entity_dof_end = entities_info.dof_end[i_e]
+                # Factor each mass block rooted in this entity, iterated flat over the rooted range with per-DOF block
+                # bounds (see entities_mass_block_dof_start in array_class.py and the forward scalar arm); the
+                # per-block index reversal this AD-safe factor uses maps each block onto itself, so the perturbed
+                # indices stay within the DOF's own block.
+                blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
+                blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
+                for i_d in range(blocks_dof_start, blocks_dof_end):
+                    block_start = rigid_global_info.dofs_mass_block_start[i_d]
+                    block_end = rigid_global_info.dofs_mass_block_end[i_d]
+                    i_pr = (block_start + block_end - 1) - i_d
+                    for j_d in range(block_start, i_d + 1):
+                        j_pr = (block_start + block_end - 1) - j_d
+                        rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
+                        rigid_global_info.mass_mat_L_bw[0, j_pr, i_pr, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
 
-                # Factor each mass block (kinematic tree) rooted in this entity over its full [block_start, block_end)
-                # range. When two entities are merged (see attach) the child's DOFs belong to a block rooted in the
-                # parent, so the child owns no root and factors nothing while the parent factors the whole coupled
-                # block; factoring per entity would drop the parent-child coupling. Mirrors func_factor_mass's forward
-                # arms, in the perturbed (reversed) indices this AD-safe factor uses.
-                block_start = entity_dof_start
-                while block_start < entity_dof_end:
-                    block_end = rigid_global_info.dofs_mass_block_end[block_start]
-                    if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                        n_blk = block_end - block_start
-
-                        for i_d0 in range(n_blk):
-                            i_d = block_start + i_d0
-                            i_pr = (block_start + block_end - 1) - i_d
-                            for j_d in range(block_start, i_d + 1):
-                                j_pr = (block_start + block_end - 1) - j_d
-                                rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] = rigid_global_info.mass_mat[
-                                    i_d, j_d, i_b
-                                ]
-                                rigid_global_info.mass_mat_L_bw[0, j_pr, i_pr, i_b] = rigid_global_info.mass_mat[
-                                    i_d, j_d, i_b
-                                ]
-
-                            if qd.static(implicit_damping):
-                                I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                    if qd.static(implicit_damping):
+                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                        qd.atomic_add(
+                            rigid_global_info.mass_mat_L_bw[0, i_pr, i_pr, i_b],
+                            (dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]),
+                        )
+                        if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                            if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
                                 qd.atomic_add(
                                     rigid_global_info.mass_mat_L_bw[0, i_pr, i_pr, i_b],
-                                    (dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]),
+                                    -dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None],
                                 )
-                                if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                                    if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
-                                        qd.atomic_add(
-                                            rigid_global_info.mass_mat_L_bw[0, i_pr, i_pr, i_b],
-                                            -dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None],
-                                        )
 
-                        # Cholesky-Banachiewicz algorithm (in the perturbed indices), access pattern is safe for
-                        # autodiff https://en.wikipedia.org/wiki/Cholesky_decomposition
-                        for p_i0 in range(n_blk):
-                            for p_j0 in range(p_i0 + 1):
-                                # j_pr <= i_pr
-                                i_pr = block_start + p_i0
-                                j_pr = block_start + p_j0
+                # Cholesky-Banachiewicz algorithm (in the perturbed indices), access pattern is safe for
+                # autodiff https://en.wikipedia.org/wiki/Cholesky_decomposition
+                for i_pr in range(blocks_dof_start, blocks_dof_end):
+                    block_start = rigid_global_info.dofs_mass_block_start[i_pr]
+                    for j_pr in range(block_start, i_pr + 1):
+                        sum = gs.qd_float(0.0)
+                        for k_pr in range(block_start, j_pr):
+                            sum = sum + (
+                                rigid_global_info.mass_mat_L_bw[1, i_pr, k_pr, i_b]
+                                * rigid_global_info.mass_mat_L_bw[1, j_pr, k_pr, i_b]
+                            )
 
-                                sum = gs.qd_float(0.0)
-                                for p_k0 in range(p_j0):
-                                    # k_pr < j_pr
-                                    k_pr = block_start + p_k0
-                                    sum = sum + (
-                                        rigid_global_info.mass_mat_L_bw[1, i_pr, k_pr, i_b]
-                                        * rigid_global_info.mass_mat_L_bw[1, j_pr, k_pr, i_b]
-                                    )
+                        a = rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] - sum
+                        b = qd.math.clamp(
+                            rigid_global_info.mass_mat_L_bw[1, j_pr, j_pr, i_b],
+                            EPS,
+                            qd.math.inf,
+                        )
+                        if i_pr == j_pr:
+                            rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = qd.sqrt(
+                                qd.math.clamp(a, EPS, qd.math.inf)
+                            )
+                        else:
+                            rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = a / b
 
-                                a = rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] - sum
-                                b = qd.math.clamp(
-                                    rigid_global_info.mass_mat_L_bw[1, j_pr, j_pr, i_b],
-                                    EPS,
-                                    qd.math.inf,
-                                )
-                                if p_i0 == p_j0:
-                                    rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = qd.sqrt(
-                                        qd.math.clamp(a, EPS, qd.math.inf)
-                                    )
-                                else:
-                                    rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = a / b
+                for i_d in range(blocks_dof_start, blocks_dof_end):
+                    block_start = rigid_global_info.dofs_mass_block_start[i_d]
+                    block_end = rigid_global_info.dofs_mass_block_end[i_d]
+                    i_pr = (block_start + block_end - 1) - i_d
+                    for j_d in range(block_start, i_d + 1):
+                        j_pr = (block_start + block_end - 1) - j_d
 
-                        for i_d0 in range(n_blk):
-                            for i_d1 in range(i_d0 + 1):
-                                i_d = block_start + i_d0
-                                j_d = block_start + i_d1
-                                i_pr = (block_start + block_end - 1) - i_d
-                                j_pr = (block_start + block_end - 1) - j_d
+                        a = rigid_global_info.mass_mat_L_bw[1, i_pr, i_pr, i_b]
+                        rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat_L_bw[
+                            1, j_pr, i_pr, i_b
+                        ] / qd.math.clamp(a, EPS, qd.math.inf)
 
-                                a = rigid_global_info.mass_mat_L_bw[1, i_pr, i_pr, i_b]
-                                rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat_L_bw[
-                                    1, j_pr, i_pr, i_b
-                                ] / qd.math.clamp(a, EPS, qd.math.inf)
-
-                                if i_d == j_d:
-                                    rigid_global_info.mass_mat_D_inv[i_d, i_b] = 1.0 / (
-                                        qd.math.clamp(a**2, EPS, qd.math.inf)
-                                    )
-                    block_start = block_end
+                        if i_d == j_d:
+                            rigid_global_info.mass_mat_D_inv[i_d, i_b] = 1.0 / (qd.math.clamp(a**2, EPS, qd.math.inf))
 
 
 @qd.func
@@ -1072,56 +1042,53 @@ def func_solve_mass_entity(
     BW = qd.static(is_backward)
 
     if rigid_global_info.mass_mat_mask[i_e, i_b]:
-        entity_dof_start = entities_info.dof_start[i_e]
-        entity_dof_end = entities_info.dof_end[i_e]
+        # Solve M x = y for each mass block rooted in this entity, iterated flat over the rooted range with per-DOF
+        # block bounds (see entities_mass_block_dof_start in array_class.py); the triangular substitutions never cross
+        # block boundaries, so interleaving independent blocks in one scan is exact. When two entities are merged (see
+        # attach) the child owns no root and solves nothing; the parent solves the whole coupled block, as splitting
+        # the substitutions at the entity boundary would break them.
+        blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
+        blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
 
-        # Solve M x = y for each mass block (kinematic tree) whose root DOF lies in this entity, over its full
-        # [block_start, block_end) range. When two entities are merged (see attach) the child's DOFs belong to a block
-        # rooted in the parent, so the child owns no root and solves nothing while the parent solves the whole coupled
-        # block; splitting the triangular solve at the entity boundary would break the back/forward substitution.
-        # Mirrors func_factor_mass's per-block loop.
-        block_start = entity_dof_start
-        while block_start < entity_dof_end:
-            block_end = rigid_global_info.dofs_mass_block_end[block_start]
-            if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                # Step 1: Solve w st. L^T @ w = y
-                for i_d_ in range(block_end - block_start):
-                    i_d = block_end - i_d_ - 1
-                    curr_out = vec[i_d, i_b]
-                    if qd.static(BW):
-                        out_bw[0, i_d, i_b] = vec[i_d, i_b]
+        # Step 1: Solve w st. L^T @ w = y
+        for i_d_ in range(blocks_dof_end - blocks_dof_start):
+            i_d = blocks_dof_end - i_d_ - 1
+            block_end = rigid_global_info.dofs_mass_block_end[i_d]
+            curr_out = vec[i_d, i_b]
+            if qd.static(BW):
+                out_bw[0, i_d, i_b] = vec[i_d, i_b]
 
-                    for j_d in range(i_d + 1, block_end):
-                        # Since we read out[j_d, i_b], and j_d > i_d, which means that out[j_d, i_b] is already
-                        # finalized at this point, we don't need to care about AD mutation rule.
-                        if qd.static(BW):
-                            out_bw[0, i_d, i_b] = (
-                                out_bw[0, i_d, i_b] - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out_bw[0, j_d, i_b]
-                            )
-                        else:
-                            curr_out = curr_out - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out[j_d, i_b]
+            for j_d in range(i_d + 1, block_end):
+                # Since we read out[j_d, i_b], and j_d > i_d, which means that out[j_d, i_b] is already
+                # finalized at this point, we don't need to care about AD mutation rule.
+                if qd.static(BW):
+                    out_bw[0, i_d, i_b] = (
+                        out_bw[0, i_d, i_b] - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out_bw[0, j_d, i_b]
+                    )
+                else:
+                    curr_out = curr_out - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out[j_d, i_b]
 
-                    if qd.static(not BW):
-                        out[i_d, i_b] = curr_out
+            if qd.static(not BW):
+                out[i_d, i_b] = curr_out
 
-                # Step 2: z = D^{-1} w
-                for i_d in range(block_start, block_end):
-                    if qd.static(BW):
-                        out_bw[1, i_d, i_b] = out_bw[0, i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
-                    else:
-                        out[i_d, i_b] = out[i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
+        # Step 2: z = D^{-1} w
+        for i_d in range(blocks_dof_start, blocks_dof_end):
+            if qd.static(BW):
+                out_bw[1, i_d, i_b] = out_bw[0, i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
+            else:
+                out[i_d, i_b] = out[i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
 
-                # Step 3: Solve x st. L @ x = z
-                for i_d in range(block_start, block_end):
-                    curr_out = out[i_d, i_b]
-                    if qd.static(BW):
-                        curr_out = out_bw[1, i_d, i_b]
+        # Step 3: Solve x st. L @ x = z
+        for i_d in range(blocks_dof_start, blocks_dof_end):
+            block_start = rigid_global_info.dofs_mass_block_start[i_d]
+            curr_out = out[i_d, i_b]
+            if qd.static(BW):
+                curr_out = out_bw[1, i_d, i_b]
 
-                    for j_d in range(block_start, i_d):
-                        curr_out = curr_out - rigid_global_info.mass_mat_L[i_d, j_d, i_b] * out[j_d, i_b]
+            for j_d in range(block_start, i_d):
+                curr_out = curr_out - rigid_global_info.mass_mat_L[i_d, j_d, i_b] * out[j_d, i_b]
 
-                    out[i_d, i_b] = curr_out
-            block_start = block_end
+            out[i_d, i_b] = curr_out
 
 
 @qd.func
@@ -1888,27 +1855,22 @@ def func_implicit_damping(
 
         qd.loop_config(serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.PARTIAL))
         for i_e, i_b in qd.ndrange(n_entities, _B):
-            entity_dof_start = entities_info.dof_start[i_e]
-            entity_dof_end = entities_info.dof_end[i_e]
-            # Set the mask over each mass block ROOTED in this entity, spanning its full [block_start, block_end) range.
-            # The block-root entity factors the whole coupled block (which for a merged pair extends into the child), so
-            # the refactor must be triggered by damping/act_bias anywhere in that range - including a merged child whose
-            # own DOFs live in a later entity. Mirrors func_factor_mass's per-block iteration.
-            block_start = entity_dof_start
-            while block_start < entity_dof_end:
-                block_end = rigid_global_info.dofs_mass_block_end[block_start]
-                if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
-                    for i_d in range(block_start, block_end):
-                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                        if dofs_info.damping[I_d] > EPS:
-                            rigid_global_info.mass_mat_mask[i_e, i_b] = True
-                        if qd.static(static_rigid_sim_config.integrator != gs.integrator.Euler):
-                            if (
-                                dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY
-                                and qd.abs(dofs_info.act_bias[I_d][2]) > EPS
-                            ):
-                                rigid_global_info.mass_mat_mask[i_e, i_b] = True
-                block_start = block_end
+            # Set the mask over the mass blocks ROOTED in this entity (see entities_mass_block_dof_start in
+            # array_class.py). The block-root entity factors the whole coupled block (which for a merged pair extends
+            # into the child), so the refactor must be triggered by damping/act_bias anywhere in that range - including
+            # a merged child whose own DOFs live in a later entity.
+            blocks_dof_start = rigid_global_info.entities_mass_block_dof_start[i_e]
+            blocks_dof_end = rigid_global_info.entities_mass_block_dof_end[i_e]
+            for i_d in range(blocks_dof_start, blocks_dof_end):
+                I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                if dofs_info.damping[I_d] > EPS:
+                    rigid_global_info.mass_mat_mask[i_e, i_b] = True
+                if qd.static(static_rigid_sim_config.integrator != gs.integrator.Euler):
+                    if (
+                        dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY
+                        and qd.abs(dofs_info.act_bias[I_d][2]) > EPS
+                    ):
+                        rigid_global_info.mass_mat_mask[i_e, i_b] = True
 
     func_factor_mass(
         implicit_damping=True,

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -317,38 +317,56 @@ def func_compute_mass_matrix(
                 links_state.crb_quat[i_l, i_b] = links_state.cinr_quat[i_l, i_b]
                 links_state.crb_mass[i_l, i_b] = links_state.cinr_mass[i_l, i_b]
 
-    # crb
+    # crb: composite-rigid-body inertia, folded leaf-to-root. Parallelized over kinematic TREES, not entities: each tree
+    # is reduced by one thread rooted at its root link (root_idx == itself), over the contiguous run of links sharing
+    # that root_idx, iterated high-index-to-low so a child folds into its parent before the parent propagates further. A
+    # tree spans merged entities (a merged child's links share the parent tree's root_idx; see attach) and, conversely,
+    # a single entity holding several free bodies (e.g. dominos) splits into one tree per body - so this exposes far more
+    # parallelism than the per-entity fold on multi-tree entities. A tree's top link may fold into a fixed (0-DOF) anchor
+    # of another tree (e.g. a world link); that anchor carries no DOF so its crb is unused, making the cross-tree write
+    # harmless even if several trees share it. Mirrors the root_idx tree walk in func_update_cartesian_space.
     qd.loop_config(name="crb", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
     for i_0, i_b in (
         qd.ndrange(1, links_state.pos.shape[1])
         if qd.static(static_rigid_sim_config.use_hibernation)
-        else qd.ndrange(entities_info.n_links.shape[0], links_state.pos.shape[1])
+        else qd.ndrange(links_state.pos.shape[0], links_state.pos.shape[1])
     ):
         for i_1 in (
-            range(rigid_global_info.n_awake_entities[i_b])
+            range(rigid_global_info.n_awake_links[i_b])
             if qd.static(static_rigid_sim_config.use_hibernation)
             else qd.static(range(1))
         ):
             if func_check_index_range(
-                i_1, 0, rigid_global_info.n_awake_entities[i_b], static_rigid_sim_config.use_hibernation
+                i_1, 0, rigid_global_info.n_awake_links[i_b], static_rigid_sim_config.use_hibernation
             ):
-                i_e = (
-                    rigid_global_info.awake_entities[i_1, i_b]
+                i_l_root = (
+                    rigid_global_info.awake_links[i_1, i_b]
                     if qd.static(static_rigid_sim_config.use_hibernation)
                     else i_0
                 )
+                I_l_root = [i_l_root, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l_root
+                if links_info.root_idx[I_l_root] == i_l_root:
+                    n_links_total = links_state.pos.shape[0]
+                    tree_end = i_l_root + 1
+                    while tree_end < n_links_total:
+                        I_l_next = [tree_end, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else tree_end
+                        if links_info.root_idx[I_l_next] != i_l_root:
+                            break
+                        tree_end = tree_end + 1
 
-                for i in range(entities_info.n_links[i_e]):
-                    i_l = entities_info.link_end[i_e] - 1 - i
-                    I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
-                    i_p = links_info.parent_idx[I_l]
-                    I_p = [i_p, i_b]
+                    for k in range(tree_end - i_l_root):
+                        i_l = tree_end - 1 - k
+                        I_l = [i_l, i_b] if qd.static(static_rigid_sim_config.batch_links_info) else i_l
+                        i_p = links_info.parent_idx[I_l]
+                        I_p = [i_p, i_b]
 
-                    if i_p != -1:
-                        func_add_safe_backward(links_state.crb_inertial, I_p, links_state.crb_inertial[i_l, i_b], BW)
-                        func_add_safe_backward(links_state.crb_mass, I_p, links_state.crb_mass[i_l, i_b], BW)
-                        func_add_safe_backward(links_state.crb_pos, I_p, links_state.crb_pos[i_l, i_b], BW)
-                        func_add_safe_backward(links_state.crb_quat, I_p, links_state.crb_quat[i_l, i_b], BW)
+                        if i_p != -1:
+                            func_add_safe_backward(
+                                links_state.crb_inertial, I_p, links_state.crb_inertial[i_l, i_b], BW
+                            )
+                            func_add_safe_backward(links_state.crb_mass, I_p, links_state.crb_mass[i_l, i_b], BW)
+                            func_add_safe_backward(links_state.crb_pos, I_p, links_state.crb_pos[i_l, i_b], BW)
+                            func_add_safe_backward(links_state.crb_quat, I_p, links_state.crb_quat[i_l, i_b], BW)
 
     # mass_mat
     qd.loop_config(name="mass_mat", serialize=static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
@@ -400,32 +418,37 @@ def func_compute_mass_matrix(
             i_e = i_eb % n_entities
             i_b = i_eb // n_entities
 
-            d_s = entities_info.dof_start[i_e]
-            d_e = entities_info.dof_end[i_e]
-            n_e_e = d_e - d_s
-            n_lower_tri = n_e_e * (n_e_e + 1) // 2
-
-            i_pair = tid
-            while i_pair < n_lower_tri:
-                # Compressed lower-tri-inclusive index (matches tiled func_factor_mass): i_pair = i_d_ * (i_d_ + 1) / 2
-                # + j_d_, with j_d_ in [0, i_d_]. The fast-math-robust inversion is required here: a raw sqrt drops the
-                # j=0 entry of every perfect-square row on GPU, leaving M missing long-range coupling -> indefinite.
-                i_d_, j_d_ = linear_to_lower_tri(i_pair)
-                i_d = d_s + i_d_
-                j_d = d_s + j_d_
-                # The mass matrix is block-diagonal per kinematic tree, so only within-block (j_d in i_d's block) pairs
-                # can be non-zero. Skipping cross-block pairs avoids their dot products; those entries stay zero
-                # (mass_mat is zeroed and nothing else writes them). This makes the assemble cost scale with the sum of
-                # per-tree blocks instead of the whole (possibly multi-body) entity.
-                if j_d >= rigid_global_info.dofs_mass_block_start[i_d]:
-                    val = (
-                        dofs_state.f_ang[i_d, i_b].dot(dofs_state.cdof_ang[j_d, i_b])
-                        + dofs_state.f_vel[i_d, i_b].dot(dofs_state.cdof_vel[j_d, i_b])
-                    ) * rigid_global_info.mass_parent_mask[i_d, j_d]
-                    rigid_global_info.mass_mat[i_d, j_d, i_b] = val
-                    if i_d_ != j_d_:
-                        rigid_global_info.mass_mat[j_d, i_d, i_b] = val
-                i_pair += _T
+            # Assemble each mass block (kinematic tree) whose root DOF lies in this entity, over its full
+            # [block_start, block_end) lower triangle. When two entities are merged (see attach) the child's DOFs
+            # belong to a block rooted in the parent, so the parent assembles the whole coupled block (its columns
+            # extend past the entity into the child) and the child assembles nothing; iterating only the entity's own
+            # DOF range would drop the parent-child coupling. mass_parent_mask zeroes the within-block ancestor gaps.
+            entity_dof_start = entities_info.dof_start[i_e]
+            entity_dof_end = entities_info.dof_end[i_e]
+            block_start = entity_dof_start
+            while block_start < entity_dof_end:
+                block_end = rigid_global_info.dofs_mass_block_end[block_start]
+                if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                    n_blk = block_end - block_start
+                    n_lower_tri = n_blk * (n_blk + 1) // 2
+                    i_pair = tid
+                    while i_pair < n_lower_tri:
+                        # Compressed lower-tri-inclusive index (matches tiled func_factor_mass): i_pair = i_d_ * (i_d_ +
+                        # 1) / 2 + j_d_, with j_d_ in [0, i_d_]. The fast-math-robust inversion is required here: a raw
+                        # sqrt drops the j=0 entry of every perfect-square row on GPU, leaving M missing long-range
+                        # coupling -> indefinite.
+                        i_d_, j_d_ = linear_to_lower_tri(i_pair)
+                        i_d = block_start + i_d_
+                        j_d = block_start + j_d_
+                        val = (
+                            dofs_state.f_ang[i_d, i_b].dot(dofs_state.cdof_ang[j_d, i_b])
+                            + dofs_state.f_vel[i_d, i_b].dot(dofs_state.cdof_vel[j_d, i_b])
+                        ) * rigid_global_info.mass_parent_mask[i_d, j_d]
+                        rigid_global_info.mass_mat[i_d, j_d, i_b] = val
+                        if i_d_ != j_d_:
+                            rigid_global_info.mass_mat[j_d, i_d, i_b] = val
+                        i_pair += _T
+                block_start = block_end
     else:
         qd.loop_config(
             name="mass_mat_assemble", serialize=qd.static(static_rigid_sim_config.para_level < gs.PARA_LEVEL.ALL)
@@ -539,101 +562,108 @@ def func_factor_mass_tiled(
         if not rigid_global_info.mass_mat_mask[i_e, i_b]:
             continue
 
-        # Factor each mass block (kinematic tree) independently: a multi-tree entity has several blocks, a single-tree
-        # entity (the common case) just one spanning the whole entity. This matches the cooperative path, which likewise
-        # restricts to [block_start, block_end). The block's M and factor live at its own DOFs [block_start, ...), but
-        # the tile workspace reuses the entity's region [d_s, d_s + n_block_dofs) across the entity's blocks (processed
-        # sequentially by this warp; disjoint from other entities' regions), keeping the scratch indices short.
-        d_s = entities_info.dof_start[i_e]
+        # Factor each mass block (kinematic tree) whose root DOF lies in this entity, over its full [block_start,
+        # block_end) range. A single-tree entity (the common case) has one block spanning it; a multi-tree entity has
+        # several. When two entities are merged (see attach) the child's DOFs belong to a block rooted in the parent, so
+        # the child owns no root and factors nothing while the parent factors the whole coupled block (whose range
+        # extends past the entity). Each block owns its own scratch region [block_start, block_end); distinct blocks
+        # (across entities too) are disjoint, so the scatter stays race-free.
+        entity_dof_start = entities_info.dof_start[i_e]
         entity_dof_end = entities_info.dof_end[i_e]
-        block_start = d_s
+        block_start = entity_dof_start
         while block_start < entity_dof_end:
-            n_block_dofs = rigid_global_info.dofs_mass_block_end[block_start] - block_start
-            n_blocks = (n_block_dofs + T - 1) // T
+            block_end = rigid_global_info.dofs_mass_block_end[block_start]
+            if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                n_block_dofs = block_end - block_start
+                n_blocks = (n_block_dofs + T - 1) // T
 
-            # Phase 1: copy the reverse-indexed symmetric M block (+ implicit damping) into the scratch workspace.
-            # mass_mat stores M's lower triangle, so M[ri_, rj_] with ri_ <= rj_ is read from the stored M[rj_, ri_].
-            i_d_ = tid
-            while i_d_ < n_block_dofs:
-                ri_ = n_block_dofs - 1 - i_d_
-                for j_d_ in range(i_d_ + 1):
-                    rj_ = n_block_dofs - 1 - j_d_  # i_d_ >= j_d_  =>  ri_ <= rj_
-                    m = rigid_global_info.mass_mat[block_start + rj_, block_start + ri_, i_b]
-                    rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i_d_, d_s + j_d_] = m
-                    rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + j_d_, d_s + i_d_] = m
-                if qd.static(implicit_damping):
-                    # Reverse-diagonal slot i_d_ holds M[ri_, ri_]; damping/act_bias index the original DOF.
-                    i_d = block_start + ri_
-                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                    rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i_d_, d_s + i_d_] = (
-                        rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i_d_, d_s + i_d_]
-                        + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
-                    )
-                    if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                        if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
-                            rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i_d_, d_s + i_d_] = (
-                                rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i_d_, d_s + i_d_]
-                                - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
-                            )
-                i_d_ = i_d_ + T
-            qd.simt.block.sync()
+                # Phase 1: copy the reverse-indexed symmetric M block (+ implicit damping) into the scratch workspace.
+                # mass_mat stores M's lower triangle, so M[ri_, rj_] with ri_ <= rj_ is read from the stored M[rj_, ri_].
+                i_d_ = tid
+                while i_d_ < n_block_dofs:
+                    ri_ = n_block_dofs - 1 - i_d_
+                    for j_d_ in range(i_d_ + 1):
+                        rj_ = n_block_dofs - 1 - j_d_  # i_d_ >= j_d_  =>  ri_ <= rj_
+                        m = rigid_global_info.mass_mat[block_start + rj_, block_start + ri_, i_b]
+                        rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + i_d_, block_start + j_d_] = m
+                        rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + j_d_, block_start + i_d_] = m
+                    if qd.static(implicit_damping):
+                        # Reverse-diagonal slot i_d_ holds M[ri_, ri_]; damping/act_bias index the original DOF.
+                        i_d = block_start + ri_
+                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                        rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + i_d_, block_start + i_d_] = (
+                            rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + i_d_, block_start + i_d_]
+                            + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
+                        )
+                        if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                            if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                rigid_global_info.mass_mat_tiled_scratch[
+                                    i_b, block_start + i_d_, block_start + i_d_
+                                ] = (
+                                    rigid_global_info.mass_mat_tiled_scratch[
+                                        i_b, block_start + i_d_, block_start + i_d_
+                                    ]
+                                    - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                )
+                    i_d_ = i_d_ + T
+                qd.simt.block.sync()
 
-            # Phase 2: blocked Cholesky G_rev G_rev^T = M_rev in the scratch workspace (mirrors the constraint Hessian's
-            # func_cholesky_factor_direct_tiled; the tile ops are warp-synchronous, so no sync inside the loop).
-            for kb in range(n_blocks):
-                k0 = kb * T
-                k1 = qd.min(k0 + T, n_block_dofs)
+                # Phase 2: blocked Cholesky G_rev G_rev^T = M_rev in the scratch workspace (mirrors the constraint
+                # Hessian's func_cholesky_factor_direct_tiled; the tile ops are warp-synchronous, so no sync in loop).
+                for kb in range(n_blocks):
+                    k0 = block_start + kb * T
+                    k1 = qd.min(k0 + T, block_end)
 
-                L_kk = TileCls.eye(dtype=gs.qd_float)  # rows past n_block_dofs stay identity
-                L_kk[:] = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + k0 : d_s + k1, d_s + k0 : d_s + k1]
-                for jb in range(kb):
-                    j0 = jb * T
-                    for t in range(T):
-                        v = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + k0 : d_s + k1, d_s + j0 + t]
-                        L_kk -= qd.outer(v, v)
-                L_kk.cholesky_(EPS)
-
-                for ib in range(kb + 1, n_blocks):
-                    i0 = ib * T
-                    i1 = qd.min(i0 + T, n_block_dofs)
-
-                    L_ik = TileCls.zeros(dtype=gs.qd_float)
-                    L_ik[:] = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i0 : d_s + i1, d_s + k0 : d_s + k1]
+                    L_kk = TileCls.eye(dtype=gs.qd_float)  # rows past n_block_dofs stay identity
+                    L_kk[:] = rigid_global_info.mass_mat_tiled_scratch[i_b, k0:k1, k0:k1]
                     for jb in range(kb):
-                        j0 = jb * T
+                        j0 = block_start + jb * T
                         for t in range(T):
-                            v_own = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i0 : d_s + i1, d_s + j0 + t]
-                            v_diag = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + k0 : d_s + k1, d_s + j0 + t]
-                            L_ik -= qd.outer(v_own, v_diag)
-                    L_kk.solve_triangular_(L_ik)
-                    rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + i0 : d_s + i1, d_s + k0 : d_s + k1] = L_ik
+                            v = rigid_global_info.mass_mat_tiled_scratch[i_b, k0:k1, j0 + t]
+                            L_kk -= qd.outer(v, v)
+                    L_kk.cholesky_(EPS)
 
-                rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + k0 : d_s + k1, d_s + k0 : d_s + k1] = L_kk
-            qd.simt.block.sync()
+                    for ib in range(kb + 1, n_blocks):
+                        i0 = block_start + ib * T
+                        i1 = qd.min(i0 + T, block_end)
 
-            # Phase 3: scatter the LTDL factor of M from G_rev (scratch) into canonical mass_mat_L / mass_mat_D_inv.
-            # Reads the scratch, writes the distinct mass_mat_L (no in-place hazard). Only the strict-lower triangle and
-            # unit diagonal are meaningful to the solve; the upper triangle is left untouched.
-            n_strict_lower = n_block_dofs * (n_block_dofs - 1) // 2
-            i_pair = tid
-            while i_pair < n_strict_lower:
-                i_d_, j_d_ = linear_to_lower_tri(i_pair, strict=True)
-                ri_ = n_block_dofs - 1 - i_d_
-                rj_ = n_block_dofs - 1 - j_d_  # i_d_ > j_d_  =>  rj_ > ri_  (a lower G_rev entry)
-                g_num = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + rj_, d_s + ri_]
-                g_den = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + ri_, d_s + ri_]
-                rigid_global_info.mass_mat_L[block_start + i_d_, block_start + j_d_, i_b] = g_num / g_den
-                i_pair = i_pair + T
+                        L_ik = TileCls.zeros(dtype=gs.qd_float)
+                        L_ik[:] = rigid_global_info.mass_mat_tiled_scratch[i_b, i0:i1, k0:k1]
+                        for jb in range(kb):
+                            j0 = block_start + jb * T
+                            for t in range(T):
+                                v_own = rigid_global_info.mass_mat_tiled_scratch[i_b, i0:i1, j0 + t]
+                                v_diag = rigid_global_info.mass_mat_tiled_scratch[i_b, k0:k1, j0 + t]
+                                L_ik -= qd.outer(v_own, v_diag)
+                        L_kk.solve_triangular_(L_ik)
+                        rigid_global_info.mass_mat_tiled_scratch[i_b, i0:i1, k0:k1] = L_ik
 
-            i_d_ = tid
-            while i_d_ < n_block_dofs:
-                ri_ = n_block_dofs - 1 - i_d_
-                g_den = rigid_global_info.mass_mat_tiled_scratch[i_b, d_s + ri_, d_s + ri_]
-                rigid_global_info.mass_mat_D_inv[block_start + i_d_, i_b] = 1.0 / (g_den * g_den)
-                rigid_global_info.mass_mat_L[block_start + i_d_, block_start + i_d_, i_b] = 1.0
-                i_d_ = i_d_ + T
+                    rigid_global_info.mass_mat_tiled_scratch[i_b, k0:k1, k0:k1] = L_kk
+                qd.simt.block.sync()
 
-            block_start = rigid_global_info.dofs_mass_block_end[block_start]
+                # Phase 3: scatter the LTDL factor of M from G_rev (scratch) into canonical mass_mat_L / mass_mat_D_inv.
+                # Reads the scratch, writes the distinct mass_mat_L (no in-place hazard). Only the strict-lower triangle
+                # and unit diagonal are meaningful to the solve; the upper triangle is left untouched.
+                n_strict_lower = n_block_dofs * (n_block_dofs - 1) // 2
+                i_pair = tid
+                while i_pair < n_strict_lower:
+                    i_d_, j_d_ = linear_to_lower_tri(i_pair, strict=True)
+                    ri_ = n_block_dofs - 1 - i_d_
+                    rj_ = n_block_dofs - 1 - j_d_  # i_d_ > j_d_  =>  rj_ > ri_  (a lower G_rev entry)
+                    g_num = rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + rj_, block_start + ri_]
+                    g_den = rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + ri_, block_start + ri_]
+                    rigid_global_info.mass_mat_L[block_start + i_d_, block_start + j_d_, i_b] = g_num / g_den
+                    i_pair = i_pair + T
+
+                i_d_ = tid
+                while i_d_ < n_block_dofs:
+                    ri_ = n_block_dofs - 1 - i_d_
+                    g_den = rigid_global_info.mass_mat_tiled_scratch[i_b, block_start + ri_, block_start + ri_]
+                    rigid_global_info.mass_mat_D_inv[block_start + i_d_, i_b] = 1.0 / (g_den * g_den)
+                    rigid_global_info.mass_mat_L[block_start + i_d_, block_start + i_d_, i_b] = 1.0
+                    i_d_ = i_d_ + T
+                qd.simt.block.sync()
+            block_start = block_end
 
 
 @qd.func
@@ -675,7 +705,7 @@ def func_factor_mass(
             # trailing submatrix, so the parallel per-row updates only READ the pivot row (from shared) -- race-free
             # regardless of scheduling. Numerically identical to the scalar branch below; only parallelization differs.
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_ENTITY = qd.static(static_rigid_sim_config.tiled_n_dofs_per_entity)
+            MAX_DOFS_PER_BLOCK = qd.static(static_rigid_sim_config.tiled_n_dofs_per_block)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
             for i in range(n_entities * _B * BLOCK_DIM):
@@ -694,70 +724,79 @@ def func_factor_mass(
                 if rigid_global_info.mass_mat_mask[i_e, i_b]:
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
-                    n_dofs = entities_info.n_dofs[i_e]
 
-                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_ENTITY,), gs.qd_float)
+                    pivot_row = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK,), gs.qd_float)
 
-                    # Copy the lower triangle of M into mass_mat_L (+ implicit damping on the diagonal), cooperatively.
-                    # The mass matrix is block-diagonal per kinematic tree, so only the within-block lower triangle is
-                    # non-zero; restricting to it makes the factorization cost the sum of per-tree cubes instead of the
-                    # whole (possibly multi-body) entity cube. Cross-block entries stay zero (mass_mat_L is zeroed).
-                    i_d_ = tid
-                    while i_d_ < n_dofs:
-                        i_d = entity_dof_start + i_d_
-                        block_start = rigid_global_info.dofs_mass_block_start[i_d]
-                        for j_d in range(block_start, i_d + 1):
-                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
-                        if qd.static(implicit_damping):
-                            I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
-                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
-                            )
-                            if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                                if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                    # Factor each mass block (kinematic tree) rooted in this entity in-place in global memory over its
+                    # full [block_start, block_end) range, block-relative so shared indices are >= 0. When two entities
+                    # are merged (see attach) the child's DOFs belong to a block rooted in the parent; the child owns no
+                    # root and factors nothing while the parent factors the whole coupled block.
+                    block_start = entity_dof_start
+                    while block_start < entity_dof_end:
+                        block_end = rigid_global_info.dofs_mass_block_end[block_start]
+                        if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                            n_blk = block_end - block_start
+
+                            # Copy the lower triangle of the block into mass_mat_L (+ implicit damping on the diagonal),
+                            # cooperatively. Restricting to the block makes the factorization cost the sum of per-tree
+                            # cubes instead of the whole (possibly multi-body) entity cube.
+                            i_d_ = tid
+                            while i_d_ < n_blk:
+                                i_d = block_start + i_d_
+                                for j_d in range(block_start, i_d + 1):
+                                    rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[
+                                        i_d, j_d, i_b
+                                    ]
+                                if qd.static(implicit_damping):
+                                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
                                     rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
                                         rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                        - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                        + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
                                     )
-                        i_d_ = i_d_ + BLOCK_DIM
-                    qd.simt.block.sync()
+                                    if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                                        if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
+                                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                                - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                            )
+                                i_d_ = i_d_ + BLOCK_DIM
+                            qd.simt.block.sync()
 
-                    # In-place LDL^T, eliminating dofs from last to first (matches the scalar branch). Each pivot only
-                    # touches the trailing submatrix within its own block, so blocks factor independently.
-                    for j in range(n_dofs):
-                        i_d = entity_dof_end - j - 1
-                        block_start = rigid_global_info.dofs_mass_block_start[i_d]
-                        i_d_local = i_d - block_start
-                        D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                        if tid == 0:
-                            rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
+                            # In-place LDL^T, eliminating dofs from last to first (matches the scalar branch).
+                            for j in range(n_blk):
+                                i_d = block_end - j - 1
+                                i_d_local = i_d - block_start
+                                D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                if tid == 0:
+                                    rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
 
-                        # Phase A: snapshot the (Schur-updated) pivot-row entries below the diagonal into shared.
-                        j_d_ = tid
-                        while j_d_ < i_d_local:
-                            pivot_row[j_d_] = rigid_global_info.mass_mat_L[i_d, block_start + j_d_, i_b]
-                            j_d_ = j_d_ + BLOCK_DIM
-                        qd.simt.block.sync()
+                                # Phase A: snapshot the (Schur-updated) pivot-row entries below the diagonal into shared.
+                                j_d_ = tid
+                                while j_d_ < i_d_local:
+                                    pivot_row[j_d_] = rigid_global_info.mass_mat_L[i_d, block_start + j_d_, i_b]
+                                    j_d_ = j_d_ + BLOCK_DIM
+                                qd.simt.block.sync()
 
-                        # Phase B: each lane eliminates one column j_d, updating its own row j_d of the trailing
-                        # submatrix from the read-only snapshot. Distinct rows per lane => no write conflicts, and
-                        # the pivot row is only read (from shared) => no read/write race on row i_d.
-                        j_d_ = tid
-                        while j_d_ < i_d_local:
-                            a = pivot_row[j_d_] * D_inv
-                            j_d = block_start + j_d_
-                            for k_d_ in range(j_d_ + 1):
-                                rigid_global_info.mass_mat_L[j_d, block_start + k_d_, i_b] = (
-                                    rigid_global_info.mass_mat_L[j_d, block_start + k_d_, i_b] - a * pivot_row[k_d_]
-                                )
-                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
-                            j_d_ = j_d_ + BLOCK_DIM
-                        qd.simt.block.sync()
+                                # Phase B: each lane eliminates one column j_d, updating its own row j_d of the trailing
+                                # submatrix from the read-only snapshot. Distinct rows per lane => no write conflicts,
+                                # and the pivot row is only read (from shared) => no read/write race on row i_d.
+                                j_d_ = tid
+                                while j_d_ < i_d_local:
+                                    a = pivot_row[j_d_] * D_inv
+                                    j_d = block_start + j_d_
+                                    for k_d_ in range(j_d_ + 1):
+                                        rigid_global_info.mass_mat_L[j_d, block_start + k_d_, i_b] = (
+                                            rigid_global_info.mass_mat_L[j_d, block_start + k_d_, i_b]
+                                            - a * pivot_row[k_d_]
+                                        )
+                                    rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
+                                    j_d_ = j_d_ + BLOCK_DIM
+                                qd.simt.block.sync()
 
-                        # Diagonal coeffs of L are ignored downstream (see scalar branch) but set to 1.0 to match.
-                        if tid == 0:
-                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
+                                # Diagonal coeffs of L are ignored downstream (see scalar branch) but set to 1.0 to match.
+                                if tid == 0:
+                                    rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
+                        block_start = block_end
         elif qd.static(
             not static_rigid_sim_config.enable_tiled_cholesky_mass_matrix or static_rigid_sim_config.backend == gs.cpu
         ):
@@ -773,46 +812,55 @@ def func_factor_mass(
                 if rigid_global_info.mass_mat_mask[i_e, i_b]:
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
-                    n_dofs = entities_info.n_dofs[i_e]
 
-                    for i_d in range(entity_dof_start, entity_dof_end):
-                        block_start = rigid_global_info.dofs_mass_block_start[i_d]
-                        for j_d in range(block_start, i_d + 1):
-                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
+                    # Factor each mass block (kinematic tree) whose root DOF lies in this entity, over its full
+                    # [block_start, block_end) range. When two entities are merged (see attach), the child's DOFs
+                    # belong to a block rooted in the parent, so the child owns no root and factors nothing while the
+                    # parent factors the whole coupled block. Blocks are disjoint per root, so distinct entities never
+                    # write the same rows. block_end may extend past entity_dof_end into a merged child.
+                    block_start = entity_dof_start
+                    while block_start < entity_dof_end:
+                        block_end = rigid_global_info.dofs_mass_block_end[block_start]
+                        if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                            for i_d in range(block_start, block_end):
+                                for j_d in range(block_start, i_d + 1):
+                                    rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat[
+                                        i_d, j_d, i_b
+                                    ]
 
-                        if qd.static(implicit_damping):
-                            I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
-                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
-                            )
-                            if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                                if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                if qd.static(implicit_damping):
+                                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
                                     rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
                                         rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                                        - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                        + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
                                     )
+                                    if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                                        if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = (
+                                                rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                                - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                            )
 
-                    for i_d_ in range(n_dofs):
-                        i_d = entity_dof_end - i_d_ - 1
-                        block_start = rigid_global_info.dofs_mass_block_start[i_d]
-                        D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
-                        rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
+                            for i_d_ in range(block_end - block_start):
+                                i_d = block_end - i_d_ - 1
+                                D_inv = 1.0 / rigid_global_info.mass_mat_L[i_d, i_d, i_b]
+                                rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
 
-                        for j_d_ in range(i_d - block_start):
-                            j_d = i_d - j_d_ - 1
-                            a = rigid_global_info.mass_mat_L[i_d, j_d, i_b] * D_inv
-                            for k_d in range(block_start, j_d + 1):
-                                rigid_global_info.mass_mat_L[j_d, k_d, i_b] -= (
-                                    a * rigid_global_info.mass_mat_L[i_d, k_d, i_b]
-                                )
-                            rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
+                                for j_d_ in range(i_d - block_start):
+                                    j_d = i_d - j_d_ - 1
+                                    a = rigid_global_info.mass_mat_L[i_d, j_d, i_b] * D_inv
+                                    for k_d in range(block_start, j_d + 1):
+                                        rigid_global_info.mass_mat_L[j_d, k_d, i_b] -= (
+                                            a * rigid_global_info.mass_mat_L[i_d, k_d, i_b]
+                                        )
+                                    rigid_global_info.mass_mat_L[i_d, j_d, i_b] = a
 
-                        # FIXME: Diagonal coeffs of L are ignored in computations, so no need to update them.
-                        rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
+                                # FIXME: Diagonal coeffs of L are ignored in computations, so no need to update them.
+                                rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
+                        block_start = block_end
         else:
             BLOCK_DIM = qd.static(32)
-            MAX_DOFS_PER_ENTITY = qd.static(static_rigid_sim_config.tiled_n_dofs_per_entity)
+            MAX_DOFS_PER_BLOCK = qd.static(static_rigid_sim_config.tiled_n_dofs_per_block)
             WARP_SIZE = qd.static(32)
 
             qd.loop_config(name="factor_mass", block_dim=BLOCK_DIM)
@@ -832,73 +880,83 @@ def func_factor_mass(
                 if rigid_global_info.mass_mat_mask[i_e, i_b]:
                     entity_dof_start = entities_info.dof_start[i_e]
                     entity_dof_end = entities_info.dof_end[i_e]
-                    n_dofs = entities_info.n_dofs[i_e]
-                    n_lower_tri = n_dofs * (n_dofs + 1) // 2
 
-                    mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_ENTITY, MAX_DOFS_PER_ENTITY + 1), gs.qd_float)
+                    mass_mat = qd.simt.block.SharedArray((MAX_DOFS_PER_BLOCK, MAX_DOFS_PER_BLOCK + 1), gs.qd_float)
 
-                    i_pair = tid
-                    while i_pair < n_lower_tri:
-                        i_d_, j_d_ = linear_to_lower_tri(i_pair)
-                        i_d = entity_dof_start + i_d_
-                        j_d = entity_dof_start + j_d_
-                        mass_mat[i_d_, j_d_] = rigid_global_info.mass_mat[i_d, j_d, i_b]
-                        i_pair = i_pair + BLOCK_DIM
-                    qd.simt.block.sync()
+                    # Factor each mass block (kinematic tree) rooted in this entity in shared memory, indexed
+                    # block-relative so shared indices are always >= 0. When two entities are merged (see attach) the
+                    # child's DOFs belong to a block rooted in the parent; using entity_dof_start as the origin would
+                    # make the child's block-local indices negative. The child entity owns no root and factors nothing;
+                    # the parent factors the whole coupled block, whose range extends past entity_dof_end.
+                    block_start = entity_dof_start
+                    while block_start < entity_dof_end:
+                        block_end = rigid_global_info.dofs_mass_block_end[block_start]
+                        if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                            n_blk = block_end - block_start
+                            n_lower_tri = n_blk * (n_blk + 1) // 2
 
-                    if qd.static(implicit_damping):
-                        i_d_ = tid
-                        while i_d_ < n_dofs:
-                            i_d = entity_dof_start + i_d_
-                            I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                            mass_mat[i_d_, i_d_] = (
-                                mass_mat[i_d_, i_d_] + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
-                            )
-                            if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                                if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
-                                    mass_mat[i_d_, i_d_] = (
-                                        mass_mat[i_d_, i_d_]
-                                        - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
-                                    )
-                            i_d_ = i_d_ + BLOCK_DIM
-                        qd.simt.block.sync()
-
-                    for j in range(n_dofs):
-                        i_d_ = n_dofs - j - 1
-                        i_d = entity_dof_end - j - 1
-                        # Block-local lower bound (in entity-local shared-memory indices): the mass matrix is
-                        # block-diagonal per kinematic tree, so each pivot only eliminates within its own block.
-                        block_start_ = rigid_global_info.dofs_mass_block_start[i_d] - entity_dof_start
-
-                        D_inv = 1.0 / mass_mat[i_d_, i_d_]
-                        if tid == 0:
-                            rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
-                            # FIXME: Diagonal coeffs of L are ignored in computations, so no need to update them.
-                            rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
-
-                        j_d_ = i_d_ - 1 - tid
-                        while j_d_ >= block_start_:
-                            a = mass_mat[i_d_, j_d_] * D_inv
-                            for k_d in range(block_start_, j_d_ + 1):
-                                mass_mat[j_d_, k_d] = mass_mat[j_d_, k_d] - a * mass_mat[i_d_, k_d]
-                            mass_mat[i_d_, j_d_] = a
-                            j_d_ = j_d_ - BLOCK_DIM
-                        if qd.static(static_rigid_sim_config.backend == gs.cuda):
-                            if i_d_ <= WARP_SIZE:
-                                qd.simt.warp.sync(qd.u32(0xFFFFFFFF))
-                            else:
-                                qd.simt.block.sync()
-                        else:
+                            i_pair = tid
+                            while i_pair < n_lower_tri:
+                                i_d_, j_d_ = linear_to_lower_tri(i_pair)
+                                mass_mat[i_d_, j_d_] = rigid_global_info.mass_mat[
+                                    block_start + i_d_, block_start + j_d_, i_b
+                                ]
+                                i_pair = i_pair + BLOCK_DIM
                             qd.simt.block.sync()
 
-                    i_pair = tid
-                    n_strict_lower_tri = n_dofs * (n_dofs - 1) // 2
-                    while i_pair < n_strict_lower_tri:
-                        i_d_, j_d_ = linear_to_lower_tri(i_pair, strict=True)
-                        i_d = entity_dof_start + i_d_
-                        j_d = entity_dof_start + j_d_
-                        rigid_global_info.mass_mat_L[i_d, j_d, i_b] = mass_mat[i_d_, j_d_]
-                        i_pair = i_pair + BLOCK_DIM
+                            if qd.static(implicit_damping):
+                                i_d_ = tid
+                                while i_d_ < n_blk:
+                                    i_d = block_start + i_d_
+                                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                                    mass_mat[i_d_, i_d_] = (
+                                        mass_mat[i_d_, i_d_]
+                                        + dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]
+                                    )
+                                    if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                                        if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                            mass_mat[i_d_, i_d_] = (
+                                                mass_mat[i_d_, i_d_]
+                                                - dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None]
+                                            )
+                                    i_d_ = i_d_ + BLOCK_DIM
+                                qd.simt.block.sync()
+
+                            for j in range(n_blk):
+                                i_d_ = n_blk - j - 1
+                                i_d = block_end - j - 1
+
+                                D_inv = 1.0 / mass_mat[i_d_, i_d_]
+                                if tid == 0:
+                                    rigid_global_info.mass_mat_D_inv[i_d, i_b] = D_inv
+                                    # FIXME: Diagonal coeffs of L are ignored in computations, so no need to update them.
+                                    rigid_global_info.mass_mat_L[i_d, i_d, i_b] = 1.0
+
+                                j_d_ = i_d_ - 1 - tid
+                                while j_d_ >= 0:
+                                    a = mass_mat[i_d_, j_d_] * D_inv
+                                    for k_d in range(j_d_ + 1):
+                                        mass_mat[j_d_, k_d] = mass_mat[j_d_, k_d] - a * mass_mat[i_d_, k_d]
+                                    mass_mat[i_d_, j_d_] = a
+                                    j_d_ = j_d_ - BLOCK_DIM
+                                if qd.static(static_rigid_sim_config.backend == gs.cuda):
+                                    if i_d_ <= WARP_SIZE:
+                                        qd.simt.warp.sync(qd.u32(0xFFFFFFFF))
+                                    else:
+                                        qd.simt.block.sync()
+                                else:
+                                    qd.simt.block.sync()
+
+                            i_pair = tid
+                            n_strict_lower_tri = n_blk * (n_blk - 1) // 2
+                            while i_pair < n_strict_lower_tri:
+                                i_d_, j_d_ = linear_to_lower_tri(i_pair, strict=True)
+                                rigid_global_info.mass_mat_L[block_start + i_d_, block_start + j_d_, i_b] = mass_mat[
+                                    i_d_, j_d_
+                                ]
+                                i_pair = i_pair + BLOCK_DIM
+                            qd.simt.block.sync()
+                        block_start = block_end
     else:
         # Cholesky decomposition that has safe access pattern and robust handling of divide by zero for AD. Even though
         # it is logically equivalent to the above block, it shows slightly numerical difference in the result, and thus
@@ -913,73 +971,90 @@ def func_factor_mass(
 
                 entity_dof_start = entities_info.dof_start[i_e]
                 entity_dof_end = entities_info.dof_end[i_e]
-                n_dofs = entities_info.n_dofs[i_e]
 
-                for i_d0 in range(n_dofs):
-                    i_d = entity_dof_start + i_d0
-                    i_pr = (entity_dof_start + entity_dof_end - 1) - i_d
-                    for j_d in range(entity_dof_start, i_d + 1):
-                        j_pr = (entity_dof_start + entity_dof_end - 1) - j_d
-                        rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
-                        rigid_global_info.mass_mat_L_bw[0, j_pr, i_pr, i_b] = rigid_global_info.mass_mat[i_d, j_d, i_b]
+                # Factor each mass block (kinematic tree) rooted in this entity over its full [block_start, block_end)
+                # range. When two entities are merged (see attach) the child's DOFs belong to a block rooted in the
+                # parent, so the child owns no root and factors nothing while the parent factors the whole coupled
+                # block; factoring per entity would drop the parent-child coupling. Mirrors func_factor_mass's forward
+                # arms, in the perturbed (reversed) indices this AD-safe factor uses.
+                block_start = entity_dof_start
+                while block_start < entity_dof_end:
+                    block_end = rigid_global_info.dofs_mass_block_end[block_start]
+                    if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                        n_blk = block_end - block_start
 
-                    if qd.static(implicit_damping):
-                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                        qd.atomic_add(
-                            rigid_global_info.mass_mat_L_bw[0, i_pr, i_pr, i_b],
-                            (dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]),
-                        )
-                        if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
-                            if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                        for i_d0 in range(n_blk):
+                            i_d = block_start + i_d0
+                            i_pr = (block_start + block_end - 1) - i_d
+                            for j_d in range(block_start, i_d + 1):
+                                j_pr = (block_start + block_end - 1) - j_d
+                                rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] = rigid_global_info.mass_mat[
+                                    i_d, j_d, i_b
+                                ]
+                                rigid_global_info.mass_mat_L_bw[0, j_pr, i_pr, i_b] = rigid_global_info.mass_mat[
+                                    i_d, j_d, i_b
+                                ]
+
+                            if qd.static(implicit_damping):
+                                I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
                                 qd.atomic_add(
                                     rigid_global_info.mass_mat_L_bw[0, i_pr, i_pr, i_b],
-                                    -dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None],
+                                    (dofs_info.damping[I_d] * rigid_global_info.substep_dt[None]),
                                 )
+                                if qd.static(static_rigid_sim_config.integrator == gs.integrator.implicitfast):
+                                    if dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                                        qd.atomic_add(
+                                            rigid_global_info.mass_mat_L_bw[0, i_pr, i_pr, i_b],
+                                            -dofs_info.act_bias[I_d][2] * rigid_global_info.substep_dt[None],
+                                        )
 
-                # Cholesky-Banachiewicz algorithm (in the perturbed indices), access pattern is safe for autodiff
-                # https://en.wikipedia.org/wiki/Cholesky_decomposition
-                for p_i0 in range(n_dofs):
-                    for p_j0 in range(p_i0 + 1):
-                        # j_pr <= i_pr
-                        i_pr = entity_dof_start + p_i0
-                        j_pr = entity_dof_start + p_j0
+                        # Cholesky-Banachiewicz algorithm (in the perturbed indices), access pattern is safe for
+                        # autodiff https://en.wikipedia.org/wiki/Cholesky_decomposition
+                        for p_i0 in range(n_blk):
+                            for p_j0 in range(p_i0 + 1):
+                                # j_pr <= i_pr
+                                i_pr = block_start + p_i0
+                                j_pr = block_start + p_j0
 
-                        sum = gs.qd_float(0.0)
-                        for p_k0 in range(p_j0):
-                            # k_pr < j_pr
-                            k_pr = entity_dof_start + p_k0
-                            sum = sum + (
-                                rigid_global_info.mass_mat_L_bw[1, i_pr, k_pr, i_b]
-                                * rigid_global_info.mass_mat_L_bw[1, j_pr, k_pr, i_b]
-                            )
+                                sum = gs.qd_float(0.0)
+                                for p_k0 in range(p_j0):
+                                    # k_pr < j_pr
+                                    k_pr = block_start + p_k0
+                                    sum = sum + (
+                                        rigid_global_info.mass_mat_L_bw[1, i_pr, k_pr, i_b]
+                                        * rigid_global_info.mass_mat_L_bw[1, j_pr, k_pr, i_b]
+                                    )
 
-                        a = rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] - sum
-                        b = qd.math.clamp(
-                            rigid_global_info.mass_mat_L_bw[1, j_pr, j_pr, i_b],
-                            EPS,
-                            qd.math.inf,
-                        )
-                        if p_i0 == p_j0:
-                            rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = qd.sqrt(
-                                qd.math.clamp(a, EPS, qd.math.inf)
-                            )
-                        else:
-                            rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = a / b
+                                a = rigid_global_info.mass_mat_L_bw[0, i_pr, j_pr, i_b] - sum
+                                b = qd.math.clamp(
+                                    rigid_global_info.mass_mat_L_bw[1, j_pr, j_pr, i_b],
+                                    EPS,
+                                    qd.math.inf,
+                                )
+                                if p_i0 == p_j0:
+                                    rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = qd.sqrt(
+                                        qd.math.clamp(a, EPS, qd.math.inf)
+                                    )
+                                else:
+                                    rigid_global_info.mass_mat_L_bw[1, i_pr, j_pr, i_b] = a / b
 
-                for i_d0 in range(n_dofs):
-                    for i_d1 in range(i_d0 + 1):
-                        i_d = entity_dof_start + i_d0
-                        j_d = entity_dof_start + i_d1
-                        i_pr = (entity_dof_start + entity_dof_end - 1) - i_d
-                        j_pr = (entity_dof_start + entity_dof_end - 1) - j_d
+                        for i_d0 in range(n_blk):
+                            for i_d1 in range(i_d0 + 1):
+                                i_d = block_start + i_d0
+                                j_d = block_start + i_d1
+                                i_pr = (block_start + block_end - 1) - i_d
+                                j_pr = (block_start + block_end - 1) - j_d
 
-                        a = rigid_global_info.mass_mat_L_bw[1, i_pr, i_pr, i_b]
-                        rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat_L_bw[
-                            1, j_pr, i_pr, i_b
-                        ] / qd.math.clamp(a, EPS, qd.math.inf)
+                                a = rigid_global_info.mass_mat_L_bw[1, i_pr, i_pr, i_b]
+                                rigid_global_info.mass_mat_L[i_d, j_d, i_b] = rigid_global_info.mass_mat_L_bw[
+                                    1, j_pr, i_pr, i_b
+                                ] / qd.math.clamp(a, EPS, qd.math.inf)
 
-                        if i_d == j_d:
-                            rigid_global_info.mass_mat_D_inv[i_d, i_b] = 1.0 / (qd.math.clamp(a**2, EPS, qd.math.inf))
+                                if i_d == j_d:
+                                    rigid_global_info.mass_mat_D_inv[i_d, i_b] = 1.0 / (
+                                        qd.math.clamp(a**2, EPS, qd.math.inf)
+                                    )
+                    block_start = block_end
 
 
 @qd.func
@@ -999,45 +1074,54 @@ def func_solve_mass_entity(
     if rigid_global_info.mass_mat_mask[i_e, i_b]:
         entity_dof_start = entities_info.dof_start[i_e]
         entity_dof_end = entities_info.dof_end[i_e]
-        n_dofs = entities_info.n_dofs[i_e]
 
-        # Step 1: Solve w st. L^T @ w = y
-        for i_d_ in range(n_dofs):
-            i_d = entity_dof_end - i_d_ - 1
-            curr_out = vec[i_d, i_b]
-            if qd.static(BW):
-                out_bw[0, i_d, i_b] = vec[i_d, i_b]
+        # Solve M x = y for each mass block (kinematic tree) whose root DOF lies in this entity, over its full
+        # [block_start, block_end) range. When two entities are merged (see attach) the child's DOFs belong to a block
+        # rooted in the parent, so the child owns no root and solves nothing while the parent solves the whole coupled
+        # block; splitting the triangular solve at the entity boundary would break the back/forward substitution.
+        # Mirrors func_factor_mass's per-block loop.
+        block_start = entity_dof_start
+        while block_start < entity_dof_end:
+            block_end = rigid_global_info.dofs_mass_block_end[block_start]
+            if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                # Step 1: Solve w st. L^T @ w = y
+                for i_d_ in range(block_end - block_start):
+                    i_d = block_end - i_d_ - 1
+                    curr_out = vec[i_d, i_b]
+                    if qd.static(BW):
+                        out_bw[0, i_d, i_b] = vec[i_d, i_b]
 
-            for j_d in range(i_d + 1, rigid_global_info.dofs_mass_block_end[i_d]):
-                # Since we read out[j_d, i_b], and j_d > i_d, which means that out[j_d, i_b] is already
-                # finalized at this point, we don't need to care about AD mutation rule.
-                if qd.static(BW):
-                    out_bw[0, i_d, i_b] = (
-                        out_bw[0, i_d, i_b] - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out_bw[0, j_d, i_b]
-                    )
-                else:
-                    curr_out = curr_out - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out[j_d, i_b]
+                    for j_d in range(i_d + 1, block_end):
+                        # Since we read out[j_d, i_b], and j_d > i_d, which means that out[j_d, i_b] is already
+                        # finalized at this point, we don't need to care about AD mutation rule.
+                        if qd.static(BW):
+                            out_bw[0, i_d, i_b] = (
+                                out_bw[0, i_d, i_b] - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out_bw[0, j_d, i_b]
+                            )
+                        else:
+                            curr_out = curr_out - rigid_global_info.mass_mat_L[j_d, i_d, i_b] * out[j_d, i_b]
 
-            if qd.static(not BW):
-                out[i_d, i_b] = curr_out
+                    if qd.static(not BW):
+                        out[i_d, i_b] = curr_out
 
-        # Step 2: z = D^{-1} w
-        for i_d in range(entity_dof_start, entity_dof_end):
-            if qd.static(BW):
-                out_bw[1, i_d, i_b] = out_bw[0, i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
-            else:
-                out[i_d, i_b] = out[i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
+                # Step 2: z = D^{-1} w
+                for i_d in range(block_start, block_end):
+                    if qd.static(BW):
+                        out_bw[1, i_d, i_b] = out_bw[0, i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
+                    else:
+                        out[i_d, i_b] = out[i_d, i_b] * rigid_global_info.mass_mat_D_inv[i_d, i_b]
 
-        # Step 3: Solve x st. L @ x = z
-        for i_d in range(entity_dof_start, entity_dof_end):
-            curr_out = out[i_d, i_b]
-            if qd.static(BW):
-                curr_out = out_bw[1, i_d, i_b]
+                # Step 3: Solve x st. L @ x = z
+                for i_d in range(block_start, block_end):
+                    curr_out = out[i_d, i_b]
+                    if qd.static(BW):
+                        curr_out = out_bw[1, i_d, i_b]
 
-            for j_d in range(rigid_global_info.dofs_mass_block_start[i_d], i_d):
-                curr_out = curr_out - rigid_global_info.mass_mat_L[i_d, j_d, i_b] * out[j_d, i_b]
+                    for j_d in range(block_start, i_d):
+                        curr_out = curr_out - rigid_global_info.mass_mat_L[i_d, j_d, i_b] * out[j_d, i_b]
 
-            out[i_d, i_b] = curr_out
+                    out[i_d, i_b] = curr_out
+            block_start = block_end
 
 
 @qd.func
@@ -1806,18 +1890,25 @@ def func_implicit_damping(
         for i_e, i_b in qd.ndrange(n_entities, _B):
             entity_dof_start = entities_info.dof_start[i_e]
             entity_dof_end = entities_info.dof_end[i_e]
-            for i_d_ in range(entity_dof_start, entity_dof_end):
-                i_d = i_d_
-                if i_d < entity_dof_end:
-                    I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
-                    if dofs_info.damping[I_d] > EPS:
-                        rigid_global_info.mass_mat_mask[i_e, i_b] = True
-                    if qd.static(static_rigid_sim_config.integrator != gs.integrator.Euler):
-                        if (
-                            dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY
-                            and qd.abs(dofs_info.act_bias[I_d][2]) > EPS
-                        ):
+            # Set the mask over each mass block ROOTED in this entity, spanning its full [block_start, block_end) range.
+            # The block-root entity factors the whole coupled block (which for a merged pair extends into the child), so
+            # the refactor must be triggered by damping/act_bias anywhere in that range - including a merged child whose
+            # own DOFs live in a later entity. Mirrors func_factor_mass's per-block iteration.
+            block_start = entity_dof_start
+            while block_start < entity_dof_end:
+                block_end = rigid_global_info.dofs_mass_block_end[block_start]
+                if rigid_global_info.dofs_mass_block_start[block_start] == block_start:
+                    for i_d in range(block_start, block_end):
+                        I_d = [i_d, i_b] if qd.static(static_rigid_sim_config.batch_dofs_info) else i_d
+                        if dofs_info.damping[I_d] > EPS:
                             rigid_global_info.mass_mat_mask[i_e, i_b] = True
+                        if qd.static(static_rigid_sim_config.integrator != gs.integrator.Euler):
+                            if (
+                                dofs_state.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY
+                                and qd.abs(dofs_info.act_bias[I_d][2]) > EPS
+                            ):
+                                rigid_global_info.mass_mat_mask[i_e, i_b] = True
+                block_start = block_end
 
     func_factor_mass(
         implicit_damping=True,

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -11,10 +11,10 @@ def func_solve_mass_block(
     vec: qd.Tensor,
     rigid_global_info: array_class.RigidGlobalInfo,
 ):
-    """LDL^T forward-backward substitution on vec, restricted to the mass-matrix block containing dof i_d0.
+    """LDL^T forward-backward substitution on vec, restricted to the mass block containing dof i_d0.
 
-    The factor is block-diagonal per kinematic tree, with constant block bounds shared by every member dof
-    (dofs_mass_block_start/end), so a block is solvable independently from any member dof.
+    The factor is block-diagonal per mass block (see dofs_mass_block_start in array_class.py), with constant block
+    bounds shared by every member dof, so a block is solvable independently from any member dof.
     """
     block_start = rigid_global_info.dofs_mass_block_start[i_d0]
     block_end = rigid_global_info.dofs_mass_block_end[i_d0]
@@ -60,23 +60,23 @@ def func_apply_Minv_rows(
     per pass. Working at block granularity (not entity granularity) keeps the touched dof range within the row's own
     island, which makes concurrent per-island sweeps of the same env race-free.
     """
-    block_start_prev = gs.qd_int(-1)
+    tree_start_prev = gs.qd_int(-1)
     for i_d_ in range(jac_n_dofs[i_row_0, i_b]):
         i_d = jac_dofs_idx[i_row_0, i_d_, i_b]
         block_start = rigid_global_info.dofs_mass_block_start[i_d]
-        if block_start != block_start_prev:
+        if block_start != tree_start_prev:
             for j_d in range(block_start, rigid_global_info.dofs_mass_block_end[i_d]):
                 vec[j_d, i_b] = gs.qd_float(0.0)
-            block_start_prev = block_start
+            tree_start_prev = block_start
         vec[i_d, i_b] = coef_0 * jac[i_row_0, i_d, i_b] + coef_1 * jac[i_row_1, i_d, i_b]
 
-    block_start_prev = gs.qd_int(-1)
+    tree_start_prev = gs.qd_int(-1)
     for i_d_ in range(jac_n_dofs[i_row_0, i_b]):
         i_d = jac_dofs_idx[i_row_0, i_d_, i_b]
         block_start = rigid_global_info.dofs_mass_block_start[i_d]
-        if block_start != block_start_prev:
+        if block_start != tree_start_prev:
             func_solve_mass_block(i_d, i_b, vec, rigid_global_info)
-            block_start_prev = block_start
+            tree_start_prev = block_start
 
 
 @qd.func
@@ -90,14 +90,14 @@ def func_accumulate_row_blocks(
     rigid_global_info: array_class.RigidGlobalInfo,
 ):
     """Add vec_src to vec_dst over the mass blocks touched by constraint row i_row."""
-    block_start_prev = gs.qd_int(-1)
+    tree_start_prev = gs.qd_int(-1)
     for i_d_ in range(jac_n_dofs[i_row, i_b]):
         i_d = jac_dofs_idx[i_row, i_d_, i_b]
         block_start = rigid_global_info.dofs_mass_block_start[i_d]
-        if block_start != block_start_prev:
+        if block_start != tree_start_prev:
             for j_d in range(block_start, rigid_global_info.dofs_mass_block_end[i_d]):
                 vec_dst[j_d, i_b] = vec_dst[j_d, i_b] + vec_src[j_d, i_b]
-            block_start_prev = block_start
+            tree_start_prev = block_start
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -2396,9 +2396,9 @@ def func_hessian_direct_batch(
                             constraint_state.nt_H[i_b, row, col]
                             + constraint_state.jac[i_c, i_d1, i_b] * constraint_state.jac[i_c, i_d2, i_b] * efc_D
                         )
-        # H += M, restricted to the island's DOFs. Mass couples only DOFs within the same kinematic-tree block, which
-        # is a contiguous global DOF range and so maps to a contiguous local range (dof_id is ascending). Bound the add
-        # by that block (dofs_mass_block_start, mapped to local via dof_local_pos) rather than the full constraint
+        # H += M, restricted to the island's DOFs. Mass couples only DOFs within the same mass block, which is a
+        # contiguous global DOF range and so maps to a contiguous local range (dof_id is ascending). Bound the add by
+        # that block (dofs_mass_block_start, mapped to local via dof_local_pos) rather than the full constraint
         # envelope: the envelope already includes mass coupling so block_start >= env_start, and entries below
         # block_start are structurally zero mass. For an aligned free body the block is the diagonal, so only the
         # diagonal mass is added; for articulated bodies the whole branch block is added.

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -566,21 +566,57 @@ class RigidSolver(KinematicSolver):
         if gs.backend == gs.cpu or self.sim.options.requires_grad:
             static_rigid_sim_config["prefer_decomposed_solver"] = 0
 
+        # Per-DOF mass-block bounds (see dofs_mass_block_start in array_class.py): each DOF's block is rooted at its
+        # topmost DOF-bearing ancestor reachable before the world; DOFs are numbered depth-first, so a block is an
+        # interval whose root's first DOF is the block start. Computed here because the tiled factor arms below must
+        # be sized for the largest block; _init_mass_mat consumes and uploads the bounds.
+        links_by_idx = {link.idx: link for link in self.links}
+        dofs_mass_block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
+        for link in self.links:
+            if link.n_dofs == 0:
+                continue
+            root_link = link
+            node = link
+            while node.parent_idx != -1:
+                node = links_by_idx[node.parent_idx]
+                if node.n_dofs > 0:
+                    root_link = node
+            dofs_mass_block_start[link.dof_start : link.dof_end] = root_link.dof_start
+        dofs_mass_block_end = np.empty(self.n_dofs_, dtype=gs.np_int)
+        for i_d in range(self.n_dofs_):
+            dofs_mass_block_end[dofs_mass_block_start[i_d]] = i_d + 1
+        dofs_mass_block_end = dofs_mass_block_end[dofs_mass_block_start]
+
+        # Interval closure: attach() can leave other entities' DOFs interleaved inside a merged block's interval (the
+        # entities created between the parent and its attached child keep their numbering). Coupling never crosses
+        # blocks, so widening each block to its enclosing interval and merging overlaps keeps the factorization exact:
+        # the swallowed DOFs carry exactly zero coupling (see mass_parent_mask) which the elimination preserves, at
+        # the price of wasted flops on their rows - proportional to the DOFs created between attached entities, hence
+        # the advice to instantiate them consecutively (see RigidEntity.attach).
+        roots_idx = np.flatnonzero(dofs_mass_block_start == np.arange(self.n_dofs_, dtype=gs.np_int))
+        span_start, span_end = 0, 0
+        for i_d_root in roots_idx:
+            if i_d_root < span_end:
+                span_end = max(span_end, dofs_mass_block_end[i_d_root])
+            else:
+                dofs_mass_block_start[span_start:span_end] = span_start
+                dofs_mass_block_end[span_start:span_end] = span_end
+                span_start, span_end = i_d_root, dofs_mass_block_end[i_d_root]
+        dofs_mass_block_start[span_start:span_end] = span_start
+        dofs_mass_block_end[span_start:span_end] = span_end
+        self._dofs_mass_block_start = dofs_mass_block_start
+        self._dofs_mass_block_end = dofs_mass_block_end
+
         if self.is_active:
             # The tiled and cooperative Cholesky kernels trade per-env serial work for cross-lane parallelism, so they
             # only help while envs alone do not already saturate the GPU. Above that env count one-thread-per-env keeps
             # every core busy and the scalar path wins; below it the parallel kernels hide latency by swapping warps.
             # The crossover is also hardware- and kernel-dependent, so the env threshold (GPU core count) is a heuristic
             # and a dynamic timer-based selection would be more accurate still.
-            # Largest kinematic tree in DOFs, grouped by the tree root link (root_idx): an upper bound on the largest
-            # mass block (blocks split trees at fixed links; see dofs_mass_block_start in array_class.py). A tree
-            # spans merged entities (so it can exceed any single entity) while a multi-block entity's blocks are each
-            # smaller than the entity, so this - not the per-entity DOF count - is what the per-block factor must be
-            # sized for.
-            tree_dofs: dict[int, int] = {}
-            for link in self.links:
-                tree_dofs[link.root_idx] = tree_dofs.get(link.root_idx, 0) + link.n_dofs
-            max_tree_dofs = max(tree_dofs.values()) if tree_dofs else 0
+            # Largest mass block in DOFs: the biggest independently-factorable unit, which the per-block factor must
+            # be sized for. A block can span merged entities (see attach), so it can exceed any single entity, while a
+            # multi-block entity's blocks are each smaller than the entity.
+            max_block_dofs = int((dofs_mass_block_end - dofs_mass_block_start).max()) if self.n_dofs else 0
             if gs.backend != gs.cpu:
                 max_tiled_envs = get_gpu_core_count()
                 envs_undersaturate = self.n_envs <= max_tiled_envs
@@ -594,7 +630,7 @@ class RigidSolver(KinematicSolver):
                 # Confirmed by dex_hand (n_dofs=62, T=32 +2.6 %) and g1_fall (n_dofs=35, T=16 +2.9 %).
                 cholesky_tile_size = 16 if (self.n_dofs <= 16 or 32 < self.n_dofs <= 48) else 32
                 tiled_n_dofs = max(math.ceil(self.n_dofs / cholesky_tile_size), 1) * cholesky_tile_size
-                tiled_n_dofs_per_tree = max(math.ceil(max_tree_dofs / 32), 1) * 32
+                tiled_n_dofs_per_block = max(math.ceil(max_block_dofs / 32), 1) * 32
 
                 # The decomposed arm's cooperative per-island solve stages one island's tile in shared memory.
                 # Size it to the largest tile-size multiple that fits shared (precision-aware), but no larger
@@ -620,8 +656,8 @@ class RigidSolver(KinematicSolver):
                 # The cooperative in-place LDL^T has no cap; the shared-memory tile is faster but capped. Same env logic
                 # as the Hessian: tile from the largest block >= 8 DOFs, drop the env guard above the cap where the
                 # scalar O(n_block_dofs^3) per-(block, env) factor is always worse.
-                mass_matrix_fits_shared = fits_in_gpu_shared_memory(tiled_n_dofs_per_tree, tiled_n_dofs_per_tree + 1)
-                enable_tiled_cholesky_mass_matrix = max_tree_dofs >= 8 and (
+                mass_matrix_fits_shared = fits_in_gpu_shared_memory(tiled_n_dofs_per_block, tiled_n_dofs_per_block + 1)
+                enable_tiled_cholesky_mass_matrix = max_block_dofs >= 8 and (
                     not mass_matrix_fits_shared or envs_undersaturate
                 )
 
@@ -654,7 +690,7 @@ class RigidSolver(KinematicSolver):
                     enable_per_island_solve=(
                         self._use_contact_island and (self._use_hibernation or not hessian_fits_shared)
                     ),
-                    tiled_n_dofs_per_tree=tiled_n_dofs_per_tree,
+                    tiled_n_dofs_per_block=tiled_n_dofs_per_block,
                     tiled_n_dofs=tiled_n_dofs,
                     tiled_n_island_dofs=tiled_n_island_dofs,
                     # Persistent block grid for the cooperative per-island factor+solve: enough T-lane blocks to fill the
@@ -915,70 +951,16 @@ class RigidSolver(KinematicSolver):
                     mass_parent_mask[i_d, j_d] = 1.0
                 j_l = self.links[j_l].parent_idx
 
-        # Partition each entity's DOFs into contiguous, independently-factorable blocks. M is block-diagonal between
-        # DOFs whose links are not kinematic ancestor/descendant of one another, so the per-block bounds let the
-        # assemble/factor/solve restrict to one block instead of the whole entity. A block is the set of DOFs coupled
-        # through a chain of moving joints; a fixed link (0 DOFs) does not couple, so several bodies attached to the
-        # world - or the independent arms of a fixed-base robot - factor as separate per-branch blocks. Each DOF's block
-        # is rooted at the topmost DOF-bearing ancestor reachable before the world; DOFs are numbered depth-first, so a
-        # block is a contiguous range whose root link's first DOF is the block start.
-        links_by_idx = {link.idx: link for link in self.links}
-        dofs_mass_block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
-        for link in self.links:
-            if link.n_dofs == 0:
-                continue
-            root_link = link
-            node = link
-            while node.parent_idx != -1:
-                node = links_by_idx[node.parent_idx]
-                if node.n_dofs > 0:
-                    root_link = node
-            dofs_mass_block_start[link.dof_start : link.dof_end] = root_link.dof_start
-        dofs_mass_block_end = np.empty(self.n_dofs_, dtype=gs.np_int)
-        for i_d in range(self.n_dofs_):
-            dofs_mass_block_end[dofs_mass_block_start[i_d]] = i_d + 1
-        dofs_mass_block_end = dofs_mass_block_end[dofs_mass_block_start]
+        # Per-DOF mass-block bounds, computed by _build_static_config (which sizes the tiled factor arms from them).
+        dofs_mass_block_start = self._dofs_mass_block_start
+        dofs_mass_block_end = self._dofs_mass_block_end
 
-        # Each kinematic tree's links must form one contiguous range: the CRB fold reduces a tree over the contiguous
-        # run of links sharing its root (root_idx), and the mass-block partition assumes the same. attach() can leave
-        # them split when a third entity is numbered between the parent and its attached child - including a zero-DOF
-        # prop, which keeps the DOFs contiguous yet still interleaves a link. Raise clearly instead of silently dropping
-        # the child's inertia; the resolution is to instantiate the child right after its parent, or attach before
-        # adding the intervening entity.
-        previous_root = -1
-        seen_roots = set()
-        for root in (link.root_idx for link in self.links):
-            if root != previous_root:
-                if root in seen_roots:
-                    gs.raise_exception(
-                        "Attaching an entity onto a parent that is not adjacent in the entity ordering (another "
-                        "entity's links fall between them) is not supported: it splits a kinematic tree. Instantiate "
-                        "the child entity right after its parent, or attach before adding the intervening entity."
-                    )
-                seen_roots.add(root)
-                previous_root = root
-
-        # See links_tree_end in array_class.py. The contiguity check above certifies each tree's link run, so a run
-        # ends where the next one starts.
+        # See links_tree_end in array_class.py: one past the last link of each tree, which may reach past interleaved
+        # links of other trees (the CRB fold gates on root_idx).
         links_root_idx = np.array([link.root_idx for link in self.links], dtype=gs.np_int)
         links_tree_end = np.zeros(self.n_links_, dtype=gs.np_int)
         if self.links:
-            run_starts = np.flatnonzero(np.r_[True, links_root_idx[1:] != links_root_idx[:-1]])
-            links_tree_end[run_starts] = np.r_[run_starts[1:], self.n_links]
-
-        # A parent in another tree is only sound as a fixed (0-DOF-chain) anchor: the CRB fold and the cartesian-space
-        # tree walk both stop at tree boundaries, so a moving cross-tree parent would never receive its child subtree's
-        # composite inertia nor propagate its motion - the roots are inconsistent with the kinematic structure and mass
-        # would be silently lost (see the crb tree walk in forward_dynamics.py).
-        for link in self.links:
-            if link.parent_idx != -1:
-                parent_link = links_by_idx[link.parent_idx]
-                if link.root_idx != parent_link.root_idx and not parent_link.is_fixed:
-                    gs.raise_exception(
-                        f"Link '{link.name}' and its moving parent link '{parent_link.name}' belong to different "
-                        f"kinematic trees (root {link.root_idx} vs {parent_link.root_idx}). Kinematic tree root "
-                        f"indices are inconsistent with the parent structure."
-                    )
+            np.maximum.at(links_tree_end, links_root_idx, np.arange(self.n_links) + 1)
 
         # An aligned free body whose only DOFs are its own free joint has a diagonal joint-space mass block, so zero its
         # within-link off-diagonal mask to make the assembled mass exactly diagonal (else ~1e-6 round-off once it

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -568,8 +568,8 @@ class RigidSolver(KinematicSolver):
 
         # Per-DOF mass-block bounds (see dofs_mass_block_start in array_class.py): each DOF's block is rooted at its
         # topmost DOF-bearing ancestor reachable before the world; DOFs are numbered depth-first, so a block is an
-        # interval whose root's first DOF is the block start. Computed here because the tiled factor arms below must
-        # be sized for the largest block; _init_mass_mat consumes and uploads the bounds.
+        # interval whose root's first DOF is the block start. Computed here because the tiled factor arms below must be
+        # sized for the largest block; _init_mass_mat consumes and uploads the bounds.
         links_by_idx = {link.idx: link for link in self.links}
         dofs_mass_block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
         for link in self.links:
@@ -587,42 +587,20 @@ class RigidSolver(KinematicSolver):
             dofs_mass_block_end[dofs_mass_block_start[i_d]] = i_d + 1
         dofs_mass_block_end = dofs_mass_block_end[dofs_mass_block_start]
 
-        # Interval closure: attach() can leave other entities' DOFs interleaved inside a merged block's interval (the
-        # entities created between the parent and its attached child keep their numbering). Coupling never crosses
-        # blocks, so widening each block to its enclosing interval and merging overlaps keeps the factorization exact:
-        # the swallowed DOFs carry exactly zero coupling (see mass_parent_mask) which the elimination preserves, at
-        # the price of wasted flops on their rows - proportional to the DOFs created between attached entities, hence
-        # the advice to instantiate them consecutively (see RigidEntity.attach).
-        roots_idx = np.flatnonzero(dofs_mass_block_start == np.arange(self.n_dofs_, dtype=gs.np_int))
-        has_interleaved_blocks = False
-        span_start, span_end = 0, 0
-        for i_d_root in roots_idx:
-            if i_d_root < span_end:
-                span_end = max(span_end, dofs_mass_block_end[i_d_root])
-                has_interleaved_blocks = True
-            else:
-                dofs_mass_block_start[span_start:span_end] = span_start
-                dofs_mass_block_end[span_start:span_end] = span_end
-                span_start, span_end = i_d_root, dofs_mass_block_end[i_d_root]
-        dofs_mass_block_start[span_start:span_end] = span_start
-        dofs_mass_block_end[span_start:span_end] = span_end
+        # Blocks form clean intervals: attach() is the only source of cross-entity blocks and rejects any layout that
+        # would interleave foreign DOFs inside a merged one (see RigidEntity.attach).
         self._dofs_mass_block_start = dofs_mass_block_start
         self._dofs_mass_block_end = dofs_mass_block_end
-        if has_interleaved_blocks:
-            gs.logger.warning(
-                "Attached entities are interleaved with unrelated degrees of freedom, which inflates the mass "
-                "factorization cost. Instantiate attached entities consecutively to avoid it."
-            )
 
         if self.is_active:
             # The tiled and cooperative Cholesky kernels trade per-env serial work for cross-lane parallelism, so they
             # only help while envs alone do not already saturate the GPU. Above that env count one-thread-per-env keeps
             # every core busy and the scalar path wins; below it the parallel kernels hide latency by swapping warps.
             # The crossover is also hardware- and kernel-dependent, so the env threshold (GPU core count) is a heuristic
-            # and a dynamic timer-based selection would be more accurate still.
-            # Largest mass block in DOFs: the biggest independently-factorable unit, which the per-block factor must
-            # be sized for. A block can span merged entities (see attach), so it can exceed any single entity, while a
-            # multi-block entity's blocks are each smaller than the entity.
+            # and a dynamic timer-based selection would be more accurate still. Largest mass block in DOFs: the biggest
+            # independently-factorable unit, which the per-block factor must be sized for. A block can span merged
+            # entities (see attach), so it can exceed any single entity, while a multi-block entity's blocks are each
+            # smaller than the entity.
             max_block_dofs = int((dofs_mass_block_end - dofs_mass_block_start).max()) if self.n_dofs else 0
             if gs.backend != gs.cpu:
                 max_tiled_envs = get_gpu_core_count()
@@ -989,9 +967,9 @@ class RigidSolver(KinematicSolver):
                 dofs_mass_block_start[i_d] = i_d
                 dofs_mass_block_end[i_d] = i_d + 1
 
-        # See entities_mass_block_dof_start in array_class.py: skip a leading run of DOFs merged into an
-        # earlier-rooted block; the end is the last rooted block's end, which may extend past the entity's own DOFs
-        # into a merged child.
+        # See entities_mass_block_dof_start in array_class.py: skip a leading run of DOFs merged into an earlier-rooted
+        # block; the end is the last rooted block's end, which may extend past the entity's own DOFs into a merged
+        # child.
         entities_mass_block_dof_start = np.zeros(self.n_entities_, dtype=gs.np_int)
         entities_mass_block_dof_end = np.zeros(self.n_entities_, dtype=gs.np_int)
         for i_e, entity in enumerate(self.entities):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -572,14 +572,15 @@ class RigidSolver(KinematicSolver):
             # every core busy and the scalar path wins; below it the parallel kernels hide latency by swapping warps.
             # The crossover is also hardware- and kernel-dependent, so the env threshold (GPU core count) is a heuristic
             # and a dynamic timer-based selection would be more accurate still.
-            # Largest mass block in DOFs = largest kinematic tree, grouped by the moving-tree root link (root_idx). A
-            # tree spans merged entities (so a block can exceed any single entity) while a multi-tree entity's blocks
-            # are each smaller than the entity, so this - not the per-entity DOF count - is what the per-block factor
-            # actually processes and must be sized for.
+            # Largest kinematic tree in DOFs, grouped by the tree root link (root_idx): an upper bound on the largest
+            # mass block (blocks split trees at fixed links; see dofs_mass_block_start in array_class.py). A tree
+            # spans merged entities (so it can exceed any single entity) while a multi-block entity's blocks are each
+            # smaller than the entity, so this - not the per-entity DOF count - is what the per-block factor must be
+            # sized for.
             tree_dofs: dict[int, int] = {}
             for link in self.links:
                 tree_dofs[link.root_idx] = tree_dofs.get(link.root_idx, 0) + link.n_dofs
-            max_block_dofs = max(tree_dofs.values()) if tree_dofs else 0
+            max_tree_dofs = max(tree_dofs.values()) if tree_dofs else 0
             if gs.backend != gs.cpu:
                 max_tiled_envs = get_gpu_core_count()
                 envs_undersaturate = self.n_envs <= max_tiled_envs
@@ -593,7 +594,7 @@ class RigidSolver(KinematicSolver):
                 # Confirmed by dex_hand (n_dofs=62, T=32 +2.6 %) and g1_fall (n_dofs=35, T=16 +2.9 %).
                 cholesky_tile_size = 16 if (self.n_dofs <= 16 or 32 < self.n_dofs <= 48) else 32
                 tiled_n_dofs = max(math.ceil(self.n_dofs / cholesky_tile_size), 1) * cholesky_tile_size
-                tiled_n_dofs_per_block = max(math.ceil(max_block_dofs / 32), 1) * 32
+                tiled_n_dofs_per_tree = max(math.ceil(max_tree_dofs / 32), 1) * 32
 
                 # The decomposed arm's cooperative per-island solve stages one island's tile in shared memory.
                 # Size it to the largest tile-size multiple that fits shared (precision-aware), but no larger
@@ -619,15 +620,15 @@ class RigidSolver(KinematicSolver):
                 # The cooperative in-place LDL^T has no cap; the shared-memory tile is faster but capped. Same env logic
                 # as the Hessian: tile from the largest block >= 8 DOFs, drop the env guard above the cap where the
                 # scalar O(n_block_dofs^3) per-(block, env) factor is always worse.
-                mass_matrix_fits_shared = fits_in_gpu_shared_memory(tiled_n_dofs_per_block, tiled_n_dofs_per_block + 1)
-                enable_tiled_cholesky_mass_matrix = max_block_dofs >= 8 and (
+                mass_matrix_fits_shared = fits_in_gpu_shared_memory(tiled_n_dofs_per_tree, tiled_n_dofs_per_tree + 1)
+                enable_tiled_cholesky_mass_matrix = max_tree_dofs >= 8 and (
                     not mass_matrix_fits_shared or envs_undersaturate
                 )
 
-                # Register-streaming tiled mass factor for the >shared-cap forward GPU path: it factors each mass block
-                # (kinematic tree) in registers via the same primitive as the Hessian, and is faster than and
-                # numerically matches the cooperative LDL^T. Reuses cholesky_tile_size (always 32 here, since the path
-                # needs a per-entity block exceeding shared memory).
+                # Register-streaming tiled mass factor for the >shared-cap forward GPU path: it factors each kinematic
+                # tree in registers via the same primitive as the Hessian, and is faster than and numerically matches
+                # the cooperative LDL^T. Reuses cholesky_tile_size (always 32 here, since the path needs a tree
+                # exceeding shared memory).
                 enable_register_tiled_mass = (
                     enable_tiled_cholesky_mass_matrix and not mass_matrix_fits_shared and not self._requires_grad
                 )
@@ -653,7 +654,7 @@ class RigidSolver(KinematicSolver):
                     enable_per_island_solve=(
                         self._use_contact_island and (self._use_hibernation or not hessian_fits_shared)
                     ),
-                    tiled_n_dofs_per_block=tiled_n_dofs_per_block,
+                    tiled_n_dofs_per_tree=tiled_n_dofs_per_tree,
                     tiled_n_dofs=tiled_n_dofs,
                     tiled_n_island_dofs=tiled_n_island_dofs,
                     # Persistent block grid for the cooperative per-island factor+solve: enough T-lane blocks to fill the
@@ -922,7 +923,7 @@ class RigidSolver(KinematicSolver):
         # is rooted at the topmost DOF-bearing ancestor reachable before the world; DOFs are numbered depth-first, so a
         # block is a contiguous range whose root link's first DOF is the block start.
         links_by_idx = {link.idx: link for link in self.links}
-        block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
+        dofs_mass_block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
         for link in self.links:
             if link.n_dofs == 0:
                 continue
@@ -932,11 +933,11 @@ class RigidSolver(KinematicSolver):
                 node = links_by_idx[node.parent_idx]
                 if node.n_dofs > 0:
                     root_link = node
-            block_start[link.dof_start : link.dof_end] = root_link.dof_start
-        block_end = np.empty(self.n_dofs_, dtype=gs.np_int)
+            dofs_mass_block_start[link.dof_start : link.dof_end] = root_link.dof_start
+        dofs_mass_block_end = np.empty(self.n_dofs_, dtype=gs.np_int)
         for i_d in range(self.n_dofs_):
-            block_end[block_start[i_d]] = i_d + 1
-        block_end = block_end[block_start]
+            dofs_mass_block_end[dofs_mass_block_start[i_d]] = i_d + 1
+        dofs_mass_block_end = dofs_mass_block_end[dofs_mass_block_start]
 
         # Each kinematic tree's links must form one contiguous range: the CRB fold reduces a tree over the contiguous
         # run of links sharing its root (root_idx), and the mass-block partition assumes the same. attach() can leave
@@ -956,6 +957,14 @@ class RigidSolver(KinematicSolver):
                     )
                 seen_roots.add(root)
                 previous_root = root
+
+        # See links_tree_end in array_class.py. The contiguity check above certifies each tree's link run, so a run
+        # ends where the next one starts.
+        links_root_idx = np.array([link.root_idx for link in self.links], dtype=gs.np_int)
+        links_tree_end = np.zeros(self.n_links_, dtype=gs.np_int)
+        if self.links:
+            run_starts = np.flatnonzero(np.r_[True, links_root_idx[1:] != links_root_idx[:-1]])
+            links_tree_end[run_starts] = np.r_[run_starts[1:], self.n_links]
 
         # A parent in another tree is only sound as a fixed (0-DOF-chain) anchor: the CRB fold and the cartesian-space
         # tree walk both stop at tree boundaries, so a moving cross-tree parent would never receive its child subtree's
@@ -980,20 +989,38 @@ class RigidSolver(KinematicSolver):
             # (no DOF-bearing ancestor or descendant), otherwise the coupled block is not diagonal.
             if (
                 not link.aligned
-                or block_start[link.dof_start] != link.dof_start
-                or block_end[link.dof_start] != link.dof_end
+                or dofs_mass_block_start[link.dof_start] != link.dof_start
+                or dofs_mass_block_end[link.dof_start] != link.dof_end
             ):
                 continue
             for i_d in range(link.dof_start, link.dof_end):
                 for j_d in range(link.dof_start, link.dof_end):
                     if i_d != j_d:
                         mass_parent_mask[i_d, j_d] = 0.0
-                block_start[i_d] = i_d
-                block_end[i_d] = i_d + 1
+                dofs_mass_block_start[i_d] = i_d
+                dofs_mass_block_end[i_d] = i_d + 1
+
+        # See entities_mass_block_dof_start in array_class.py: skip a leading run of DOFs merged into an
+        # earlier-rooted block; the end is the last rooted block's end, which may extend past the entity's own DOFs
+        # into a merged child.
+        entities_mass_block_dof_start = np.zeros(self.n_entities_, dtype=gs.np_int)
+        entities_mass_block_dof_end = np.zeros(self.n_entities_, dtype=gs.np_int)
+        for i_e, entity in enumerate(self.entities):
+            blocks_dof_start = entity.dof_start
+            blocks_dof_end = entity.dof_start
+            if entity.n_dofs > 0:
+                if dofs_mass_block_start[entity.dof_start] != entity.dof_start:
+                    blocks_dof_start = dofs_mass_block_end[entity.dof_start]
+                blocks_dof_end = dofs_mass_block_end[entity.dof_end - 1]
+            entities_mass_block_dof_start[i_e] = blocks_dof_start
+            entities_mass_block_dof_end[i_e] = blocks_dof_end
 
         self._rigid_global_info.mass_parent_mask.from_numpy(mass_parent_mask)
-        self._rigid_global_info.dofs_mass_block_start.from_numpy(block_start)
-        self._rigid_global_info.dofs_mass_block_end.from_numpy(block_end)
+        self._rigid_global_info.dofs_mass_block_start.from_numpy(dofs_mass_block_start)
+        self._rigid_global_info.dofs_mass_block_end.from_numpy(dofs_mass_block_end)
+        self._rigid_global_info.links_tree_end.from_numpy(links_tree_end)
+        self._rigid_global_info.entities_mass_block_dof_start.from_numpy(entities_mass_block_dof_start)
+        self._rigid_global_info.entities_mass_block_dof_end.from_numpy(entities_mass_block_dof_end)
 
         self._rigid_global_info.gravity.from_numpy(self.gravity)
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -566,10 +566,8 @@ class RigidSolver(KinematicSolver):
         if gs.backend == gs.cpu or self.sim.options.requires_grad:
             static_rigid_sim_config["prefer_decomposed_solver"] = 0
 
-        # Per-DOF mass-block bounds (see dofs_mass_block_start in array_class.py): each DOF's block is rooted at its
-        # topmost DOF-bearing ancestor reachable before the world; DOFs are numbered depth-first, so a block is an
-        # interval whose root's first DOF is the block start. Computed here because the tiled factor arms below must be
-        # sized for the largest block; _init_mass_mat consumes and uploads the bounds.
+        # Per-DOF mass-block bounds (see dofs_mass_block_start in array_class.py), computed here because the tiled
+        # factor arms below are sized for the largest block; _init_mass_mat uploads them.
         links_by_idx = {link.idx: link for link in self.links}
         dofs_mass_block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
         for link in self.links:
@@ -597,10 +595,9 @@ class RigidSolver(KinematicSolver):
             # only help while envs alone do not already saturate the GPU. Above that env count one-thread-per-env keeps
             # every core busy and the scalar path wins; below it the parallel kernels hide latency by swapping warps.
             # The crossover is also hardware- and kernel-dependent, so the env threshold (GPU core count) is a heuristic
-            # and a dynamic timer-based selection would be more accurate still. Largest mass block in DOFs: the biggest
-            # independently-factorable unit, which the per-block factor must be sized for. A block can span merged
-            # entities (see attach), so it can exceed any single entity, while a multi-block entity's blocks are each
-            # smaller than the entity.
+            # and a dynamic timer-based selection would be more accurate still.
+            # Largest mass block in DOFs, the unit the per-block factor is sized for: merged entities can make a block
+            # exceed any single entity (see attach).
             max_block_dofs = int((dofs_mass_block_end - dofs_mass_block_start).max()) if self.n_dofs else 0
             if gs.backend != gs.cpu:
                 max_tiled_envs = get_gpu_core_count()
@@ -646,10 +643,9 @@ class RigidSolver(KinematicSolver):
                     not mass_matrix_fits_shared or envs_undersaturate
                 )
 
-                # Register-streaming tiled mass factor for the >shared-cap forward GPU path: it factors each kinematic
-                # tree in registers via the same primitive as the Hessian, and is faster than and numerically matches
-                # the cooperative LDL^T. Reuses cholesky_tile_size (always 32 here, since the path needs a tree
-                # exceeding shared memory).
+                # Register-streaming tiled mass factor for the >shared-cap forward GPU path: factors each mass
+                # block in registers via the same primitive as the Hessian, faster than and numerically matching the
+                # cooperative LDL^T. Reuses cholesky_tile_size (always 32 here).
                 enable_register_tiled_mass = (
                     enable_tiled_cholesky_mass_matrix and not mass_matrix_fits_shared and not self._requires_grad
                 )

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -572,7 +572,14 @@ class RigidSolver(KinematicSolver):
             # every core busy and the scalar path wins; below it the parallel kernels hide latency by swapping warps.
             # The crossover is also hardware- and kernel-dependent, so the env threshold (GPU core count) is a heuristic
             # and a dynamic timer-based selection would be more accurate still.
-            max_n_dofs_per_entity = max(entity.n_dofs for entity in self.entities) if self.entities else 0
+            # Largest mass block in DOFs = largest kinematic tree, grouped by the moving-tree root link (root_idx). A
+            # tree spans merged entities (so a block can exceed any single entity) while a multi-tree entity's blocks
+            # are each smaller than the entity, so this - not the per-entity DOF count - is what the per-block factor
+            # actually processes and must be sized for.
+            tree_dofs: dict[int, int] = {}
+            for link in self.links:
+                tree_dofs[link.root_idx] = tree_dofs.get(link.root_idx, 0) + link.n_dofs
+            max_block_dofs = max(tree_dofs.values()) if tree_dofs else 0
             if gs.backend != gs.cpu:
                 max_tiled_envs = get_gpu_core_count()
                 envs_undersaturate = self.n_envs <= max_tiled_envs
@@ -586,7 +593,7 @@ class RigidSolver(KinematicSolver):
                 # Confirmed by dex_hand (n_dofs=62, T=32 +2.6 %) and g1_fall (n_dofs=35, T=16 +2.9 %).
                 cholesky_tile_size = 16 if (self.n_dofs <= 16 or 32 < self.n_dofs <= 48) else 32
                 tiled_n_dofs = max(math.ceil(self.n_dofs / cholesky_tile_size), 1) * cholesky_tile_size
-                tiled_n_dofs_per_entity = max(math.ceil(max_n_dofs_per_entity / 32), 1) * 32
+                tiled_n_dofs_per_block = max(math.ceil(max_block_dofs / 32), 1) * 32
 
                 # The decomposed arm's cooperative per-island solve stages one island's tile in shared memory.
                 # Size it to the largest tile-size multiple that fits shared (precision-aware), but no larger
@@ -610,12 +617,10 @@ class RigidSolver(KinematicSolver):
                 enable_tiled_cholesky_hessian = self.n_dofs >= 16 and (not hessian_fits_shared or envs_undersaturate)
 
                 # The cooperative in-place LDL^T has no cap; the shared-memory tile is faster but capped. Same env logic
-                # as the Hessian: tile from n_dofs_per_entity >= 8, drop the env guard above the cap where the scalar
-                # O(n_dofs^3) per-(entity, env) factor is always worse.
-                mass_matrix_fits_shared = fits_in_gpu_shared_memory(
-                    tiled_n_dofs_per_entity, tiled_n_dofs_per_entity + 1
-                )
-                enable_tiled_cholesky_mass_matrix = max_n_dofs_per_entity >= 8 and (
+                # as the Hessian: tile from the largest block >= 8 DOFs, drop the env guard above the cap where the
+                # scalar O(n_block_dofs^3) per-(block, env) factor is always worse.
+                mass_matrix_fits_shared = fits_in_gpu_shared_memory(tiled_n_dofs_per_block, tiled_n_dofs_per_block + 1)
+                enable_tiled_cholesky_mass_matrix = max_block_dofs >= 8 and (
                     not mass_matrix_fits_shared or envs_undersaturate
                 )
 
@@ -648,7 +653,7 @@ class RigidSolver(KinematicSolver):
                     enable_per_island_solve=(
                         self._use_contact_island and (self._use_hibernation or not hessian_fits_shared)
                     ),
-                    tiled_n_dofs_per_entity=tiled_n_dofs_per_entity,
+                    tiled_n_dofs_per_block=tiled_n_dofs_per_block,
                     tiled_n_dofs=tiled_n_dofs,
                     tiled_n_island_dofs=tiled_n_island_dofs,
                     # Persistent block grid for the cooperative per-island factor+solve: enough T-lane blocks to fill the
@@ -932,6 +937,25 @@ class RigidSolver(KinematicSolver):
         for i_d in range(self.n_dofs_):
             block_end[block_start[i_d]] = i_d + 1
         block_end = block_end[block_start]
+
+        # Each kinematic tree's links must form one contiguous range: the CRB fold reduces a tree over the contiguous
+        # run of links sharing its root (root_idx), and the mass-block partition assumes the same. attach() can leave
+        # them split when a third entity is numbered between the parent and its attached child - including a zero-DOF
+        # prop, which keeps the DOFs contiguous yet still interleaves a link. Raise clearly instead of silently dropping
+        # the child's inertia; the resolution is to instantiate the child right after its parent, or attach before
+        # adding the intervening entity.
+        previous_root = -1
+        seen_roots = set()
+        for root in (link.root_idx for link in self.links):
+            if root != previous_root:
+                if root in seen_roots:
+                    gs.raise_exception(
+                        "Attaching an entity onto a parent that is not adjacent in the entity ordering (another "
+                        "entity's links fall between them) is not supported: it splits a kinematic tree. Instantiate "
+                        "the child entity right after its parent, or attach before adding the intervening entity."
+                    )
+                seen_roots.add(root)
+                previous_root = root
 
         # An aligned free body whose only DOFs are its own free joint has a diagonal joint-space mass block, so zero its
         # within-link off-diagonal mask to make the assembled mass exactly diagonal (else ~1e-6 round-off once it

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -594,10 +594,12 @@ class RigidSolver(KinematicSolver):
         # the price of wasted flops on their rows - proportional to the DOFs created between attached entities, hence
         # the advice to instantiate them consecutively (see RigidEntity.attach).
         roots_idx = np.flatnonzero(dofs_mass_block_start == np.arange(self.n_dofs_, dtype=gs.np_int))
+        has_interleaved_blocks = False
         span_start, span_end = 0, 0
         for i_d_root in roots_idx:
             if i_d_root < span_end:
                 span_end = max(span_end, dofs_mass_block_end[i_d_root])
+                has_interleaved_blocks = True
             else:
                 dofs_mass_block_start[span_start:span_end] = span_start
                 dofs_mass_block_end[span_start:span_end] = span_end
@@ -606,6 +608,11 @@ class RigidSolver(KinematicSolver):
         dofs_mass_block_end[span_start:span_end] = span_end
         self._dofs_mass_block_start = dofs_mass_block_start
         self._dofs_mass_block_end = dofs_mass_block_end
+        if has_interleaved_blocks:
+            gs.logger.warning(
+                "Attached entities are interleaved with unrelated degrees of freedom, which inflates the mass "
+                "factorization cost. Instantiate attached entities consecutively to avoid it."
+            )
 
         if self.is_active:
             # The tiled and cooperative Cholesky kernels trade per-env serial work for cross-lane parallelism, so they

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -957,6 +957,20 @@ class RigidSolver(KinematicSolver):
                 seen_roots.add(root)
                 previous_root = root
 
+        # A parent in another tree is only sound as a fixed (0-DOF-chain) anchor: the CRB fold and the cartesian-space
+        # tree walk both stop at tree boundaries, so a moving cross-tree parent would never receive its child subtree's
+        # composite inertia nor propagate its motion - the roots are inconsistent with the kinematic structure and mass
+        # would be silently lost (see the crb tree walk in forward_dynamics.py).
+        for link in self.links:
+            if link.parent_idx != -1:
+                parent_link = links_by_idx[link.parent_idx]
+                if link.root_idx != parent_link.root_idx and not parent_link.is_fixed:
+                    gs.raise_exception(
+                        f"Link '{link.name}' and its moving parent link '{parent_link.name}' belong to different "
+                        f"kinematic trees (root {link.root_idx} vs {parent_link.root_idx}). Kinematic tree root "
+                        f"indices are inconsistent with the parent structure."
+                    )
+
         # An aligned free body whose only DOFs are its own free joint has a diagonal joint-space mass block, so zero its
         # within-link off-diagonal mask to make the assembled mass exactly diagonal (else ~1e-6 round-off once it
         # rotates) and the skyline envelope tighter. A DOF-bearing (articulated) descendant adds off-diagonal base

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -113,28 +113,18 @@ class RigidGlobalInfo:
     mass_mat_D_inv: qd.Tensor
     mass_mat_tiled_scratch: qd.Tensor
     mass_mat_mask: qd.Tensor
-    # Per-DOF bounds of the mass block the DOF belongs to: a maximal contiguous set of DOFs coupled through chains of
-    # moving joints (contiguity is enforced by RigidEntity.attach). A mass block is FINER than a kinematic tree (the
-    # root_idx link unit): a tree splits into one block per moving-rooted branch hanging under its fixed links (e.g. per
-    # arm of a fixed-base robot), while attach() welds merge blocks across entities. The mass matrix is block-diagonal
-    # across mass blocks, so the assemble/factor/solve restrict to [block_start, block_end) instead of the full entity
-    # DOF range - making a multi-block entity (e.g. an MJCF file with many free bodies) cost the same as the equivalent
-    # separate entities.
+    # Per-DOF bounds of the mass block the DOF belongs to: the DOFs of its branch rooted where the fixed structure
+    # ends (deeper branches stay mass-coupled to their chain and belong to the enclosing block), merged across
+    # entities and kept contiguous by attach(). The assemble/factor/solve restrict to these bounds.
     dofs_mass_block_start: qd.Tensor
     dofs_mass_block_end: qd.Tensor
     # One-past-the-last link of the kinematic tree rooted at each root link (root_idx == itself); unused for non-root
-    # links. attach() can leave other trees' links interleaved inside the span (only 0-DOF entities created between
-    # attached ones - DOF-level interleaving is rejected by attach itself), so consumers gate each link on the tree's
-    # root. This cannot be derived from the mass-block DOF bounds above (a tree's trailing fixed links carry no DOF) and
-    # is precomputed at build time so the CRB tree fold reads its bounds directly - autodiff supports no while-loop
-    # scan.
+    # links. The span may contain interleaved links of 0-DOF entities created between attached ones, so consumers gate
+    # each link on the tree's root. Underivable from the DOF bounds above: trailing fixed links carry no DOF.
     links_tree_end: qd.Tensor
-    # DOF range spanned by the mass blocks rooted in each entity. Rooted blocks chain contiguously, so the per-DOF block
-    # bounds above fully partition the range: a leading run of DOFs merged into an earlier-rooted block (see attach) is
-    # excluded, and the last rooted block may extend past the entity's own DOFs into a merged child. A fully-merged
-    # child entity gets an empty range. Precomputed at build time so the per-entity assemble/factor/solve iterate their
-    # blocks as one flat range-for over DOFs, which reverse-mode autodiff supports (a nested per-block loop overflows
-    # the autodiff stack, and a while loop is not supported at all).
+    # DOF range spanned by the mass blocks rooted in each entity: a leading run merged into an earlier-rooted block is
+    # excluded, and the last rooted block may extend into a merged child (empty range for a fully-merged child). Lets
+    # the per-entity assemble/factor/solve iterate their blocks as one flat, autodiff-compatible loop over DOFs.
     entities_mass_block_dof_start: qd.Tensor
     entities_mass_block_dof_end: qd.Tensor
     meaninertia: qd.Tensor

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -113,18 +113,21 @@ class RigidGlobalInfo:
     mass_mat_D_inv: qd.Tensor
     mass_mat_tiled_scratch: qd.Tensor
     mass_mat_mask: qd.Tensor
-    # Per-DOF bounds of the mass block the DOF belongs to: a maximal contiguous set of DOFs coupled through chains of
-    # moving joints. A mass block is FINER than a kinematic tree (the root_idx link unit): a tree splits into one
-    # block per moving-rooted branch hanging under its fixed links (e.g. per arm of a fixed-base robot), while
-    # attach() welds merge blocks across entities. The mass matrix is block-diagonal across mass blocks, so the
-    # assemble/factor/solve restrict to [block_start, block_end) instead of the full entity DOF range - making a
-    # multi-block entity (e.g. an MJCF file with many free bodies) cost the same as the equivalent separate entities.
+    # Per-DOF bounds of the mass block the DOF belongs to: the enclosing interval of a maximal set of DOFs coupled
+    # through chains of moving joints, with overlapping intervals merged (see the closure in _build_static_config). A
+    # mass block is FINER than a kinematic tree (the root_idx link unit): a tree splits into one block per
+    # moving-rooted branch hanging under its fixed links (e.g. per arm of a fixed-base robot), while attach() welds
+    # merge blocks across entities - possibly swallowing the DOFs created in between, which carry exactly zero
+    # coupling. The mass matrix is block-diagonal across mass blocks, so the assemble/factor/solve restrict to
+    # [block_start, block_end) instead of the full entity DOF range - making a multi-block entity (e.g. an MJCF file
+    # with many free bodies) cost the same as the equivalent separate entities.
     dofs_mass_block_start: qd.Tensor
     dofs_mass_block_end: qd.Tensor
     # One-past-the-last link of the kinematic tree rooted at each root link (root_idx == itself); unused for non-root
-    # links. This cannot be derived from the mass-block DOF bounds above (a tree's trailing fixed links carry no DOF)
-    # and is precomputed at build time so the CRB tree fold reads its bounds directly - autodiff supports no
-    # while-loop scan, and the contiguity of each tree's links is validated at build time anyway.
+    # links. attach() can leave other trees' links interleaved inside the span, so consumers gate each link on the
+    # tree's root. This cannot be derived from the mass-block DOF bounds above (a tree's trailing fixed links carry no
+    # DOF) and is precomputed at build time so the CRB tree fold reads its bounds directly - autodiff supports no
+    # while-loop scan.
     links_tree_end: qd.Tensor
     # DOF range spanned by the mass blocks rooted in each entity. Rooted blocks chain contiguously, so the per-DOF
     # block bounds above fully partition the range: a leading run of DOFs merged into an earlier-rooted block (see
@@ -2409,7 +2412,7 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # flattened index decompositions) key on this flag, while algorithm selection (warp-cooperative vs serial
     # reductions) keys on enable_cooperative_constraint_kernels alone.
     constraint_layout_batch_first: bool = False
-    tiled_n_dofs_per_tree: int = -1
+    tiled_n_dofs_per_block: int = -1
     tiled_n_dofs: int = -1
     tiled_n_island_dofs: int = -1  # shared-tile cap for the cooperative per-island solve (fits GPU shared memory)
     # Number of persistent T-lane blocks the cooperative per-island factor+solve launches. The grid is static (for

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -113,12 +113,27 @@ class RigidGlobalInfo:
     mass_mat_D_inv: qd.Tensor
     mass_mat_tiled_scratch: qd.Tensor
     mass_mat_mask: qd.Tensor
-    # Per-DOF bounds of the contiguous, independently-factorable mass-matrix block the DOF belongs to (a kinematic
-    # tree, or merged trees whose DOF intervals interleave). The mass matrix is block-diagonal across these blocks, so
-    # the assemble/factor/solve restrict to [block_start, block_end) instead of the full entity DOF range - making a
-    # multi-tree entity (e.g. an MJCF file with many free bodies) cost the same as the equivalent separate entities.
+    # Per-DOF bounds of the mass block the DOF belongs to: a maximal contiguous set of DOFs coupled through chains of
+    # moving joints. A mass block is FINER than a kinematic tree (the root_idx link unit): a tree splits into one
+    # block per moving-rooted branch hanging under its fixed links (e.g. per arm of a fixed-base robot), while
+    # attach() welds merge blocks across entities. The mass matrix is block-diagonal across mass blocks, so the
+    # assemble/factor/solve restrict to [block_start, block_end) instead of the full entity DOF range - making a
+    # multi-block entity (e.g. an MJCF file with many free bodies) cost the same as the equivalent separate entities.
     dofs_mass_block_start: qd.Tensor
     dofs_mass_block_end: qd.Tensor
+    # One-past-the-last link of the kinematic tree rooted at each root link (root_idx == itself); unused for non-root
+    # links. This cannot be derived from the mass-block DOF bounds above (a tree's trailing fixed links carry no DOF)
+    # and is precomputed at build time so the CRB tree fold reads its bounds directly - autodiff supports no
+    # while-loop scan, and the contiguity of each tree's links is validated at build time anyway.
+    links_tree_end: qd.Tensor
+    # DOF range spanned by the mass blocks rooted in each entity. Rooted blocks chain contiguously, so the per-DOF
+    # block bounds above fully partition the range: a leading run of DOFs merged into an earlier-rooted block (see
+    # attach) is excluded, and the last rooted block may extend past the entity's own DOFs into a merged child. A
+    # fully-merged child entity gets an empty range. Precomputed at build time so the per-entity assemble/factor/solve
+    # iterate their blocks as one flat range-for over DOFs, which reverse-mode autodiff supports (a nested per-block
+    # loop overflows the autodiff stack, and a while loop is not supported at all).
+    entities_mass_block_dof_start: qd.Tensor
+    entities_mass_block_dof_end: qd.Tensor
     meaninertia: qd.Tensor
     mass_parent_mask: qd.Tensor
     gravity: qd.Tensor
@@ -199,6 +214,9 @@ def get_rigid_global_info(solver, kinematic_only):
             mass_mat_mask=V(dtype=gs.qd_bool, shape=()),
             dofs_mass_block_start=V(dtype=gs.qd_int, shape=()),
             dofs_mass_block_end=V(dtype=gs.qd_int, shape=()),
+            links_tree_end=V(dtype=gs.qd_int, shape=()),
+            entities_mass_block_dof_start=V(dtype=gs.qd_int, shape=()),
+            entities_mass_block_dof_end=V(dtype=gs.qd_int, shape=()),
             mass_parent_mask=V(dtype=gs.qd_float, shape=()),
             substep_dt=V_SCALAR_FROM(dtype=gs.qd_float, value=0.0),
             iterations=V_SCALAR_FROM(dtype=gs.qd_int, value=0),
@@ -237,6 +255,9 @@ def get_rigid_global_info(solver, kinematic_only):
         mass_mat_mask=V(dtype=gs.qd_bool, shape=(solver.n_entities_, _B)),
         dofs_mass_block_start=V(dtype=gs.qd_int, shape=(solver.n_dofs_,)),
         dofs_mass_block_end=V(dtype=gs.qd_int, shape=(solver.n_dofs_,)),
+        links_tree_end=V(dtype=gs.qd_int, shape=(solver.n_links_,)),
+        entities_mass_block_dof_start=V(dtype=gs.qd_int, shape=(solver.n_entities_,)),
+        entities_mass_block_dof_end=V(dtype=gs.qd_int, shape=(solver.n_entities_,)),
         mass_parent_mask=V(dtype=gs.qd_float, shape=(solver.n_dofs_, solver.n_dofs_)),
         substep_dt=V_SCALAR_FROM(dtype=gs.qd_float, value=solver._substep_dt),
         iterations=V_SCALAR_FROM(dtype=gs.qd_int, value=solver._options.iterations),
@@ -2388,7 +2409,7 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # flattened index decompositions) key on this flag, while algorithm selection (warp-cooperative vs serial
     # reductions) keys on enable_cooperative_constraint_kernels alone.
     constraint_layout_batch_first: bool = False
-    tiled_n_dofs_per_block: int = -1
+    tiled_n_dofs_per_tree: int = -1
     tiled_n_dofs: int = -1
     tiled_n_island_dofs: int = -1  # shared-tile cap for the cooperative per-island solve (fits GPU shared memory)
     # Number of persistent T-lane blocks the cooperative per-island factor+solve launches. The grid is static (for

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -2388,7 +2388,7 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # flattened index decompositions) key on this flag, while algorithm selection (warp-cooperative vs serial
     # reductions) keys on enable_cooperative_constraint_kernels alone.
     constraint_layout_batch_first: bool = False
-    tiled_n_dofs_per_entity: int = -1
+    tiled_n_dofs_per_block: int = -1
     tiled_n_dofs: int = -1
     tiled_n_island_dofs: int = -1  # shared-tile cap for the cooperative per-island solve (fits GPU shared memory)
     # Number of persistent T-lane blocks the cooperative per-island factor+solve launches. The grid is static (for

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -113,28 +113,28 @@ class RigidGlobalInfo:
     mass_mat_D_inv: qd.Tensor
     mass_mat_tiled_scratch: qd.Tensor
     mass_mat_mask: qd.Tensor
-    # Per-DOF bounds of the mass block the DOF belongs to: the enclosing interval of a maximal set of DOFs coupled
-    # through chains of moving joints, with overlapping intervals merged (see the closure in _build_static_config). A
-    # mass block is FINER than a kinematic tree (the root_idx link unit): a tree splits into one block per
-    # moving-rooted branch hanging under its fixed links (e.g. per arm of a fixed-base robot), while attach() welds
-    # merge blocks across entities - possibly swallowing the DOFs created in between, which carry exactly zero
-    # coupling. The mass matrix is block-diagonal across mass blocks, so the assemble/factor/solve restrict to
-    # [block_start, block_end) instead of the full entity DOF range - making a multi-block entity (e.g. an MJCF file
-    # with many free bodies) cost the same as the equivalent separate entities.
+    # Per-DOF bounds of the mass block the DOF belongs to: a maximal contiguous set of DOFs coupled through chains of
+    # moving joints (contiguity is enforced by RigidEntity.attach). A mass block is FINER than a kinematic tree (the
+    # root_idx link unit): a tree splits into one block per moving-rooted branch hanging under its fixed links (e.g. per
+    # arm of a fixed-base robot), while attach() welds merge blocks across entities. The mass matrix is block-diagonal
+    # across mass blocks, so the assemble/factor/solve restrict to [block_start, block_end) instead of the full entity
+    # DOF range - making a multi-block entity (e.g. an MJCF file with many free bodies) cost the same as the equivalent
+    # separate entities.
     dofs_mass_block_start: qd.Tensor
     dofs_mass_block_end: qd.Tensor
     # One-past-the-last link of the kinematic tree rooted at each root link (root_idx == itself); unused for non-root
-    # links. attach() can leave other trees' links interleaved inside the span, so consumers gate each link on the
-    # tree's root. This cannot be derived from the mass-block DOF bounds above (a tree's trailing fixed links carry no
-    # DOF) and is precomputed at build time so the CRB tree fold reads its bounds directly - autodiff supports no
-    # while-loop scan.
+    # links. attach() can leave other trees' links interleaved inside the span (only 0-DOF entities created between
+    # attached ones - DOF-level interleaving is rejected by attach itself), so consumers gate each link on the tree's
+    # root. This cannot be derived from the mass-block DOF bounds above (a tree's trailing fixed links carry no DOF) and
+    # is precomputed at build time so the CRB tree fold reads its bounds directly - autodiff supports no while-loop
+    # scan.
     links_tree_end: qd.Tensor
-    # DOF range spanned by the mass blocks rooted in each entity. Rooted blocks chain contiguously, so the per-DOF
-    # block bounds above fully partition the range: a leading run of DOFs merged into an earlier-rooted block (see
-    # attach) is excluded, and the last rooted block may extend past the entity's own DOFs into a merged child. A
-    # fully-merged child entity gets an empty range. Precomputed at build time so the per-entity assemble/factor/solve
-    # iterate their blocks as one flat range-for over DOFs, which reverse-mode autodiff supports (a nested per-block
-    # loop overflows the autodiff stack, and a while loop is not supported at all).
+    # DOF range spanned by the mass blocks rooted in each entity. Rooted blocks chain contiguously, so the per-DOF block
+    # bounds above fully partition the range: a leading run of DOFs merged into an earlier-rooted block (see attach) is
+    # excluded, and the last rooted block may extend past the entity's own DOFs into a merged child. A fully-merged
+    # child entity gets an empty range. Precomputed at build time so the per-entity assemble/factor/solve iterate their
+    # blocks as one flat range-for over DOFs, which reverse-mode autodiff supports (a nested per-block loop overflows
+    # the autodiff stack, and a while loop is not supported at all).
     entities_mass_block_dof_start: qd.Tensor
     entities_mass_block_dof_end: qd.Tensor
     meaninertia: qd.Tensor

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -118,6 +118,8 @@ def order_links_depth_first(l_infos, j_infos, links_g_infos=None):
     for l_info in l_infos:
         if l_info["parent_idx"] >= 0:  # non-base link
             l_info["parent_idx"] = ordered_links_idx.index(l_info["parent_idx"])
+        if "root_idx" in l_info:
+            l_info["root_idx"] = ordered_links_idx.index(l_info["root_idx"])
 
     new_l_infos = [l_infos[i] for i in ordered_links_idx]
     new_j_infos = [j_infos[i] for i in ordered_links_idx]

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -695,11 +695,17 @@ def xacro_robot(tmp_path):
 
 @pytest.fixture(scope="session")
 def merged_arm_hand_models():
-    # Three MJCF models built from shared fragments so the merged pair is kinematically identical to the single
-    # equivalent entity by construction: an arm (fixed base -> a1 -> a2 -> tip, hinges about z, links along +x so the
-    # neutral tip frame is identity) and a branching hand (palm + 4 fingers x 3 hinges = 12 DOFs). Returns
-    # (monolith, arm_only, hand_only): the monolith splices the hand rigidly under the arm tip; the split pair attaches
-    # the (floating-base) hand to the tip with an identity offset (child morph pos 0 == coincident with the parent link).
+    """MJCF models built from shared fragments so the merged entities are kinematically identical to the single
+    equivalent entity by construction: an arm (fixed base -> a1 -> a2 -> tip, hinges about z, links along +x so the
+    neutral tip frame is identity) and a branching hand (palm + 4 fingers x 3 hinges = 12 DOFs).
+
+    Returns (monolith, arm_only, arm_with_free_box, hand_only): the monolith splices three hands rigidly - one under
+    the tip, one chained under the first hand's palm, and one under a2 (a second branch of the same tree) - declared
+    in that depth-first order so its DOF layout matches attaching three hand entities in the same creation order, each
+    with an identity offset (child morph pos 0 == coincident with the parent link). arm_with_free_box additionally
+    declares a free body after the arm, making it a two-tree entity.
+    """
+
     def _finger(parent, name, y):
         b0 = ET.SubElement(parent, "body", name=f"{name}_0", pos=f"0.05 {y} 0")
         ET.SubElement(b0, "joint", name=f"{name}_j0", type="hinge", axis="0 1 0", pos="0 0 0")
@@ -711,13 +717,14 @@ def merged_arm_hand_models():
         ET.SubElement(b2, "joint", name=f"{name}_j2", type="hinge", axis="0 1 0", pos="0 0 0")
         ET.SubElement(b2, "geom", type="box", size="0.02 0.008 0.008", mass="0.03")
 
-    def _palm(parent, is_root):
-        palm = ET.SubElement(parent, "body", name="palm", pos="0 0 0")
+    def _palm(parent, is_root, prefix=""):
+        palm = ET.SubElement(parent, "body", name=f"{prefix}palm", pos="0 0 0")
         if is_root:
             ET.SubElement(palm, "freejoint")
         ET.SubElement(palm, "geom", type="box", size="0.03 0.05 0.02", mass="0.2")
         for i, y in enumerate((-0.03, -0.01, 0.01, 0.03)):
-            _finger(palm, f"f{i}", y)
+            _finger(palm, f"{prefix}f{i}", y)
+        return palm
 
     def _arm_tip(worldbody):
         base = ET.SubElement(worldbody, "body", name="base", pos="0 0 0.5")
@@ -728,25 +735,41 @@ def merged_arm_hand_models():
         tip = ET.SubElement(a2, "body", name="tip", pos="0.2 0 0")
         ET.SubElement(tip, "joint", name="a2", type="hinge", axis="0 0 1", pos="0 0 0")
         ET.SubElement(tip, "geom", type="capsule", fromto="0 0 0 0.02 0 0", size="0.02", mass="0.2")
-        return tip
+        return a2, tip
 
-    def _model(with_hand):
+    def _arm_model(with_free_box):
         mjcf = ET.Element("mujoco")
-        tip = _arm_tip(ET.SubElement(mjcf, "worldbody"))
-        if with_hand:
-            _palm(tip, is_root=False)
+        wb = ET.SubElement(mjcf, "worldbody")
+        _arm_tip(wb)
+        if with_free_box:
+            box = ET.SubElement(wb, "body", name="freebox", pos="0 2 1")
+            ET.SubElement(box, "freejoint")
+            ET.SubElement(box, "geom", type="box", size="0.05 0.05 0.05", mass="0.2")
         return ET.tostring(mjcf, encoding="unicode")
+
+    mono_mjcf = ET.Element("mujoco")
+    mono_a2, mono_tip = _arm_tip(ET.SubElement(mono_mjcf, "worldbody"))
+    mono_h1_palm = _palm(mono_tip, is_root=False, prefix="h1_")
+    _palm(mono_h1_palm, is_root=False, prefix="h3_")
+    _palm(mono_a2, is_root=False, prefix="h2_")
 
     hand_mjcf = ET.Element("mujoco")
     _palm(ET.SubElement(hand_mjcf, "worldbody"), is_root=True)
-    return _model(with_hand=True), _model(with_hand=False), ET.tostring(hand_mjcf, encoding="unicode")
+    return (
+        ET.tostring(mono_mjcf, encoding="unicode"),
+        _arm_model(with_free_box=False),
+        _arm_model(with_free_box=True),
+        ET.tostring(hand_mjcf, encoding="unicode"),
+    )
 
 
 @pytest.fixture(scope="session")
 def merged_overlapping_models():
-    # An arm (fixed base -> a2 -> tip) and a floating-base hand whose palm geom, once attached to the tip, overlaps the
-    # arm's a2 link (which is NOT adjacent to the palm) in the neutral configuration. Returns (arm, hand). Used to check
-    # that self-collision / neutral-overlap masking spans the attach merge boundary.
+    """An arm (fixed base -> a2 -> tip) and a floating-base hand whose palm geom, once attached to the tip, overlaps
+    the arm's a2 link (which is NOT adjacent to the palm) in the neutral configuration.
+
+    Returns (arm, hand). Used to check that self-collision / neutral-overlap masking spans the attach merge boundary.
+    """
     arm = ET.Element("mujoco")
     wb = ET.SubElement(arm, "worldbody")
     base = ET.SubElement(wb, "body", name="base", pos="0 0 0.5")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -699,11 +699,11 @@ def merged_arm_hand_models():
     equivalent entity by construction: an arm (fixed base -> a1 -> a2 -> tip, hinges about z, links along +x so the
     neutral tip frame is identity) and a branching hand (palm + 4 fingers x 3 hinges = 12 DOFs).
 
-    Returns (monolith, arm_only, arm_with_free_box, hand_only): the monolith splices three hands rigidly - one under
-    the tip, one chained under the first hand's palm, and one under a2 (a second branch of the same tree) - declared
-    in that depth-first order so its DOF layout matches attaching three hand entities in the same creation order, each
-    with an identity offset (child morph pos 0 == coincident with the parent link). arm_with_free_box additionally
-    declares a free body after the arm, making it a two-tree entity.
+    Returns (monolith, arm_only, arm_free_box_last, arm_free_box_first, hand_only): the monolith splices three hands
+    rigidly - one under the tip, one chained under the first hand's palm, and one under a2 (a second branch of the
+    same tree) - declared in that depth-first order so its DOF layout matches attaching three hand entities in the
+    same creation order, each with an identity offset (child morph pos 0 == coincident with the parent link). The
+    arm_free_box variants additionally declare a free body after or before the arm, making it a two-tree entity.
     """
 
     def _finger(parent, name, y):
@@ -737,14 +737,19 @@ def merged_arm_hand_models():
         ET.SubElement(tip, "geom", type="capsule", fromto="0 0 0 0.02 0 0", size="0.02", mass="0.2")
         return a2, tip
 
-    def _arm_model(with_free_box):
+    def _free_box(worldbody):
+        box = ET.SubElement(worldbody, "body", name="freebox", pos="0 2 1")
+        ET.SubElement(box, "freejoint")
+        ET.SubElement(box, "geom", type="box", size="0.05 0.05 0.05", mass="0.2")
+
+    def _arm_model(free_box_position):
         mjcf = ET.Element("mujoco")
         wb = ET.SubElement(mjcf, "worldbody")
+        if free_box_position == "first":
+            _free_box(wb)
         _arm_tip(wb)
-        if with_free_box:
-            box = ET.SubElement(wb, "body", name="freebox", pos="0 2 1")
-            ET.SubElement(box, "freejoint")
-            ET.SubElement(box, "geom", type="box", size="0.05 0.05 0.05", mass="0.2")
+        if free_box_position == "last":
+            _free_box(wb)
         return ET.tostring(mjcf, encoding="unicode")
 
     mono_mjcf = ET.Element("mujoco")
@@ -757,8 +762,9 @@ def merged_arm_hand_models():
     _palm(ET.SubElement(hand_mjcf, "worldbody"), is_root=True)
     return (
         ET.tostring(mono_mjcf, encoding="unicode"),
-        _arm_model(with_free_box=False),
-        _arm_model(with_free_box=True),
+        _arm_model(free_box_position=None),
+        _arm_model(free_box_position="last"),
+        _arm_model(free_box_position="first"),
         ET.tostring(hand_mjcf, encoding="unicode"),
     )
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -691,3 +691,76 @@ def xacro_robot(tmp_path):
     file_path = str(tmp_path / "two_link.urdf.xacro")
     ET.ElementTree(robot).write(file_path, encoding="utf-8", xml_declaration=True)
     return file_path
+
+
+@pytest.fixture(scope="session")
+def merged_arm_hand_models():
+    # Three MJCF models built from shared fragments so the merged pair is kinematically identical to the single
+    # equivalent entity by construction: an arm (fixed base -> a1 -> a2 -> tip, hinges about z, links along +x so the
+    # neutral tip frame is identity) and a branching hand (palm + 4 fingers x 3 hinges = 12 DOFs). Returns
+    # (monolith, arm_only, hand_only): the monolith splices the hand rigidly under the arm tip; the split pair attaches
+    # the (floating-base) hand to the tip with an identity offset (child morph pos 0 == coincident with the parent link).
+    def _finger(parent, name, y):
+        b0 = ET.SubElement(parent, "body", name=f"{name}_0", pos=f"0.05 {y} 0")
+        ET.SubElement(b0, "joint", name=f"{name}_j0", type="hinge", axis="0 1 0", pos="0 0 0")
+        ET.SubElement(b0, "geom", type="box", size="0.02 0.008 0.008", mass="0.05")
+        b1 = ET.SubElement(b0, "body", name=f"{name}_1", pos="0.04 0 0")
+        ET.SubElement(b1, "joint", name=f"{name}_j1", type="hinge", axis="0 1 0", pos="0 0 0")
+        ET.SubElement(b1, "geom", type="box", size="0.02 0.008 0.008", mass="0.04")
+        b2 = ET.SubElement(b1, "body", name=f"{name}_2", pos="0.04 0 0")
+        ET.SubElement(b2, "joint", name=f"{name}_j2", type="hinge", axis="0 1 0", pos="0 0 0")
+        ET.SubElement(b2, "geom", type="box", size="0.02 0.008 0.008", mass="0.03")
+
+    def _palm(parent, is_root):
+        palm = ET.SubElement(parent, "body", name="palm", pos="0 0 0")
+        if is_root:
+            ET.SubElement(palm, "freejoint")
+        ET.SubElement(palm, "geom", type="box", size="0.03 0.05 0.02", mass="0.2")
+        for i, y in enumerate((-0.03, -0.01, 0.01, 0.03)):
+            _finger(palm, f"f{i}", y)
+
+    def _arm_tip(worldbody):
+        base = ET.SubElement(worldbody, "body", name="base", pos="0 0 0.5")
+        ET.SubElement(base, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.03", mass="1.0")
+        a2 = ET.SubElement(base, "body", name="a2", pos="0.2 0 0")
+        ET.SubElement(a2, "joint", name="a1", type="hinge", axis="0 0 1", pos="0 0 0")
+        ET.SubElement(a2, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.03", mass="1.0")
+        tip = ET.SubElement(a2, "body", name="tip", pos="0.2 0 0")
+        ET.SubElement(tip, "joint", name="a2", type="hinge", axis="0 0 1", pos="0 0 0")
+        ET.SubElement(tip, "geom", type="capsule", fromto="0 0 0 0.02 0 0", size="0.02", mass="0.2")
+        return tip
+
+    def _model(with_hand):
+        mjcf = ET.Element("mujoco")
+        tip = _arm_tip(ET.SubElement(mjcf, "worldbody"))
+        if with_hand:
+            _palm(tip, is_root=False)
+        return ET.tostring(mjcf, encoding="unicode")
+
+    hand_mjcf = ET.Element("mujoco")
+    _palm(ET.SubElement(hand_mjcf, "worldbody"), is_root=True)
+    return _model(with_hand=True), _model(with_hand=False), ET.tostring(hand_mjcf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
+def merged_overlapping_models():
+    # An arm (fixed base -> a2 -> tip) and a floating-base hand whose palm geom, once attached to the tip, overlaps the
+    # arm's a2 link (which is NOT adjacent to the palm) in the neutral configuration. Returns (arm, hand). Used to check
+    # that self-collision / neutral-overlap masking spans the attach merge boundary.
+    arm = ET.Element("mujoco")
+    wb = ET.SubElement(arm, "worldbody")
+    base = ET.SubElement(wb, "body", name="base", pos="0 0 0.5")
+    ET.SubElement(base, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.03", mass="1.0")
+    a2 = ET.SubElement(base, "body", name="a2", pos="0.2 0 0")
+    ET.SubElement(a2, "joint", name="a1", type="hinge", axis="0 0 1")
+    ET.SubElement(a2, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.03", mass="1.0")
+    tip = ET.SubElement(a2, "body", name="tip", pos="0.2 0 0")
+    ET.SubElement(tip, "joint", name="a2", type="hinge", axis="0 0 1")
+    ET.SubElement(tip, "geom", type="capsule", fromto="0 0 0 0.02 0 0", size="0.02", mass="0.2")
+
+    hand = ET.Element("mujoco")
+    palm = ET.SubElement(ET.SubElement(hand, "worldbody"), "body", name="palm", pos="0 0 0")
+    ET.SubElement(palm, "freejoint")
+    # Long box reaching back from the tip over the (non-adjacent) a2 link.
+    ET.SubElement(palm, "geom", type="box", size="0.15 0.03 0.03", pos="-0.1 0 0", mass="0.2")
+    return ET.tostring(arm, encoding="unicode"), ET.tostring(hand, encoding="unicode")

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -1346,3 +1346,43 @@ def test_nan_reset(gs_sim, mode):
         gs_sim.scene.step()
     qvel = gs_sim.rigid_solver.get_dofs_velocity()
     assert not torch.isnan(qvel).any()
+
+
+@pytest.mark.required
+def test_neutral_self_collision_masks_across_merged_entities(merged_overlapping_models, show_viewer):
+    # attach() merges the hand into the arm's kinematic tree, and self-collision masking (adjacency and neutral overlap)
+    # keys on root_idx, so it must span the merge boundary. The palm geom overlaps the non-adjacent a2 link at the
+    # neutral pose, so that cross-entity pair must be masked out.
+    arm_xml, hand_xml = merged_overlapping_models
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            enable_self_collision=True,
+            enable_adjacent_collision=False,
+        ),
+        show_viewer=show_viewer,
+    )
+    arm = scene.add_entity(
+        gs.morphs.MJCF(
+            file=arm_xml,
+        ),
+    )
+    hand = scene.add_entity(
+        gs.morphs.MJCF(
+            file=hand_xml,
+        ),
+    )
+    hand.attach(arm, "tip")
+    scene.build(n_envs=0)
+
+    # The merged hand shares the arm's kinematic-tree root, so cross-entity pairs are self-collision candidates.
+    geoms_root_idx = np.array([geom.link.root_idx for geom in scene.rigid_solver.geoms])
+    arm_geoms = [geom.idx for geom in arm.geoms]
+    hand_geoms = [geom.idx for geom in hand.geoms]
+    assert set(geoms_root_idx[arm_geoms].tolist()) == set(geoms_root_idx[hand_geoms].tolist())
+
+    # The palm overlaps the non-adjacent a2 link at qpos0, so the neutral-overlap check masks this cross-entity pair.
+    collision_pair_idx = scene.rigid_solver.collider._collider_info.collision_pair_idx.to_numpy()
+    a2_geom = arm.get_link("a2").geoms[0].idx
+    palm_geom = hand.get_link("palm").geoms[0].idx
+    assert_equal(collision_pair_idx[a2_geom, palm_geom], -1)
+    assert_equal(collision_pair_idx[palm_geom, a2_geom], -1)

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -1372,7 +1372,7 @@ def test_neutral_self_collision_masks_across_merged_entities(merged_overlapping_
         ),
     )
     hand.attach(arm, "tip")
-    scene.build(n_envs=0)
+    scene.build()
 
     # The merged hand shares the arm's kinematic-tree root, so cross-entity pairs are self-collision candidates.
     geoms_root_idx = np.array([geom.link.root_idx for geom in scene.rigid_solver.geoms])

--- a/tests/rigid/test_control.py
+++ b/tests/rigid/test_control.py
@@ -8,6 +8,7 @@ from genesis.utils.misc import qd_to_torch, tensor_to_array
 
 from ..utils import (
     assert_allclose,
+    assert_equal,
     check_mujoco_data_consistency,
     check_mujoco_model_consistency,
     get_hf_dataset,
@@ -302,6 +303,11 @@ def test_drone_advanced(show_viewer):
         )
         drones.append(drone)
     scene.build()
+
+    for drone in drones:
+        assert drone.base_link.parent_idx == -1
+        assert_equal([link.root_idx for link in drone.links], drone.base_link.idx)
+        assert all(drone.link_start <= link.parent_idx < link.idx for link in drone.links[1:])
 
     for drone in drones:
         chain_dofs = range(6, drone.n_dofs)

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -440,7 +440,7 @@ def test_mass_block_partition(xml_path, show_viewer, tol):
         ("inside", 2),
     ],
 )
-def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_position, n_envs, show_viewer, tol):
+def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_position, n_envs, show_viewer, caplog, tol):
     # A tree merged across several entities by attach() - one hand on the arm tip, a second hand chained onto the
     # first hand's palm, and a third hand on another branch (a2) - has the same mass matrix, LTDL factor, and one-step
     # dynamics as the single equivalent entity built as one model, and a dynamically-independent free body stays
@@ -499,7 +499,12 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
             ),
         )
         hand_box.attach(arm, "freebox")
-    scene.build(n_envs=n_envs)
+    with caplog.at_level("WARNING"):
+        scene.build(n_envs=n_envs)
+
+    # Interleaved DOFs inflate the mass factorization cost, which build reports; contiguous merges stay silent.
+    has_interleaved_warning = any("Instantiate attached entities" in record.getMessage() for record in caplog.records)
+    assert has_interleaved_warning == (box_position in ("between", "inside"))
 
     # attach() re-roots every child link - including previously attached grandchildren - into the parent's tree.
     tip_link = arm.get_link("tip")
@@ -554,6 +559,11 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
 
     pair_vel = torch.cat([arm.get_dofs_velocity(arm_dofs_local), *(h.get_dofs_velocity() for h in hands)], dim=-1)
     assert_allclose(pair_vel, mono.get_dofs_velocity(), tol=tol)
+
+    # The mass matrix reassembled at the new configuration matches too: cross-entity couplings are written by the
+    # block-root entity, so they cannot lag one recompute behind when the configuration changes.
+    mass_mat = solver.get_mass_mat(decompose=False)
+    assert_allclose(mass_mat[..., pair_dofs[:, None], pair_dofs], mass_mat[..., mono_dofs[:, None], mono_dofs], tol=tol)
 
 
 @pytest.mark.slow  # ~500s

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -10,6 +10,7 @@ from genesis.utils.misc import qd_to_numpy, tensor_to_array
 
 from ..utils import (
     assert_allclose,
+    assert_equal,
     init_simulators,
 )
 
@@ -465,6 +466,11 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, n_envs, 
     )
     hand.attach(arm, "tip")
     scene.build(n_envs=n_envs)
+
+    # attach() re-roots every child link into the parent's kinematic tree.
+    tip_link = arm.get_link("tip")
+    assert hand.base_link.parent_idx == tip_link.idx
+    assert_equal([link.root_idx for link in hand.links], tip_link.root_idx)
 
     mono_dofs = torch.arange(mono.dof_start, mono.dof_start + mono.n_dofs)
     pair_dofs = torch.cat(

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -429,6 +429,75 @@ def test_mass_block_partition(xml_path, show_viewer, tol):
     assert_allclose(mass_mat_L.T @ torch.diag(1.0 / mass_mat_D_inv) @ mass_mat_L, mass_mat, tol=tol)
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, n_envs, show_viewer, tol):
+    # A tree merged across two entities by attach() has the same mass matrix, LTDL factor, and one-step dynamics as
+    # the single equivalent entity built as one model, and a dynamically-independent free body stays block-diagonal
+    # from it. The equivalent entity is added first so its mass block is the contiguous prefix [0, n).
+    mono_xml, arm_xml, hand_xml = merged_arm_hand_models
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            enable_collision=False,
+        ),
+        show_viewer=show_viewer,
+    )
+    mono = scene.add_entity(
+        gs.morphs.MJCF(
+            file=mono_xml,
+        ),
+    )
+    arm = scene.add_entity(
+        gs.morphs.MJCF(
+            file=arm_xml,
+        ),
+    )
+    hand = scene.add_entity(
+        gs.morphs.MJCF(
+            file=hand_xml,
+        ),
+    )
+    box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+            pos=(0.0, 2.0, 1.0),
+        ),
+    )
+    hand.attach(arm, "tip")
+    scene.build(n_envs=n_envs)
+
+    mono_dofs = torch.arange(mono.dof_start, mono.dof_start + mono.n_dofs)
+    pair_dofs = torch.cat(
+        [
+            torch.arange(arm.dof_start, arm.dof_start + arm.n_dofs),
+            torch.arange(hand.dof_start, hand.dof_start + hand.n_dofs),
+        ]
+    )
+    box_dofs = torch.arange(box.dof_start, box.dof_start + box.n_dofs)
+
+    solver = scene.rigid_solver
+    mass_mat = solver.get_mass_mat(decompose=False)
+    # The merged pair reproduces the single equivalent entity's full coupled mass matrix.
+    assert_allclose(mass_mat[..., pair_dofs[:, None], pair_dofs], mass_mat[..., mono_dofs[:, None], mono_dofs], tol=tol)
+    # The free body is a separate kinematic tree, so it stays block-diagonal from the merged pair.
+    assert_allclose(mass_mat[..., pair_dofs[:, None], box_dofs], 0.0, tol=tol)
+    # The LTDL factor reconstructs the mass matrix.
+    mass_mat_L, mass_mat_D_inv = solver.get_mass_mat(decompose=True)
+    reconstructed = mass_mat_L.transpose(-2, -1) @ (mass_mat_L * (1.0 / mass_mat_D_inv).unsqueeze(-1))
+    assert_allclose(reconstructed, mass_mat, tol=tol)
+
+    # One step from a nontrivial pose at rest: the post-step velocities (accelerations times dt, from zero) match the
+    # single equivalent entity's, exercising the solve.
+    q = np.linspace(-0.3, 0.3, mono.n_dofs)
+    mono.set_dofs_position(q)
+    arm.set_dofs_position(q[: arm.n_dofs])
+    hand.set_dofs_position(q[arm.n_dofs :])
+    scene.step()
+
+    pair_vel = torch.cat([arm.get_dofs_velocity(), hand.get_dofs_velocity()], dim=-1)
+    assert_allclose(pair_vel, mono.get_dofs_velocity(), tol=tol)
+
+
 @pytest.mark.slow  # ~500s
 @pytest.mark.required
 @pytest.mark.parametrize("precision", ["32", "64"])

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -431,12 +431,24 @@ def test_mass_block_partition(xml_path, show_viewer, tol):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("n_envs", [0, 2])
-def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, n_envs, show_viewer, tol):
-    # A tree merged across two entities by attach() has the same mass matrix, LTDL factor, and one-step dynamics as
-    # the single equivalent entity built as one model, and a dynamically-independent free body stays block-diagonal
-    # from it. The equivalent entity is added first so its tree is the contiguous DOF prefix [0, n).
-    mono_xml, arm_xml, hand_xml = merged_arm_hand_models
+@pytest.mark.parametrize(
+    "box_position, n_envs",
+    [
+        ("after", 0),
+        ("after", 2),
+        ("between", 2),
+        ("inside", 2),
+    ],
+)
+def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_position, n_envs, show_viewer, tol):
+    # A tree merged across several entities by attach() - one hand on the arm tip, a second hand chained onto the
+    # first hand's palm, and a third hand on another branch (a2) - has the same mass matrix, LTDL factor, and one-step
+    # dynamics as the single equivalent entity built as one model, and a dynamically-independent free body stays
+    # block-diagonal from it. The equivalent entity is added first so its mass block is the contiguous DOF prefix
+    # [0, n). The free body 'between' the arm and the hands leaves its DOFs interleaved inside the merged block's
+    # interval; 'inside' declares it in the arm's own file (a second tree of the parent entity) and attaches a fourth
+    # hand onto it, so two merged trees interleave each other; 'after' is already contiguous.
+    mono_xml, arm_xml, arm_box_xml, hand_xml = merged_arm_hand_models
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             enable_collision=False,
@@ -450,43 +462,79 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, n_envs, 
     )
     arm = scene.add_entity(
         gs.morphs.MJCF(
-            file=arm_xml,
+            file=arm_box_xml if box_position == "inside" else arm_xml,
         ),
     )
+    box_morph = gs.morphs.Box(
+        size=(0.1, 0.1, 0.1),
+        pos=(0.0, 2.0, 1.0),
+    )
+    if box_position == "between":
+        box = scene.add_entity(box_morph)
     hand = scene.add_entity(
         gs.morphs.MJCF(
             file=hand_xml,
         ),
     )
-    box = scene.add_entity(
-        gs.morphs.Box(
-            size=(0.1, 0.1, 0.1),
-            pos=(0.0, 2.0, 1.0),
+    hand_chained = scene.add_entity(
+        gs.morphs.MJCF(
+            file=hand_xml,
         ),
     )
+    hand_branch = scene.add_entity(
+        gs.morphs.MJCF(
+            file=hand_xml,
+        ),
+    )
+    if box_position == "after":
+        box = scene.add_entity(box_morph)
+    # Chained attach runs before its own parent is attached: re-rooting is transitive, so the order is free.
+    hand_chained.attach(hand, "palm")
     hand.attach(arm, "tip")
+    hand_branch.attach(arm, "a2")
+    if box_position == "inside":
+        hand_box = scene.add_entity(
+            gs.morphs.MJCF(
+                file=hand_xml,
+            ),
+        )
+        hand_box.attach(arm, "freebox")
     scene.build(n_envs=n_envs)
 
-    # attach() re-roots every child link into the parent's kinematic tree.
+    # attach() re-roots every child link - including previously attached grandchildren - into the parent's tree.
     tip_link = arm.get_link("tip")
     assert hand.base_link.parent_idx == tip_link.idx
-    assert_equal([link.root_idx for link in hand.links], tip_link.root_idx)
+    assert hand_chained.base_link.parent_idx == hand.get_link("palm").idx
+    assert hand_branch.base_link.parent_idx == arm.get_link("a2").idx
+    for child in (hand, hand_chained, hand_branch):
+        assert_equal([link.root_idx for link in child.links], tip_link.root_idx)
 
     mono_dofs = torch.arange(mono.dof_start, mono.dof_start + mono.n_dofs)
-    pair_dofs = torch.cat(
-        [
-            torch.arange(arm.dof_start, arm.dof_start + arm.n_dofs),
-            torch.arange(hand.dof_start, hand.dof_start + hand.n_dofs),
-        ]
-    )
-    box_dofs = torch.arange(box.dof_start, box.dof_start + box.n_dofs)
+    if box_position == "inside":
+        box_link = arm.get_link("freebox")
+        box_dofs = torch.arange(box_link.dof_start, box_link.dof_end)
+        arm_dofs = torch.cat(
+            [
+                torch.arange(arm.dof_start, box_link.dof_start),
+                torch.arange(box_link.dof_end, arm.dof_end),
+            ]
+        )
+        assert_equal([link.root_idx for link in hand_box.links], box_link.root_idx)
+    else:
+        box_dofs = torch.arange(box.dof_start, box.dof_start + box.n_dofs)
+        arm_dofs = torch.arange(arm.dof_start, arm.dof_start + arm.n_dofs)
+    hands = (hand, hand_chained, hand_branch)
+    pair_dofs = torch.cat([arm_dofs, *(torch.arange(h.dof_start, h.dof_start + h.n_dofs) for h in hands)])
 
     solver = scene.rigid_solver
     mass_mat = solver.get_mass_mat(decompose=False)
-    # The merged pair reproduces the single equivalent entity's full coupled mass matrix.
+    # The merged tree reproduces the single equivalent entity's full coupled mass matrix.
     assert_allclose(mass_mat[..., pair_dofs[:, None], pair_dofs], mass_mat[..., mono_dofs[:, None], mono_dofs], tol=tol)
-    # The free body is a separate kinematic tree, so it stays block-diagonal from the merged pair.
+    # The free body is a separate kinematic tree, so it stays block-diagonal from the merged tree.
     assert_allclose(mass_mat[..., pair_dofs[:, None], box_dofs], 0.0, tol=tol)
+    if box_position == "inside":
+        hand_box_dofs = torch.arange(hand_box.dof_start, hand_box.dof_start + hand_box.n_dofs)
+        assert_allclose(mass_mat[..., pair_dofs[:, None], hand_box_dofs], 0.0, tol=tol)
     # The LTDL factor reconstructs the mass matrix.
     mass_mat_L, mass_mat_D_inv = solver.get_mass_mat(decompose=True)
     reconstructed = mass_mat_L.transpose(-2, -1) @ (mass_mat_L * (1.0 / mass_mat_D_inv).unsqueeze(-1))
@@ -494,13 +542,17 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, n_envs, 
 
     # One step from a nontrivial pose at rest: the post-step velocities (accelerations times dt, from zero) match the
     # single equivalent entity's, exercising the solve.
+    arm_dofs_local = arm_dofs - arm.dof_start
     q = np.linspace(-0.3, 0.3, mono.n_dofs)
     mono.set_dofs_position(q)
-    arm.set_dofs_position(q[: arm.n_dofs])
-    hand.set_dofs_position(q[arm.n_dofs :])
+    arm.set_dofs_position(q[: len(arm_dofs)], arm_dofs_local)
+    i_q = len(arm_dofs)
+    for h in hands:
+        h.set_dofs_position(q[i_q : i_q + h.n_dofs])
+        i_q += h.n_dofs
     scene.step()
 
-    pair_vel = torch.cat([arm.get_dofs_velocity(), hand.get_dofs_velocity()], dim=-1)
+    pair_vel = torch.cat([arm.get_dofs_velocity(arm_dofs_local), *(h.get_dofs_velocity() for h in hands)], dim=-1)
     assert_allclose(pair_vel, mono.get_dofs_velocity(), tol=tol)
 
 

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -438,17 +438,25 @@ def test_mass_block_partition(xml_path, show_viewer, tol):
         ("after", 2),
         ("between", 2),
         ("inside", 2),
+        ("inside_target", 2),
     ],
 )
-def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_position, n_envs, show_viewer, caplog, tol):
-    # A tree merged across several entities by attach() - one hand on the arm tip, a second hand chained onto the
-    # first hand's palm, and a third hand on another branch (a2) - has the same mass matrix, LTDL factor, and one-step
+def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_position, n_envs, show_viewer, tol):
+    # A tree merged across several entities by attach() - one hand on the arm tip, a second hand chained onto the first
+    # hand's palm, and a third hand on another branch (a2) - has the same mass matrix, LTDL factor, and one-step
     # dynamics as the single equivalent entity built as one model, and a dynamically-independent free body stays
-    # block-diagonal from it. The equivalent entity is added first so its mass block is the contiguous DOF prefix
-    # [0, n). The free body 'between' the arm and the hands leaves its DOFs interleaved inside the merged block's
-    # interval; 'inside' declares it in the arm's own file (a second tree of the parent entity) and attaches a fourth
-    # hand onto it, so two merged trees interleave each other; 'after' is already contiguous.
-    mono_xml, arm_xml, arm_box_xml, hand_xml = merged_arm_hand_models
+    # block-diagonal from it. The equivalent entity is added first so its mass block is the contiguous DOF prefix [0,
+    # n). A free body whose DOFs would end up interleaved inside the merged block makes attach() raise the
+    # cause-specific error: created 'between' the arm and the hands, declared 'inside' the arm's own file after the arm
+    # ('inside_target' declares it before and attaches a fourth hand onto it, extending two trees of the same entity);
+    # 'after' is contiguous and simulates.
+    mono_xml, arm_xml, arm_box_last_xml, arm_box_first_xml, hand_xml = merged_arm_hand_models
+    arm_xml_by_box_position = {
+        "after": arm_xml,
+        "between": arm_xml,
+        "inside": arm_box_last_xml,
+        "inside_target": arm_box_first_xml,
+    }
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             enable_collision=False,
@@ -462,7 +470,7 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
     )
     arm = scene.add_entity(
         gs.morphs.MJCF(
-            file=arm_box_xml if box_position == "inside" else arm_xml,
+            file=arm_xml_by_box_position[box_position],
         ),
     )
     box_morph = gs.morphs.Box(
@@ -490,21 +498,26 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
         box = scene.add_entity(box_morph)
     # Chained attach runs before its own parent is attached: re-rooting is transitive, so the order is free.
     hand_chained.attach(hand, "palm")
+    if box_position == "between":
+        with np.testing.assert_raises_regex(gs.GenesisException, "Instantiate attached entities consecutively"):
+            hand.attach(arm, "tip")
+        return
+    if box_position == "inside":
+        with np.testing.assert_raises_regex(gs.GenesisException, "Declare the attached-onto tree last"):
+            hand.attach(arm, "tip")
+        return
     hand.attach(arm, "tip")
     hand_branch.attach(arm, "a2")
-    if box_position == "inside":
+    if box_position == "inside_target":
         hand_box = scene.add_entity(
             gs.morphs.MJCF(
                 file=hand_xml,
             ),
         )
-        hand_box.attach(arm, "freebox")
-    with caplog.at_level("WARNING"):
-        scene.build(n_envs=n_envs)
-
-    # Interleaved DOFs inflate the mass factorization cost, which build reports; contiguous merges stay silent.
-    has_interleaved_warning = any("Instantiate attached entities" in record.getMessage() for record in caplog.records)
-    assert has_interleaved_warning == (box_position in ("between", "inside"))
+        with np.testing.assert_raises_regex(gs.GenesisException, "Load the parent's trees as separate entities"):
+            hand_box.attach(arm, "freebox")
+        return
+    scene.build(n_envs=n_envs)
 
     # attach() re-roots every child link - including previously attached grandchildren - into the parent's tree.
     tip_link = arm.get_link("tip")
@@ -515,21 +528,14 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
         assert_equal([link.root_idx for link in child.links], tip_link.root_idx)
 
     mono_dofs = torch.arange(mono.dof_start, mono.dof_start + mono.n_dofs)
-    if box_position == "inside":
-        box_link = arm.get_link("freebox")
-        box_dofs = torch.arange(box_link.dof_start, box_link.dof_end)
-        arm_dofs = torch.cat(
-            [
-                torch.arange(arm.dof_start, box_link.dof_start),
-                torch.arange(box_link.dof_end, arm.dof_end),
-            ]
-        )
-        assert_equal([link.root_idx for link in hand_box.links], box_link.root_idx)
-    else:
-        box_dofs = torch.arange(box.dof_start, box.dof_start + box.n_dofs)
-        arm_dofs = torch.arange(arm.dof_start, arm.dof_start + arm.n_dofs)
     hands = (hand, hand_chained, hand_branch)
-    pair_dofs = torch.cat([arm_dofs, *(torch.arange(h.dof_start, h.dof_start + h.n_dofs) for h in hands)])
+    pair_dofs = torch.cat(
+        [
+            torch.arange(arm.dof_start, arm.dof_start + arm.n_dofs),
+            *(torch.arange(h.dof_start, h.dof_start + h.n_dofs) for h in hands),
+        ]
+    )
+    box_dofs = torch.arange(box.dof_start, box.dof_start + box.n_dofs)
 
     solver = scene.rigid_solver
     mass_mat = solver.get_mass_mat(decompose=False)
@@ -537,9 +543,6 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
     assert_allclose(mass_mat[..., pair_dofs[:, None], pair_dofs], mass_mat[..., mono_dofs[:, None], mono_dofs], tol=tol)
     # The free body is a separate kinematic tree, so it stays block-diagonal from the merged tree.
     assert_allclose(mass_mat[..., pair_dofs[:, None], box_dofs], 0.0, tol=tol)
-    if box_position == "inside":
-        hand_box_dofs = torch.arange(hand_box.dof_start, hand_box.dof_start + hand_box.n_dofs)
-        assert_allclose(mass_mat[..., pair_dofs[:, None], hand_box_dofs], 0.0, tol=tol)
     # The LTDL factor reconstructs the mass matrix.
     mass_mat_L, mass_mat_D_inv = solver.get_mass_mat(decompose=True)
     reconstructed = mass_mat_L.transpose(-2, -1) @ (mass_mat_L * (1.0 / mass_mat_D_inv).unsqueeze(-1))
@@ -547,17 +550,16 @@ def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_posi
 
     # One step from a nontrivial pose at rest: the post-step velocities (accelerations times dt, from zero) match the
     # single equivalent entity's, exercising the solve.
-    arm_dofs_local = arm_dofs - arm.dof_start
     q = np.linspace(-0.3, 0.3, mono.n_dofs)
     mono.set_dofs_position(q)
-    arm.set_dofs_position(q[: len(arm_dofs)], arm_dofs_local)
-    i_q = len(arm_dofs)
+    arm.set_dofs_position(q[: arm.n_dofs])
+    i_q = arm.n_dofs
     for h in hands:
         h.set_dofs_position(q[i_q : i_q + h.n_dofs])
         i_q += h.n_dofs
     scene.step()
 
-    pair_vel = torch.cat([arm.get_dofs_velocity(arm_dofs_local), *(h.get_dofs_velocity() for h in hands)], dim=-1)
+    pair_vel = torch.cat([arm.get_dofs_velocity(), *(h.get_dofs_velocity() for h in hands)], dim=-1)
     assert_allclose(pair_vel, mono.get_dofs_velocity(), tol=tol)
 
     # The mass matrix reassembled at the new configuration matches too: cross-entity couplings are written by the

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -442,14 +442,10 @@ def test_mass_block_partition(xml_path, show_viewer, tol):
     ],
 )
 def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, box_position, n_envs, show_viewer, tol):
-    # A tree merged across several entities by attach() - one hand on the arm tip, a second hand chained onto the first
-    # hand's palm, and a third hand on another branch (a2) - has the same mass matrix, LTDL factor, and one-step
-    # dynamics as the single equivalent entity built as one model, and a dynamically-independent free body stays
-    # block-diagonal from it. The equivalent entity is added first so its mass block is the contiguous DOF prefix [0,
-    # n). A free body whose DOFs would end up interleaved inside the merged block makes attach() raise the
-    # cause-specific error: created 'between' the arm and the hands, declared 'inside' the arm's own file after the arm
-    # ('inside_target' declares it before and attaches a fourth hand onto it, extending two trees of the same entity);
-    # 'after' is contiguous and simulates.
+    # A tree merged across several entities by attach() - a hand on the arm tip, a second chained onto that hand's
+    # palm, a third on another branch - has the same mass matrix, LTDL factor, and one-step dynamics as the single
+    # equivalent entity, and a free body stays block-diagonal from it. Layouts interleaving the free body's DOFs
+    # inside the merged block ('between', 'inside', 'inside_target') make attach() raise their cause-specific error.
     mono_xml, arm_xml, arm_box_last_xml, arm_box_first_xml, hand_xml = merged_arm_hand_models
     arm_xml_by_box_position = {
         "after": arm_xml,

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -402,7 +402,7 @@ def test_mass_mat(xml_path, show_viewer, tol):
 @pytest.mark.parametrize("model_name", ["two_fixed_branches"])
 def test_mass_block_partition(xml_path, show_viewer, tol):
     # Two chains rigidly attached to the fixed world are kinematically independent: the mass matrix is block-diagonal,
-    # so it must partition into one mass block per branch (factoring two n/2 blocks instead of one dense n block).
+    # so it must partition into one kinematic tree per branch (factoring two n/2 trees instead of one dense n tree).
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             enable_collision=False,
@@ -435,7 +435,7 @@ def test_mass_block_partition(xml_path, show_viewer, tol):
 def test_merge_matches_single_equivalent_entity(merged_arm_hand_models, n_envs, show_viewer, tol):
     # A tree merged across two entities by attach() has the same mass matrix, LTDL factor, and one-step dynamics as
     # the single equivalent entity built as one model, and a dynamically-independent free body stays block-diagonal
-    # from it. The equivalent entity is added first so its mass block is the contiguous prefix [0, n).
+    # from it. The equivalent entity is added first so its tree is the contiguous DOF prefix [0, n).
     mono_xml, arm_xml, hand_xml = merged_arm_hand_models
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(


### PR DESCRIPTION
## Description

`RigidEntity.attach()` grafts a child entity into the parent's kinematic tree while keeping it a separate entity, but the mass-matrix pipeline assumed one entity per kinematic tree: scene build crashed on GPU (illegal shared-memory access in the per-entity factor) and, on all backends, the assemble dropped the cross-entity coupling while the composite-rigid-body (CRB) fold missed the merged child's inertia.

The assemble, all factor arms, and the solve now operate per mass block (the DOF interval coupled through moving joints), and the CRB fold reduces each kinematic tree independently, keyed on `root_idx` - which also parallelizes it over trees instead of entities. A merged tree must keep contiguous DOFs, so `attach()` rejects any layout that would interleave foreign DOFs inside the merged block - entities created between an attached pair, attaching onto a tree that other trees follow in its file, or attaching onto several trees of the same entity - each with its own actionable error; 0-DOF entities in between stay supported (the CRB fold gates each link on its tree's root). Re-rooting is transitive across the scene, so chained attaches work in any order. Autodiff-reachable kernels iterate blocks as a flat range-for over precomputed per-entity bounds, since autodiff supports neither while loops nor an extra nested dynamic loop.

This also fixes stale `root_idx` for URDFs loaded through the MuJoCo parser that receive a free root joint at load time (e.g. `gs.morphs.Drone` with `merge_fixed_links=True`), which silently dropped the merged links' mass, and `order_links_depth_first` now remaps `root_idx` alongside `parent_idx`. Naming is settled as: kinematic tree = the `root_idx` link unit, mass block = the DOF factor unit; definitions live on the fields in `array_class.py`.

## Related Issue

Reported downstream for a Franka + XHand merge that builds fine on CPU and on Genesis 1.1.2 but crashes on GPU since 1.2.0.

## Motivation and Context

Merging a dexterous hand onto an arm via `attach()` is a common setup; it crashed at build on CUDA and produced a wrong mass matrix elsewhere. This restores correctness for any entity ordering and attachment topology (chains, multiple children, several trees per entity).

## How Has This Been / Can This Be Tested?

`tests/rigid/test_dynamics.py::test_merge_matches_single_equivalent_entity` builds an attach-merged assembly (three hands: on the arm tip, chained under the first hand's palm in reverse attach order, and on another branch) in the same scene as the single equivalent monolithic entity and asserts the same mass matrix, LTDL factor, and one-step dynamics; a free body is parametrized after or between the merged entities, or declared inside the arm's file with a fourth hand attached onto it (two interleaving merged trees). The test also asserts `attach()` raises the matching cause-specific error for each interleaved layout and re-compares the mass matrix reassembled after the step (catching stale cross-entity couplings in the fallback assemble). It fails on `main` and passes with the fix. `test_drone_advanced` asserts the root/parent structure and `test_neutral_self_collision_masks_across_merged_entities` covers self-collision masking across the merge. Verified on CPU and Apple Metal, including `tests/core/test_grad.py`, `test_dynamics.py`, `test_friction.py`, `test_islands.py`, and `test_asset_loading.py`.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
