### PR TITLE
[AMDGPU] Fix: increase Quadrants device memory pool on ROCm (hipMemset)

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -257,6 +257,14 @@ def init(
 
     # init quadrants
     qd_debug = debug and (os.environ.get("QD_DEBUG") != "0")
+    # Set Quadrants device memory pool size. The default (1 GB) is far too small for large-scale simulations.
+    # Use the GS_DEVICE_MEMORY_GB env var if set, otherwise allocate up to 80% of total device memory.
+    if backend != _gs_backend.cpu:
+        _device_mem_gb_env = os.environ.get("GS_DEVICE_MEMORY_GB")
+        if _device_mem_gb_env is not None:
+            qd_init_kwargs["device_memory_GB"] = float(_device_mem_gb_env)
+        elif "device_memory_GB" not in qd_init_kwargs:
+            qd_init_kwargs["device_memory_GB"] = round(total_mem * 0.8, 1)
     with redirect_stdout(_qd_outputs):
         qd.init(
             arch=getattr(qd, backend.name),

--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -28,7 +28,7 @@ class Rasterizer(RBC):
         if self._offscreen:
             # Select PyOpenGL backend for `pyrender.OffscreenRenderer`.
             # If env variable is set, use specified platform if supported, otherwise some platform-specific default.
-            platform = os.environ.get("PYOPENGL_PLATFORM", "egl" if sys.platform == "linux" else "pyglet")
+            platform = os.environ.get("PYOPENGL_PLATFORM", "").strip() or ("egl" if sys.platform == "linux" else "pyglet")
             if platform not in ("osmesa", "pyglet", "egl"):
                 gs.logger.warning(f"PYOPENGL_PLATFORM='{platform}' not supported. Falling back to 'pyglet'.")
                 platform = "pyglet"


### PR DESCRIPTION
## Summary
On ROCm/AMDGPU, Genesis init now sets Quadrants `device_memory_GB` from `GS_DEVICE_MEMORY_GB` when set, otherwise ~80% of total device memory. The default 1 GB pool is too small for large-scale sims and can cause hipMemset allocation failures.

Also adjusts the default `PYOPENGL_PLATFORM` handling in the rasterizer so an empty env var does not force an invalid platform string on headless nodes.

## Correctness
No numerical/physics change — memory pool sizing and renderer platform selection only.

## Verification
Tested on AMD MI300X/MI325X (gfx942) vs baseline.

Made with [Cursor](https://cursor.com)