### PR TITLE
[BUG FIX] Fix crash parsing MJCF assets whose included files declare mesh defaults.

### DIFF
--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -104,14 +104,12 @@ def build_model(
             for elem in tuple(xml_root.findall("include")):
                 include_path = parent_path / elem.attrib["file"]
                 include_root = ET.parse(Path(asset_path) / include_path).getroot()
-                # Rewrite relative mesh paths against the included file's directory. Mesh elements under
-                # <default> (e.g. <mesh maxhullvert="64"/>) are valid MuJoCo and have no `file` attribute —
-                # skip those so include preprocessing does not raise KeyError (issue #3016).
-                for include_elem in include_root.findall(".//mesh"):
-                    mesh_file = include_elem.attrib.get("file")
-                    if mesh_file is None:
-                        continue
-                    include_elem.attrib["file"] = str(include_path.parent / mesh_file)
+                # Mesh file paths in the included file are relative to that file's directory, whereas meshdir
+                # points at the top-level model, so rewrite them to stay valid once inlined. Only <asset> meshes
+                # reference a file; a <mesh> under <default> is a default class setting attributes (e.g.
+                # maxhullvert) and a vertex mesh under <asset> is procedural, both carrying no file to rewrite.
+                for include_elem in include_root.findall(".//asset/mesh[@file]"):
+                    include_elem.attrib["file"] = str(include_path.parent / include_elem.attrib["file"])
                 for child in include_root:
                     mjcf.append(child)
                 mjcf.remove(elem)

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -104,8 +104,14 @@ def build_model(
             for elem in tuple(xml_root.findall("include")):
                 include_path = parent_path / elem.attrib["file"]
                 include_root = ET.parse(Path(asset_path) / include_path).getroot()
+                # Rewrite relative mesh paths against the included file's directory. Mesh elements under
+                # <default> (e.g. <mesh maxhullvert="64"/>) are valid MuJoCo and have no `file` attribute —
+                # skip those so include preprocessing does not raise KeyError (issue #3016).
                 for include_elem in include_root.findall(".//mesh"):
-                    include_elem.attrib["file"] = str(include_path.parent / include_elem.attrib["file"])
+                    mesh_file = include_elem.attrib.get("file")
+                    if mesh_file is None:
+                        continue
+                    include_elem.attrib["file"] = str(include_path.parent / mesh_file)
                 for child in include_root:
                     mjcf.append(child)
                 mjcf.remove(elem)

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -175,6 +175,32 @@ def decompose_fusion_groups(asset_tmp_path):
 
 
 @pytest.fixture(scope="session")
+def mjcf_include_default_and_asset_mesh(asset_tmp_path):
+    """Scene MJCF that <include>s a subdirectory model mixing a file-less <default> mesh class with a real <asset>
+    mesh, so the include preprocessing must rewrite only the asset mesh path (relative to the included file). Returns
+    the scene file path and the authored box extents."""
+    extents = (0.2, 0.4, 0.6)
+    include_dir = asset_tmp_path / "mjcf_include"
+    include_dir.mkdir(exist_ok=True)
+    trimesh.creation.box(extents=extents).export(include_dir / "box.obj")
+
+    robot = ET.Element("mujoco", model="robot")
+    default = ET.SubElement(robot, "default")
+    ET.SubElement(default, "mesh", maxhullvert="64")
+    asset = ET.SubElement(robot, "asset")
+    ET.SubElement(asset, "mesh", name="box", file="box.obj")
+    worldbody = ET.SubElement(robot, "worldbody")
+    ET.SubElement(worldbody, "geom", type="mesh", mesh="box")
+    ET.ElementTree(robot).write(include_dir / "robot.xml", encoding="utf-8", xml_declaration=True)
+
+    scene_mjcf = ET.Element("mujoco", model="scene")
+    ET.SubElement(scene_mjcf, "include", file="mjcf_include/robot.xml")
+    scene_path = str(asset_tmp_path / "mjcf_include_scene.xml")
+    ET.ElementTree(scene_mjcf).write(scene_path, encoding="utf-8", xml_declaration=True)
+    return scene_path, extents
+
+
+@pytest.fixture(scope="session")
 def two_aligned_hinges():
     mjcf = ET.Element("mujoco", model="two_aligned_hinges")
     ET.SubElement(mjcf, "option", timestep="0.05")

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -59,6 +59,42 @@ def test_mjcf_parsing_with_include():
 
 
 @pytest.mark.required
+def test_mjcf_include_default_mesh_without_file(tmp_path):
+    # MuJoCo allows <default><mesh maxhullvert="..."/></default> with no file= attribute. Include
+    # preprocessing must not KeyError when rewriting mesh paths (issue #3016).
+    robot_xml = tmp_path / "robot.xml"
+    scene_xml = tmp_path / "scene.xml"
+    robot_xml.write_text(
+        """
+        <mujoco model="robot">
+          <default>
+            <mesh maxhullvert="64"/>
+            <geom type="box" size="0.1 0.1 0.1"/>
+          </default>
+          <worldbody>
+            <body name="base" pos="0 0 0.5">
+              <freejoint/>
+              <geom/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+    )
+    scene_xml.write_text(
+        """
+        <mujoco model="scene">
+          <include file="robot.xml"/>
+        </mujoco>
+        """
+    )
+
+    scene = gs.Scene(show_viewer=False)
+    entity = scene.add_entity(gs.morphs.MJCF(file=str(scene_xml)))
+    scene.build()
+    assert len(entity.geoms) >= 1
+
+
+@pytest.mark.required
 def test_ground_plane_preservation(box_plan):
     mjcf = ET.tostring(box_plan, encoding="unicode")
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -59,39 +59,21 @@ def test_mjcf_parsing_with_include():
 
 
 @pytest.mark.required
-def test_mjcf_include_default_mesh_without_file(tmp_path):
-    # MuJoCo allows <default><mesh maxhullvert="..."/></default> with no file= attribute. Include
-    # preprocessing must not KeyError when rewriting mesh paths (issue #3016).
-    robot_xml = tmp_path / "robot.xml"
-    scene_xml = tmp_path / "scene.xml"
-    robot_xml.write_text(
-        """
-        <mujoco model="robot">
-          <default>
-            <mesh maxhullvert="64"/>
-            <geom type="box" size="0.1 0.1 0.1"/>
-          </default>
-          <worldbody>
-            <body name="base" pos="0 0 0.5">
-              <freejoint/>
-              <geom/>
-            </body>
-          </worldbody>
-        </mujoco>
-        """
-    )
-    scene_xml.write_text(
-        """
-        <mujoco model="scene">
-          <include file="robot.xml"/>
-        </mujoco>
-        """
-    )
+def test_mjcf_include_rewrites_asset_mesh_and_skips_default_mesh(mjcf_include_default_and_asset_mesh):
+    scene_path, extents = mjcf_include_default_and_asset_mesh
 
-    scene = gs.Scene(show_viewer=False)
-    entity = scene.add_entity(gs.morphs.MJCF(file=str(scene_xml)))
+    scene = gs.Scene()
+    entity = scene.add_entity(
+        gs.morphs.MJCF(
+            file=scene_path,
+        )
+    )
     scene.build()
-    assert len(entity.geoms) >= 1
+
+    (geom,) = entity.geoms
+    assert geom.type == gs.GEOM_TYPE.MESH
+    aabb = geom.get_AABB()
+    assert_allclose(aabb[1] - aabb[0], extents, tol=gs.EPS)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

MJCF include rewrite crashed with `KeyError` when an included file contained a default `<mesh>` element without a `file` attribute. MuJoCo allows this pattern for mesh defaults; Genesis treated every mesh tag as a path rewrite target.

This skips mesh elements that have no `file` attribute during include path rewriting, matching MuJoCo's default-mesh semantics, and adds a focused regression test.

## Related Issue

Resolves #3016

## Motivation and Context

Asset packs (and many third-party MJCF includes) declare mesh defaults without an immediate file path. Loading those assets currently fails hard in Genesis even though MuJoCo loads them fine.

## How Has This Been Tested?

- Added `tests/rigid/test_asset_loading.py::test_mjcf_include_default_mesh_without_file`
- Local reproduction: include with bare `<mesh>` default no longer raises `KeyError`

## Checklist

- [x] Focused bug fix
- [x] Regression test included
- [x] No unrelated refactors
