### PR TITLE
[BUG FIX] Fix fastcache support (cont'd).

### DIFF
--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -916,7 +916,9 @@ def _func_elastomer_direct_dilate_contribution(
         if compressibility <= 0.0:  # pure incompressible r_hat / r
             w = depth * inv
         else:  # blend, each kernel peak-normalized (see the FFT builder for the closed-form peaks)
-            norm_g = gs.qd_float(qd.static(_INV_SQRT_E)) / qd.sqrt(gs.qd_float(2.0) * lam)
+            # Inline math.exp(-0.5) (== _INV_SQRT_E) rather than capturing the global: the math module is an
+            # allowed fastcache capture, so this stays purity-clean; a bare _INV_SQRT_E would violate purity.
+            norm_g = gs.qd_float(qd.static(math.exp(-0.5))) / qd.sqrt(gs.qd_float(2.0) * lam)
             norm_i = gs.qd_float(1.0) / (gs.qd_float(2.0) * eps)
             w = depth * (compressibility * gaussian / norm_g + (gs.qd_float(1.0) - compressibility) * inv / norm_i)
     return (planar_diff * w + normal_bulge) * scale
@@ -1337,6 +1339,7 @@ def _kernel_elastomer_surface_state_bvh(
     elastomer_geom_active_envs_mask: qd.types.ndarray(),
     bvh_chunk_sensor_idx: qd.types.ndarray(),
     bvh: ChunkedBVHData,
+    bvh_stack_size: qd.template(),
     pc_pos_link: qd.types.ndarray(),
     pc_active_envs_mask: qd.types.ndarray(),
     sdf_enter: qd.types.ndarray(),
@@ -1425,7 +1428,7 @@ def _kernel_elastomer_surface_state_bvh(
         sensor_pos = links_state.pos[sensor_link_idx, i_b]
         sensor_quat = links_state.quat[sensor_link_idx, i_b]
 
-        stack = qd.Vector.zero(gs.qd_int, qd.static(BVH_STACK_SIZE))
+        stack = qd.Vector.zero(gs.qd_int, qd.static(bvh_stack_size))
         stack[0] = bvh.chunk_node_start[i_c]
         stack_idx = 1
 
@@ -1480,7 +1483,7 @@ def _kernel_elastomer_surface_state_bvh(
                 right = bvh.node_right[n]
                 # Median split bounds depth at log2(N / leaf_size) << BVH_STACK_SIZE; the guard mirrors the
                 # global rigid-BVH kernel so a future build strategy can't silently overflow the stack.
-                if stack_idx < qd.static(BVH_STACK_SIZE - 2):
+                if stack_idx < qd.static(bvh_stack_size - 2):
                     stack[stack_idx] = left
                     stack[stack_idx + 1] = right
                     stack_idx += 2
@@ -2311,6 +2314,7 @@ class ElastomerTaxelSensor(
                     shared_metadata.elastomer_geom_active_envs_mask,
                     bvh.chunk_sensor_idx,
                     bvh.kernel_bvh,
+                    BVH_STACK_SIZE,
                     shared_metadata.pc_pos_link,
                     shared_metadata.pc_active_envs_mask,
                     shared_metadata.shear_anchor_sd_enter,

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -916,8 +916,8 @@ def _func_elastomer_direct_dilate_contribution(
         if compressibility <= 0.0:  # pure incompressible r_hat / r
             w = depth * inv
         else:  # blend, each kernel peak-normalized (see the FFT builder for the closed-form peaks)
-            # Inline math.exp(-0.5) (== _INV_SQRT_E) rather than capturing the global: the math module is an
-            # allowed fastcache capture, so this stays purity-clean; a bare _INV_SQRT_E would violate purity.
+            # math.exp(-0.5) == 1/sqrt(e) is the peak of r*exp(-lambda r^2); read it inline rather than from a
+            # module constant so the fastcache purity check stays happy (the math module is an allowed capture).
             norm_g = gs.qd_float(qd.static(math.exp(-0.5))) / qd.sqrt(gs.qd_float(2.0) * lam)
             norm_i = gs.qd_float(1.0) / (gs.qd_float(2.0) * eps)
             w = depth * (compressibility * gaussian / norm_g + (gs.qd_float(1.0) - compressibility) * inv / norm_i)
@@ -960,9 +960,6 @@ def _collect_collision_geom_idx(solver, track_link_idx: np.ndarray) -> tuple[tor
         gs.raise_exception("ElastomerTaxel tracked links must have collision geometry for SDF queries.")
     return torch.tensor(geom_idx, dtype=gs.tc_int, device=gs.device), torch.stack(active_masks, dim=0)
 
-
-# Peak of r * exp(-lambda r^2) is this / sqrt(2 lambda); peak-normalizes the local kernel in the blend.
-_INV_SQRT_E = math.exp(-0.5)
 
 # Clamp bounds for q = |k| * h in _bonded_layer_transfer, chosen where S(q) is already flat.
 _LAYER_Q_MIN: Final[float] = 1e-3
@@ -1056,7 +1053,7 @@ def _precompute_hydroshear_dilate_kernel_fft(
         ku_hat, kv_hat = gu_hat, gv_hat
     else:
         loc = torch.fft.rfft2(torch.fft.ifftshift(torch.stack((uu * g, vv * g), dim=0), dim=(-2, -1)))
-        norm_g = math.exp(-0.5) / math.sqrt(2.0 * lambda_d)  # peak of r*exp(-lambda_d r^2), see _INV_SQRT_E
+        norm_g = math.exp(-0.5) / math.sqrt(2.0 * lambda_d)  # 1/sqrt(e) is the peak of r*exp(-lambda_d r^2)
         c = compressibility
         ku_hat = c * loc[0] / norm_g + (1.0 - c) * gu_hat / norm_i
         kv_hat = c * loc[1] / norm_g + (1.0 - c) * gv_hat / norm_i


### PR DESCRIPTION
The earlier purity PR fixed the host-side copy of the 1/sqrt(e) constant but not the kernel-side one, and left BVH_STACK_SIZE captured in a fastcache kernel. Both are [PURE.VIOLATION] warnings that Genesis CI escalates to errors.

- _INV_SQRT_E in _func_elastomer_direct_dilate_contribution (reached by the fastcache kernel _kernel_elastomer_dilate_accumulate): inline math.exp(-0.5) instead of capturing the global. The math module is an allowed fastcache capture, so this is exempt and cache-safe. This is the site the tactile sensor tests were failing on.

- BVH_STACK_SIZE in the fastcache kernel _kernel_elastomer_surface_state_bvh: pass it as a qd.template() param (bvh_stack_size), matching the existing qd.template() usage in these sensor kernels. Template primitives are baked and keyed into the fastcache key, so distinct stack sizes recompile correctly. BVH_STACK_SIZE stays the uppercase source of truth, captured only in host code at the call site. This one was latent: the failing tests errored in the dilate path before reaching this kernel.