### PR TITLE
[BUG FIX] Fix loading of textures packed in .usdz archives.

### DIFF
--- a/genesis/utils/usd/usd_material.py
+++ b/genesis/utils/usd/usd_material.py
@@ -8,29 +8,6 @@ import genesis as gs
 from genesis.utils import mesh as mu
 
 
-def _load_texture_image(texture):
-    """Load a ``UsdUVTexture`` image as a numpy array.
-
-    Handles textures packed inside ``.usdz`` archives, whose ``resolvedPath`` is
-    an archive-internal path (e.g. ``mesh.usdz[0/texture.jpg]``) that PIL cannot
-    open directly — USD's asset resolver reads those correctly. Returns ``None``
-    if the texture can't be read (matching the MDL branch's graceful fallback),
-    so geometry still loads untextured.
-    """
-    path = texture.resolvedPath
-    try:
-        asset = Ar.GetResolver().OpenAsset(Ar.ResolvedPath(path))
-        if asset is not None:
-            return np.asarray(Image.open(io.BytesIO(bytes(asset.GetBuffer()))))
-    except Exception:
-        pass
-    try:
-        return np.asarray(Image.open(path))
-    except Exception as e:
-        gs.logger.warning(f"Failed to load UsdUVTexture {path}: {e}")
-        return None
-
-
 CS_ENCODE = {
     "raw": "linear",
     "sRGB": "srgb",
@@ -142,8 +119,13 @@ def parse_preview_surface(prim: Usd.Prim, output_name):
     elif shader_id == "UsdUVTexture":
         texture = get_input_attribute_value(shader, "file", "value")[0]
         if texture is not None:
-            texture_image = _load_texture_image(texture)
-            if texture_image is not None and texture_image.ndim == 3:
+            # The resolved path may point inside a .usdz package (e.g. 'mesh.usdz[texture.png]'), so the texture
+            # is read through the USD asset resolver, which handles package and plain filesystem paths alike.
+            texture_asset = Ar.GetResolver().OpenAsset(Ar.ResolvedPath(texture.resolvedPath))
+            if texture_asset is None:
+                gs.raise_exception(f"Unable to open UsdUVTexture asset: {texture.resolvedPath}")
+            texture_image = np.asarray(Image.open(io.BytesIO(texture_asset.GetBuffer())))
+            if texture_image.ndim == 3:
                 if output_name == "r":
                     texture_image = texture_image[:, :, 0]
                 elif output_name == "g":

--- a/genesis/utils/usd/usd_material.py
+++ b/genesis/utils/usd/usd_material.py
@@ -1,9 +1,34 @@
+import io
+
 import numpy as np
 from PIL import Image
-from pxr import Usd, UsdShade
+from pxr import Ar, Usd, UsdShade
 
 import genesis as gs
 from genesis.utils import mesh as mu
+
+
+def _load_texture_image(texture):
+    """Load a ``UsdUVTexture`` image as a numpy array.
+
+    Handles textures packed inside ``.usdz`` archives, whose ``resolvedPath`` is
+    an archive-internal path (e.g. ``mesh.usdz[0/texture.jpg]``) that PIL cannot
+    open directly — USD's asset resolver reads those correctly. Returns ``None``
+    if the texture can't be read (matching the MDL branch's graceful fallback),
+    so geometry still loads untextured.
+    """
+    path = texture.resolvedPath
+    try:
+        asset = Ar.GetResolver().OpenAsset(Ar.ResolvedPath(path))
+        if asset is not None:
+            return np.asarray(Image.open(io.BytesIO(bytes(asset.GetBuffer()))))
+    except Exception:
+        pass
+    try:
+        return np.asarray(Image.open(path))
+    except Exception as e:
+        gs.logger.warning(f"Failed to load UsdUVTexture {path}: {e}")
+        return None
 
 
 CS_ENCODE = {
@@ -117,8 +142,8 @@ def parse_preview_surface(prim: Usd.Prim, output_name):
     elif shader_id == "UsdUVTexture":
         texture = get_input_attribute_value(shader, "file", "value")[0]
         if texture is not None:
-            texture_image = np.asarray(Image.open(texture.resolvedPath))
-            if texture_image.ndim == 3:
+            texture_image = _load_texture_image(texture)
+            if texture_image is not None and texture_image.ndim == 3:
                 if output_name == "r":
                     texture_image = texture_image[:, :, 0]
                 elif output_name == "g":

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -14,7 +14,7 @@ from genesis.utils.misc import get_assets_dir
 from ..utils import assert_allclose, assert_equal, get_hf_dataset
 
 try:
-    from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, UsdUtils
 
     from genesis.utils.usd import UsdContext
 except ImportError:
@@ -1397,3 +1397,62 @@ def oriented_capsule_usd(asset_tmp_path):
 
     stage.Save()
     return usd_file
+
+
+@pytest.fixture(scope="session")
+def usdz_packaged_texture_usd(asset_tmp_path):
+    """Stage referencing a .usdz package whose mesh material samples a texture packed in the archive, so the
+    texture resolves to a package-internal path (e.g. 'packaged_mesh.usdz[usdz_texture.png]').
+
+    Returns the stage file path and the expected texture pixels.
+    """
+    texture_image = np.arange(4 * 4 * 3, dtype=np.uint8).reshape((4, 4, 3))
+    Image.fromarray(texture_image).save(str(asset_tmp_path / "usdz_texture.png"))
+
+    packaged_file = str(asset_tmp_path / "packaged_mesh.usda")
+    stage = Usd.Stage.CreateNew(packaged_file)
+    UsdGeom.SetStageUpAxis(stage, "Z")
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    root_prim = stage.DefinePrim("/root", "Xform")
+    stage.SetDefaultPrim(root_prim)
+
+    mesh = UsdGeom.Mesh.Define(stage, "/root/mesh")
+    mesh.GetPointsAttr().Set([Gf.Vec3f(0, 0, 0), Gf.Vec3f(1, 0, 0), Gf.Vec3f(0, 1, 0), Gf.Vec3f(1, 1, 0)])
+    mesh.GetFaceVertexIndicesAttr().Set([0, 1, 2, 1, 3, 2])
+    mesh.GetFaceVertexCountsAttr().Set([3, 3])
+    uv_primvar = UsdGeom.PrimvarsAPI(mesh.GetPrim()).CreatePrimvar(
+        "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex
+    )
+    uv_primvar.Set([Gf.Vec2f(0, 0), Gf.Vec2f(1, 0), Gf.Vec2f(0, 1), Gf.Vec2f(1, 1)])
+    UsdPhysics.CollisionAPI.Apply(mesh.GetPrim())
+
+    material = UsdShade.Material.Define(stage, "/root/material")
+    pbr_shader = UsdShade.Shader.Define(stage, "/root/material/pbr")
+    pbr_shader.CreateIdAttr("UsdPreviewSurface")
+    texture_shader = UsdShade.Shader.Define(stage, "/root/material/texture")
+    texture_shader.CreateIdAttr("UsdUVTexture")
+    texture_shader.CreateInput("file", Sdf.ValueTypeNames.Asset).Set("./usdz_texture.png")
+    st_reader = UsdShade.Shader.Define(stage, "/root/material/st_reader")
+    st_reader.CreateIdAttr("UsdPrimvarReader_float2")
+    st_reader.CreateInput("varname", Sdf.ValueTypeNames.Token).Set("st")
+    texture_shader.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(st_reader.ConnectableAPI(), "result")
+    pbr_shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(
+        texture_shader.ConnectableAPI(), "rgb"
+    )
+    material.CreateSurfaceOutput().ConnectToSource(pbr_shader.ConnectableAPI(), "surface")
+    UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(material)
+    stage.Save()
+
+    usdz_file = str(asset_tmp_path / "packaged_mesh.usdz")
+    assert UsdUtils.CreateNewUsdzPackage(packaged_file, usdz_file)
+
+    scene_file = str(asset_tmp_path / "usdz_reference_scene.usda")
+    scene_stage = Usd.Stage.CreateNew(scene_file)
+    UsdGeom.SetStageUpAxis(scene_stage, "Z")
+    UsdGeom.SetStageMetersPerUnit(scene_stage, 1.0)
+    world_prim = scene_stage.DefinePrim("/world", "Xform")
+    scene_stage.SetDefaultPrim(world_prim)
+    scene_stage.DefinePrim("/world/asset", "Xform").GetReferences().AddReference("./packaged_mesh.usdz")
+    scene_stage.Save()
+
+    return scene_file, texture_image

--- a/tests/parsers/test_usd.py
+++ b/tests/parsers/test_usd.py
@@ -23,7 +23,7 @@ from ..conftest import SKIP_NO_OMNIVERSE_KIT
 import genesis as gs
 from genesis.utils.misc import tensor_to_array
 
-from ..utils import assert_allclose, get_hf_dataset
+from ..utils import assert_allclose, assert_equal, get_hf_dataset
 from .conftest import (
     USD_COLOR_TOL,
     build_mesh_scene,
@@ -93,6 +93,15 @@ def test_parse_nodegraph(usd_file):
     assert isinstance(texture1, gs.textures.ColorTexture)
     assert_allclose(texture0.color, (0.8, 0.2, 0.2), rtol=USD_COLOR_TOL)
     assert_allclose(texture1.color, (0.2, 0.6, 0.9), rtol=USD_COLOR_TOL)
+
+
+@pytest.mark.required
+def test_usdz_packaged_texture_resolution(usdz_packaged_texture_usd):
+    scene_file, texture_image = usdz_packaged_texture_usd
+    usd_scene = build_usd_scene(scene_file, scale=1.0, vis_mode="visual", fixed=True)
+    texture = usd_scene.entities[0].vgeoms[0].vmesh.surface.diffuse_texture
+    assert isinstance(texture, gs.textures.ImageTexture)
+    assert_equal(texture.image_array, texture_image)
 
 
 @pytest.mark.slow  # ~400s


### PR DESCRIPTION
## Problem

`parse_preview_surface` opens `UsdUVTexture` files with PIL straight from `texture.resolvedPath`. When a stage references an asset packed in a `.usdz` archive, the resolved path is package-internal (e.g. `mesh.usdz[texture.png]`), so PIL raises `FileNotFoundError` and the whole entity load aborts. This blocks loading USD scenes whose objects reference `.usdz`-packed textures.

## Fix

Textures are now read through the USD asset resolver (`Ar.GetResolver().OpenAsset`), which handles both package-internal and plain filesystem paths, so the previous direct filesystem read is subsumed. An unresolvable texture asset raises a clear Genesis exception.

## Test

`test_usdz_packaged_texture_resolution` builds a `.usdz` package containing a textured mesh, references it from a `.usda` stage, and checks that the parsed diffuse texture matches the source pixels exactly. It fails on `main` with the original `FileNotFoundError` and passes with the fix.
