### PR TITLE
[FEATURE] Add support of torsional and rolling friction to the rigid solver.

### DIFF
--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -1,0 +1,89 @@
+"""Coulomb breakaway under both friction cones, documenting the pyramidal cone's limitations.
+
+A box and a torsional-friction sphere rest on a plane, so each contact carries the exact normal load m * g. A
+generalized force (box, tangential) and torque (sphere, about the vertical axis) ramp up linearly across the Coulomb
+limits mu * m * g and mu_torsional * m * g; the load at which each entity starts moving is the measured breakaway.
+The pyramidal cone at its default 'impratio' of 1 mixes the normal direction into every friction row, so it creeps
+well below the Coulomb limit and breaks away early; the elliptic cone (auto-resolved 'impratio' of 100) sticks until
+the limit and tracks it closely. See the 'friction_cone' and 'impratio' options of 'gs.options.RigidOptions'.
+"""
+
+import argparse
+
+import genesis as gs
+
+
+GRAVITY = 9.81
+
+
+def measure_breakaway(friction_cone, show_viewer, slip_threshold=0.05, n_steps=300, load_margin=1.5):
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, -GRAVITY),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=friction_cone,
+            enable_torsional_friction=True,
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.2, 0.2, 0.2),
+            pos=(0.0, 0.0, 0.1),
+        ),
+    )
+    sphere = scene.add_entity(
+        gs.morphs.Sphere(
+            radius=0.1,
+            pos=(0.6, 0.0, 0.1),
+        ),
+        material=gs.materials.Rigid(
+            friction_torsional=0.05,
+        ),
+    )
+    scene.build()
+
+    box_load_coulomb = box.geoms[0].friction * float(box.get_mass()) * GRAVITY
+    sphere_load_coulomb = sphere.geoms[0].friction_torsional * float(sphere.get_mass()) * GRAVITY
+    for _ in range(50):
+        scene.step()
+
+    breakaway_ratios = [None, None]
+    creep_speeds_half_load = [None, None]
+    for i_step in range(n_steps):
+        load_ratio = load_margin * (i_step + 1) / n_steps
+        box.control_dofs_force([load_ratio * box_load_coulomb, 0.0, 0.0, 0.0, 0.0, 0.0])
+        sphere.control_dofs_force([0.0, 0.0, 0.0, 0.0, 0.0, load_ratio * sphere_load_coulomb])
+        scene.step()
+        speeds = (float(box.get_dofs_velocity()[..., 0]), float(sphere.get_dofs_velocity()[..., 5]))
+        for i_e, speed in enumerate(speeds):
+            if creep_speeds_half_load[i_e] is None and load_ratio >= 0.5:
+                creep_speeds_half_load[i_e] = speed
+            if breakaway_ratios[i_e] is None and speed > slip_threshold:
+                breakaway_ratios[i_e] = load_ratio
+    return breakaway_ratios, creep_speeds_half_load
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
+
+    gs.init(backend=gs.gpu)
+
+    for friction_cone in (gs.friction_cone.pyramidal, gs.friction_cone.elliptic):
+        breakaway_ratios, creep_speeds_half_load = measure_breakaway(friction_cone, args.vis)
+        print(f"{friction_cone.name} cone:")
+        for name, breakaway_ratio, creep_speed in zip(
+            ("tangential (box)", "torsional (sphere)"), breakaway_ratios, creep_speeds_half_load
+        ):
+            breakaway = f"{breakaway_ratio:.2f} x Coulomb limit" if breakaway_ratio is not None else "above the ramp"
+            print(f"  {name}: breakaway at {breakaway}, creep speed at half load {creep_speed:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -11,18 +11,48 @@ limit and slips past it. See the 'friction_cone' and 'impratio' options of 'gs.o
 """
 
 import argparse
+import xml.etree.ElementTree as ET
 
 import genesis as gs
+from genesis.utils.misc import get_assets_dir
 
 
 GRAVITY = 9.81
 DT = 1e-2
+RADIUS = 0.1
+# Half-extent of the wooden sphere asset, whose origin sits at the bottom of its y-up frame.
+WOODEN_SPHERE_MESH_RADIUS = 3.486346
 # Load fractions straddling the Coulomb limit, so both the sub-limit creep and the past-limit slip show up.
 LOAD_RATIOS = (0.25, 0.5, 0.75, 0.95, 1.05)
 # A load holds when the drift accumulated over the horizon stays below this bound, the criterion of the
 # static-friction unit tests: a displacement (meters) for the box, a swept angle (radians) for the sphere.
 DRIFT_TOLERANCE = 5e-3
 N_STEPS = 300
+
+
+def checkered_ball_mjcf():
+    """MJCF model of a free ball: a sphere collision geom with a checker-textured ball mesh as its visual, whose
+    colorful pattern makes the rotation visible."""
+    mjcf = ET.Element("mujoco", model="checkered_ball")
+    asset = ET.SubElement(mjcf, "asset")
+    scale = RADIUS / WOODEN_SPHERE_MESH_RADIUS
+    ET.SubElement(
+        asset,
+        "mesh",
+        name="ball_visual",
+        file=f"{get_assets_dir()}/meshes/wooden_sphere_OBJ/wooden_sphere.obj",
+        scale=f"{scale} {scale} {scale}",
+    )
+    tex_kwargs = {"builtin": "checker", "rgb1": "0.9 0.2 0.2", "rgb2": "1. 0.9 0.3", "width": "128", "height": "128"}
+    ET.SubElement(asset, "texture", name="checker", type="cube", **tex_kwargs)
+    ET.SubElement(asset, "material", name="checker", texture="checker", texrepeat="4 4")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ball_body = ET.SubElement(worldbody, "body", name="ball", pos="0. 0. 0.")
+    ET.SubElement(ball_body, "joint", name="root", type="free")
+    ET.SubElement(ball_body, "geom", type="sphere", size=f"{RADIUS}")
+    visual_kwargs = {"contype": "0", "conaffinity": "0", "mass": "0.", "euler": "90 0 0", "material": "checker"}
+    ET.SubElement(ball_body, "geom", type="mesh", mesh="ball_visual", pos=f"0. 0. -{RADIUS}", **visual_kwargs)
+    return ET.tostring(mjcf, encoding="unicode")
 
 
 def measure_stiction(friction_cone, show_viewer):
@@ -48,18 +78,18 @@ def measure_stiction(friction_cone, show_viewer):
         ),
     )
     spinner = scene.add_entity(
-        gs.morphs.Sphere(
-            radius=0.1,
-            pos=(0.6, 0.0, 0.1),
+        gs.morphs.MJCF(
+            file=checkered_ball_mjcf(),
+            pos=(0.6, 0.0, RADIUS),
         ),
         material=gs.materials.Rigid(
             friction_torsional=0.05,
         ),
     )
     roller = scene.add_entity(
-        gs.morphs.Sphere(
-            radius=0.1,
-            pos=(1.2, 0.0, 0.1),
+        gs.morphs.MJCF(
+            file=checkered_ball_mjcf(),
+            pos=(1.2, 0.0, RADIUS),
         ),
         material=gs.materials.Rigid(
             friction_rolling=0.05,
@@ -88,7 +118,11 @@ def measure_stiction(friction_cone, show_viewer):
             scene.step()
             spinner_swept_angle += abs(float(spinner.get_dofs_velocity()[..., 5])) * DT
             roller_swept_angle += abs(float(roller.get_dofs_velocity()[..., 4])) * DT
-        box_drift = abs(float(box.get_pos()[..., 0]) - box_pos_start)
+            box_drift = abs(float(box.get_pos()[..., 0]) - box_pos_start)
+            # Once every entity has drifted past the tolerance the verdicts are settled; stopping there keeps the
+            # slipped entities from accelerating without bound over the rest of the horizon.
+            if min(box_drift, spinner_swept_angle, roller_swept_angle) > DRIFT_TOLERANCE:
+                break
         is_load_held.append(
             (
                 box_drift < DRIFT_TOLERANCE,

--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -14,9 +14,14 @@ import genesis as gs
 
 
 GRAVITY = 9.81
+# SAFETY_FACTOR scales the ramp end past the analytic Coulomb limit so the breakaway is bracketed on both cones,
+# whether it lands below the limit (regularized pyramid) or slightly above it.
+SAFETY_FACTOR = 1.5
+SLIP_THRESHOLD = 0.05
+N_STEPS = 300
 
 
-def measure_breakaway(friction_cone, show_viewer, slip_threshold=0.05, n_steps=300, load_margin=1.5):
+def measure_breakaway(friction_cone, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             gravity=(0.0, 0.0, -GRAVITY),
@@ -54,8 +59,8 @@ def measure_breakaway(friction_cone, show_viewer, slip_threshold=0.05, n_steps=3
 
     breakaway_ratios = [None, None]
     creep_speeds_half_load = [None, None]
-    for i_step in range(n_steps):
-        load_ratio = load_margin * (i_step + 1) / n_steps
+    for i_step in range(N_STEPS):
+        load_ratio = SAFETY_FACTOR * (i_step + 1) / N_STEPS
         box.control_dofs_force([load_ratio * box_load_coulomb, 0.0, 0.0, 0.0, 0.0, 0.0])
         sphere.control_dofs_force([0.0, 0.0, 0.0, 0.0, 0.0, load_ratio * sphere_load_coulomb])
         scene.step()
@@ -63,7 +68,7 @@ def measure_breakaway(friction_cone, show_viewer, slip_threshold=0.05, n_steps=3
         for i_e, speed in enumerate(speeds):
             if creep_speeds_half_load[i_e] is None and load_ratio >= 0.5:
                 creep_speeds_half_load[i_e] = speed
-            if breakaway_ratios[i_e] is None and speed > slip_threshold:
+            if breakaway_ratios[i_e] is None and speed > SLIP_THRESHOLD:
                 breakaway_ratios[i_e] = load_ratio
     return breakaway_ratios, creep_speeds_half_load
 

--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -1,11 +1,13 @@
-"""Coulomb breakaway under both friction cones, documenting the pyramidal cone's limitations.
+"""Coulomb stiction under both friction cones, documenting the pyramidal cone's limitations.
 
 A box and a torsional-friction sphere rest on a plane, so each contact carries the exact normal load m * g. A
-generalized force (box, tangential) and torque (sphere, about the vertical axis) ramp up linearly across the Coulomb
-limits mu * m * g and mu_torsional * m * g; the load at which each entity starts moving is the measured breakaway.
-The pyramidal cone at its default 'impratio' of 1 mixes the normal direction into every friction row, so it creeps
-well below the Coulomb limit and breaks away early; the elliptic cone (auto-resolved 'impratio' of 100) sticks until
-the limit and tracks it closely. See the 'friction_cone' and 'impratio' options of 'gs.options.RigidOptions'.
+constant generalized force (box, tangential) and torque (sphere, about the vertical axis) is applied at a sweep of
+fractions of the Coulomb limits mu * m * g and mu_torsional * m * g, and each load is classified as held or slipped
+from the drift accumulated over the horizon, the criterion of the static-friction unit tests. The pyramidal cone at
+its default 'impratio' of 1 mixes the normal direction into every friction row, so it creeps far past the drift
+tolerance well below the Coulomb limit, especially on the torsional axis; the elliptic cone (auto-resolved
+'impratio' of 100) holds near the limit and slips past it. See the 'friction_cone' and 'impratio' options of
+'gs.options.RigidOptions'.
 """
 
 import argparse
@@ -14,16 +16,19 @@ import genesis as gs
 
 
 GRAVITY = 9.81
-# SAFETY_FACTOR scales the ramp end past the analytic Coulomb limit so the breakaway is bracketed on both cones,
-# whether it lands below the limit (regularized pyramid) or slightly above it.
-SAFETY_FACTOR = 1.5
-SLIP_THRESHOLD = 0.05
+DT = 1e-2
+# Load fractions straddling the Coulomb limit, so both the sub-limit creep and the past-limit slip show up.
+LOAD_RATIOS = (0.25, 0.5, 0.75, 0.95, 1.05)
+# A load holds when the drift accumulated over the horizon stays below this bound, the criterion of the
+# static-friction unit tests: a displacement (meters) for the box, a swept angle (radians) for the sphere.
+DRIFT_TOLERANCE = 5e-3
 N_STEPS = 300
 
 
-def measure_breakaway(friction_cone, show_viewer):
+def measure_stiction(friction_cone, show_viewer):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
+            dt=DT,
             gravity=(0.0, 0.0, -GRAVITY),
         ),
         rigid_options=gs.options.RigidOptions(
@@ -54,23 +59,24 @@ def measure_breakaway(friction_cone, show_viewer):
 
     box_load_coulomb = box.geoms[0].friction * float(box.get_mass()) * GRAVITY
     sphere_load_coulomb = sphere.geoms[0].friction_torsional * float(sphere.get_mass()) * GRAVITY
-    for _ in range(50):
-        scene.step()
 
-    breakaway_ratios = [None, None]
-    creep_speeds_half_load = [None, None]
-    for i_step in range(N_STEPS):
-        load_ratio = SAFETY_FACTOR * (i_step + 1) / N_STEPS
+    is_load_held = []
+    for load_ratio in LOAD_RATIOS:
+        scene.reset()
         box.control_dofs_force([load_ratio * box_load_coulomb, 0.0, 0.0, 0.0, 0.0, 0.0])
         sphere.control_dofs_force([0.0, 0.0, 0.0, 0.0, 0.0, load_ratio * sphere_load_coulomb])
-        scene.step()
-        speeds = (float(box.get_dofs_velocity()[..., 0]), float(sphere.get_dofs_velocity()[..., 5]))
-        for i_e, speed in enumerate(speeds):
-            if creep_speeds_half_load[i_e] is None and load_ratio >= 0.5:
-                creep_speeds_half_load[i_e] = speed
-            if breakaway_ratios[i_e] is None and speed > SLIP_THRESHOLD:
-                breakaway_ratios[i_e] = load_ratio
-    return breakaway_ratios, creep_speeds_half_load
+        # Contact warmup under load, then drift accumulated over the horizon (the unit tests' protocol). The sphere
+        # drift integrates the spin speed so multiple slipped turns cannot alias back to a small orientation change.
+        for _ in range(50):
+            scene.step()
+        box_pos_start = float(box.get_pos()[..., 0])
+        sphere_swept_angle = 0.0
+        for _ in range(N_STEPS):
+            scene.step()
+            sphere_swept_angle += abs(float(sphere.get_dofs_velocity()[..., 5])) * DT
+        box_drift = abs(float(box.get_pos()[..., 0]) - box_pos_start)
+        is_load_held.append((box_drift < DRIFT_TOLERANCE, sphere_swept_angle < DRIFT_TOLERANCE))
+    return is_load_held
 
 
 def main():
@@ -81,13 +87,14 @@ def main():
     gs.init(backend=gs.gpu)
 
     for friction_cone in (gs.friction_cone.pyramidal, gs.friction_cone.elliptic):
-        breakaway_ratios, creep_speeds_half_load = measure_breakaway(friction_cone, args.vis)
-        print(f"{friction_cone.name} cone:")
-        for name, breakaway_ratio, creep_speed in zip(
-            ("tangential (box)", "torsional (sphere)"), breakaway_ratios, creep_speeds_half_load
-        ):
-            breakaway = f"{breakaway_ratio:.2f} x Coulomb limit" if breakaway_ratio is not None else "above the ramp"
-            print(f"  {name}: breakaway at {breakaway}, creep speed at half load {creep_speed:.4f}")
+        is_load_held = measure_stiction(friction_cone, args.vis)
+        print(f"{friction_cone.name} cone (load as a fraction of the Coulomb limit):")
+        for i_e, name in enumerate(("tangential (box)", "torsional (sphere)")):
+            verdicts = ", ".join(
+                f"{load_ratio:.2f}: {'holds' if is_load_held[i_load][i_e] else 'slips'}"
+                for i_load, load_ratio in enumerate(LOAD_RATIOS)
+            )
+            print(f"  {name}: {verdicts}")
 
 
 if __name__ == "__main__":

--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -28,6 +28,9 @@ LOAD_RATIOS = (0.25, 0.5, 0.75, 0.95, 1.05)
 # static-friction unit tests: a displacement (meters) for the box, a swept angle (radians) for the sphere.
 DRIFT_TOLERANCE = 5e-3
 N_STEPS = 300
+# Steps simulated past the point where every entity has drifted beyond the tolerance: long enough to make the slip
+# visible, short enough that nothing accelerates out of frame.
+N_STEPS_SLIPPED = 80
 
 
 def checkered_ball_mjcf():
@@ -114,15 +117,18 @@ def measure_stiction(friction_cone, show_viewer):
         box_pos_start = float(box.get_pos()[..., 0])
         spinner_swept_angle = 0.0
         roller_swept_angle = 0.0
+        n_steps_slipped = 0
         for _ in range(N_STEPS):
             scene.step()
             spinner_swept_angle += abs(float(spinner.get_dofs_velocity()[..., 5])) * DT
             roller_swept_angle += abs(float(roller.get_dofs_velocity()[..., 4])) * DT
             box_drift = abs(float(box.get_pos()[..., 0]) - box_pos_start)
-            # Once every entity has drifted past the tolerance the verdicts are settled; stopping there keeps the
-            # slipped entities from accelerating without bound over the rest of the horizon.
+            # Once every entity has drifted past the tolerance the verdicts are settled; the bounded tail then shows
+            # the slip without letting anything accelerate over the rest of the horizon.
             if min(box_drift, spinner_swept_angle, roller_swept_angle) > DRIFT_TOLERANCE:
-                break
+                n_steps_slipped += 1
+                if n_steps_slipped > N_STEPS_SLIPPED:
+                    break
         is_load_held.append(
             (
                 box_drift < DRIFT_TOLERANCE,

--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -1,13 +1,13 @@
 """Coulomb stiction under both friction cones, documenting the pyramidal cone's limitations.
 
-A box and a torsional-friction sphere rest on a plane, so each contact carries the exact normal load m * g. A
-constant generalized force (box, tangential) and torque (sphere, about the vertical axis) is applied at a sweep of
-fractions of the Coulomb limits mu * m * g and mu_torsional * m * g, and each load is classified as held or slipped
-from the drift accumulated over the horizon, the criterion of the static-friction unit tests. The pyramidal cone at
-its default 'impratio' of 1 mixes the normal direction into every friction row, so it creeps far past the drift
-tolerance well below the Coulomb limit, especially on the torsional axis; the elliptic cone (auto-resolved
-'impratio' of 100) holds near the limit and slips past it. See the 'friction_cone' and 'impratio' options of
-'gs.options.RigidOptions'.
+A box and two spheres rest on a plane, so each contact carries the exact normal load m * g. A constant generalized
+force (box, tangential) and torque (spinning sphere, about the vertical axis; rolling sphere, about a horizontal
+axis) is applied at a sweep of fractions of the Coulomb limits mu * m * g, mu_torsional * m * g, and
+mu_rolling * m * g, and each load is classified as held or slipped from the drift accumulated over the horizon, the
+criterion of the static-friction unit tests. The pyramidal cone at its default 'impratio' of 1 mixes the normal
+direction into every friction row, so it creeps far past the drift tolerance well below the Coulomb limit,
+especially on the torsional and rolling axes; the elliptic cone (auto-resolved 'impratio' of 100) holds near the
+limit and slips past it. See the 'friction_cone' and 'impratio' options of 'gs.options.RigidOptions'.
 """
 
 import argparse
@@ -34,6 +34,7 @@ def measure_stiction(friction_cone, show_viewer):
         rigid_options=gs.options.RigidOptions(
             friction_cone=friction_cone,
             enable_torsional_friction=True,
+            enable_rolling_friction=True,
         ),
         show_viewer=show_viewer,
     )
@@ -46,7 +47,7 @@ def measure_stiction(friction_cone, show_viewer):
             pos=(0.0, 0.0, 0.1),
         ),
     )
-    sphere = scene.add_entity(
+    spinner = scene.add_entity(
         gs.morphs.Sphere(
             radius=0.1,
             pos=(0.6, 0.0, 0.1),
@@ -55,27 +56,46 @@ def measure_stiction(friction_cone, show_viewer):
             friction_torsional=0.05,
         ),
     )
+    roller = scene.add_entity(
+        gs.morphs.Sphere(
+            radius=0.1,
+            pos=(1.2, 0.0, 0.1),
+        ),
+        material=gs.materials.Rigid(
+            friction_rolling=0.05,
+        ),
+    )
     scene.build()
 
     box_load_coulomb = box.geoms[0].friction * float(box.get_mass()) * GRAVITY
-    sphere_load_coulomb = sphere.geoms[0].friction_torsional * float(sphere.get_mass()) * GRAVITY
+    spinner_load_coulomb = spinner.geoms[0].friction_torsional * float(spinner.get_mass()) * GRAVITY
+    roller_load_coulomb = roller.geoms[0].friction_rolling * float(roller.get_mass()) * GRAVITY
 
     is_load_held = []
     for load_ratio in LOAD_RATIOS:
         scene.reset()
         box.control_dofs_force([load_ratio * box_load_coulomb, 0.0, 0.0, 0.0, 0.0, 0.0])
-        sphere.control_dofs_force([0.0, 0.0, 0.0, 0.0, 0.0, load_ratio * sphere_load_coulomb])
+        spinner.control_dofs_force([0.0, 0.0, 0.0, 0.0, 0.0, load_ratio * spinner_load_coulomb])
+        roller.control_dofs_force([0.0, 0.0, 0.0, 0.0, load_ratio * roller_load_coulomb, 0.0])
         # Contact warmup under load, then drift accumulated over the horizon (the unit tests' protocol). The sphere
-        # drift integrates the spin speed so multiple slipped turns cannot alias back to a small orientation change.
+        # drifts integrate the spin speed so multiple slipped turns cannot alias back to a small orientation change.
         for _ in range(50):
             scene.step()
         box_pos_start = float(box.get_pos()[..., 0])
-        sphere_swept_angle = 0.0
+        spinner_swept_angle = 0.0
+        roller_swept_angle = 0.0
         for _ in range(N_STEPS):
             scene.step()
-            sphere_swept_angle += abs(float(sphere.get_dofs_velocity()[..., 5])) * DT
+            spinner_swept_angle += abs(float(spinner.get_dofs_velocity()[..., 5])) * DT
+            roller_swept_angle += abs(float(roller.get_dofs_velocity()[..., 4])) * DT
         box_drift = abs(float(box.get_pos()[..., 0]) - box_pos_start)
-        is_load_held.append((box_drift < DRIFT_TOLERANCE, sphere_swept_angle < DRIFT_TOLERANCE))
+        is_load_held.append(
+            (
+                box_drift < DRIFT_TOLERANCE,
+                spinner_swept_angle < DRIFT_TOLERANCE,
+                roller_swept_angle < DRIFT_TOLERANCE,
+            )
+        )
     return is_load_held
 
 
@@ -89,7 +109,7 @@ def main():
     for friction_cone in (gs.friction_cone.pyramidal, gs.friction_cone.elliptic):
         is_load_held = measure_stiction(friction_cone, args.vis)
         print(f"{friction_cone.name} cone (load as a fraction of the Coulomb limit):")
-        for i_e, name in enumerate(("tangential (box)", "torsional (sphere)")):
+        for i_e, name in enumerate(("tangential (box)", "torsional (spinning sphere)", "rolling (rolling sphere)")):
             verdicts = ", ".join(
                 f"{load_ratio:.2f}: {'holds' if is_load_held[i_load][i_e] else 'slips'}"
                 for i_load, load_ratio in enumerate(LOAD_RATIOS)

--- a/examples/rigid/rolling_coast.py
+++ b/examples/rigid/rolling_coast.py
@@ -1,0 +1,90 @@
+"""A rolling ball coasting to rest under rolling friction, the everyday behavior a point contact cannot produce.
+
+Two balls are launched rolling side by side at the same speed. Sliding friction does no work on a rolling contact,
+so the zero-coefficient ball coasts forever; the other carries a rolling friction coefficient and slows to a stop
+within a couple of meters, like a real ball on a floor. The elliptic cone brakes it at the exact Coulomb bound, a
+constant deceleration of (5/7) * friction_rolling * g / r. Marker bars show the rotation in the viewer.
+"""
+
+import argparse
+import xml.etree.ElementTree as ET
+
+import genesis as gs
+
+
+def marked_ball_mjcf():
+    """MJCF model of a free ball with a marker bar (visual only) so its rotation shows in the viewer."""
+    mjcf = ET.Element("mujoco", model="marked_ball")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ball_body = ET.SubElement(worldbody, "body", name="ball", pos="0. 0. 0.1")
+    ET.SubElement(ball_body, "joint", name="root", type="free")
+    ET.SubElement(ball_body, "geom", type="sphere", size="0.1")
+    bar_kwargs = {"contype": "0", "conaffinity": "0", "rgba": "1. 1. 0. 1."}
+    ET.SubElement(ball_body, "geom", type="box", size="0.13 0.012 0.012", pos="0. 0. 0.06", **bar_kwargs)
+    return ET.tostring(mjcf, encoding="unicode")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(backend=gs.gpu)
+
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, -4.5, 2.0),
+            camera_lookat=(2.0, 0.3, 0.1),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=gs.friction_cone.elliptic,
+            enable_torsional_friction=True,
+            enable_rolling_friction=True,
+        ),
+        show_viewer=args.vis,
+    )
+
+    ########################## entities ##########################
+    # The contact coefficient is the maximum over the pair, so the zero-coefficient plane leaves each ball coasting
+    # at its own rate.
+    scene.add_entity(
+        gs.morphs.Plane(),
+        material=gs.materials.Rigid(
+            friction_torsional=0.0,
+            friction_rolling=0.0,
+        ),
+    )
+    balls = [
+        scene.add_entity(
+            gs.morphs.MJCF(
+                file=marked_ball_mjcf(),
+                pos=(0.0, 0.6 * i_ball, 0.0),
+            ),
+            material=gs.materials.Rigid(
+                friction_rolling=friction_rolling,
+            ),
+        )
+        for i_ball, friction_rolling in enumerate((0.0, 0.005))
+    ]
+
+    ########################## build ##########################
+    scene.build()
+
+    # Launch both balls rolling without slipping: v = w * r.
+    for ball in balls:
+        ball.set_dofs_velocity([1.0, 0.0, 0.0, 0.0, 10.0, 0.0])
+    for i_step in range(500):
+        scene.step()
+        if i_step % 100 == 99:
+            speeds = [float(ball.get_dofs_velocity()[..., 0]) for ball in balls]
+            distances = [float(ball.get_pos()[..., 0]) for ball in balls]
+            print(
+                f"step {i_step + 1}: free ball {speeds[0]:.2f} m/s at {distances[0]:.2f} m, "
+                f"braked ball {speeds[1]:.2f} m/s at {distances[1]:.2f} m"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rigid/rolling_coast.py
+++ b/examples/rigid/rolling_coast.py
@@ -1,26 +1,45 @@
 """A rolling ball coasting to rest under rolling friction, the everyday behavior a point contact cannot produce.
 
-Two balls are launched rolling side by side at the same speed. Sliding friction does no work on a rolling contact,
-so the zero-coefficient ball coasts forever; the other carries a rolling friction coefficient and slows to a stop
-within a couple of meters, like a real ball on a floor. The elliptic cone brakes it at the exact Coulomb bound, a
-constant deceleration of (5/7) * friction_rolling * g / r. Marker bars show the rotation in the viewer.
+Two checkered balls are launched rolling side by side at the same speed. Sliding friction does no work on a rolling
+contact, so the zero-coefficient ball coasts forever; the other carries a rolling friction coefficient and slows to
+a stop within a couple of meters, like a real ball on a floor. The elliptic cone brakes it at the exact Coulomb
+bound, a constant deceleration of (5/7) * friction_rolling * g / r. The checker pattern shows the rotation in the viewer.
 """
 
 import argparse
 import xml.etree.ElementTree as ET
 
 import genesis as gs
+from genesis.utils.misc import get_assets_dir
 
 
-def marked_ball_mjcf():
-    """MJCF model of a free ball with a marker bar (visual only) so its rotation shows in the viewer."""
-    mjcf = ET.Element("mujoco", model="marked_ball")
+RADIUS = 0.1
+# Half-extent of the wooden sphere asset, whose origin sits at the bottom of its y-up frame.
+WOODEN_SPHERE_MESH_RADIUS = 3.486346
+
+
+def checkered_ball_mjcf():
+    """MJCF model of a free ball: a sphere collision geom with a checker-textured ball mesh as its visual, whose
+    colorful pattern makes the rotation visible."""
+    mjcf = ET.Element("mujoco", model="checkered_ball")
+    asset = ET.SubElement(mjcf, "asset")
+    scale = RADIUS / WOODEN_SPHERE_MESH_RADIUS
+    ET.SubElement(
+        asset,
+        "mesh",
+        name="ball_visual",
+        file=f"{get_assets_dir()}/meshes/wooden_sphere_OBJ/wooden_sphere.obj",
+        scale=f"{scale} {scale} {scale}",
+    )
+    tex_kwargs = {"builtin": "checker", "rgb1": "0.9 0.2 0.2", "rgb2": "1. 0.9 0.3", "width": "128", "height": "128"}
+    ET.SubElement(asset, "texture", name="checker", type="cube", **tex_kwargs)
+    ET.SubElement(asset, "material", name="checker", texture="checker", texrepeat="4 4")
     worldbody = ET.SubElement(mjcf, "worldbody")
-    ball_body = ET.SubElement(worldbody, "body", name="ball", pos="0. 0. 0.1")
+    ball_body = ET.SubElement(worldbody, "body", name="ball", pos="0. 0. 0.")
     ET.SubElement(ball_body, "joint", name="root", type="free")
-    ET.SubElement(ball_body, "geom", type="sphere", size="0.1")
-    bar_kwargs = {"contype": "0", "conaffinity": "0", "rgba": "1. 1. 0. 1."}
-    ET.SubElement(ball_body, "geom", type="box", size="0.13 0.012 0.012", pos="0. 0. 0.06", **bar_kwargs)
+    ET.SubElement(ball_body, "geom", type="sphere", size=f"{RADIUS}")
+    visual_kwargs = {"contype": "0", "conaffinity": "0", "mass": "0.", "euler": "90 0 0", "material": "checker"}
+    ET.SubElement(ball_body, "geom", type="mesh", mesh="ball_visual", pos=f"0. 0. -{RADIUS}", **visual_kwargs)
     return ET.tostring(mjcf, encoding="unicode")
 
 
@@ -59,8 +78,8 @@ def main():
     balls = [
         scene.add_entity(
             gs.morphs.MJCF(
-                file=marked_ball_mjcf(),
-                pos=(0.0, 0.6 * i_ball, 0.0),
+                file=checkered_ball_mjcf(),
+                pos=(0.0, 0.6 * i_ball, RADIUS),
             ),
             material=gs.materials.Rigid(
                 friction_rolling=friction_rolling,

--- a/examples/rigid/torsional_grasp.py
+++ b/examples/rigid/torsional_grasp.py
@@ -1,27 +1,46 @@
 """In-hand pivoting under the elliptic cone with torsional friction, the maximum-realism friction configuration.
 
-A sphere is pinched between two fixed plates and spun about the pinch axis, the canonical grasp scenario a point
-contact cannot resist with sliding friction alone: without torsional friction the grasped sphere pivots forever.
-The elliptic cone with its auto-resolved high 'impratio' holds the sphere against gravity without the tangential
-creep of the pyramidal cone, and its exact Coulomb bound brakes the spin at the rate set by 'friction_torsional'
-times the grip normal force. A marker bar shows the rotation in the viewer.
+A checkered ball is pinched between two fixed plates and spun about the pinch axis, the canonical grasp scenario a
+point contact cannot resist with sliding friction alone: without torsional friction the grasped ball pivots forever.
+The elliptic cone with its auto-resolved high 'impratio' holds the ball against gravity without the tangential creep
+of the pyramidal cone, and its exact Coulomb bound brakes the spin at the rate set by 'friction_torsional' times the
+grip normal force. The checker pattern shows the rotation in the viewer.
 """
 
 import argparse
 import xml.etree.ElementTree as ET
 
 import genesis as gs
+from genesis.utils.misc import get_assets_dir
 
 
-def marked_sphere_mjcf():
-    """MJCF model of a free sphere with a marker bar (visual only) so its spin shows in the viewer."""
-    mjcf = ET.Element("mujoco", model="marked_sphere")
+RADIUS = 0.1
+# Half-extent of the wooden sphere asset, whose origin sits at the bottom of its y-up frame.
+WOODEN_SPHERE_MESH_RADIUS = 3.486346
+
+
+def checkered_ball_mjcf():
+    """MJCF model of a free ball: a sphere collision geom with a checker-textured ball mesh as its visual, whose
+    colorful pattern makes the rotation visible."""
+    mjcf = ET.Element("mujoco", model="checkered_ball")
+    asset = ET.SubElement(mjcf, "asset")
+    scale = RADIUS / WOODEN_SPHERE_MESH_RADIUS
+    ET.SubElement(
+        asset,
+        "mesh",
+        name="ball_visual",
+        file=f"{get_assets_dir()}/meshes/wooden_sphere_OBJ/wooden_sphere.obj",
+        scale=f"{scale} {scale} {scale}",
+    )
+    tex_kwargs = {"builtin": "checker", "rgb1": "0.9 0.2 0.2", "rgb2": "1. 0.9 0.3", "width": "128", "height": "128"}
+    ET.SubElement(asset, "texture", name="checker", type="cube", **tex_kwargs)
+    ET.SubElement(asset, "material", name="checker", texture="checker", texrepeat="4 4")
     worldbody = ET.SubElement(mjcf, "worldbody")
-    sphere_body = ET.SubElement(worldbody, "body", name="sphere", pos="0. 0. 0.")
-    ET.SubElement(sphere_body, "joint", name="root", type="free")
-    ET.SubElement(sphere_body, "geom", type="sphere", size="0.1")
-    bar_kwargs = {"contype": "0", "conaffinity": "0", "rgba": "1. 1. 0. 1."}
-    ET.SubElement(sphere_body, "geom", type="box", size="0.13 0.012 0.012", pos="0. 0. 0.06", **bar_kwargs)
+    ball_body = ET.SubElement(worldbody, "body", name="ball", pos="0. 0. 0.")
+    ET.SubElement(ball_body, "joint", name="root", type="free")
+    ET.SubElement(ball_body, "geom", type="sphere", size=f"{RADIUS}")
+    visual_kwargs = {"contype": "0", "conaffinity": "0", "mass": "0.", "euler": "90 0 0", "material": "checker"}
+    ET.SubElement(ball_body, "geom", type="mesh", mesh="ball_visual", pos=f"0. 0. -{RADIUS}", **visual_kwargs)
     return ET.tostring(mjcf, encoding="unicode")
 
 
@@ -50,7 +69,7 @@ def main():
     scene.add_entity(
         gs.morphs.Plane(),
     )
-    # Two fixed plates pinch the sphere with a slight interpenetration that supplies the grip normal force.
+    # Two fixed plates pinch the ball with a slight interpenetration that supplies the grip normal force.
     for i_side in range(2):
         scene.add_entity(
             gs.morphs.Box(
@@ -62,9 +81,9 @@ def main():
                 friction_torsional=0.002,
             ),
         )
-    sphere = scene.add_entity(
+    ball = scene.add_entity(
         gs.morphs.MJCF(
-            file=marked_sphere_mjcf(),
+            file=checkered_ball_mjcf(),
             pos=(0.0, 0.0, 0.3),
         ),
         material=gs.materials.Rigid(
@@ -75,16 +94,16 @@ def main():
     ########################## build ##########################
     scene.build()
 
-    # Let the pinch settle, then spin the sphere about the pinch axis.
+    # Let the pinch settle, then spin the ball about the pinch axis.
     for _ in range(50):
         scene.step()
-    z_settled = float(sphere.get_dofs_position()[..., 2])
-    sphere.set_dofs_velocity([0.0, 0.0, 0.0, 0.0, 8.0, 0.0])
+    z_settled = float(ball.get_dofs_position()[..., 2])
+    ball.set_dofs_velocity([0.0, 0.0, 0.0, 0.0, 8.0, 0.0])
     for i_step in range(300):
         scene.step()
         if (i_step < 100 and i_step % 20 == 19) or i_step % 100 == 99:
-            spin = float(sphere.get_dofs_velocity()[..., 4])
-            sag = z_settled - float(sphere.get_dofs_position()[..., 2])
+            spin = float(ball.get_dofs_velocity()[..., 4])
+            sag = z_settled - float(ball.get_dofs_position()[..., 2])
             print(f"step {i_step + 1}: spin {spin:.2f} rad/s, sag since settling {1e3 * sag:.2f} mm")
 
 

--- a/examples/rigid/torsional_grasp.py
+++ b/examples/rigid/torsional_grasp.py
@@ -66,9 +66,6 @@ def main():
     )
 
     ########################## entities ##########################
-    scene.add_entity(
-        gs.morphs.Plane(),
-    )
     # Two fixed plates pinch the ball with a slight interpenetration that supplies the grip normal force.
     for i_side in range(2):
         scene.add_entity(

--- a/examples/rigid/torsional_grasp.py
+++ b/examples/rigid/torsional_grasp.py
@@ -1,0 +1,92 @@
+"""In-hand pivoting under the elliptic cone with torsional friction, the maximum-realism friction configuration.
+
+A sphere is pinched between two fixed plates and spun about the pinch axis, the canonical grasp scenario a point
+contact cannot resist with sliding friction alone: without torsional friction the grasped sphere pivots forever.
+The elliptic cone with its auto-resolved high 'impratio' holds the sphere against gravity without the tangential
+creep of the pyramidal cone, and its exact Coulomb bound brakes the spin at the rate set by 'friction_torsional'
+times the grip normal force. A marker bar shows the rotation in the viewer.
+"""
+
+import argparse
+import xml.etree.ElementTree as ET
+
+import genesis as gs
+
+
+def marked_sphere_mjcf():
+    """MJCF model of a free sphere with a marker bar (visual only) so its spin shows in the viewer."""
+    mjcf = ET.Element("mujoco", model="marked_sphere")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    sphere_body = ET.SubElement(worldbody, "body", name="sphere", pos="0. 0. 0.")
+    ET.SubElement(sphere_body, "joint", name="root", type="free")
+    ET.SubElement(sphere_body, "geom", type="sphere", size="0.1")
+    bar_kwargs = {"contype": "0", "conaffinity": "0", "rgba": "1. 1. 0. 1."}
+    ET.SubElement(sphere_body, "geom", type="box", size="0.13 0.012 0.012", pos="0. 0. 0.06", **bar_kwargs)
+    return ET.tostring(mjcf, encoding="unicode")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", default=False)
+    args = parser.parse_args()
+
+    ########################## init ##########################
+    gs.init(backend=gs.gpu)
+
+    ########################## create a scene ##########################
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.9, -0.9, 0.6),
+            camera_lookat=(0.0, 0.0, 0.3),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=gs.friction_cone.elliptic,
+            enable_torsional_friction=True,
+        ),
+        show_viewer=args.vis,
+    )
+
+    ########################## entities ##########################
+    scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    # Two fixed plates pinch the sphere with a slight interpenetration that supplies the grip normal force.
+    for i_side in range(2):
+        scene.add_entity(
+            gs.morphs.Box(
+                size=(0.3, 0.02, 0.3),
+                pos=(0.0, (2 * i_side - 1) * 0.1095, 0.3),
+                fixed=True,
+            ),
+            material=gs.materials.Rigid(
+                friction_torsional=0.002,
+            ),
+        )
+    sphere = scene.add_entity(
+        gs.morphs.MJCF(
+            file=marked_sphere_mjcf(),
+            pos=(0.0, 0.0, 0.3),
+        ),
+        material=gs.materials.Rigid(
+            friction_torsional=0.002,
+        ),
+    )
+
+    ########################## build ##########################
+    scene.build()
+
+    # Let the pinch settle, then spin the sphere about the pinch axis.
+    for _ in range(50):
+        scene.step()
+    z_settled = float(sphere.get_dofs_position()[..., 2])
+    sphere.set_dofs_velocity([0.0, 0.0, 0.0, 0.0, 8.0, 0.0])
+    for i_step in range(300):
+        scene.step()
+        if (i_step < 100 and i_step % 20 == 19) or i_step % 100 == 99:
+            spin = float(sphere.get_dofs_velocity()[..., 4])
+            sag = z_settled - float(sphere.get_dofs_position()[..., 2])
+            print(f"step {i_step + 1}: spin {spin:.2f} rad/s, sag since settling {1e3 * sag:.2f} mm")
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2452,6 +2452,9 @@ class RigidEntity(KinematicEntity):
             friction_torsional = self.material.friction_torsional
             if friction_torsional is None:
                 friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
+            friction_rolling = self.material.friction_rolling
+            if friction_rolling is None:
+                friction_rolling = g_info.get("friction_rolling", gu.default_friction_rolling())
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
             link._add_geom(
                 mesh=g_info["mesh"],
@@ -2460,6 +2463,7 @@ class RigidEntity(KinematicEntity):
                 type=g_info["type"],
                 friction=friction,
                 friction_torsional=friction_torsional,
+                friction_rolling=friction_rolling,
                 sol_params=g_info["sol_params"],
                 data=g_info.get("data"),
                 needs_coup=needs_coup,
@@ -2714,6 +2718,9 @@ class RigidEntity(KinematicEntity):
             friction_torsional = self.material.friction_torsional
             if friction_torsional is None:
                 friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
+            friction_rolling = self.material.friction_rolling
+            if friction_rolling is None:
+                friction_rolling = g_info.get("friction_rolling", gu.default_friction_rolling())
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
             link._add_geom(
                 mesh=g_info["mesh"],
@@ -2722,6 +2729,7 @@ class RigidEntity(KinematicEntity):
                 type=g_info["type"],
                 friction=friction,
                 friction_torsional=friction_torsional,
+                friction_rolling=friction_rolling,
                 sol_params=g_info["sol_params"],
                 data=g_info.get("data"),
                 needs_coup=needs_coup,
@@ -4440,6 +4448,27 @@ class RigidEntity(KinematicEntity):
 
         for link in self._links:
             link.set_friction_torsional(friction_torsional)
+
+    def set_friction_rolling(self, friction_rolling):
+        """
+        Set the rolling friction coefficient of all the links (and in turn, geometries) of the rigid entity.
+
+        Note
+        ----
+        The rolling friction coefficient associated with a pair of geometries in contact is defined as the maximum
+        between their respective values (see 'gs.materials.Rigid'). Only effective when rolling friction is enabled
+        at the scene level (see 'RigidOptions.enable_rolling_friction').
+
+        Parameters
+        ----------
+        friction_rolling : float
+            The rolling friction coefficient to set.
+        """
+        if friction_rolling < 0:
+            gs.raise_exception("`friction_rolling` must be non-negative.")
+
+        for link in self._links:
+            link.set_friction_rolling(friction_rolling)
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- mass / inertia -----------------------------------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -600,7 +600,7 @@ class KinematicEntity(Entity):
         # initialized undetermined physics parameters.
         if isinstance(morph, gs.morphs.MJCF):
             # Mujoco's unified MJCF+URDF parser systematically for MJCF files
-            l_infos, links_j_infos, links_g_infos, eqs_info = mju.parse_xml(morph, surface)
+            l_infos, links_j_infos, links_g_infos, eqs_info = mju.parse_xml(morph, surface, self._solver._options)
         elif isinstance(morph, (gs.morphs.URDF, gs.morphs.Drone)):
             # Custom "legacy" URDF parser for loading geometries (visual and collision) and equality constraints.
             # This is necessary because Mujoco cannot parse visual geometries (meshes) reliably for URDF.

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2449,6 +2449,9 @@ class RigidEntity(KinematicEntity):
             friction = self.material.friction
             if friction is None:
                 friction = g_info.get("friction", gu.default_friction())
+            friction_torsional = self.material.friction_torsional
+            if friction_torsional is None:
+                friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
             link._add_geom(
                 mesh=g_info["mesh"],
@@ -2456,6 +2459,7 @@ class RigidEntity(KinematicEntity):
                 init_quat=g_info.get("quat", gu.identity_quat()),
                 type=g_info["type"],
                 friction=friction,
+                friction_torsional=friction_torsional,
                 sol_params=g_info["sol_params"],
                 data=g_info.get("data"),
                 needs_coup=needs_coup,
@@ -2707,6 +2711,9 @@ class RigidEntity(KinematicEntity):
             friction = self.material.friction
             if friction is None:
                 friction = g_info.get("friction", gu.default_friction())
+            friction_torsional = self.material.friction_torsional
+            if friction_torsional is None:
+                friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
             link._add_geom(
                 mesh=g_info["mesh"],
@@ -2714,6 +2721,7 @@ class RigidEntity(KinematicEntity):
                 init_quat=g_info.get("quat", gu.identity_quat()),
                 type=g_info["type"],
                 friction=friction,
+                friction_torsional=friction_torsional,
                 sol_params=g_info["sol_params"],
                 data=g_info.get("data"),
                 needs_coup=needs_coup,
@@ -4411,6 +4419,27 @@ class RigidEntity(KinematicEntity):
 
         for link in self._links:
             link.set_friction(friction)
+
+    def set_friction_torsional(self, friction_torsional):
+        """
+        Set the torsional friction coefficient of all the links (and in turn, geometries) of the rigid entity.
+
+        Note
+        ----
+        The torsional friction coefficient associated with a pair of geometries in contact is defined as the maximum
+        between their respective values (see 'gs.materials.Rigid'). Only effective when torsional friction is enabled
+        at the scene level (see 'RigidOptions.enable_torsional_friction').
+
+        Parameters
+        ----------
+        friction_torsional : float
+            The torsional friction coefficient to set.
+        """
+        if friction_torsional < 0:
+            gs.raise_exception("`friction_torsional` must be non-negative.")
+
+        for link in self._links:
+            link.set_friction_torsional(friction_torsional)
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- mass / inertia -----------------------------------

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -43,6 +43,7 @@ class RigidGeom(RBC):
         mesh: "Mesh",
         type: gs.GEOM_TYPE,
         friction: float,
+        friction_torsional: float,
         sol_params,
         init_pos,
         init_quat,
@@ -62,6 +63,7 @@ class RigidGeom(RBC):
         self._idx = idx
         self._type: gs.GEOM_TYPE = type
         self._friction: float = friction
+        self._friction_torsional: float = friction_torsional
         self._sol_params = sol_params
         self._needs_coup: bool = needs_coup
         self._contype = int(contype)
@@ -352,6 +354,17 @@ class RigidGeom(RBC):
         if self._solver.is_built:
             self._solver.set_geom_friction(friction, self._idx)
 
+    def set_friction_torsional(self, friction_torsional):
+        """
+        Set the torsional friction coefficient of this geometry (see 'gs.materials.Rigid').
+        """
+        if friction_torsional < 0:
+            gs.raise_exception("`friction_torsional` must be non-negative.")
+        self._friction_torsional = friction_torsional
+
+        if self._solver.is_built:
+            self._solver.set_geom_friction_torsional(friction_torsional, self._idx)
+
     # ------------------------------------------------------------------------------------
     # -------------------------------- real-time state -----------------------------------
     # ------------------------------------------------------------------------------------
@@ -449,6 +462,13 @@ class RigidGeom(RBC):
         Get the friction coefficient of the geom.
         """
         return self._friction
+
+    @property
+    def friction_torsional(self):
+        """
+        Get the torsional friction coefficient of the geom (see 'gs.materials.Rigid').
+        """
+        return self._friction_torsional
 
     @property
     def data(self):

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -44,6 +44,7 @@ class RigidGeom(RBC):
         type: gs.GEOM_TYPE,
         friction: float,
         friction_torsional: float,
+        friction_rolling: float,
         sol_params,
         init_pos,
         init_quat,
@@ -64,6 +65,7 @@ class RigidGeom(RBC):
         self._type: gs.GEOM_TYPE = type
         self._friction: float = friction
         self._friction_torsional: float = friction_torsional
+        self._friction_rolling: float = friction_rolling
         self._sol_params = sol_params
         self._needs_coup: bool = needs_coup
         self._contype = int(contype)
@@ -365,6 +367,17 @@ class RigidGeom(RBC):
         if self._solver.is_built:
             self._solver.set_geom_friction_torsional(friction_torsional, self._idx)
 
+    def set_friction_rolling(self, friction_rolling):
+        """
+        Set the rolling friction coefficient of this geometry (see 'gs.materials.Rigid').
+        """
+        if friction_rolling < 0:
+            gs.raise_exception("`friction_rolling` must be non-negative.")
+        self._friction_rolling = friction_rolling
+
+        if self._solver.is_built:
+            self._solver.set_geom_friction_rolling(friction_rolling, self._idx)
+
     # ------------------------------------------------------------------------------------
     # -------------------------------- real-time state -----------------------------------
     # ------------------------------------------------------------------------------------
@@ -469,6 +482,13 @@ class RigidGeom(RBC):
         Get the torsional friction coefficient of the geom (see 'gs.materials.Rigid').
         """
         return self._friction_torsional
+
+    @property
+    def friction_rolling(self):
+        """
+        Get the rolling friction coefficient of the geom (see 'gs.materials.Rigid').
+        """
+        return self._friction_rolling
 
     @property
     def data(self):

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -916,6 +916,7 @@ class RigidLink(KinematicLink):
         type,
         friction,
         friction_torsional,
+        friction_rolling,
         sol_params,
         center_init=None,
         needs_coup=False,
@@ -937,6 +938,7 @@ class RigidLink(KinematicLink):
             type=type,
             friction=friction,
             friction_torsional=friction_torsional,
+            friction_rolling=friction_rolling,
             sol_params=sol_params,
             center_init=center_init,
             needs_coup=needs_coup,
@@ -1043,6 +1045,13 @@ class RigidLink(KinematicLink):
         """
         for geom in self._geoms:
             geom.set_friction_torsional(friction_torsional)
+
+    def set_friction_rolling(self, friction_rolling):
+        """
+        Set the rolling friction of all the link's geoms (see 'gs.materials.Rigid').
+        """
+        for geom in self._geoms:
+            geom.set_friction_rolling(friction_rolling)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -915,6 +915,7 @@ class RigidLink(KinematicLink):
         init_quat,
         type,
         friction,
+        friction_torsional,
         sol_params,
         center_init=None,
         needs_coup=False,
@@ -935,6 +936,7 @@ class RigidLink(KinematicLink):
             init_quat=init_quat,
             type=type,
             friction=friction,
+            friction_torsional=friction_torsional,
             sol_params=sol_params,
             center_init=center_init,
             needs_coup=needs_coup,
@@ -1034,6 +1036,13 @@ class RigidLink(KinematicLink):
         """
         for geom in self._geoms:
             geom.set_friction(friction)
+
+    def set_friction_torsional(self, friction_torsional):
+        """
+        Set the torsional friction of all the link's geoms (see 'gs.materials.Rigid').
+        """
+        for geom in self._geoms:
+            geom.set_friction_torsional(friction_torsional)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -31,6 +31,11 @@ class Rigid(Kinematic["RigidEntity"]):
         robots. Default is None.
     friction : float, optional
         Friction coefficient within the rigid solver. If None, a default of 1.0 may be used or parsed from file.
+    friction_torsional : float, optional
+        Torsional friction coefficient, resisting relative spin about the contact normal. Expressed in meters, as it
+        stands for the effective contact patch radius over which sliding friction acts. Only effective when torsional
+        friction is enabled at the scene level (see 'RigidOptions.enable_torsional_friction'). If None, parsed from
+        file when available (MJCF), otherwise 0.005. Default is None.
     needs_coup : bool, optional
         Whether the material participates in coupling with other solvers. Default is True.
     coup_friction : float, optional
@@ -80,6 +85,7 @@ class Rigid(Kinematic["RigidEntity"]):
 
     rho: ValidFloat | None = None
     friction: Annotated[ValidFloat, Field(ge=0.01, le=5.0)] | None = None
+    friction_torsional: Annotated[ValidFloat, Field(ge=0.0)] | None = None
     needs_coup: StrictBool = True
     coup_friction: NonNegativeFloat = 0.1
     coup_softness: NonNegativeFloat = 0.002

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -36,6 +36,11 @@ class Rigid(Kinematic["RigidEntity"]):
         stands for the effective contact patch radius over which sliding friction acts. Only effective when torsional
         friction is enabled at the scene level (see 'RigidOptions.enable_torsional_friction'). If None, parsed from
         file when available (MJCF), otherwise 0.005. Default is None.
+    friction_rolling : float, optional
+        Rolling friction coefficient, resisting rolling about the two contact tangent axes. Expressed in meters, like
+        the torsional coefficient. Only effective when rolling friction is enabled at the scene level (see
+        'RigidOptions.enable_rolling_friction'). If None, parsed from file when available (MJCF), otherwise 0.0001.
+        Default is None.
     needs_coup : bool, optional
         Whether the material participates in coupling with other solvers. Default is True.
     coup_friction : float, optional
@@ -86,6 +91,7 @@ class Rigid(Kinematic["RigidEntity"]):
     rho: ValidFloat | None = None
     friction: Annotated[ValidFloat, Field(ge=0.01, le=5.0)] | None = None
     friction_torsional: Annotated[ValidFloat, Field(ge=0.0)] | None = None
+    friction_rolling: Annotated[ValidFloat, Field(ge=0.0)] | None = None
     needs_coup: StrictBool = True
     coup_friction: NonNegativeFloat = 0.1
     coup_softness: NonNegativeFloat = 0.002

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1139,6 +1139,18 @@ def kernel_set_geoms_friction(
 
 
 @qd.kernel(fastcache=True)
+def kernel_set_geoms_friction_torsional(
+    geoms_idx: qd.types.ndarray(),
+    friction_torsional: qd.types.ndarray(),
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_g_ in range(geoms_idx.shape[0]):
+        dyn_info.geoms.friction_torsional[geoms_idx[i_g_]] = friction_torsional[i_g_]
+
+
+@qd.kernel(fastcache=True)
 def kernel_set_vverts(
     vvert_start: qd.i32,
     envs_idx: qd.types.ndarray(),

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1122,6 +1122,11 @@ def kernel_set_geom_friction(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, f
 
 
 @qd.kernel(fastcache=True)
+def kernel_set_geom_friction_torsional(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_torsional: qd.f32):
+    dyn_info.geoms.friction_torsional[geoms_idx] = friction_torsional
+
+
+@qd.kernel(fastcache=True)
 def kernel_set_geoms_friction(
     geoms_idx: qd.types.ndarray(),
     friction: qd.types.ndarray(),

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1127,6 +1127,11 @@ def kernel_set_geom_friction_torsional(geoms_idx: qd.i32, dyn_info: array_class.
 
 
 @qd.kernel(fastcache=True)
+def kernel_set_geom_friction_rolling(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_rolling: qd.f32):
+    dyn_info.geoms.friction_rolling[geoms_idx] = friction_rolling
+
+
+@qd.kernel(fastcache=True)
 def kernel_set_geoms_friction(
     geoms_idx: qd.types.ndarray(),
     friction: qd.types.ndarray(),
@@ -1148,6 +1153,18 @@ def kernel_set_geoms_friction_torsional(
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_g_ in range(geoms_idx.shape[0]):
         dyn_info.geoms.friction_torsional[geoms_idx[i_g_]] = friction_torsional[i_g_]
+
+
+@qd.kernel(fastcache=True)
+def kernel_set_geoms_friction_rolling(
+    geoms_idx: qd.types.ndarray(),
+    friction_rolling: qd.types.ndarray(),
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_g_ in range(geoms_idx.shape[0]):
+        dyn_info.geoms.friction_rolling[geoms_idx[i_g_]] = friction_rolling[i_g_]
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -513,6 +513,7 @@ def kernel_init_geom_fields(
     geoms_quat: qd.types.ndarray(),
     geoms_type: qd.types.ndarray(),
     geoms_friction: qd.types.ndarray(),
+    geoms_friction_torsional: qd.types.ndarray(),
     geoms_sol_params: qd.types.ndarray(),
     geoms_data: qd.types.ndarray(),
     geoms_is_convex: qd.types.ndarray(),
@@ -564,6 +565,7 @@ def kernel_init_geom_fields(
         dyn_info.geoms.link_idx[i_g] = geoms_link_idx[i_g]
         dyn_info.geoms.type[i_g] = geoms_type[i_g]
         dyn_info.geoms.friction[i_g] = geoms_friction[i_g]
+        dyn_info.geoms.friction_torsional[i_g] = geoms_friction_torsional[i_g]
 
         dyn_info.geoms.is_convex[i_g] = geoms_is_convex[i_g]
         dyn_info.geoms.is_hollow[i_g] = geoms_is_hollow[i_g]

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -514,6 +514,7 @@ def kernel_init_geom_fields(
     geoms_type: qd.types.ndarray(),
     geoms_friction: qd.types.ndarray(),
     geoms_friction_torsional: qd.types.ndarray(),
+    geoms_friction_rolling: qd.types.ndarray(),
     geoms_sol_params: qd.types.ndarray(),
     geoms_data: qd.types.ndarray(),
     geoms_is_convex: qd.types.ndarray(),
@@ -566,6 +567,7 @@ def kernel_init_geom_fields(
         dyn_info.geoms.type[i_g] = geoms_type[i_g]
         dyn_info.geoms.friction[i_g] = geoms_friction[i_g]
         dyn_info.geoms.friction_torsional[i_g] = geoms_friction_torsional[i_g]
+        dyn_info.geoms.friction_rolling[i_g] = geoms_friction_rolling[i_g]
 
         dyn_info.geoms.is_convex[i_g] = geoms_is_convex[i_g]
         dyn_info.geoms.is_hollow[i_g] = geoms_is_hollow[i_g]

--- a/genesis/engine/solvers/rigid/collider/broadphase.py
+++ b/genesis/engine/solvers/rigid/collider/broadphase.py
@@ -91,6 +91,7 @@ def func_collision_clear(
                         collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
                         collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
                         collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
+                        collider_state.contact_data.friction_rolling[i_c_hibernated, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
                         collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
                         collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
                         collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]

--- a/genesis/engine/solvers/rigid/collider/broadphase.py
+++ b/genesis/engine/solvers/rigid/collider/broadphase.py
@@ -90,6 +90,7 @@ def func_collision_clear(
                         collider_state.contact_data.normal[i_c_hibernated, i_b] = collider_state.contact_data.normal[i_c, i_b]
                         collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
                         collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
+                        collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
                         collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
                         collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
                         collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -207,6 +207,7 @@ def func_collider_clear_env(
                     collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
                     collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
                     collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
+                    collider_state.contact_data.friction_rolling[i_c_hibernated, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
                     collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
                     collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
                     collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]
@@ -331,6 +332,8 @@ def func_add_contact(
         friction_b = dyn_info.geoms.friction[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
         friction_torsional_a = dyn_info.geoms.friction_torsional[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
         friction_torsional_b = dyn_info.geoms.friction_torsional[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
+        friction_rolling_a = dyn_info.geoms.friction_rolling[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
+        friction_rolling_b = dyn_info.geoms.friction_rolling[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
 
         # b to a
         collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -340,6 +343,7 @@ def func_add_contact(
         collider_state.contact_data.penetration[i_c, i_b] = penetration
         collider_state.contact_data.friction[i_c, i_b] = qd.max(qd.max(friction_a, friction_b), 1e-2)
         collider_state.contact_data.friction_torsional[i_c, i_b] = qd.max(friction_torsional_a, friction_torsional_b)
+        collider_state.contact_data.friction_rolling[i_c, i_b] = qd.max(friction_rolling_a, friction_rolling_b)
         collider_state.contact_data.sol_params[i_c, i_b] = 0.5 * (
             dyn_info.geoms.sol_params[i_ga] + dyn_info.geoms.sol_params[i_gb]
         )
@@ -376,6 +380,8 @@ def func_set_contact(
     friction_b = dyn_info.geoms.friction[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
     friction_torsional_a = dyn_info.geoms.friction_torsional[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
     friction_torsional_b = dyn_info.geoms.friction_torsional[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
+    friction_rolling_a = dyn_info.geoms.friction_rolling[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
+    friction_rolling_b = dyn_info.geoms.friction_rolling[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
 
     # b to a
     collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -385,6 +391,7 @@ def func_set_contact(
     collider_state.contact_data.penetration[i_c, i_b] = penetration
     collider_state.contact_data.friction[i_c, i_b] = qd.max(qd.max(friction_a, friction_b), 1e-2)
     collider_state.contact_data.friction_torsional[i_c, i_b] = qd.max(friction_torsional_a, friction_torsional_b)
+    collider_state.contact_data.friction_rolling[i_c, i_b] = qd.max(friction_rolling_a, friction_rolling_b)
     collider_state.contact_data.sol_params[i_c, i_b] = 0.5 * (
         dyn_info.geoms.sol_params[i_ga] + dyn_info.geoms.sol_params[i_gb]
     )

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -206,6 +206,7 @@ def func_collider_clear_env(
                     collider_state.contact_data.normal[i_c_hibernated, i_b] = collider_state.contact_data.normal[i_c, i_b]
                     collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
                     collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
+                    collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
                     collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
                     collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
                     collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]
@@ -328,6 +329,8 @@ def func_add_contact(
     if i_c < collider_info.max_candidate_contacts[None]:
         friction_a = dyn_info.geoms.friction[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
         friction_b = dyn_info.geoms.friction[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
+        friction_torsional_a = dyn_info.geoms.friction_torsional[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
+        friction_torsional_b = dyn_info.geoms.friction_torsional[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
 
         # b to a
         collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -336,6 +339,7 @@ def func_add_contact(
         collider_state.contact_data.pos[i_c, i_b] = contact_pos
         collider_state.contact_data.penetration[i_c, i_b] = penetration
         collider_state.contact_data.friction[i_c, i_b] = qd.max(qd.max(friction_a, friction_b), 1e-2)
+        collider_state.contact_data.friction_torsional[i_c, i_b] = qd.max(friction_torsional_a, friction_torsional_b)
         collider_state.contact_data.sol_params[i_c, i_b] = 0.5 * (
             dyn_info.geoms.sol_params[i_ga] + dyn_info.geoms.sol_params[i_gb]
         )
@@ -370,6 +374,8 @@ def func_set_contact(
     """
     friction_a = dyn_info.geoms.friction[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
     friction_b = dyn_info.geoms.friction[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
+    friction_torsional_a = dyn_info.geoms.friction_torsional[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
+    friction_torsional_b = dyn_info.geoms.friction_torsional[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
 
     # b to a
     collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -378,6 +384,7 @@ def func_set_contact(
     collider_state.contact_data.pos[i_c, i_b] = contact_pos
     collider_state.contact_data.penetration[i_c, i_b] = penetration
     collider_state.contact_data.friction[i_c, i_b] = qd.max(qd.max(friction_a, friction_b), 1e-2)
+    collider_state.contact_data.friction_torsional[i_c, i_b] = qd.max(friction_torsional_a, friction_torsional_b)
     collider_state.contact_data.sol_params[i_c, i_b] = 0.5 * (
         dyn_info.geoms.sol_params[i_ga] + dyn_info.geoms.sol_params[i_gb]
     )

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -202,7 +202,7 @@ def func_noslip_batch(
     ne = constraint_state.n_constraints_equality[i_b]
     nf = constraint_state.n_constraints_frictionloss[i_b]
     const_start = ne + nf
-    const_end = const_start + 4 * collider_state.n_contacts[i_b]
+    const_end = const_start + qd.static(rigid_config.rows_per_contact) * collider_state.n_contacts[i_b]
 
     n_rows = constraint_state.n_constraints[i_b]
     row_start = gs.qd_int(0)

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -148,6 +148,7 @@ class ConstraintSolver:
         self.n_constraints = cs.n_constraints
         self.n_constraints_equality = cs.n_constraints_equality
         self.n_constraints_frictionloss = cs.n_constraints_frictionloss
+        self.n_constraints_cone = cs.n_constraints_cone
         self.improved = cs.improved
         self.Jaref = cs.Jaref
         self.Ma = cs.Ma
@@ -3431,8 +3432,8 @@ def func_apply_rank1_sparse_whole_env(
     The working vector is pre-staged at permuted positions in nt_vec (L is stored in permuted layout); the sweep runs
     ascending columns from p_min within the skyline envelope (nt_H_env_start) and self-clears nt_vec as each column is
     consumed. Returns True on a non-positive downdate pivot. Shared by the active-set flip update (working vector
-    jac * sqrt(D)) and the coupled cone update (block factor staged one column at a time), so both
-    maintain the skyline factor through one code path.
+    jac * sqrt(D)) and the coupled cone update (block factor staged one column at a time), so both maintain the
+    skyline factor through one code path.
     """
     EPS = rigid_info.EPS[None]
     n_dofs = constraint_state.nt_H.shape[1]
@@ -3539,13 +3540,13 @@ def func_apply_staged_rank_updates_island(
 
     The caller stages each update's working vector into nt_vec (slot-minor [i_d * hessian_rank_update_batch + i_u])
     and its sign (+1 update, -1 downdate) into signs, with ld_start the smallest island-local support row across the
-    staged vectors. This sweep is agnostic to the source: batched per-constraint J^T D J rows (one rank-1 each) or
-    a contact's coupled second-order-cone block (staged as its block factor's columns). A rank-1 rotation at
-    column ld only reads state produced by earlier updates at that column and by its own rotations at earlier
-    columns, so interleaving the n_u updates per column is bit-identical to running them sequentially while
-    visiting each L column once. The sweep
-    is bounded per column by the skyline height (dof_env_col_end). Returns whether any downdate went indefinite, in
-    which case the caller refactors the island directly (discarding the partially updated L).
+    staged vectors. This sweep is agnostic to the source: batched per-constraint J^T D J rows (one rank-1 each) or a
+    contact's coupled second-order-cone block (staged as its block factor's columns). A rank-1 rotation at column ld
+    only reads state produced by earlier updates at that column and by its own rotations at earlier columns, so
+    interleaving the n_u updates per column is bit-identical to running them sequentially while visiting each L
+    column once. The sweep is bounded per column by the skyline height (dof_env_col_end). Returns whether any
+    downdate went indefinite, in which case the caller refactors the island directly (discarding the partially
+    updated L).
     """
     EPS = rigid_info.EPS[None]
     dof_base = constraint_state.island.dof_slices.start[i_island, i_b]
@@ -3831,10 +3832,9 @@ def func_factor_island_incremental_or_direct(
     One rank-1 update sweeps the island's skyline envelope at O(sum_span) (sum_span = total row span = envelope
     nonzeros), so n_changed of them cost O(n_changed * sum_span); a direct refactor factors it at O(sum_span_sq)
     (sum_span_sq = sum of squared row spans). The elliptic cone adds one fused multi-rank sweep per middle-zone
-    contact to the incremental side, which the rebuild bakes into the Hessian instead. Both costs are read
-    straight off the envelope, so the decision compares them directly, with no scene-tuned constant. The choice
-    must be per island, not on the env-wide flip count: the rebuild path refactors every island, so a global
-    decision would
+    contact to the incremental side, which the rebuild bakes into the Hessian instead. Both costs are read straight
+    off the envelope, so the decision compares them directly, with no scene-tuned constant. The choice must be per
+    island, not on the env-wide flip count: the rebuild path refactors every island, so a global decision would
     needlessly refactor quiescent islands whenever flips are spread thin across many of them (e.g. several separated
     piles each toggling a single contact).
     """
@@ -6189,10 +6189,10 @@ def func_solve_iter(
                 # Count middle-zone cone contacts: each rides 2 rank-1 sweeps per cone row (one per staged factor
                 # column of its downdated + updated blocks) on the incremental factor every iteration regardless of
                 # active-set flips, so it must weigh into the crossover below (and n_changed alone is often 0 while
-                # the cone still moves). The count reads cone_prev_jaref, which only the CPU
-                # backend allocates; a GPU build of this branch (explicit sparse_solve on GPU) rebuilds with the cone
-                # baked in each iteration instead, and the static backend gate keeps the cone helpers out of the GPU
-                # compilation. cone_passes stays 0 for the pyramidal cone.
+                # the cone still moves). The count reads cone_prev_jaref, which only the CPU backend allocates; a GPU
+                # build of this branch (explicit sparse_solve on GPU) rebuilds with the cone baked in each iteration
+                # instead, and the static backend gate keeps the cone helpers out of the GPU compilation. cone_passes
+                # stays 0 for the pyramidal cone.
                 cone_passes = 0
                 if qd.static(rigid_config.enable_elliptic_friction and rigid_config.backend == gs.cpu):
                     n_rows = qd.static(rigid_config.rows_per_contact)
@@ -6226,8 +6226,8 @@ def func_solve_iter(
                         )
                 # The coupled middle-zone cone block varies with the residual, so whenever some cone sits in the
                 # middle zone on either side (cone_passes > 0) and the active-set update stayed incremental, it rides
-                # the same skyline factor via its downdate/update. With cone_passes == 0 no block is baked in
-                # the factor and none is due, so the update is skipped; a skipped cone's stale cone_prev_jaref stays
+                # the same skyline factor via its downdate/update. With cone_passes == 0 no block is baked in the
+                # factor and none is due, so the update is skipped; a skipped cone's stale cone_prev_jaref stays
                 # classified non-middle until its update runs again on current residuals.
                 if qd.static(rigid_config.enable_elliptic_friction):
                     if qd.static(rigid_config.backend == gs.cpu):
@@ -6400,7 +6400,7 @@ def func_update_contact_force(
                     for i_dir in qd.static(range(4, rows_per_contact)):
                         force = (
                             force
-                            + (-contact_data_normal)
+                            - contact_data_normal
                             * constraint_state.efc_force[i_c * rows_per_contact + i_dir + const_start, i_b]
                         )
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -102,7 +102,8 @@ class ConstraintSolver:
         self.sparse_solve = rigid_solver.rigid_config.sparse_solve
 
         # Note that it must be over-estimated because friction parameters and joint limits may be updated dynamically.
-        # * 4 constraints per contact, bounded by the post-pruning contact budget enforced by the collider
+        # * rows_per_contact constraints per contact, bounded by the post-pruning contact budget enforced by the
+        #   collider
         # * 1 constraint per 1DoF joint limit (upper and lower, if not inf)
         # * 1 constraint per dof frictionloss
         # * up to 6 constraints per equality (weld)
@@ -117,16 +118,18 @@ class ConstraintSolver:
                 rigid_solver._options.max_contacts, collider_info.max_candidate_contacts[None]
             )
             collider_info.max_contacts[None] = rigid_solver._options.max_contacts
+        rows_per_contact = rigid_solver.rigid_config.rows_per_contact
         self.len_constraints = (
-            4 * rigid_solver._options.max_contacts
+            rows_per_contact * rigid_solver._options.max_contacts
             + sum(joint.type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC) for joint in self._solver.joints)
             + self._solver.n_dofs
             + self._solver.n_candidate_equalities_ * 6
         )
         self.len_constraints_ = max(1, self.len_constraints)
-        # Max cone rows (3 per contact); sizes the elliptic-only previous-residual buffer to exactly the contact rows,
-        # below the full constraint count that also covers equalities, joint limits, and frictionloss.
-        self.n_cone_constraints_ = max(1, 3 * rigid_solver._options.max_contacts)
+        # Max cone rows (rows_per_contact per contact); sizes the elliptic-only previous-residual buffer to exactly
+        # the contact rows, below the full constraint count that also covers equalities, joint limits, and
+        # frictionloss.
+        self.n_cone_constraints_ = max(1, rows_per_contact * rigid_solver._options.max_contacts)
 
         self.constraint_state = array_class.get_constraint_state(self, self._solver, self._collider)
         self.constraint_state.qd_n_equalities.from_numpy(
@@ -595,6 +598,55 @@ def constraint_solver_kernel_masked_clear(
 
 
 @qd.func
+def _func_contact_row_direction(
+    i_friction,
+    normal,
+    d1,
+    d2,
+    friction,
+    friction_torsional,
+    rigid_config: qd.template(),
+):
+    """Direction of collision row i_friction, as a translational part n and an angular part n_ang.
+
+    With the elliptic cone the rows [normal, t1, t2(, spin)] follow the contact frame with no friction mixing (the
+    cone couples them in the solver); the spin row is the relative angular velocity about the normal, its friction
+    strength carried by its regularization (see the diag computation in _add_friction_constraint). With the pyramidal
+    cone each row is one of 2 opposing friction-mixed edges per axis (friction * axis - normal), the torsional pair
+    mixing the spin axis through the angular jacobian.
+    """
+    n = -normal
+    n_ang = qd.Vector.zero(gs.qd_float, 3)
+    if qd.static(rigid_config.enable_elliptic_friction):
+        if i_friction == 1:
+            n = d1
+        elif i_friction == 2:
+            n = d2
+        if qd.static(rigid_config.enable_torsional_friction):
+            # The spin axis opposes the contact normal like the normal row's translational direction. A zero
+            # torsional coefficient zeroes the whole row (jacobian and velocity reference alike), leaving it inert:
+            # the cone never bounds a zero-weighted axis, so its regularization alone would still leak a spurious
+            # viscous torque.
+            if i_friction == 3:
+                n = qd.Vector.zero(gs.qd_float, 3)
+                if friction_torsional > 0.0:
+                    n_ang = -normal
+    else:
+        d = (2 * (i_friction % 2) - 1) * (d1 if i_friction < 2 else d2)
+        n = d * friction - normal
+        if qd.static(rigid_config.enable_torsional_friction):
+            # A zero torsional coefficient zeroes the pair like the elliptic spin row (its aref is zeroed alongside,
+            # see the diag computation in _add_friction_constraint): the rows would otherwise degenerate to two extra
+            # pure-normal rows that stiffen the normal response and report phantom contact force.
+            if i_friction >= 4:
+                n = qd.Vector.zero(gs.qd_float, 3)
+                if friction_torsional > 0.0:
+                    n = -normal
+                    n_ang = ((2 * (i_friction % 2) - 1) * friction_torsional) * normal
+    return n, n_ang
+
+
+@qd.func
 def _add_friction_constraint(
     i_b,
     i_col_,
@@ -608,9 +660,10 @@ def _add_friction_constraint(
 ):
     """Add one collision row to the constraint Jacobian and write its matching diag/aref/efc_D scalars.
 
-    With the pyramidal friction cone this is one of the 4 friction-basis rows (i_friction in [0, 4)); with the
-    elliptic cone (enable_elliptic_friction) it is one of the 3 cone rows (i_friction 0 = normal, 1/2 = tangent),
-    which the Newton solver couples into a single second-order friction cone.
+    With the pyramidal friction cone this is one of the rows_per_contact friction-basis rows (2 opposing edges per
+    friction axis); with the elliptic cone (enable_elliptic_friction) it is one of the cone rows (i_friction 0 =
+    normal, then one row per friction axis), which the Newton solver couples into a single second-order friction
+    cone. Torsional friction appends the spin axis (relative rotation about the contact normal) to either basis.
     """
     EPS = rigid_info.EPS[None]
     n_dofs = dyn_state.dofs.ctrl_mode.shape[0]
@@ -644,19 +697,20 @@ def _add_friction_constraint(
     if link_b > -1:
         invweight = invweight + dyn_info.links.invweight[link_b_maybe_batch][0]
 
-    n = -contact_data_normal
-    if qd.static(rigid_config.enable_elliptic_friction):
-        # Cone rows [normal, t1, t2]: the normal row opposes the contact normal, the tangent rows follow the
-        # orthonormal contact frame (no friction mixing - the cone couples the three rows in the solver).
-        if i_friction == 1:
-            n = d1
-        elif i_friction == 2:
-            n = d2
-    else:
-        d = (2 * (i_friction % 2) - 1) * (d1 if i_friction < 2 else d2)
-        n = d * contact_data_friction - contact_data_normal
+    contact_data_friction_torsional = gs.qd_float(0.0)
+    if qd.static(rigid_config.enable_torsional_friction):
+        contact_data_friction_torsional = collider_state.contact_data.friction_torsional[i_col, i_b]
+    n, n_ang = _func_contact_row_direction(
+        i_friction,
+        contact_data_normal,
+        d1,
+        d2,
+        contact_data_friction,
+        contact_data_friction_torsional,
+        rigid_config,
+    )
 
-    rows_per_contact = qd.static(3 if rigid_config.enable_elliptic_friction else 4)
+    rows_per_contact = qd.static(rigid_config.rows_per_contact)
     n_con = collision_con_start + i_col_ * rows_per_contact + i_friction
     if qd.static(rigid_config.sparse_solve):
         for i_d_ in range(constraint_state.jac_n_dofs[n_con, i_b]):
@@ -694,6 +748,10 @@ def _add_friction_constraint(
 
                 diff = sign * vel
                 jac = diff @ n
+                if qd.static(rigid_config.enable_torsional_friction):
+                    # Unconditional fma even though n_ang is zero on the tangential rows: a per-row gate would
+                    # diverge the per-friction kernel's warps, whose adjacent lanes hold different rows.
+                    jac = jac + (sign * cdof_ang) @ n_ang
                 jac_qvel = jac_qvel + jac * dyn_state.dofs.vel[i_d, i_b]
                 constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
@@ -709,16 +767,28 @@ def _add_friction_constraint(
     diag = gs.qd_float(0.0)
     aref = gs.qd_float(0.0)
     if qd.static(rigid_config.enable_elliptic_friction):
-        # Tangent rows carry no positional error (pure damping reference); the normal row references the penetration
-        # depth. The impedance is shared (it depends only on penetration), and the tangent rows are impratio times
+        # Friction rows carry no positional error (pure damping reference); the normal row references the penetration
+        # depth. The impedance is shared (it depends only on penetration), and the friction rows are impratio times
         # stiffer than the normal row (R_t = R_n / impratio), matching MuJoCo's elliptic cone.
         pos_ref = -contact_data_penetration if i_friction == 0 else 0.0
         imp, aref = gu.imp_aref(contact_data_sol_params, -contact_data_penetration, jac_qvel, pos_ref)
         diag = invweight * (1 - imp) / imp
         if i_friction > 0:
             diag = diag / rigid_info.impratio[None]
-        # The cone solver reads the contact friction coefficient off the head (normal) row.
-        constraint_state.efc_frictionloss[n_con, i_b] = contact_data_friction if i_friction == 0 else 0.0
+        # The cone solver reads the contact friction coefficient off the head (normal) row, and the torsional one
+        # off the spin row.
+        efc_frictionloss = contact_data_friction if i_friction == 0 else gs.qd_float(0.0)
+        if qd.static(rigid_config.enable_torsional_friction):
+            # The spin row keeps the unscaled angular jacobian and instead carries the squared sliding-to-torsional
+            # coefficient ratio in its regularization, matching MuJoCo's elliptic cone: the cone then bounds the
+            # torsional torque at friction_torsional times the normal force. A zero coefficient keeps the shared
+            # friction-row regularization: its row is zeroed at the source (see _func_contact_row_direction), so the
+            # value is inert and only has to stay finite.
+            if i_friction == 3:
+                if contact_data_friction_torsional > 0.0:
+                    diag = diag * contact_data_friction**2 / contact_data_friction_torsional**2
+                efc_frictionloss = contact_data_friction_torsional
+        constraint_state.efc_frictionloss[n_con, i_b] = efc_frictionloss
     else:
         imp, aref = gu.imp_aref(contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration)
         # MuJoCo's regularized pyramid impedance: impratio shrinks the effective cone coefficient (mu_reg^2 = mu^2 /
@@ -727,6 +797,11 @@ def _add_friction_constraint(
         friction_sq_reg = contact_data_friction * contact_data_friction / rigid_info.impratio[None]
         diag = invweight + friction_sq_reg * invweight
         diag = diag * 2 * friction_sq_reg * (1 - imp) / imp
+        if qd.static(rigid_config.enable_torsional_friction):
+            # A zeroed torsional pair (see _func_contact_row_direction) must also drop the positional reference:
+            # with it, the zero-jacobian rows would carry a phantom force that pollutes the reported contact force.
+            if i_friction >= 4 and contact_data_friction_torsional <= 0.0:
+                aref = gs.qd_float(0.0)
     diag = qd.max(diag, EPS)
     constraint_state.diag[n_con, i_b] = diag
     constraint_state.aref[n_con, i_b] = aref
@@ -744,13 +819,13 @@ def _add_collision_constraints_per_friction(
 ):
     """Build all collision-contact constraints with one GPU thread per friction-basis constraint.
 
-    Per-friction threading: 4x more threads than the legacy path; adjacent lanes vary the friction slot
-    i_col_ * 4 + i_friction so within a warp adjacent threads write adjacent n_con values. Under the flipped jac
-    layout (_B, n_dofs, n_constraints), n_con is stride-1, so jac writes coalesce.
+    Per-friction threading: rows_per_contact times more threads than the legacy path; adjacent lanes vary the
+    friction slot i_col_ * rows_per_contact + i_friction so within a warp adjacent threads write adjacent n_con
+    values. Under the flipped jac layout (_B, n_dofs, n_constraints), n_con is stride-1, so jac writes coalesce.
     """
     _B = dyn_state.dofs.ctrl_mode.shape[1]
     max_candidate_contacts = collider_state.contact_data.link_a.shape[0]
-    rows_per_contact = qd.static(3 if rigid_config.enable_elliptic_friction else 4)
+    rows_per_contact = qd.static(rigid_config.rows_per_contact)
 
     qd.loop_config(name="add_collision_constraints", serialize=rigid_config.para_level < gs.PARA_LEVEL.PARTIAL)
     for flat_idx in range(_B * max_candidate_contacts * rows_per_contact):
@@ -778,7 +853,7 @@ def _add_collision_constraints_per_contact(
     _B = dyn_state.dofs.ctrl_mode.shape[1]
     n_dofs = dyn_state.dofs.ctrl_mode.shape[0]
     max_candidate_contacts = collider_state.contact_data.link_a.shape[0]
-    rows_per_contact = qd.static(3 if rigid_config.enable_elliptic_friction else 4)
+    rows_per_contact = qd.static(rigid_config.rows_per_contact)
 
     # Iteration order follows the jac layout: batch-outer keeps every write within one env's batch-first block, while
     # the batch-inner order keeps consecutive GPU threads on consecutive envs (coalesced batch-last).
@@ -850,17 +925,20 @@ def _add_collision_constraints_per_contact(
             if link_b > -1:
                 invweight = invweight + dyn_info.links.invweight[link_b_maybe_batch][0]
 
+            contact_data_friction_torsional = gs.qd_float(0.0)
+            if qd.static(rigid_config.enable_torsional_friction):
+                contact_data_friction_torsional = collider_state.contact_data.friction_torsional[i_col, i_b]
+
             for i_friction in range(rows_per_contact):
-                n = -contact_data_normal
-                if qd.static(rigid_config.enable_elliptic_friction):
-                    # Cone rows [normal, t1, t2]: tangent rows follow the orthonormal contact frame (no mixing).
-                    if i_friction == 1:
-                        n = d1
-                    elif i_friction == 2:
-                        n = d2
-                else:
-                    d = (2 * (i_friction % 2) - 1) * (d1 if i_friction < 2 else d2)
-                    n = d * contact_data_friction - contact_data_normal
+                n, n_ang = _func_contact_row_direction(
+                    i_friction,
+                    contact_data_normal,
+                    d1,
+                    d2,
+                    contact_data_friction,
+                    contact_data_friction_torsional,
+                    rigid_config,
+                )
 
                 n_con = collision_con_start + i_col_ * rows_per_contact + i_friction
                 if qd.static(rigid_config.sparse_solve):
@@ -900,6 +978,9 @@ def _add_collision_constraints_per_contact(
 
                             diff = sign * vel
                             jac = diff @ n
+                            if qd.static(rigid_config.enable_torsional_friction):
+                                # Unconditional fma on zero n_ang rows: see _add_friction_constraint.
+                                jac = jac + (sign * cdof_ang) @ n_ang
                             jac_qvel = jac_qvel + jac * dyn_state.dofs.vel[i_d, i_b]
                             constraint_state.jac[n_con, i_d, i_b] = constraint_state.jac[n_con, i_d, i_b] + jac
 
@@ -915,14 +996,21 @@ def _add_collision_constraints_per_contact(
                 diag = gs.qd_float(0.0)
                 aref = gs.qd_float(0.0)
                 if qd.static(rigid_config.enable_elliptic_friction):
-                    # Tangent rows carry no positional error (pure damping reference) and are impratio times stiffer
+                    # Friction rows carry no positional error (pure damping reference) and are impratio times stiffer
                     # than the normal row; the head (normal) row stores the contact friction for the cone solver.
                     pos_ref = -contact_data_penetration if i_friction == 0 else 0.0
                     imp, aref = gu.imp_aref(contact_data_sol_params, -contact_data_penetration, jac_qvel, pos_ref)
                     diag = invweight * (1 - imp) / imp
                     if i_friction > 0:
                         diag = diag / rigid_info.impratio[None]
-                    constraint_state.efc_frictionloss[n_con, i_b] = contact_data_friction if i_friction == 0 else 0.0
+                    efc_frictionloss = contact_data_friction if i_friction == 0 else gs.qd_float(0.0)
+                    if qd.static(rigid_config.enable_torsional_friction):
+                        # Spin-row regularization and torsional coefficient storage: see _add_friction_constraint.
+                        if i_friction == 3:
+                            if contact_data_friction_torsional > 0.0:
+                                diag = diag * contact_data_friction**2 / contact_data_friction_torsional**2
+                            efc_frictionloss = contact_data_friction_torsional
+                    constraint_state.efc_frictionloss[n_con, i_b] = efc_frictionloss
                 else:
                     imp, aref = gu.imp_aref(
                         contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration
@@ -932,6 +1020,10 @@ def _add_collision_constraints_per_contact(
                     friction_sq_reg = contact_data_friction * contact_data_friction / rigid_info.impratio[None]
                     diag = invweight + friction_sq_reg * invweight
                     diag = diag * 2 * friction_sq_reg * (1 - imp) / imp
+                    if qd.static(rigid_config.enable_torsional_friction):
+                        # A zeroed torsional pair drops its positional reference: see _add_friction_constraint.
+                        if i_friction >= 4 and contact_data_friction_torsional <= 0.0:
+                            aref = gs.qd_float(0.0)
                 diag = qd.max(diag, EPS)
                 constraint_state.diag[n_con, i_b] = diag
                 constraint_state.aref[n_con, i_b] = aref
@@ -958,12 +1050,13 @@ def add_collision_constraints(
             dyn_state, collider_state, constraint_state, dyn_info, rigid_info, rigid_config
         )
 
-    rows_per_contact = qd.static(3 if rigid_config.enable_elliptic_friction else 4)
+    rows_per_contact = qd.static(rigid_config.rows_per_contact)
     qd.loop_config(name="add_collision_count", serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
         n_collision_rows = collider_state.n_contacts[i_b] * rows_per_contact
         constraint_state.n_constraints[i_b] = constraint_state.n_constraints[i_b] + n_collision_rows
-        # The elliptic cone rows are the whole collision segment (3 contiguous per contact); joint limits follow.
+        # The elliptic cone rows are the whole collision segment (rows_per_contact contiguous per contact); joint
+        # limits follow.
         if qd.static(rigid_config.enable_elliptic_friction):
             constraint_state.n_constraints_cone[i_b] = n_collision_rows
         else:
@@ -1970,7 +2063,7 @@ def func_add_cone_hessian_block(
 ):
     """Accumulate scale * J_c^T H_c J_c (the coupled elliptic-cone contribution) into the Hessian nt_H[i_b].
 
-    A middle-zone contact adds the symmetric 3x3 local block H_c over the three cone rows' shared DOF support (top
+    A middle-zone contact adds the packed symmetric local block H_c over the cone rows' shared DOF support (top
     zone adds nothing; bottom zone is the plain per-row J^T D J the caller already accumulated with active=True). H_c
     is positive semi-definite (PSD), so nt_H stays symmetric positive definite (SPD) and the factor kernels are
     unchanged. The block is read in natural DOF order and stored at the layout the factor uses - natural for the
@@ -1979,25 +2072,23 @@ def func_add_cone_hessian_block(
     nt_H without a rebuild.
 
     On the CPU backend every cone's cone_prev_jaref is seeded from its current residuals, so the incremental factor's
-    rank-3 downdate targets exactly the block baked here (a +1 caller always precedes the factor there).
+    downdate targets exactly the block baked here (a +1 caller always precedes the factor there).
     """
+    n_rows = qd.static(rigid_config.rows_per_contact)
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_cone = constraint_state.n_constraints_cone[i_b]
-    for i_cone in range(n_cone // 3):
-        i_head = nef + i_cone * 3
-        j1 = i_head + 1
-        j2 = i_head + 2
-        d0, _d1, _d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_head, i_b, constraint_state)
+    for i_cone in range(n_cone // n_rows):
+        i_head = nef + i_cone * n_rows
+        rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
+            i_head, i_b, constraint_state, rigid_config
+        )
         if qd.static(rigid_config.backend == gs.cpu):
-            constraint_state.cone_prev_jaref[i_cone * 3, i_b] = jar0
-            constraint_state.cone_prev_jaref[i_cone * 3 + 1, i_b] = jar1
-            constraint_state.cone_prev_jaref[i_cone * 3 + 2, i_b] = jar2
-        zone, N, T = _func_cone_zone(jar0, jar1, jar2, con_mu, friction)
+            for k in qd.static(range(n_rows)):
+                constraint_state.cone_prev_jaref[i_cone * n_rows + k, i_b] = rows_jaref[k]
+        zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
         if zone == 2:
-            _f0, _f1, _f2, _c, h00, h01, h02, h11, h12, h22 = _func_cone_middle(
-                jar0, jar1, jar2, d0, con_mu, friction, N, T
-            )
+            _fs, _c, cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
             jac_n = constraint_state.jac_n_dofs[i_head, i_b]
             for i_d1_ in range(jac_n):
                 i_d1 = constraint_state.jac_dofs_idx[i_head, i_d1_, i_b]
@@ -2005,20 +2096,12 @@ def func_add_cone_hessian_block(
                     i_d2 = constraint_state.jac_dofs_idx[i_head, i_d2_, i_b]
                     row = qd.max(i_d1, i_d2)
                     col = qd.min(i_d1, i_d2)
-                    block = _func_cone_block_product(
-                        h00,
-                        h01,
-                        h02,
-                        h11,
-                        h12,
-                        h22,
-                        constraint_state.jac[i_head, row, i_b],
-                        constraint_state.jac[j1, row, i_b],
-                        constraint_state.jac[j2, row, i_b],
-                        constraint_state.jac[i_head, col, i_b],
-                        constraint_state.jac[j1, col, i_b],
-                        constraint_state.jac[j2, col, i_b],
-                    )
+                    rows_jac_row = qd.Vector.zero(gs.qd_float, n_rows)
+                    rows_jac_col = qd.Vector.zero(gs.qd_float, n_rows)
+                    for k in qd.static(range(n_rows)):
+                        rows_jac_row[k] = constraint_state.jac[i_head + k, row, i_b]
+                        rows_jac_col[k] = constraint_state.jac[i_head + k, col, i_b]
+                    block = _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col)
                     # jac is read in natural DOF order (row/col above); only the storage position is permuted (sparse).
                     w_row = row
                     w_col = col
@@ -2037,11 +2120,12 @@ def func_add_cone_hessian_block_island(
     """Accumulate the coupled elliptic-cone contribution J_c^T H_c J_c of one island's middle-zone cones into nt_H.
 
     Island analogue of func_add_cone_hessian_block: a cone's three rows share one DOF support and land in one island,
-    so its middle-zone 3x3 coupling is scattered over that support in the same island-local orientation as the
+    so its middle-zone coupling is scattered over that support in the same island-local orientation as the
     assembly's J^T D J loop; the per-row J^T D J of the active rows is the caller's job. On the CPU backend every
-    cone's cone_prev_jaref is seeded from its current residuals, so the incremental factor's rank-3 downdate targets
+    cone's cone_prev_jaref is seeded from its current residuals, so the incremental factor's downdate targets
     exactly the block baked here.
     """
+    n_rows = qd.static(rigid_config.rows_per_contact)
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_cone = constraint_state.n_constraints_cone[i_b]
@@ -2049,21 +2133,18 @@ def func_add_cone_hessian_block_island(
     con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
     for i_lcon in range(con_n):
         i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
-        if i_c >= nef and i_c < nef + n_cone and (i_c - nef) % 3 == 0:
-            j1 = i_c + 1
-            j2 = i_c + 2
-            d0, _d1, _d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_c, i_b, constraint_state)
-            # cone_prev_jaref backs the CPU incremental rank-3 downdate, so seed it on the CPU backend.
+        if i_c >= nef and i_c < nef + n_cone and (i_c - nef) % n_rows == 0:
+            rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
+                i_c, i_b, constraint_state, rigid_config
+            )
+            # cone_prev_jaref backs the CPU incremental downdate, so seed it on the CPU backend.
             if qd.static(rigid_config.backend == gs.cpu):
                 i_cone_row = i_c - nef
-                constraint_state.cone_prev_jaref[i_cone_row, i_b] = jar0
-                constraint_state.cone_prev_jaref[i_cone_row + 1, i_b] = jar1
-                constraint_state.cone_prev_jaref[i_cone_row + 2, i_b] = jar2
-            zone, N, T = _func_cone_zone(jar0, jar1, jar2, con_mu, friction)
+                for k in qd.static(range(n_rows)):
+                    constraint_state.cone_prev_jaref[i_cone_row + k, i_b] = rows_jaref[k]
+            zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
             if zone == 2:
-                _f0, _f1, _f2, _c, h00, h01, h02, h11, h12, h22 = _func_cone_middle(
-                    jar0, jar1, jar2, d0, con_mu, friction, N, T
-                )
+                _fs, _c, cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
                 jac_n = constraint_state.jac_n_dofs[i_c, i_b]
                 for i_d1_ in range(jac_n):
                     i_d1 = constraint_state.jac_dofs_idx[i_c, i_d1_, i_b]
@@ -2077,20 +2158,12 @@ def func_add_cone_hessian_block_island(
                                 >= constraint_state.island.dof_local_pos[i_d2, i_b]
                             ) != (i_d1 >= i_d2):
                                 row, col = col, row
-                        block = _func_cone_block_product(
-                            h00,
-                            h01,
-                            h02,
-                            h11,
-                            h12,
-                            h22,
-                            constraint_state.jac[i_c, row, i_b],
-                            constraint_state.jac[j1, row, i_b],
-                            constraint_state.jac[j2, row, i_b],
-                            constraint_state.jac[i_c, col, i_b],
-                            constraint_state.jac[j1, col, i_b],
-                            constraint_state.jac[j2, col, i_b],
-                        )
+                        rows_jac_row = qd.Vector.zero(gs.qd_float, n_rows)
+                        rows_jac_col = qd.Vector.zero(gs.qd_float, n_rows)
+                        for k in qd.static(range(n_rows)):
+                            rows_jac_row[k] = constraint_state.jac[i_c + k, row, i_b]
+                            rows_jac_col[k] = constraint_state.jac[i_c + k, col, i_b]
+                        block = _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col)
                         constraint_state.nt_H[i_b, row, col] = constraint_state.nt_H[i_b, row, col] + block
 
 
@@ -2354,8 +2427,9 @@ def func_hessian_direct_batch(
     if qd.static(rigid_config.enable_cone_free_hessian_reuse):
         func_copy_cone_free_hessian_whole_env(i_b, constraint_state, save=True)
 
-    # Coupled elliptic-cone Hessian: a middle-zone contact contributes J_c^T H_c J_c with the symmetric 3x3 local block
-    # H_c (top zone contributes nothing; bottom zone is the plain per-row J^T D J already added above with active=True).
+    # Coupled elliptic-cone Hessian: a middle-zone contact contributes J_c^T H_c J_c with the packed symmetric
+    # local block H_c (top zone contributes nothing; bottom zone is the plain per-row J^T D J already added above
+    # with active=True).
     # The three cone rows share one DOF support, so the block is scattered over that support once and keeps the Hessian
     # symmetric positive definite (SPD), leaving the factor kernels unchanged.
     if qd.static(rigid_config.enable_elliptic_friction):
@@ -3272,7 +3346,7 @@ def func_hessian_and_cholesky_factor_direct(
         # The tiled kernel assembles M + J^T D J only. Add the coupled elliptic-cone block as an additive post-pass
         # before factoring: the block is positive semi-definite (PSD) so the factor kernels are unchanged, and the tiled
         # kernel already gave middle/top cone rows active=0 (no per-row term) and bottom rows their diagonal D, so this
-        # adds exactly the middle-zone 3x3 coupling with no double-count. Same guard as the tiled kernel (skip settled
+        # adds exactly the middle-zone coupling with no double-count. Same guard as the tiled kernel (skip settled
         # or empty envs).
         if qd.static(rigid_config.enable_elliptic_friction):
             qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL, block_dim=32)
@@ -3317,7 +3391,7 @@ def func_apply_rank1_dense_whole_env(
     """Apply one rank-1 update (sign +1) or downdate (sign -1) to the whole-env dense factor L in nt_H.
 
     The working vector is pre-staged over all DOFs in nt_vec. Returns True on a non-positive downdate pivot. Shared
-    by the active-set flip update (working vector jac * sqrt(D)) and the coupled cone update (rank-3 factor of the
+    by the active-set flip update (working vector jac * sqrt(D)) and the coupled cone update (block factor of the
     block staged one column at a time), so both maintain the dense factor through one code path.
     """
     EPS = rigid_info.EPS[None]
@@ -3357,7 +3431,7 @@ def func_apply_rank1_sparse_whole_env(
     The working vector is pre-staged at permuted positions in nt_vec (L is stored in permuted layout); the sweep runs
     ascending columns from p_min within the skyline envelope (nt_H_env_start) and self-clears nt_vec as each column is
     consumed. Returns True on a non-positive downdate pivot. Shared by the active-set flip update (working vector
-    jac * sqrt(D)) and the coupled cone update (rank-3 factor of the block staged one column at a time), so both
+    jac * sqrt(D)) and the coupled cone update (block factor staged one column at a time), so both
     maintain the skyline factor through one code path.
     """
     EPS = rigid_info.EPS[None]
@@ -3465,10 +3539,11 @@ def func_apply_staged_rank_updates_island(
 
     The caller stages each update's working vector into nt_vec (slot-minor [i_d * hessian_rank_update_batch + i_u])
     and its sign (+1 update, -1 downdate) into signs, with ld_start the smallest island-local support row across the
-    staged vectors. This sweep is agnostic to the source: batched per-constraint J^T D J rows (one rank-1 each) or a
-    contact's coupled second-order-cone block (staged as its rank-3 factor). A rank-1 rotation at column ld only reads
-    state produced by earlier updates at that column and by its own rotations at earlier columns, so interleaving the
-    n_u updates per column is bit-identical to running them sequentially while visiting each L column once. The sweep
+    staged vectors. This sweep is agnostic to the source: batched per-constraint J^T D J rows (one rank-1 each) or
+    a contact's coupled second-order-cone block (staged as its block factor's columns). A rank-1 rotation at
+    column ld only reads state produced by earlier updates at that column and by its own rotations at earlier
+    columns, so interleaving the n_u updates per column is bit-identical to running them sequentially while
+    visiting each L column once. The sweep
     is bounded per column by the skyline height (dof_env_col_end). Returns whether any downdate went indefinite, in
     which case the caller refactors the island directly (discarding the partially updated L).
     """
@@ -3572,16 +3647,17 @@ def func_cone_rank_update_island(
     """Maintain this island's coupled elliptic-cone contribution in the Cholesky factor L incrementally.
 
     A middle-zone contact contributes J_c^T H_c J_c, which varies with the residual each iteration, so this downdates
-    the previous block and updates the current one. With H_c = L_c L_c^T (3x3), that block equals the sum of rank-1
-    terms w_k w_k^T with w_0 = l00 J_0 + l10 J_1 + l20 J_2, w_1 = l11 J_1 + l21 J_2, w_2 = l22 J_2; the previous w_k
-    stage into slots 0..2 (-1) and the current into slots 3..5 (+1), applied by the shared rank sweep. Downdating first
-    leaves the intermediate factor the well-conditioned cone-free system. cone_prev_jaref holds the previous residuals,
-    indexed by the cone row offset past the equality and frictionloss rows. Returns True on a degenerate downdate, so
-    the caller refactors the island directly.
+    the previous block and updates the current one. With H_c = L_c L_c^T, that block equals the sum of rank-1 terms
+    w_t w_t^T with w_t = sum over rows k >= t of L_c[k][t] J_k; the previous w_t stage into slots [0, n_rows) (-1) and
+    the current into slots [n_rows, 2*n_rows) (+1), applied by the shared rank sweep. Downdating first leaves the
+    intermediate factor the well-conditioned cone-free system. cone_prev_jaref holds the previous residuals, indexed
+    by the cone row offset past the equality and frictionloss rows. Returns True on a degenerate downdate, so the
+    caller refactors the island directly.
     """
     EPS = rigid_info.EPS[None]
     B = qd.static(rigid_config.hessian_rank_update_batch)
-    qd.static_assert(B >= 6, "the cone rank-3 downdate + update stages 6 nt_vec slots per DOF")
+    n_rows = qd.static(rigid_config.rows_per_contact)
+    qd.static_assert(B >= 2 * n_rows, "the cone downdate + update stages 2 * rows_per_contact nt_vec slots per DOF")
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_cone = constraint_state.n_constraints_cone[i_b]
@@ -3589,60 +3665,61 @@ def func_cone_rank_update_island(
     con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
     n = constraint_state.island.dof_slices.n[i_island, i_b]
 
-    # Downdate the previous block (slots 0..2, -1) then update the current one (slots 3..5, +1); the cone-free
-    # intermediate keeps every rotation well conditioned.
+    # Downdate the previous block (slots [0, n_rows), -1) then update the current one (slots [n_rows, 2*n_rows),
+    # +1); the cone-free intermediate keeps every rotation well conditioned.
     signs = qd.Vector.zero(gs.qd_float, B)
-    for i_u in qd.static(range(6)):
-        signs[i_u] = 2 * (i_u // 3) - 1
+    for i_u in qd.static(range(2 * n_rows)):
+        signs[i_u] = 2 * (i_u // n_rows) - 1
 
     is_degenerated = False
     for i_lcon in range(con_n):
         if not is_degenerated:
             i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
-            if i_c >= nef and i_c < nef + n_cone and (i_c - nef) % 3 == 0:
-                j1 = i_c + 1
-                j2 = i_c + 2
+            if i_c >= nef and i_c < nef + n_cone and (i_c - nef) % n_rows == 0:
                 i_cone_row = i_c - nef
-                d0, _d1, _d2, friction, con_mu, cur0, cur1, cur2 = _func_cone_head_load(i_c, i_b, constraint_state)
-                cur_zone, cN, cT = _func_cone_zone(cur0, cur1, cur2, con_mu, friction)
-                prev0 = constraint_state.cone_prev_jaref[i_cone_row, i_b]
-                prev1 = constraint_state.cone_prev_jaref[i_cone_row + 1, i_b]
-                prev2 = constraint_state.cone_prev_jaref[i_cone_row + 2, i_b]
-                prev_zone, pN, pT = _func_cone_zone(prev0, prev1, prev2, con_mu, friction)
+                rows_efc_D, rows_friction, con_mu, rows_jaref_cur = _func_cone_head_load(
+                    i_c, i_b, constraint_state, rigid_config
+                )
+                cur_zone, cN, cT = _func_cone_zone(rows_jaref_cur, con_mu, rows_friction)
+                rows_jaref_prev = qd.Vector.zero(gs.qd_float, n_rows)
+                for k in qd.static(range(n_rows)):
+                    rows_jaref_prev[k] = constraint_state.cone_prev_jaref[i_cone_row + k, i_b]
+                prev_zone, pN, pT = _func_cone_zone(rows_jaref_prev, con_mu, rows_friction)
 
                 if cur_zone == 2 or prev_zone == 2:
-                    cl00, cl10, cl20, cl11, cl21, cl22 = _func_cone_block_chol(
-                        cur0, cur1, cur2, d0, con_mu, friction, cur_zone, cN, cT, EPS
+                    cone_L_cur = _func_cone_block_chol(
+                        rows_jaref_cur, rows_efc_D[0], con_mu, rows_friction, cur_zone, cN, cT, EPS
                     )
-                    pl00, pl10, pl20, pl11, pl21, pl22 = _func_cone_block_chol(
-                        prev0, prev1, prev2, d0, con_mu, friction, prev_zone, pN, pT, EPS
+                    cone_L_prev = _func_cone_block_chol(
+                        rows_jaref_prev, rows_efc_D[0], con_mu, rows_friction, prev_zone, pN, pT, EPS
                     )
                     ld_start = n
                     jac_n = constraint_state.jac_n_dofs[i_c, i_b]
                     for k_ in range(jac_n):
                         i_d = constraint_state.jac_dofs_idx[i_c, k_, i_b]
                         slot_base = i_d * B
-                        j_0 = constraint_state.jac[i_c, i_d, i_b]
-                        j_1 = constraint_state.jac[j1, i_d, i_b]
-                        j_2 = constraint_state.jac[j2, i_d, i_b]
-                        constraint_state.nt_vec[slot_base + 0, i_b] = pl00 * j_0 + pl10 * j_1 + pl20 * j_2
-                        constraint_state.nt_vec[slot_base + 1, i_b] = pl11 * j_1 + pl21 * j_2
-                        constraint_state.nt_vec[slot_base + 2, i_b] = pl22 * j_2
-                        constraint_state.nt_vec[slot_base + 3, i_b] = cl00 * j_0 + cl10 * j_1 + cl20 * j_2
-                        constraint_state.nt_vec[slot_base + 4, i_b] = cl11 * j_1 + cl21 * j_2
-                        constraint_state.nt_vec[slot_base + 5, i_b] = cl22 * j_2
+                        rows_jac = qd.Vector.zero(gs.qd_float, n_rows)
+                        for k in qd.static(range(n_rows)):
+                            rows_jac[k] = constraint_state.jac[i_c + k, i_d, i_b]
+                        for t in qd.static(range(n_rows)):
+                            w_prev = gs.qd_float(0.0)
+                            w_cur = gs.qd_float(0.0)
+                            for k in qd.static(range(t, n_rows)):
+                                w_prev = w_prev + cone_L_prev[qd.static(_tri_idx(t, k, n_rows))] * rows_jac[k]
+                                w_cur = w_cur + cone_L_cur[qd.static(_tri_idx(t, k, n_rows))] * rows_jac[k]
+                            constraint_state.nt_vec[slot_base + t, i_b] = w_prev
+                            constraint_state.nt_vec[slot_base + n_rows + t, i_b] = w_cur
                         ld_support = constraint_state.island.dof_local_pos[i_d, i_b]
                         if ld_support < ld_start:
                             ld_start = ld_support
 
                     if func_apply_staged_rank_updates_island(
-                        i_b, i_island, ld_start, 6, signs, constraint_state, rigid_info, rigid_config
+                        i_b, i_island, ld_start, 2 * n_rows, signs, constraint_state, rigid_info, rigid_config
                     ):
                         is_degenerated = True
 
-                constraint_state.cone_prev_jaref[i_cone_row, i_b] = cur0
-                constraint_state.cone_prev_jaref[i_cone_row + 1, i_b] = cur1
-                constraint_state.cone_prev_jaref[i_cone_row + 2, i_b] = cur2
+                for k in qd.static(range(n_rows)):
+                    constraint_state.cone_prev_jaref[i_cone_row + k, i_b] = rows_jaref_cur[k]
     return is_degenerated
 
 
@@ -3652,14 +3729,15 @@ def func_cone_rank_update_whole_env(
 ) -> bool:
     """Maintain the whole-env coupled elliptic-cone contribution in the Cholesky factor L incrementally.
 
-    Whole-env analogue of func_cone_rank_update_island: per middle-zone contact it applies the rank-3 factor of H_c as
-    three column sweeps of the previous block (-1) then three of the current block (+1), reusing the same single rank-1
-    sweep as the active-set update. Downdating first keeps the intermediate factor the well-conditioned cone-free
-    system. The working vector rides in the layout the factor uses: natural DOF order for the dense path, permuted
-    position (dof_iperm) for the sparse skyline. cone_prev_jaref holds the previous residuals. Returns True on a
-    degenerate downdate, so the caller refactors directly.
+    Whole-env analogue of func_cone_rank_update_island: per middle-zone contact it applies the factor of H_c as one
+    column sweep per cone row of the previous block (-1) then of the current block (+1), reusing the same single
+    rank-1 sweep as the active-set update. Downdating first keeps the intermediate factor the well-conditioned
+    cone-free system. The working vector rides in the layout the factor uses: natural DOF order for the dense path,
+    permuted position (dof_iperm) for the sparse skyline. cone_prev_jaref holds the previous residuals. Returns True
+    on a degenerate downdate, so the caller refactors directly.
     """
     EPS = rigid_info.EPS[None]
+    n_rows = qd.static(rigid_config.rows_per_contact)
     n_dofs = constraint_state.nt_H.shape[1]
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
@@ -3674,47 +3752,49 @@ def func_cone_rank_update_whole_env(
             for p in range(n_dofs):
                 constraint_state.nt_vec[p, i_b] = 0.0
 
-        for i_cone in range(n_cone // 3):
+        for i_cone in range(n_cone // n_rows):
             if not is_degenerated:
-                i_head = nef + i_cone * 3
-                j1 = i_head + 1
-                j2 = i_head + 2
+                i_head = nef + i_cone * n_rows
                 i_cone_row = i_head - nef
-                d0, _d1, _d2, friction, con_mu, cur0, cur1, cur2 = _func_cone_head_load(i_head, i_b, constraint_state)
-                cur_zone, cN, cT = _func_cone_zone(cur0, cur1, cur2, con_mu, friction)
-                prev0 = constraint_state.cone_prev_jaref[i_cone_row, i_b]
-                prev1 = constraint_state.cone_prev_jaref[i_cone_row + 1, i_b]
-                prev2 = constraint_state.cone_prev_jaref[i_cone_row + 2, i_b]
-                prev_zone, pN, pT = _func_cone_zone(prev0, prev1, prev2, con_mu, friction)
+                rows_efc_D, rows_friction, con_mu, rows_jaref_cur = _func_cone_head_load(
+                    i_head, i_b, constraint_state, rigid_config
+                )
+                cur_zone, cN, cT = _func_cone_zone(rows_jaref_cur, con_mu, rows_friction)
+                rows_jaref_prev = qd.Vector.zero(gs.qd_float, n_rows)
+                for k in qd.static(range(n_rows)):
+                    rows_jaref_prev[k] = constraint_state.cone_prev_jaref[i_cone_row + k, i_b]
+                prev_zone, pN, pT = _func_cone_zone(rows_jaref_prev, con_mu, rows_friction)
 
                 if cur_zone == 2 or prev_zone == 2:
-                    cl00, cl10, cl20, cl11, cl21, cl22 = _func_cone_block_chol(
-                        cur0, cur1, cur2, d0, con_mu, friction, cur_zone, cN, cT, EPS
+                    cone_L_cur = _func_cone_block_chol(
+                        rows_jaref_cur, rows_efc_D[0], con_mu, rows_friction, cur_zone, cN, cT, EPS
                     )
-                    pl00, pl10, pl20, pl11, pl21, pl22 = _func_cone_block_chol(
-                        prev0, prev1, prev2, d0, con_mu, friction, prev_zone, pN, pT, EPS
+                    cone_L_prev = _func_cone_block_chol(
+                        rows_jaref_prev, rows_efc_D[0], con_mu, rows_friction, prev_zone, pN, pT, EPS
                     )
-                    # Per-term coefficients over (J_0, J_1, J_2): downdate the previous block first (terms 0..2, sign
-                    # 2 * (term // 3) - 1 = -1) so the intermediate factor is the well-conditioned cone-free system,
-                    # then update the current block (terms 3..5, +1). A term whose coefficients are all zero (side
-                    # outside the middle zone) stages a zero vector and the sweep skips it.
-                    c0 = qd.Vector([pl00, 0.0, 0.0, cl00, 0.0, 0.0], dt=gs.qd_float)
-                    c1 = qd.Vector([pl10, pl11, 0.0, cl10, cl11, 0.0], dt=gs.qd_float)
-                    c2 = qd.Vector([pl20, pl21, pl22, cl20, cl21, cl22], dt=gs.qd_float)
+                    # Per-term coefficients over the cone rows' jacobians: term t stages column t of the previous
+                    # factor (downdate first, sign 2 * (term // n_rows) - 1 = -1) so the intermediate factor is the
+                    # well-conditioned cone-free system, then term n_rows + t stages column t of the current one (+1).
+                    # A term whose coefficients are all zero (side outside the middle zone) stages a zero vector and
+                    # the sweep skips it.
+                    terms_coef = qd.Matrix.zero(gs.qd_float, 2 * n_rows, n_rows)
+                    for t in qd.static(range(n_rows)):
+                        for k in qd.static(range(t, n_rows)):
+                            terms_coef[t, k] = cone_L_prev[qd.static(_tri_idx(t, k, n_rows))]
+                            terms_coef[n_rows + t, k] = cone_L_cur[qd.static(_tri_idx(t, k, n_rows))]
                     jac_n = constraint_state.jac_n_dofs[i_head, i_b]
-                    for term in range(6):
+                    for term in range(2 * n_rows):
                         if not is_degenerated:
-                            sign = 2 * (term // 3) - 1
+                            sign = 2 * (term // n_rows) - 1
                             if qd.static(rigid_config.sparse_solve):
                                 p_min = n_dofs
                                 for k_ in range(jac_n):
                                     i_d = constraint_state.jac_dofs_idx[i_head, k_, i_b]
                                     p = constraint_state.dof_iperm[i_b, i_d]
-                                    constraint_state.nt_vec[p, i_b] = (
-                                        c0[term] * constraint_state.jac[i_head, i_d, i_b]
-                                        + c1[term] * constraint_state.jac[j1, i_d, i_b]
-                                        + c2[term] * constraint_state.jac[j2, i_d, i_b]
-                                    )
+                                    w = gs.qd_float(0.0)
+                                    for k in qd.static(range(n_rows)):
+                                        w = w + terms_coef[term, k] * constraint_state.jac[i_head + k, i_d, i_b]
+                                    constraint_state.nt_vec[p, i_b] = w
                                     if p < p_min:
                                         p_min = p
                                 if func_apply_rank1_sparse_whole_env(i_b, sign, p_min, constraint_state, rigid_info):
@@ -3724,17 +3804,15 @@ def func_cone_rank_update_whole_env(
                                     constraint_state.nt_vec[p, i_b] = 0.0
                                 for k_ in range(jac_n):
                                     i_d = constraint_state.jac_dofs_idx[i_head, k_, i_b]
-                                    constraint_state.nt_vec[i_d, i_b] = (
-                                        c0[term] * constraint_state.jac[i_head, i_d, i_b]
-                                        + c1[term] * constraint_state.jac[j1, i_d, i_b]
-                                        + c2[term] * constraint_state.jac[j2, i_d, i_b]
-                                    )
+                                    w = gs.qd_float(0.0)
+                                    for k in qd.static(range(n_rows)):
+                                        w = w + terms_coef[term, k] * constraint_state.jac[i_head + k, i_d, i_b]
+                                    constraint_state.nt_vec[i_d, i_b] = w
                                 if func_apply_rank1_dense_whole_env(i_b, sign, constraint_state, rigid_info):
                                     is_degenerated = True
 
-                constraint_state.cone_prev_jaref[i_cone_row, i_b] = cur0
-                constraint_state.cone_prev_jaref[i_cone_row + 1, i_b] = cur1
-                constraint_state.cone_prev_jaref[i_cone_row + 2, i_b] = cur2
+                for k in qd.static(range(n_rows)):
+                    constraint_state.cone_prev_jaref[i_cone_row + k, i_b] = rows_jaref_cur[k]
     return is_degenerated
 
 
@@ -3752,10 +3830,11 @@ def func_factor_island_incremental_or_direct(
 
     One rank-1 update sweeps the island's skyline envelope at O(sum_span) (sum_span = total row span = envelope
     nonzeros), so n_changed of them cost O(n_changed * sum_span); a direct refactor factors it at O(sum_span_sq)
-    (sum_span_sq = sum of squared row spans). The elliptic cone adds one fused rank-6 sweep per middle-zone contact to
-    the incremental side, which the rebuild bakes into the Hessian instead. Both costs are read straight off the
-    envelope, so the decision compares them directly, with no scene-tuned constant. The choice must be per island, not
-    on the env-wide flip count: the rebuild path refactors every island, so a global decision would
+    (sum_span_sq = sum of squared row spans). The elliptic cone adds one fused multi-rank sweep per middle-zone
+    contact to the incremental side, which the rebuild bakes into the Hessian instead. Both costs are read
+    straight off the envelope, so the decision compares them directly, with no scene-tuned constant. The choice
+    must be per island, not on the env-wide flip count: the rebuild path refactors every island, so a global
+    decision would
     needlessly refactor quiescent islands whenever flips are spread thin across many of them (e.g. several separated
     piles each toggling a single contact).
     """
@@ -3763,7 +3842,7 @@ def func_factor_island_incremental_or_direct(
     c_n = constraint_state.island.constraint_slices.n[i_island, i_b]
 
     # Count active-set flips and, for the elliptic cone, the middle-zone cone contacts whose coupled block must be
-    # refreshed this iteration (each fires one rank-3 downdate + update below). A cone whose current AND previous
+    # refreshed this iteration (each fires one downdate + update below). A cone whose current AND previous
     # residuals sit outside the middle zone has no block baked in L and leaves the factor valid, so an island with no
     # flips and no middle-zone cones skips entirely; its cone_prev_jaref goes stale, which is safe because a skipped
     # cone's stale residuals stay classified non-middle until the update runs again on its current residuals.
@@ -3781,8 +3860,8 @@ def func_factor_island_incremental_or_direct(
                 # path restores it into nt_H right after.
                 if qd.static(rigid_config.enable_cone_free_hessian_reuse):
                     func_update_cone_free_hessian_flip(i_b, i_c, constraint_state, rigid_info, rigid_config)
-            if i_c >= nef and i_c < ncone and (i_c - nef) % 3 == 0:
-                if _func_cone_head_is_middle(i_c, i_b, nef, constraint_state):
+            if i_c >= nef and i_c < ncone and (i_c - nef) % qd.static(rigid_config.rows_per_contact) == 0:
+                if _func_cone_head_is_middle(i_c, i_b, nef, constraint_state, rigid_config):
                     cone_passes = cone_passes + 1
     else:
         for k in range(c_n):
@@ -3796,9 +3875,10 @@ def func_factor_island_incremental_or_direct(
         # Estimate both costs from the skyline envelope, per envelope entry: a fused pass over the envelope pays the
         # index/envelope work once (n_passes * sum_span) plus one rotation per update (n_changed * sum_span), while a
         # direct refactor pays index work and one FMA on each of the sum_span_sq entries. Each middle-zone cone contact
-        # adds a further fused rank-6 sweep to the incremental side (its rank-3 downdate + update: 6 rotations plus one
+        # adds a further fused sweep to the incremental side (its downdate + update: 2 rotations per cone row plus one
         # envelope pass), which the rebuild avoids by baking the cone into the Hessian. Incremental wins while
-        # (n_changed + n_passes + 7 * cone_passes) * sum_span < 2 * sum_span_sq. No scene-tuned constant.
+        # (n_changed + n_passes + (2 * rows_per_contact + 1) * cone_passes) * sum_span < 2 * sum_span_sq. No
+        # scene-tuned constant.
         sum_span = gs.qd_float(0.0)
         sum_span_sq = gs.qd_float(0.0)
         for ld in range(n_isl_dofs):
@@ -3806,7 +3886,11 @@ def func_factor_island_incremental_or_direct(
             sum_span = sum_span + row_span
             sum_span_sq = sum_span_sq + row_span * row_span
         n_passes = (n_changed + rigid_config.hessian_rank_update_batch - 1) // rigid_config.hessian_rank_update_batch
-        need_rebuild = gs.qd_float(n_changed + n_passes + 7 * cone_passes) * sum_span > 2.0 * sum_span_sq
+        need_rebuild = (
+            gs.qd_float(n_changed + n_passes + qd.static(2 * rigid_config.rows_per_contact + 1) * cone_passes)
+            * sum_span
+            > 2.0 * sum_span_sq
+        )
         if not need_rebuild:
             for ld in range(n_isl_dofs):
                 slot_base = constraint_state.island.dof_id[dof_base + ld, i_b] * rigid_config.hessian_rank_update_batch
@@ -3833,7 +3917,7 @@ def func_factor_island_incremental_or_direct(
                 ):
                     need_rebuild = True
             # The active-set batch above maintains the per-row J^T D J of active rows; the coupled middle-zone cone
-            # block (its rows inactive) is disjoint from that and is maintained here by its rank-3 downdate/update.
+            # block (its rows inactive) is disjoint from that and is maintained here by its downdate/update.
             if qd.static(rigid_config.enable_elliptic_friction):
                 if not need_rebuild:
                     if func_cone_rank_update_island(i_b, i_island, constraint_state, rigid_info, rigid_config):
@@ -3868,7 +3952,7 @@ def func_hessian_and_cholesky_factor_incremental_batch(
         do_full_rebuild = constraint_state.island.n_islands[i_b] > 1
         if qd.static(rigid_config.use_hibernation):
             do_full_rebuild = True
-    # The elliptic cone rides the incremental factor via a per-iteration rank-3 update backed by cone_prev_jaref, which
+    # The elliptic cone rides the incremental factor via a per-iteration block update backed by cone_prev_jaref, which
     # only the CPU backend allocates; a GPU scalar factor here instead rebuilds with the cone baked in each iteration.
     if qd.static(rigid_config.enable_elliptic_friction and rigid_config.backend != gs.cpu):
         do_full_rebuild = True
@@ -3884,7 +3968,7 @@ def func_hessian_and_cholesky_factor_incremental_batch(
         else:
             is_degenerated = func_hessian_and_cholesky_factor_incremental_dense_batch(i_b, constraint_state, rigid_info)
         # The active-set update above maintains the per-row J^T D J of the flipped rows; the coupled middle-zone cone
-        # block varies with the residual each iteration, so it rides the same factor via its rank-3 update here. Only
+        # block varies with the residual each iteration, so it rides the same factor via its block update here. Only
         # the CPU backend reaches this incremental path for elliptic (a GPU scalar factor rebuilt above); the static
         # backend guard also keeps func_cone_rank_update_whole_env (which indexes the CPU-only cone_prev_jaref) out of
         # the GPU compilation of this runtime branch.
@@ -4202,14 +4286,17 @@ def func_ls_init_and_eval_p0(
     # Elliptic cone contacts: gradient/curvature of the cone cost at alpha=0. The cone cost itself cancels in the
     # shifted convention; the per-alpha linesearch re-evaluates the cost delta via _func_cone_cost_diff_along_alpha.
     if qd.static(rigid_config.enable_elliptic_friction):
-        for i_cone in range((ncone - nef) // 3):
-            i_head = nef + i_cone * 3
-            d0, d1, d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_head, i_b, constraint_state)
-            jv0 = constraint_state.jv[i_head, i_b]
-            jv1 = constraint_state.jv[i_head + 1, i_b]
-            jv2 = constraint_state.jv[i_head + 2, i_b]
+        n_rows = qd.static(rigid_config.rows_per_contact)
+        for i_cone in range((ncone - nef) // n_rows):
+            i_head = nef + i_cone * n_rows
+            rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
+                i_head, i_b, constraint_state, rigid_config
+            )
+            rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
+            for k in qd.static(range(n_rows)):
+                rows_jv[k] = constraint_state.jv[i_head + k, i_b]
             _cost_c, grad_c, hess_c = _func_cone_cost_along_alpha(
-                jar0, jar1, jar2, jv0, jv1, jv2, 0.0, d0, d1, d2, con_mu, friction
+                rows_jaref, rows_jv, 0.0, rows_efc_D, con_mu, rows_friction
             )
             quad_total_1 = quad_total_1 + grad_c
             quad_total_2 = quad_total_2 + 0.5 * hess_c
@@ -4319,16 +4406,19 @@ def _func_linesearch_eval_constraints_at_n_alphas_serial(
     # MuJoCo's elliptic cone) and pack its value/gradient/curvature as a local quadratic centered at alpha_k, so the
     # reconstruction cost(alpha_k) = c + l*alpha_k + q*alpha_k^2 reproduces the exact cone cost delta/grad/hess there.
     if qd.static(rigid_config.enable_elliptic_friction):
-        for i_cone in range((ncone - nef) // 3):
-            i_head = nef + i_cone * 3
-            d0, d1, d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_head, i_b, constraint_state)
-            jv0 = constraint_state.jv[i_head, i_b]
-            jv1 = constraint_state.jv[i_head + 1, i_b]
-            jv2 = constraint_state.jv[i_head + 2, i_b]
+        n_rows = qd.static(rigid_config.rows_per_contact)
+        for i_cone in range((ncone - nef) // n_rows):
+            i_head = nef + i_cone * n_rows
+            rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
+                i_head, i_b, constraint_state, rigid_config
+            )
+            rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
+            for j in qd.static(range(n_rows)):
+                rows_jv[j] = constraint_state.jv[i_head + j, i_b]
             for k in qd.static(range(n_alphas)):
                 alpha_k = alphas[k]
                 cost_diff_c, grad_c, hess_c = _func_cone_cost_diff_along_alpha(
-                    jar0, jar1, jar2, jv0, jv1, jv2, alpha_k, d0, d1, d2, con_mu, friction
+                    rows_jaref, rows_jv, alpha_k, rows_efc_D, con_mu, rows_friction
                 )
                 t_0[k] = t_0[k] + cost_diff_c - grad_c * alpha_k + 0.5 * hess_c * alpha_k * alpha_k
                 t_1[k] = t_1[k] + grad_c - hess_c * alpha_k
@@ -4492,17 +4582,20 @@ def _func_linesearch_eval_constraints_at_n_alphas_coop(
     # packed as a local quadratic centered at alpha_k, matching the serial inner. Lane-strided over cone contacts
     # by 32.
     if qd.static(rigid_config.enable_elliptic_friction):
+        n_rows = qd.static(rigid_config.rows_per_contact)
         i_cone = tid
-        while i_cone < (ncone - nef) // 3:
-            i_head = nef + i_cone * 3
-            d0, d1, d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_head, i_b, constraint_state)
-            jv0 = constraint_state.jv[i_head, i_b]
-            jv1 = constraint_state.jv[i_head + 1, i_b]
-            jv2 = constraint_state.jv[i_head + 2, i_b]
+        while i_cone < (ncone - nef) // n_rows:
+            i_head = nef + i_cone * n_rows
+            rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
+                i_head, i_b, constraint_state, rigid_config
+            )
+            rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
+            for j in qd.static(range(n_rows)):
+                rows_jv[j] = constraint_state.jv[i_head + j, i_b]
             for k in qd.static(range(n_alphas)):
                 alpha_k = alphas[k]
                 cost_diff_c, grad_c, hess_c = _func_cone_cost_diff_along_alpha(
-                    jar0, jar1, jar2, jv0, jv1, jv2, alpha_k, d0, d1, d2, con_mu, friction
+                    rows_jaref, rows_jv, alpha_k, rows_efc_D, con_mu, rows_friction
                 )
                 t_0[k] = t_0[k] + cost_diff_c - grad_c * alpha_k + 0.5 * hess_c * alpha_k * alpha_k
                 t_1[k] = t_1[k] + grad_c - hess_c * alpha_k
@@ -4878,20 +4971,32 @@ def func_save_prev_grad(i_b, constraint_state: array_class.ConstraintState):
         constraint_state.cg_prev_Mgrad[i_d, i_b] = constraint_state.Mgrad[i_d, i_b]
 
 
+def _tri_idx(i, j, dim):
+    """Index of entry (i, j), i <= j, in the row-major packing of a dim x dim symmetric matrix's upper triangle.
+
+    Used at trace time only (static loop indices), so the cone block algebra stays dimension-generic across the
+    3-row (normal + 2 tangents) and 4-row (torsional friction adds the spin axis) elliptic cones. The same packing
+    stores a lower-triangular factor column-major via _tri_idx(col, row).
+    """
+    return i * dim - i * (i - 1) // 2 + (j - i)
+
+
 @qd.func
-def _func_cone_zone(jar0, jar1, jar2, con_mu, mu):
-    """Classify one 3-row (normal + 2 tangent) elliptic contact into MuJoCo's three cone zones from the per-row
-    residuals jar_j.
+def _func_cone_zone(rows_jaref, con_mu, rows_friction):
+    """Classify one elliptic contact (normal + friction-axis rows) into MuJoCo's three cone zones from the per-row
+    residuals rows_jaref.
 
     Returns (zone, N, T): zone 0 = top (dual-cone interior, inactive), 1 = bottom (polar cone, plain quadratic),
     2 = middle (cone boundary). N and T are the rescaled normal/tangential magnitudes reused by the middle-zone
-    force/cost/Hessian. con_mu is the regularized master coefficient (friction / sqrt(impratio)); mu is the raw
-    tangential friction coefficient.
+    force/cost/Hessian. con_mu is the regularized master coefficient (friction / sqrt(impratio)); rows_friction
+    carries the raw per-axis friction coefficients (see _func_cone_head_load).
     """
-    N = con_mu * jar0
-    u1 = mu * jar1
-    u2 = mu * jar2
-    T = qd.sqrt(u1 * u1 + u2 * u2)
+    N = con_mu * rows_jaref[0]
+    T_sq = gs.qd_float(0.0)
+    for k in qd.static(range(1, rows_jaref.n)):
+        u = rows_friction[k] * rows_jaref[k]
+        T_sq = T_sq + u**2
+    T = qd.sqrt(T_sq)
     zone = 2
     if N >= con_mu * T or (T <= 0.0 and N >= 0.0):
         zone = 0
@@ -4901,42 +5006,58 @@ def _func_cone_zone(jar0, jar1, jar2, con_mu, mu):
 
 
 @qd.func
-def _func_cone_head_load(i_c, i_b, constraint_state: array_class.ConstraintState):
+def _func_cone_head_load(
+    i_c,
+    i_b,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+):
     """Load the shared per-contact scalars of the elliptic cone whose head (normal) row is i_c.
 
-    Returns (d0, d1, d2, friction, con_mu, jar0, jar1, jar2): the three rows' impedances, the contact friction stored
-    on the head row, the regularized master coefficient con_mu = friction * sqrt(d0 / d1) (= friction / sqrt(impratio)
-    since the tangent rows are impratio times stiffer), and the three residuals.
+    Returns (rows_efc_D, rows_friction, con_mu, rows_jaref): the rows' impedances and residuals (one entry per
+    cone row), the per-row friction coefficients (the head entry is the sliding coefficient it stores, repeated
+    on the tangent axes, with the spin row carrying its own torsional coefficient), and the regularized master
+    coefficient con_mu = rows_friction[0] * sqrt(rows_efc_D[0] / rows_efc_D[1]) (= rows_friction[0] /
+    sqrt(impratio) since the friction rows are impratio times stiffer).
     """
-    d0 = constraint_state.efc_D[i_c, i_b]
-    d1 = constraint_state.efc_D[i_c + 1, i_b]
-    d2 = constraint_state.efc_D[i_c + 2, i_b]
+    n_rows = qd.static(rigid_config.rows_per_contact)
+    rows_efc_D = qd.Vector.zero(gs.qd_float, n_rows)
+    rows_jaref = qd.Vector.zero(gs.qd_float, n_rows)
+    for k in qd.static(range(n_rows)):
+        rows_efc_D[k] = constraint_state.efc_D[i_c + k, i_b]
+        rows_jaref[k] = constraint_state.Jaref[i_c + k, i_b]
     friction = constraint_state.efc_frictionloss[i_c, i_b]
-    con_mu = friction * qd.sqrt(d0 / d1)
-    jar0 = constraint_state.Jaref[i_c, i_b]
-    jar1 = constraint_state.Jaref[i_c + 1, i_b]
-    jar2 = constraint_state.Jaref[i_c + 2, i_b]
-    return d0, d1, d2, friction, con_mu, jar0, jar1, jar2
+    rows_friction = qd.Vector.zero(gs.qd_float, n_rows)
+    for k in qd.static(range(n_rows)):
+        rows_friction[k] = friction
+    if qd.static(rigid_config.enable_torsional_friction):
+        rows_friction[n_rows - 1] = constraint_state.efc_frictionloss[i_c + n_rows - 1, i_b]
+    con_mu = friction * qd.sqrt(rows_efc_D[0] / rows_efc_D[1])
+    return rows_efc_D, rows_friction, con_mu, rows_jaref
 
 
 @qd.func
-def _func_cone_head_is_middle(i_c, i_b, nef, constraint_state: array_class.ConstraintState) -> bool:
+def _func_cone_head_is_middle(
+    i_c,
+    i_b,
+    nef,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+) -> bool:
     """Whether elliptic cone contact head i_c sits in the middle (cone-boundary) zone this iteration or last.
 
-    The coupled cone block only fires its rank-3 downdate/update when the current or previous residual is in the middle
+    The coupled cone block only fires its downdate/update when the current or previous residual is in the middle
     zone; top/bottom zones leave the factor untouched. The incremental-vs-rebuild cost model uses this to charge only
     the cone contacts whose update actually runs.
     """
     i_cone_row = i_c - nef
-    _d0, _d1, _d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_c, i_b, constraint_state)
-    cur_zone, cur_N, cur_T = _func_cone_zone(jar0, jar1, jar2, con_mu, friction)
-    prev_zone, prev_N, prev_T = _func_cone_zone(
-        constraint_state.cone_prev_jaref[i_cone_row, i_b],
-        constraint_state.cone_prev_jaref[i_cone_row + 1, i_b],
-        constraint_state.cone_prev_jaref[i_cone_row + 2, i_b],
-        con_mu,
-        friction,
-    )
+    n_rows = qd.static(rigid_config.rows_per_contact)
+    _ds, rows_friction, con_mu, rows_jaref = _func_cone_head_load(i_c, i_b, constraint_state, rigid_config)
+    cur_zone, cur_N, cur_T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
+    rows_jaref_prev = qd.Vector.zero(gs.qd_float, n_rows)
+    for k in qd.static(range(n_rows)):
+        rows_jaref_prev[k] = constraint_state.cone_prev_jaref[i_cone_row + k, i_b]
+    prev_zone, prev_N, prev_T = _func_cone_zone(rows_jaref_prev, con_mu, rows_friction)
     return cur_zone == 2 or prev_zone == 2
 
 
@@ -4948,135 +5069,152 @@ def _func_cone_Dm(D0, con_mu):
 
 
 @qd.func
-def _func_cone_middle(jar0, jar1, jar2, D0, con_mu, mu, N, T):
-    """Middle-zone (cone-boundary) force, cost, and symmetric 3x3 local Hessian for one elliptic contact.
+def _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T):
+    """Middle-zone (cone-boundary) force, cost, and packed symmetric local Hessian for one elliptic contact.
 
-    Returns (f0, f1, f2, cost, h00, h01, h02, h11, h12, h22), the analytic second-order-cone projection of MuJoCo's
-    elliptic cone. Only valid when the contact is in the middle zone (T > 0).
+    Returns (rows_force, cost, cone_H): the per-row forces, the coupled cost, and the row-major upper-triangle
+    packing (see _tri_idx) of the analytic second-order-cone projection Hessian of MuJoCo's elliptic cone. Only
+    valid when the contact is in the middle zone (T > 0).
     """
-    u1 = mu * jar1
-    u2 = mu * jar2
+    n_rows = qd.static(rows_jaref.n)
+    rows_u = qd.Vector.zero(gs.qd_float, n_rows)
+    for k in qd.static(range(1, n_rows)):
+        rows_u[k] = rows_friction[k] * rows_jaref[k]
     Dm = _func_cone_Dm(D0, con_mu)
     NmT = N - con_mu * T
 
-    f0 = -Dm * NmT * con_mu
-    f1 = -f0 / T * u1 * mu
-    f2 = -f0 / T * u2 * mu
-    cost = 0.5 * Dm * NmT * NmT
+    rows_force = qd.Vector.zero(gs.qd_float, n_rows)
+    rows_force[0] = -Dm * NmT * con_mu
+    for k in qd.static(range(1, n_rows)):
+        rows_force[k] = -rows_force[0] / T * rows_u[k] * rows_friction[k]
+    cost = 0.5 * Dm * NmT**2
 
-    # Curvature in the rescaled U-space, then pre/post-multiplied by G = diag(con_mu, mu, mu) and scaled by Dm.
-    cN_T3 = con_mu * N / (T * T * T)
-    diag_add = con_mu * con_mu - con_mu * N / T
-    hu00 = gs.qd_float(1.0)
-    hu01 = -(con_mu / T) * u1
-    hu02 = -(con_mu / T) * u2
-    hu11 = cN_T3 * u1 * u1 + diag_add
-    hu12 = cN_T3 * u1 * u2
-    hu22 = cN_T3 * u2 * u2 + diag_add
-
-    h00 = Dm * con_mu * con_mu * hu00
-    h01 = Dm * con_mu * mu * hu01
-    h02 = Dm * con_mu * mu * hu02
-    h11 = Dm * mu * mu * hu11
-    h12 = Dm * mu * mu * hu12
-    h22 = Dm * mu * mu * hu22
-    return f0, f1, f2, cost, h00, h01, h02, h11, h12, h22
-
-
-@qd.func
-def _func_cone_block_product(h00, h01, h02, h11, h12, h22, a0, a1, a2, b0, b1, b2):
-    """One entry a^T H_c b of the scattered coupled-cone Hessian: the symmetric 3x3 local block H_c contracted with
-    the three cone rows' jacobian entries a_j (row DOF) and b_j (column DOF)."""
-    return (
-        h00 * a0 * b0
-        + h01 * (a0 * b1 + a1 * b0)
-        + h02 * (a0 * b2 + a2 * b0)
-        + h11 * a1 * b1
-        + h12 * (a1 * b2 + a2 * b1)
-        + h22 * a2 * b2
-    )
+    # Curvature in the rescaled U-space, then pre/post-multiplied by G = diag(con_mu, rows_friction[1:]) and
+    # scaled by Dm.
+    cN_T3 = con_mu * N / T**3
+    diag_add = con_mu**2 - con_mu * N / T
+    cone_H = qd.Vector.zero(gs.qd_float, n_rows * (n_rows + 1) // 2)
+    cone_H[0] = Dm * con_mu**2
+    for j in qd.static(range(1, n_rows)):
+        cone_H[qd.static(_tri_idx(0, j, n_rows))] = Dm * con_mu * rows_friction[j] * (-(con_mu / T) * rows_u[j])
+    for i in qd.static(range(1, n_rows)):
+        cone_H[qd.static(_tri_idx(i, i, n_rows))] = Dm * rows_friction[i] ** 2 * (cN_T3 * rows_u[i] ** 2 + diag_add)
+        for j in qd.static(range(i + 1, n_rows)):
+            cone_H[qd.static(_tri_idx(i, j, n_rows))] = (
+                Dm * rows_friction[i] * rows_friction[j] * (cN_T3 * rows_u[i] * rows_u[j])
+            )
+    return rows_force, cost, cone_H
 
 
 @qd.func
-def _func_cone_block_chol(jar0, jar1, jar2, D0, con_mu, friction, zone, N, T, EPS):
-    """Lower-triangular Cholesky factor (l00, l10, l20, l11, l21, l22) of one contact's middle-zone cone Hessian H_c.
+def _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col):
+    """One entry J_row^T H_c J_col of the scattered coupled-cone Hessian: the packed symmetric local block H_c (see
+    _tri_idx) contracted with the cone rows' jacobian entries at the Hessian row DOF and column DOF."""
+    n_rows = qd.static(rows_jac_row.n)
+    product = gs.qd_float(0.0)
+    for i in qd.static(range(n_rows)):
+        product = product + cone_H[qd.static(_tri_idx(i, i, n_rows))] * rows_jac_row[i] * rows_jac_col[i]
+        for j in qd.static(range(i + 1, n_rows)):
+            product = product + cone_H[qd.static(_tri_idx(i, j, n_rows))] * (
+                rows_jac_row[i] * rows_jac_col[j] + rows_jac_row[j] * rows_jac_col[i]
+            )
+    return product
 
-    All six entries are zero outside the middle zone. Diagonals are floored at EPS so a near-degenerate block cannot
-    divide by zero; a truly indefinite downdate built from the factor is caught later by the rank sweep's pivot test.
+
+@qd.func
+def _func_cone_block_chol(rows_jaref, D0, con_mu, rows_friction, zone, N, T, EPS):
+    """Packed lower-triangular Cholesky factor of one contact's middle-zone cone Hessian H_c, entry L[i][j] stored
+    column-major at _tri_idx(j, i).
+
+    All entries are zero outside the middle zone. Diagonals are floored at EPS so a near-degenerate block cannot
+    divide by zero (the last one at 0); a truly indefinite downdate built from the factor is caught later by the rank
+    sweep's pivot test.
     """
-    l00 = gs.qd_float(0.0)
-    l10 = gs.qd_float(0.0)
-    l20 = gs.qd_float(0.0)
-    l11 = gs.qd_float(0.0)
-    l21 = gs.qd_float(0.0)
-    l22 = gs.qd_float(0.0)
+    n_rows = qd.static(rows_jaref.n)
+    cone_L = qd.Vector.zero(gs.qd_float, n_rows * (n_rows + 1) // 2)
     if zone == 2:
-        _f0, _f1, _f2, _c, h00, h01, h02, h11, h12, h22 = _func_cone_middle(
-            jar0, jar1, jar2, D0, con_mu, friction, N, T
-        )
-        l00 = qd.sqrt(qd.max(h00, EPS))
-        l10 = h01 / l00
-        l20 = h02 / l00
-        l11 = qd.sqrt(qd.max(h11 - l10 * l10, EPS))
-        l21 = (h12 - l20 * l10) / l11
-        l22 = qd.sqrt(qd.max(h22 - l20 * l20 - l21 * l21, 0.0))
-    return l00, l10, l20, l11, l21, l22
+        _fs, _c, cone_H = _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T)
+        for j in qd.static(range(n_rows)):
+            pivot_sq = cone_H[qd.static(_tri_idx(j, j, n_rows))]
+            for k in qd.static(range(j)):
+                pivot_sq = pivot_sq - cone_L[qd.static(_tri_idx(k, j, n_rows))] ** 2
+            if qd.static(j < n_rows - 1):
+                cone_L[qd.static(_tri_idx(j, j, n_rows))] = qd.sqrt(qd.max(pivot_sq, EPS))
+            else:
+                cone_L[qd.static(_tri_idx(j, j, n_rows))] = qd.sqrt(qd.max(pivot_sq, 0.0))
+            for i in qd.static(range(j + 1, n_rows)):
+                offdiag = cone_H[qd.static(_tri_idx(j, i, n_rows))]
+                for k in qd.static(range(j)):
+                    offdiag = (
+                        offdiag - cone_L[qd.static(_tri_idx(k, i, n_rows))] * cone_L[qd.static(_tri_idx(k, j, n_rows))]
+                    )
+                cone_L[qd.static(_tri_idx(j, i, n_rows))] = offdiag / cone_L[qd.static(_tri_idx(j, j, n_rows))]
+    return cone_L
 
 
 @qd.func
-def func_cone_middle_cost(i_c, i_b, constraint_state: array_class.ConstraintState):
+def func_cone_middle_cost(
+    i_c,
+    i_b,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+):
     """Coupled middle-zone cost 0.5*Dm*(N - con_mu*T)^2 of the elliptic cone whose head row is i_c; 0 outside.
 
     Shared by every linesearch/cost path so the coupled term is computed identically across arms.
     """
-    d0, _d1, _d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_c, i_b, constraint_state)
-    zone, N, T = _func_cone_zone(jar0, jar1, jar2, con_mu, friction)
+    rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(i_c, i_b, constraint_state, rigid_config)
+    zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
     c = gs.qd_float(0.0)
     if zone == 2:
         NmT = N - con_mu * T
-        c = 0.5 * _func_cone_Dm(d0, con_mu) * NmT * NmT
+        c = 0.5 * _func_cone_Dm(rows_efc_D[0], con_mu) * NmT**2
     return c
 
 
 @qd.func
-def _func_cone_cost_along_alpha(jar0, jar1, jar2, jv0, jv1, jv2, alpha, d0, d1, d2, con_mu, mu):
+def _func_cone_cost_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, con_mu, rows_friction):
     """Exact elliptic-cone cost and its first/second derivatives in the linesearch step alpha (matching MuJoCo).
 
-    Evaluated at jar_j(alpha) = jar_j + alpha * jv_j, returning (cost, dcost/dalpha, d2cost/dalpha2). The zone is
-    re-classified at this alpha, so the cost is exact along the whole search line (top: 0; bottom: plain quadratic;
-    middle: the cone potential 0.5*Dm*(N - con_mu*T)^2 differentiated through T = ||(mu*jar1, mu*jar2)||).
+    Evaluated at jar_k(alpha) = rows_jaref[k] + alpha * rows_jv[k], returning (cost, dcost/dalpha,
+    d2cost/dalpha2). The zone is re-classified at this alpha, so the cost is exact along the whole search line
+    (top: 0; bottom: plain quadratic; middle: the cone potential 0.5*Dm*(N - con_mu*T)^2 differentiated through
+    T = ||rows_friction[1:] * rows_jaref[1:]||).
     """
-    x0 = jar0 + alpha * jv0
-    x1 = jar1 + alpha * jv1
-    x2 = jar2 + alpha * jv2
-    zone, N, T = _func_cone_zone(x0, x1, x2, con_mu, mu)
+    rows_jaref_alpha = rows_jaref + alpha * rows_jv
+    zone, N, T = _func_cone_zone(rows_jaref_alpha, con_mu, rows_friction)
     cost = gs.qd_float(0.0)
     grad = gs.qd_float(0.0)
     hess = gs.qd_float(0.0)
     if zone == 1:
-        cost = 0.5 * (d0 * x0 * x0 + d1 * x1 * x1 + d2 * x2 * x2)
-        grad = d0 * x0 * jv0 + d1 * x1 * jv1 + d2 * x2 * jv2
-        hess = d0 * jv0 * jv0 + d1 * jv1 * jv1 + d2 * jv2 * jv2
+        for k in qd.static(range(rows_jaref_alpha.n)):
+            cost = cost + rows_efc_D[k] * rows_jaref_alpha[k] ** 2
+            grad = grad + rows_efc_D[k] * rows_jaref_alpha[k] * rows_jv[k]
+            hess = hess + rows_efc_D[k] * rows_jv[k] ** 2
+        cost = 0.5 * cost
     elif zone == 2:
-        Dm = _func_cone_Dm(d0, con_mu)
-        u1 = mu * x1
-        u2 = mu * x2
-        du1 = mu * jv1
-        du2 = mu * jv2
-        dN = con_mu * jv0
-        dT = (u1 * du1 + u2 * du2) / T
-        d2T = (du1 * du1 + du2 * du2 - dT * dT) / T
+        Dm = _func_cone_Dm(rows_efc_D[0], con_mu)
+        dN = con_mu * rows_jv[0]
+        dT_sum = gs.qd_float(0.0)
+        d2T_sum = gs.qd_float(0.0)
+        for k in qd.static(range(1, rows_jaref_alpha.n)):
+            u = rows_friction[k] * rows_jaref_alpha[k]
+            du = rows_friction[k] * rows_jv[k]
+            dT_sum = dT_sum + u * du
+            d2T_sum = d2T_sum + du**2
+        dT = dT_sum / T
+        d2T = (d2T_sum - dT**2) / T
         g = N - con_mu * T
         dg = dN - con_mu * dT
         d2g = -con_mu * d2T
-        cost = 0.5 * Dm * g * g
+        cost = 0.5 * Dm * g**2
         grad = Dm * g * dg
-        hess = Dm * (dg * dg + g * d2g)
+        hess = Dm * (dg**2 + g * d2g)
     return cost, grad, hess
 
 
 @qd.func
-def _func_cone_cost_diff_along_alpha(jar0, jar1, jar2, jv0, jv1, jv2, alpha, d0, d1, d2, con_mu, mu):
+def _func_cone_cost_diff_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, con_mu, rows_friction):
     """Shifted elliptic-cone cost cost(alpha) - cost(0) and its first/second derivatives in alpha.
 
     Derivatives match _func_cone_cost_along_alpha exactly; the value is the delta from alpha=0, computed zone-aware so
@@ -5085,37 +5223,43 @@ def _func_cone_cost_diff_along_alpha(jar0, jar1, jar2, jv0, jv1, jv2, alpha, d0,
     zero in float32 near convergence. Mixed-zone pairs fall back to the absolute subtraction, where the two costs
     genuinely differ.
     """
-    cost_alpha, grad, hess = _func_cone_cost_along_alpha(jar0, jar1, jar2, jv0, jv1, jv2, alpha, d0, d1, d2, con_mu, mu)
-    x0 = jar0 + alpha * jv0
-    x1 = jar1 + alpha * jv1
-    x2 = jar2 + alpha * jv2
-    zone, N, T = _func_cone_zone(x0, x1, x2, con_mu, mu)
-    zone0, N0, T0 = _func_cone_zone(jar0, jar1, jar2, con_mu, mu)
+    cost_alpha, grad, hess = _func_cone_cost_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, con_mu, rows_friction)
+    rows_jaref_alpha = rows_jaref + alpha * rows_jv
+    zone, N, T = _func_cone_zone(rows_jaref_alpha, con_mu, rows_friction)
+    zone0, N0, T0 = _func_cone_zone(rows_jaref, con_mu, rows_friction)
     cost_diff = gs.qd_float(0.0)
     if zone == zone0:
         if zone == 1:
-            cost_diff = alpha * (d0 * jv0 * jar0 + d1 * jv1 * jar1 + d2 * jv2 * jar2) + alpha * alpha * (
-                0.5 * (d0 * jv0 * jv0 + d1 * jv1 * jv1 + d2 * jv2 * jv2)
-            )
+            lin = gs.qd_float(0.0)
+            quad = gs.qd_float(0.0)
+            for k in qd.static(range(rows_jaref.n)):
+                lin = lin + rows_efc_D[k] * rows_jv[k] * rows_jaref[k]
+                quad = quad + rows_efc_D[k] * rows_jv[k] ** 2
+            cost_diff = alpha * lin + alpha**2 * (0.5 * quad)
         elif zone == 2:
-            Dm = _func_cone_Dm(d0, con_mu)
+            Dm = _func_cone_Dm(rows_efc_D[0], con_mu)
             g = N - con_mu * T
             g0 = N0 - con_mu * T0
             cost_diff = 0.5 * Dm * (g - g0) * (g + g0)
     else:
         cost_0, _grad_0, _hess_0 = _func_cone_cost_along_alpha(
-            jar0, jar1, jar2, jv0, jv1, jv2, 0.0, d0, d1, d2, con_mu, mu
+            rows_jaref, rows_jv, 0.0, rows_efc_D, con_mu, rows_friction
         )
         cost_diff = cost_alpha - cost_0
     return cost_diff, grad, hess
 
 
 @qd.func
-def func_cone_update_rows(i_c, i_b, constraint_state: array_class.ConstraintState):
-    """Recompute active and efc_force for the three rows of the elliptic cone whose head (normal) row is i_c, and
+def func_cone_update_rows(
+    i_c,
+    i_b,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+):
+    """Recompute active and efc_force for the rows of the elliptic cone whose head (normal) row is i_c, and
     return the coupled middle-zone cost contribution (0 outside the middle zone).
 
-    The normal row and its two tangent rows are one second-order cone (SOC), processed together at the head. The top
+    The normal row and its friction rows are one second-order cone (SOC), processed together at the head. The top
     zone is inactive; the bottom zone reduces to the standard per-row quadratic (active=True lets the shared
     cost/Hessian passes handle it); the middle zone is the analytic cone projection, excluded from the per-row
     cost/Hessian (active=False) with its coupled cost returned here and its coupled Hessian block added in assembly.
@@ -5123,35 +5267,23 @@ def func_cone_update_rows(i_c, i_b, constraint_state: array_class.ConstraintStat
     resolved identically across arms; per-row callers invoke it from the head thread only, keeping each row written
     exactly once (race-free).
     """
-    j1 = i_c + 1
-    j2 = i_c + 2
-    d0, d1, d2, friction, con_mu, jar0, jar1, jar2 = _func_cone_head_load(i_c, i_b, constraint_state)
-    zone, N, T = _func_cone_zone(jar0, jar1, jar2, con_mu, friction)
+    n_rows = qd.static(rigid_config.rows_per_contact)
+    rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(i_c, i_b, constraint_state, rigid_config)
+    zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
     cost = gs.qd_float(0.0)
     if zone == 0:  # top: inactive
-        constraint_state.active[i_c, i_b] = False
-        constraint_state.active[j1, i_b] = False
-        constraint_state.active[j2, i_b] = False
-        constraint_state.efc_force[i_c, i_b] = 0.0
-        constraint_state.efc_force[j1, i_b] = 0.0
-        constraint_state.efc_force[j2, i_b] = 0.0
-    elif zone == 1:  # bottom: plain quadratic on all three rows
-        constraint_state.active[i_c, i_b] = True
-        constraint_state.active[j1, i_b] = True
-        constraint_state.active[j2, i_b] = True
-        constraint_state.efc_force[i_c, i_b] = -jar0 * d0
-        constraint_state.efc_force[j1, i_b] = -jar1 * d1
-        constraint_state.efc_force[j2, i_b] = -jar2 * d2
+        for k in qd.static(range(n_rows)):
+            constraint_state.active[i_c + k, i_b] = False
+            constraint_state.efc_force[i_c + k, i_b] = 0.0
+    elif zone == 1:  # bottom: plain quadratic on all rows
+        for k in qd.static(range(n_rows)):
+            constraint_state.active[i_c + k, i_b] = True
+            constraint_state.efc_force[i_c + k, i_b] = -rows_jaref[k] * rows_efc_D[k]
     else:  # middle: cone boundary. Excluded from the per-row cost/Hessian; handled coupled.
-        constraint_state.active[i_c, i_b] = False
-        constraint_state.active[j1, i_b] = False
-        constraint_state.active[j2, i_b] = False
-        f0, f1, f2, cost_m, _h00, _h01, _h02, _h11, _h12, _h22 = _func_cone_middle(
-            jar0, jar1, jar2, d0, con_mu, friction, N, T
-        )
-        constraint_state.efc_force[i_c, i_b] = f0
-        constraint_state.efc_force[j1, i_b] = f1
-        constraint_state.efc_force[j2, i_b] = f2
+        rows_force, cost_m, _hs = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
+        for k in qd.static(range(n_rows)):
+            constraint_state.active[i_c + k, i_b] = False
+            constraint_state.efc_force[i_c + k, i_b] = rows_force[k]
         cost = cost_m
     return cost
 
@@ -5187,10 +5319,10 @@ def func_update_constraint_batch(
     # Beware 'active' does not refer to whether a constraint is active, but rather whether its quadratic cost is active
     for i_c in range(constraint_state.n_constraints[i_b]):
         if qd.static(rigid_config.enable_elliptic_friction) and (nef <= i_c and i_c < ncone):
-            # Elliptic cone contact: the coupled triple is resolved at its head row, which also writes the two
-            # tangent rows.
-            if (i_c - nef) % 3 == 0:
-                cost_i = cost_i + func_cone_update_rows(i_c, i_b, constraint_state)
+            # Elliptic cone contact: the coupled rows are resolved at the head row, which also writes the friction
+            # rows.
+            if (i_c - nef) % qd.static(rigid_config.rows_per_contact) == 0:
+                cost_i = cost_i + func_cone_update_rows(i_c, i_b, constraint_state, rigid_config)
         else:
             if qd.static(
                 rigid_config.solver_type == gs.constraint_solver.Newton and not rigid_config.enable_elliptic_friction
@@ -5272,11 +5404,11 @@ def _func_update_efc_force_body(i_c, i_b, constraint_state: array_class.Constrai
         ncone = ncone + constraint_state.n_constraints_cone[i_b]
 
     if qd.static(rigid_config.enable_elliptic_friction) and (nef <= i_c and i_c < ncone):
-        # Elliptic cone contact (cooperative one-thread-per-row): only the head thread resolves the coupled triple
-        # and writes all three rows; the two tangent threads are no-ops so each row is written exactly once
+        # Elliptic cone contact (cooperative one-thread-per-row): only the head thread resolves the coupled rows
+        # and writes all of them; the friction-row threads are no-ops so each row is written exactly once
         # (race-free). The coupled middle-zone cost is discarded here; _func_update_cost_coop recomputes it.
-        if (i_c - nef) % 3 == 0:
-            func_cone_update_rows(i_c, i_b, constraint_state)
+        if (i_c - nef) % qd.static(rigid_config.rows_per_contact) == 0:
+            func_cone_update_rows(i_c, i_b, constraint_state, rigid_config)
     else:
         if qd.static(
             rigid_config.solver_type == gs.constraint_solver.Newton and not rigid_config.enable_elliptic_friction
@@ -5419,11 +5551,11 @@ def _func_update_cost_coop(
                 linear_pos = Jaref_c >= rf
                 cost_i = cost_i + linear_neg * f * (-0.5 * rf - Jaref_c) + linear_pos * f * (-0.5 * rf + Jaref_c)
             if qd.static(rigid_config.enable_elliptic_friction) and (
-                nef <= i_c and i_c < ncone and (i_c - nef) % 3 == 0
+                nef <= i_c and i_c < ncone and (i_c - nef) % qd.static(rigid_config.rows_per_contact) == 0
             ):
                 # Middle-zone cone: add the coupled cost at the head only (per-row quadratics of bottom-zone rows are
                 # covered by the active-masked term above; top/middle rows are inactive there).
-                cost_i = cost_i + func_cone_middle_cost(i_c, i_b, constraint_state)
+                cost_i = cost_i + func_cone_middle_cost(i_c, i_b, constraint_state, rigid_config)
             i_c = i_c + _K
 
         cost_i = qd.simt.subgroup.reduce_all_add_tiled(cost_i, 5)
@@ -5513,7 +5645,7 @@ def func_update_gradient_no_solve(
     """Compute the gradient only (no Cholesky solve), used with a fused factor+solve that consumes grad directly.
 
     Under enable_cooperative_constraint_kernels the ndrange is swapped so adjacent lanes vary i_d - 3 of 4 in-loop
-    accesses (grad, Ma, qfrc_constraint) are DOF-vec flipped; only dofs_state.force stays canonical.
+    accesses (grad, Ma, qfrc_constraint) are DOF-vec flipped; only dyn_state.dofs.force stays canonical.
     """
     _B = constraint_state.grad.shape[1]
     n_dofs = constraint_state.grad.shape[0]
@@ -6054,28 +6186,30 @@ def func_solve_iter(
                         func_update_cone_free_hessian_flip(
                             i_b, constraint_state.incr_changed_idx[idx, i_b], constraint_state, rigid_info, rigid_config
                         )
-                # Count middle-zone cone contacts: each rides six rank-1 sweeps (one per staged factor column of
-                # its downdated + updated blocks) on the incremental factor every iteration regardless of active-set
-                # flips, so it must weigh into the crossover below (and n_changed alone is often 0 while the cone
-                # still moves). The count reads cone_prev_jaref, which only the CPU
+                # Count middle-zone cone contacts: each rides 2 rank-1 sweeps per cone row (one per staged factor
+                # column of its downdated + updated blocks) on the incremental factor every iteration regardless of
+                # active-set flips, so it must weigh into the crossover below (and n_changed alone is often 0 while
+                # the cone still moves). The count reads cone_prev_jaref, which only the CPU
                 # backend allocates; a GPU build of this branch (explicit sparse_solve on GPU) rebuilds with the cone
                 # baked in each iteration instead, and the static backend gate keeps the cone helpers out of the GPU
                 # compilation. cone_passes stays 0 for the pyramidal cone.
                 cone_passes = 0
                 if qd.static(rigid_config.enable_elliptic_friction and rigid_config.backend == gs.cpu):
+                    n_rows = qd.static(rigid_config.rows_per_contact)
                     nef = (
                         constraint_state.n_constraints_equality[i_b] + constraint_state.n_constraints_frictionloss[i_b]
                     )
-                    for i_head in range(constraint_state.n_constraints_cone[i_b] // 3):
-                        if _func_cone_head_is_middle(nef + i_head * 3, i_b, nef, constraint_state):
+                    for i_head in range(constraint_state.n_constraints_cone[i_b] // n_rows):
+                        if _func_cone_head_is_middle(nef + i_head * n_rows, i_b, nef, constraint_state, rigid_config):
                             cone_passes = cone_passes + 1
                 need_rebuild = True
                 if n_changed == 0 and cone_passes == 0:
                     need_rebuild = False
                 elif qd.static(rigid_config.sparse_envelope):
                     # Same crossover as the per-island path, on the whole-env skyline (nt_H_env_start): incremental
-                    # beats a refactor while (n_changed + 6 * cone_passes) * sum_span <= sum_span_sq (the flop-weighted
-                    # effective bandwidth; each of a cone's six rank-1 sweeps costs the same as one flip update).
+                    # beats a refactor while (n_changed + 2 * rows_per_contact * cone_passes) * sum_span <=
+                    # sum_span_sq (the flop-weighted effective bandwidth; each of a cone's rank-1 sweeps costs the
+                    # same as one flip update).
                     n_dofs = constraint_state.nt_H.shape[1]
                     sum_span = gs.qd_float(0.0)
                     sum_span_sq = gs.qd_float(0.0)
@@ -6083,13 +6217,16 @@ def func_solve_iter(
                         row_span = gs.qd_float(p - constraint_state.nt_H_env_start[i_b, p])
                         sum_span = sum_span + row_span
                         sum_span_sq = sum_span_sq + row_span * row_span
-                    if gs.qd_float(n_changed + 6 * cone_passes) * sum_span <= sum_span_sq:
+                    if (
+                        gs.qd_float(n_changed + qd.static(2 * rigid_config.rows_per_contact) * cone_passes) * sum_span
+                        <= sum_span_sq
+                    ):
                         need_rebuild = func_hessian_and_cholesky_factor_incremental_sparse_batch(
                             i_b, constraint_state, rigid_info
                         )
                 # The coupled middle-zone cone block varies with the residual, so whenever some cone sits in the
                 # middle zone on either side (cone_passes > 0) and the active-set update stayed incremental, it rides
-                # the same skyline factor via its rank-3 downdate/update. With cone_passes == 0 no block is baked in
+                # the same skyline factor via its downdate/update. With cone_passes == 0 no block is baked in
                 # the factor and none is due, so the update is skipped; a skipped cone's stale cone_prev_jaref stays
                 # classified non-middle until its update runs again on current residuals.
                 if qd.static(rigid_config.enable_elliptic_friction):
@@ -6242,11 +6379,13 @@ def func_update_contact_force(
             contact_data_link_a = collider_state.contact_data.link_a[i_col, i_b]
             contact_data_link_b = collider_state.contact_data.link_b[i_col, i_b]
 
+            rows_per_contact = qd.static(rigid_config.rows_per_contact)
             force = qd.Vector.zero(gs.qd_float, 3)
             d1, d2 = gu.qd_orthogonals(contact_data_normal)
             if qd.static(rigid_config.enable_elliptic_friction):
-                # Cone rows [normal, t1, t2] contiguous in the collision segment.
-                base = i_c * 3 + const_start
+                # Cone rows [normal, t1, t2(, spin)] contiguous in the collision segment; the spin row carries
+                # torque only, so the linear contact force sums the three translational directions.
+                base = i_c * rows_per_contact + const_start
                 force = -contact_data_normal * constraint_state.efc_force[base, i_b]
                 force = force + d1 * constraint_state.efc_force[base + 1, i_b]
                 force = force + d2 * constraint_state.efc_force[base + 2, i_b]
@@ -6254,7 +6393,16 @@ def func_update_contact_force(
                 for i_dir in qd.static(range(4)):
                     d = (2 * (i_dir % 2) - 1) * (d1 if i_dir < 2 else d2)
                     n = d * contact_data_friction - contact_data_normal
-                    force = force + n * constraint_state.efc_force[i_c * 4 + i_dir + const_start, i_b]
+                    force = force + n * constraint_state.efc_force[i_c * rows_per_contact + i_dir + const_start, i_b]
+                # The torsional pyramid pair mixes the spin axis through the angular jacobian; its linear part is the
+                # shared normal opposition.
+                if qd.static(rigid_config.enable_torsional_friction):
+                    for i_dir in qd.static(range(4, rows_per_contact)):
+                        force = (
+                            force
+                            + (-contact_data_normal)
+                            * constraint_state.efc_force[i_c * rows_per_contact + i_dir + const_start, i_b]
+                        )
 
             collider_state.contact_data.force[i_col, i_b] = force
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -610,11 +610,10 @@ def _func_contact_row_direction(
 ):
     """Direction of collision row i_friction, as a translational part n and an angular part n_ang.
 
-    With the elliptic cone the rows [normal, t1, t2(, spin)] follow the contact frame with no friction mixing (the
-    cone couples them in the solver); the spin row is the relative angular velocity about the normal, its friction
-    strength carried by its regularization (see the diag computation in _add_friction_constraint). With the pyramidal
-    cone each row is one of 2 opposing friction-mixed edges per axis (friction * axis - normal), the torsional pair
-    mixing the spin axis through the angular jacobian.
+    Elliptic rows [normal, t1, t2(, spin)] follow the contact frame unmixed (the cone couples them in the solver; the
+    spin row's friction strength lives in its regularization, see the diag computation in _add_friction_constraint).
+    Pyramidal rows are 2 opposing friction-mixed edges per tangent axis, then the torsional pair mixing the spin axis
+    through the angular jacobian.
     """
     n = -normal
     n_ang = qd.Vector.zero(gs.qd_float, 3)
@@ -624,9 +623,8 @@ def _func_contact_row_direction(
         elif i_friction == 2:
             n = d2
         if qd.static(rigid_config.enable_torsional_friction):
-            # The spin axis opposes the contact normal like the normal row's translational direction. A zero
-            # torsional coefficient zeroes the whole row (jacobian and velocity reference alike), leaving it inert:
-            # the cone never bounds a zero-weighted axis, so its regularization alone would still leak a spurious
+            # The spin axis opposes the contact normal like the normal row. A zero coefficient must zero the whole
+            # row: the cone never bounds a zero-weighted axis, so its regularization alone would leak a spurious
             # viscous torque.
             if i_friction == 3:
                 n = qd.Vector.zero(gs.qd_float, 3)
@@ -636,9 +634,9 @@ def _func_contact_row_direction(
         d = (2 * (i_friction % 2) - 1) * (d1 if i_friction < 2 else d2)
         n = d * friction - normal
         if qd.static(rigid_config.enable_torsional_friction):
-            # A zero torsional coefficient zeroes the pair like the elliptic spin row (its aref is zeroed alongside,
-            # see the diag computation in _add_friction_constraint): the rows would otherwise degenerate to two extra
-            # pure-normal rows that stiffen the normal response and report phantom contact force.
+            # A zero coefficient zeroes the pair (aref alongside, see _add_friction_constraint): the rows would
+            # otherwise degenerate to two extra pure-normal rows that stiffen the normal response and report phantom
+            # contact force.
             if i_friction >= 4:
                 n = qd.Vector.zero(gs.qd_float, 3)
                 if friction_torsional > 0.0:
@@ -661,10 +659,9 @@ def _add_friction_constraint(
 ):
     """Add one collision row to the constraint Jacobian and write its matching diag/aref/efc_D scalars.
 
-    With the pyramidal friction cone this is one of the rows_per_contact friction-basis rows (2 opposing edges per
-    friction axis); with the elliptic cone (enable_elliptic_friction) it is one of the cone rows (i_friction 0 =
-    normal, then one row per friction axis), which the Newton solver couples into a single second-order friction
-    cone. Torsional friction appends the spin axis (relative rotation about the contact normal) to either basis.
+    Pyramidal: one of the rows_per_contact friction-basis rows. Elliptic: one cone row (normal at i_friction 0),
+    coupled by the Newton solver into a single second-order friction cone. Torsional friction appends the spin axis
+    to either basis.
     """
     EPS = rigid_info.EPS[None]
     n_dofs = dyn_state.dofs.ctrl_mode.shape[0]
@@ -780,11 +777,9 @@ def _add_friction_constraint(
         # off the spin row.
         efc_frictionloss = contact_data_friction if i_friction == 0 else gs.qd_float(0.0)
         if qd.static(rigid_config.enable_torsional_friction):
-            # The spin row keeps the unscaled angular jacobian and instead carries the squared sliding-to-torsional
-            # coefficient ratio in its regularization, matching MuJoCo's elliptic cone: the cone then bounds the
-            # torsional torque at friction_torsional times the normal force. A zero coefficient keeps the shared
-            # friction-row regularization: its row is zeroed at the source (see _func_contact_row_direction), so the
-            # value is inert and only has to stay finite.
+            # The mu ratio lives in the spin row's regularization (jacobian unscaled), matching MuJoCo's elliptic
+            # cone: it bounds the torsional torque at friction_torsional times the normal force. A zero coefficient
+            # keeps the shared regularization: the row is zeroed at the source, so the value just has to stay finite.
             if i_friction == 3:
                 if contact_data_friction_torsional > 0.0:
                     diag = diag * contact_data_friction**2 / contact_data_friction_torsional**2
@@ -2085,11 +2080,11 @@ def func_add_cone_hessian_block(
             i_head, i_b, constraint_state, rigid_config
         )
         if qd.static(rigid_config.backend == gs.cpu):
-            for k in qd.static(range(n_rows)):
-                constraint_state.cone_prev_jaref[i_cone * n_rows + k, i_b] = rows_jaref[k]
+            for i_r in qd.static(range(n_rows)):
+                constraint_state.cone_prev_jaref[i_cone * n_rows + i_r, i_b] = rows_jaref[i_r]
         zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
         if zone == 2:
-            _fs, _c, cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
+            _rows_force, _cost, cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
             jac_n = constraint_state.jac_n_dofs[i_head, i_b]
             for i_d1_ in range(jac_n):
                 i_d1 = constraint_state.jac_dofs_idx[i_head, i_d1_, i_b]
@@ -2099,9 +2094,9 @@ def func_add_cone_hessian_block(
                     col = qd.min(i_d1, i_d2)
                     rows_jac_row = qd.Vector.zero(gs.qd_float, n_rows)
                     rows_jac_col = qd.Vector.zero(gs.qd_float, n_rows)
-                    for k in qd.static(range(n_rows)):
-                        rows_jac_row[k] = constraint_state.jac[i_head + k, row, i_b]
-                        rows_jac_col[k] = constraint_state.jac[i_head + k, col, i_b]
+                    for i_r in qd.static(range(n_rows)):
+                        rows_jac_row[i_r] = constraint_state.jac[i_head + i_r, row, i_b]
+                        rows_jac_col[i_r] = constraint_state.jac[i_head + i_r, col, i_b]
                     block = _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col)
                     # jac is read in natural DOF order (row/col above); only the storage position is permuted (sparse).
                     w_row = row
@@ -2120,7 +2115,7 @@ def func_add_cone_hessian_block_island(
 ):
     """Accumulate the coupled elliptic-cone contribution J_c^T H_c J_c of one island's middle-zone cones into nt_H.
 
-    Island analogue of func_add_cone_hessian_block: a cone's three rows share one DOF support and land in one island,
+    Island analogue of func_add_cone_hessian_block: a cone's rows share one DOF support and land in one island,
     so its middle-zone coupling is scattered over that support in the same island-local orientation as the
     assembly's J^T D J loop; the per-row J^T D J of the active rows is the caller's job. On the CPU backend every
     cone's cone_prev_jaref is seeded from its current residuals, so the incremental factor's downdate targets
@@ -2141,11 +2136,11 @@ def func_add_cone_hessian_block_island(
             # cone_prev_jaref backs the CPU incremental downdate, so seed it on the CPU backend.
             if qd.static(rigid_config.backend == gs.cpu):
                 i_cone_row = i_c - nef
-                for k in qd.static(range(n_rows)):
-                    constraint_state.cone_prev_jaref[i_cone_row + k, i_b] = rows_jaref[k]
+                for i_r in qd.static(range(n_rows)):
+                    constraint_state.cone_prev_jaref[i_cone_row + i_r, i_b] = rows_jaref[i_r]
             zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
             if zone == 2:
-                _fs, _c, cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
+                _rows_force, _cost, cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
                 jac_n = constraint_state.jac_n_dofs[i_c, i_b]
                 for i_d1_ in range(jac_n):
                     i_d1 = constraint_state.jac_dofs_idx[i_c, i_d1_, i_b]
@@ -2161,9 +2156,9 @@ def func_add_cone_hessian_block_island(
                                 row, col = col, row
                         rows_jac_row = qd.Vector.zero(gs.qd_float, n_rows)
                         rows_jac_col = qd.Vector.zero(gs.qd_float, n_rows)
-                        for k in qd.static(range(n_rows)):
-                            rows_jac_row[k] = constraint_state.jac[i_c + k, row, i_b]
-                            rows_jac_col[k] = constraint_state.jac[i_c + k, col, i_b]
+                        for i_r in qd.static(range(n_rows)):
+                            rows_jac_row[i_r] = constraint_state.jac[i_c + i_r, row, i_b]
+                            rows_jac_col[i_r] = constraint_state.jac[i_c + i_r, col, i_b]
                         block = _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col)
                         constraint_state.nt_H[i_b, row, col] = constraint_state.nt_H[i_b, row, col] + block
 
@@ -3649,7 +3644,7 @@ def func_cone_rank_update_island(
 
     A middle-zone contact contributes J_c^T H_c J_c, which varies with the residual each iteration, so this downdates
     the previous block and updates the current one. With H_c = L_c L_c^T, that block equals the sum of rank-1 terms
-    w_t w_t^T with w_t = sum over rows k >= t of L_c[k][t] J_k; the previous w_t stage into slots [0, n_rows) (-1) and
+    w_j w_j^T with w_j = sum over rows i >= j of L_c[i][j] J_i; the previous w_j stage into slots [0, n_rows) (-1) and
     the current into slots [n_rows, 2*n_rows) (+1), applied by the shared rank sweep. Downdating first leaves the
     intermediate factor the well-conditioned cone-free system. cone_prev_jaref holds the previous residuals, indexed
     by the cone row offset past the equality and frictionloss rows. Returns True on a degenerate downdate, so the
@@ -3666,8 +3661,6 @@ def func_cone_rank_update_island(
     con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
     n = constraint_state.island.dof_slices.n[i_island, i_b]
 
-    # Downdate the previous block (slots [0, n_rows), -1) then update the current one (slots [n_rows, 2*n_rows),
-    # +1); the cone-free intermediate keeps every rotation well conditioned.
     signs = qd.Vector.zero(gs.qd_float, B)
     for i_u in qd.static(range(2 * n_rows)):
         signs[i_u] = 2 * (i_u // n_rows) - 1
@@ -3683,8 +3676,8 @@ def func_cone_rank_update_island(
                 )
                 cur_zone, cN, cT = _func_cone_zone(rows_jaref_cur, con_mu, rows_friction)
                 rows_jaref_prev = qd.Vector.zero(gs.qd_float, n_rows)
-                for k in qd.static(range(n_rows)):
-                    rows_jaref_prev[k] = constraint_state.cone_prev_jaref[i_cone_row + k, i_b]
+                for i_r in qd.static(range(n_rows)):
+                    rows_jaref_prev[i_r] = constraint_state.cone_prev_jaref[i_cone_row + i_r, i_b]
                 prev_zone, pN, pT = _func_cone_zone(rows_jaref_prev, con_mu, rows_friction)
 
                 if cur_zone == 2 or prev_zone == 2:
@@ -3696,20 +3689,20 @@ def func_cone_rank_update_island(
                     )
                     ld_start = n
                     jac_n = constraint_state.jac_n_dofs[i_c, i_b]
-                    for k_ in range(jac_n):
-                        i_d = constraint_state.jac_dofs_idx[i_c, k_, i_b]
+                    for i_d_ in range(jac_n):
+                        i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
                         slot_base = i_d * B
                         rows_jac = qd.Vector.zero(gs.qd_float, n_rows)
-                        for k in qd.static(range(n_rows)):
-                            rows_jac[k] = constraint_state.jac[i_c + k, i_d, i_b]
-                        for t in qd.static(range(n_rows)):
+                        for i_r in qd.static(range(n_rows)):
+                            rows_jac[i_r] = constraint_state.jac[i_c + i_r, i_d, i_b]
+                        for j_r in qd.static(range(n_rows)):
                             w_prev = gs.qd_float(0.0)
                             w_cur = gs.qd_float(0.0)
-                            for k in qd.static(range(t, n_rows)):
-                                w_prev = w_prev + cone_L_prev[qd.static(_tri_idx(t, k, n_rows))] * rows_jac[k]
-                                w_cur = w_cur + cone_L_cur[qd.static(_tri_idx(t, k, n_rows))] * rows_jac[k]
-                            constraint_state.nt_vec[slot_base + t, i_b] = w_prev
-                            constraint_state.nt_vec[slot_base + n_rows + t, i_b] = w_cur
+                            for i_r in qd.static(range(j_r, n_rows)):
+                                w_prev = w_prev + cone_L_prev[qd.static(_tri_idx(j_r, i_r, n_rows))] * rows_jac[i_r]
+                                w_cur = w_cur + cone_L_cur[qd.static(_tri_idx(j_r, i_r, n_rows))] * rows_jac[i_r]
+                            constraint_state.nt_vec[slot_base + j_r, i_b] = w_prev
+                            constraint_state.nt_vec[slot_base + n_rows + j_r, i_b] = w_cur
                         ld_support = constraint_state.island.dof_local_pos[i_d, i_b]
                         if ld_support < ld_start:
                             ld_start = ld_support
@@ -3719,8 +3712,8 @@ def func_cone_rank_update_island(
                     ):
                         is_degenerated = True
 
-                for k in qd.static(range(n_rows)):
-                    constraint_state.cone_prev_jaref[i_cone_row + k, i_b] = rows_jaref_cur[k]
+                for i_r in qd.static(range(n_rows)):
+                    constraint_state.cone_prev_jaref[i_cone_row + i_r, i_b] = rows_jaref_cur[i_r]
     return is_degenerated
 
 
@@ -3762,8 +3755,8 @@ def func_cone_rank_update_whole_env(
                 )
                 cur_zone, cN, cT = _func_cone_zone(rows_jaref_cur, con_mu, rows_friction)
                 rows_jaref_prev = qd.Vector.zero(gs.qd_float, n_rows)
-                for k in qd.static(range(n_rows)):
-                    rows_jaref_prev[k] = constraint_state.cone_prev_jaref[i_cone_row + k, i_b]
+                for i_r in qd.static(range(n_rows)):
+                    rows_jaref_prev[i_r] = constraint_state.cone_prev_jaref[i_cone_row + i_r, i_b]
                 prev_zone, pN, pT = _func_cone_zone(rows_jaref_prev, con_mu, rows_friction)
 
                 if cur_zone == 2 or prev_zone == 2:
@@ -3773,28 +3766,26 @@ def func_cone_rank_update_whole_env(
                     cone_L_prev = _func_cone_block_chol(
                         rows_jaref_prev, rows_efc_D[0], con_mu, rows_friction, prev_zone, pN, pT, EPS
                     )
-                    # Per-term coefficients over the cone rows' jacobians: term t stages column t of the previous
-                    # factor (downdate first, sign 2 * (term // n_rows) - 1 = -1) so the intermediate factor is the
-                    # well-conditioned cone-free system, then term n_rows + t stages column t of the current one (+1).
-                    # A term whose coefficients are all zero (side outside the middle zone) stages a zero vector and
-                    # the sweep skips it.
-                    terms_coef = qd.Matrix.zero(gs.qd_float, 2 * n_rows, n_rows)
-                    for t in qd.static(range(n_rows)):
-                        for k in qd.static(range(t, n_rows)):
-                            terms_coef[t, k] = cone_L_prev[qd.static(_tri_idx(t, k, n_rows))]
-                            terms_coef[n_rows + t, k] = cone_L_cur[qd.static(_tri_idx(t, k, n_rows))]
+                    # Term t stages column t of the previous factor, term n_rows + t of the current one (downdate
+                    # first, see the docstring); an all-zero term (side outside the middle zone) stages a zero vector
+                    # the sweep skips.
+                    updates_coef = qd.Matrix.zero(gs.qd_float, 2 * n_rows, n_rows)
+                    for j_r in qd.static(range(n_rows)):
+                        for i_r in qd.static(range(j_r, n_rows)):
+                            updates_coef[j_r, i_r] = cone_L_prev[qd.static(_tri_idx(j_r, i_r, n_rows))]
+                            updates_coef[n_rows + j_r, i_r] = cone_L_cur[qd.static(_tri_idx(j_r, i_r, n_rows))]
                     jac_n = constraint_state.jac_n_dofs[i_head, i_b]
-                    for term in range(2 * n_rows):
+                    for i_u in range(2 * n_rows):
                         if not is_degenerated:
-                            sign = 2 * (term // n_rows) - 1
+                            sign = 2 * (i_u // n_rows) - 1
                             if qd.static(rigid_config.sparse_solve):
                                 p_min = n_dofs
-                                for k_ in range(jac_n):
-                                    i_d = constraint_state.jac_dofs_idx[i_head, k_, i_b]
+                                for i_d_ in range(jac_n):
+                                    i_d = constraint_state.jac_dofs_idx[i_head, i_d_, i_b]
                                     p = constraint_state.dof_iperm[i_b, i_d]
                                     w = gs.qd_float(0.0)
-                                    for k in qd.static(range(n_rows)):
-                                        w = w + terms_coef[term, k] * constraint_state.jac[i_head + k, i_d, i_b]
+                                    for i_r in qd.static(range(n_rows)):
+                                        w = w + updates_coef[i_u, i_r] * constraint_state.jac[i_head + i_r, i_d, i_b]
                                     constraint_state.nt_vec[p, i_b] = w
                                     if p < p_min:
                                         p_min = p
@@ -3803,17 +3794,17 @@ def func_cone_rank_update_whole_env(
                             else:
                                 for p in range(n_dofs):
                                     constraint_state.nt_vec[p, i_b] = 0.0
-                                for k_ in range(jac_n):
-                                    i_d = constraint_state.jac_dofs_idx[i_head, k_, i_b]
+                                for i_d_ in range(jac_n):
+                                    i_d = constraint_state.jac_dofs_idx[i_head, i_d_, i_b]
                                     w = gs.qd_float(0.0)
-                                    for k in qd.static(range(n_rows)):
-                                        w = w + terms_coef[term, k] * constraint_state.jac[i_head + k, i_d, i_b]
+                                    for i_r in qd.static(range(n_rows)):
+                                        w = w + updates_coef[i_u, i_r] * constraint_state.jac[i_head + i_r, i_d, i_b]
                                     constraint_state.nt_vec[i_d, i_b] = w
                                 if func_apply_rank1_dense_whole_env(i_b, sign, constraint_state, rigid_info):
                                     is_degenerated = True
 
-                for k in qd.static(range(n_rows)):
-                    constraint_state.cone_prev_jaref[i_cone_row + k, i_b] = rows_jaref_cur[k]
+                for i_r in qd.static(range(n_rows)):
+                    constraint_state.cone_prev_jaref[i_cone_row + i_r, i_b] = rows_jaref_cur[i_r]
     return is_degenerated
 
 
@@ -4293,8 +4284,8 @@ def func_ls_init_and_eval_p0(
                 i_head, i_b, constraint_state, rigid_config
             )
             rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
-            for k in qd.static(range(n_rows)):
-                rows_jv[k] = constraint_state.jv[i_head + k, i_b]
+            for i_r in qd.static(range(n_rows)):
+                rows_jv[i_r] = constraint_state.jv[i_head + i_r, i_b]
             _cost_c, grad_c, hess_c = _func_cone_cost_along_alpha(
                 rows_jaref, rows_jv, 0.0, rows_efc_D, con_mu, rows_friction
             )
@@ -4413,8 +4404,8 @@ def _func_linesearch_eval_constraints_at_n_alphas_serial(
                 i_head, i_b, constraint_state, rigid_config
             )
             rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
-            for j in qd.static(range(n_rows)):
-                rows_jv[j] = constraint_state.jv[i_head + j, i_b]
+            for i_r in qd.static(range(n_rows)):
+                rows_jv[i_r] = constraint_state.jv[i_head + i_r, i_b]
             for k in qd.static(range(n_alphas)):
                 alpha_k = alphas[k]
                 cost_diff_c, grad_c, hess_c = _func_cone_cost_diff_along_alpha(
@@ -4590,8 +4581,8 @@ def _func_linesearch_eval_constraints_at_n_alphas_coop(
                 i_head, i_b, constraint_state, rigid_config
             )
             rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
-            for j in qd.static(range(n_rows)):
-                rows_jv[j] = constraint_state.jv[i_head + j, i_b]
+            for i_r in qd.static(range(n_rows)):
+                rows_jv[i_r] = constraint_state.jv[i_head + i_r, i_b]
             for k in qd.static(range(n_alphas)):
                 alpha_k = alphas[k]
                 cost_diff_c, grad_c, hess_c = _func_cone_cost_diff_along_alpha(
@@ -4983,18 +4974,16 @@ def _tri_idx(i, j, dim):
 
 @qd.func
 def _func_cone_zone(rows_jaref, con_mu, rows_friction):
-    """Classify one elliptic contact (normal + friction-axis rows) into MuJoCo's three cone zones from the per-row
-    residuals rows_jaref.
+    """Classify one elliptic contact into MuJoCo's three cone zones from the per-row residuals rows_jaref.
 
     Returns (zone, N, T): zone 0 = top (dual-cone interior, inactive), 1 = bottom (polar cone, plain quadratic),
     2 = middle (cone boundary). N and T are the rescaled normal/tangential magnitudes reused by the middle-zone
-    force/cost/Hessian. con_mu is the regularized master coefficient (friction / sqrt(impratio)); rows_friction
-    carries the raw per-axis friction coefficients (see _func_cone_head_load).
+    force/cost/Hessian; con_mu and rows_friction as returned by _func_cone_head_load.
     """
     N = con_mu * rows_jaref[0]
     T_sq = gs.qd_float(0.0)
-    for k in qd.static(range(1, rows_jaref.n)):
-        u = rows_friction[k] * rows_jaref[k]
+    for i_r in qd.static(range(1, rows_jaref.n)):
+        u = rows_friction[i_r] * rows_jaref[i_r]
         T_sq = T_sq + u**2
     T = qd.sqrt(T_sq)
     zone = 2
@@ -5014,22 +5003,22 @@ def _func_cone_head_load(
 ):
     """Load the shared per-contact scalars of the elliptic cone whose head (normal) row is i_c.
 
-    Returns (rows_efc_D, rows_friction, con_mu, rows_jaref): the rows' impedances and residuals (one entry per
-    cone row), the per-row friction coefficients (the head entry is the sliding coefficient it stores, repeated
-    on the tangent axes, with the spin row carrying its own torsional coefficient), and the regularized master
-    coefficient con_mu = rows_friction[0] * sqrt(rows_efc_D[0] / rows_efc_D[1]) (= rows_friction[0] /
-    sqrt(impratio) since the friction rows are impratio times stiffer).
+    Returns (rows_efc_D, rows_friction, con_mu, rows_jaref): the per-row impedances, the per-row friction
+    coefficients (sliding on the head and tangent slots, torsional on the spin slot, see efc_frictionloss in
+    array_class.py), the regularized master coefficient con_mu = friction / sqrt(impratio) (computed as
+    friction * sqrt(rows_efc_D[0] / rows_efc_D[1]) since the friction rows are impratio times stiffer), and the
+    per-row residuals.
     """
     n_rows = qd.static(rigid_config.rows_per_contact)
     rows_efc_D = qd.Vector.zero(gs.qd_float, n_rows)
     rows_jaref = qd.Vector.zero(gs.qd_float, n_rows)
-    for k in qd.static(range(n_rows)):
-        rows_efc_D[k] = constraint_state.efc_D[i_c + k, i_b]
-        rows_jaref[k] = constraint_state.Jaref[i_c + k, i_b]
+    for i_r in qd.static(range(n_rows)):
+        rows_efc_D[i_r] = constraint_state.efc_D[i_c + i_r, i_b]
+        rows_jaref[i_r] = constraint_state.Jaref[i_c + i_r, i_b]
     friction = constraint_state.efc_frictionloss[i_c, i_b]
     rows_friction = qd.Vector.zero(gs.qd_float, n_rows)
-    for k in qd.static(range(n_rows)):
-        rows_friction[k] = friction
+    for i_r in qd.static(range(n_rows)):
+        rows_friction[i_r] = friction
     if qd.static(rigid_config.enable_torsional_friction):
         rows_friction[n_rows - 1] = constraint_state.efc_frictionloss[i_c + n_rows - 1, i_b]
     con_mu = friction * qd.sqrt(rows_efc_D[0] / rows_efc_D[1])
@@ -5052,11 +5041,11 @@ def _func_cone_head_is_middle(
     """
     i_cone_row = i_c - nef
     n_rows = qd.static(rigid_config.rows_per_contact)
-    _ds, rows_friction, con_mu, rows_jaref = _func_cone_head_load(i_c, i_b, constraint_state, rigid_config)
+    _rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(i_c, i_b, constraint_state, rigid_config)
     cur_zone, cur_N, cur_T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
     rows_jaref_prev = qd.Vector.zero(gs.qd_float, n_rows)
-    for k in qd.static(range(n_rows)):
-        rows_jaref_prev[k] = constraint_state.cone_prev_jaref[i_cone_row + k, i_b]
+    for i_r in qd.static(range(n_rows)):
+        rows_jaref_prev[i_r] = constraint_state.cone_prev_jaref[i_cone_row + i_r, i_b]
     prev_zone, prev_N, prev_T = _func_cone_zone(rows_jaref_prev, con_mu, rows_friction)
     return cur_zone == 2 or prev_zone == 2
 
@@ -5078,15 +5067,15 @@ def _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T):
     """
     n_rows = qd.static(rows_jaref.n)
     rows_u = qd.Vector.zero(gs.qd_float, n_rows)
-    for k in qd.static(range(1, n_rows)):
-        rows_u[k] = rows_friction[k] * rows_jaref[k]
+    for i_r in qd.static(range(1, n_rows)):
+        rows_u[i_r] = rows_friction[i_r] * rows_jaref[i_r]
     Dm = _func_cone_Dm(D0, con_mu)
     NmT = N - con_mu * T
 
     rows_force = qd.Vector.zero(gs.qd_float, n_rows)
     rows_force[0] = -Dm * NmT * con_mu
-    for k in qd.static(range(1, n_rows)):
-        rows_force[k] = -rows_force[0] / T * rows_u[k] * rows_friction[k]
+    for i_r in qd.static(range(1, n_rows)):
+        rows_force[i_r] = -rows_force[0] / T * rows_u[i_r] * rows_friction[i_r]
     cost = 0.5 * Dm * NmT**2
 
     # Curvature in the rescaled U-space, then pre/post-multiplied by G = diag(con_mu, rows_friction[1:]) and
@@ -5095,13 +5084,15 @@ def _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T):
     diag_add = con_mu**2 - con_mu * N / T
     cone_H = qd.Vector.zero(gs.qd_float, n_rows * (n_rows + 1) // 2)
     cone_H[0] = Dm * con_mu**2
-    for j in qd.static(range(1, n_rows)):
-        cone_H[qd.static(_tri_idx(0, j, n_rows))] = Dm * con_mu * rows_friction[j] * (-(con_mu / T) * rows_u[j])
-    for i in qd.static(range(1, n_rows)):
-        cone_H[qd.static(_tri_idx(i, i, n_rows))] = Dm * rows_friction[i] ** 2 * (cN_T3 * rows_u[i] ** 2 + diag_add)
-        for j in qd.static(range(i + 1, n_rows)):
-            cone_H[qd.static(_tri_idx(i, j, n_rows))] = (
-                Dm * rows_friction[i] * rows_friction[j] * (cN_T3 * rows_u[i] * rows_u[j])
+    for j_r in qd.static(range(1, n_rows)):
+        cone_H[qd.static(_tri_idx(0, j_r, n_rows))] = Dm * con_mu * rows_friction[j_r] * (-(con_mu / T) * rows_u[j_r])
+    for i_r in qd.static(range(1, n_rows)):
+        cone_H[qd.static(_tri_idx(i_r, i_r, n_rows))] = (
+            Dm * rows_friction[i_r] ** 2 * (cN_T3 * rows_u[i_r] ** 2 + diag_add)
+        )
+        for j_r in qd.static(range(i_r + 1, n_rows)):
+            cone_H[qd.static(_tri_idx(i_r, j_r, n_rows))] = (
+                Dm * rows_friction[i_r] * rows_friction[j_r] * (cN_T3 * rows_u[i_r] * rows_u[j_r])
             )
     return rows_force, cost, cone_H
 
@@ -5112,11 +5103,11 @@ def _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col):
     _tri_idx) contracted with the cone rows' jacobian entries at the Hessian row DOF and column DOF."""
     n_rows = qd.static(rows_jac_row.n)
     product = gs.qd_float(0.0)
-    for i in qd.static(range(n_rows)):
-        product = product + cone_H[qd.static(_tri_idx(i, i, n_rows))] * rows_jac_row[i] * rows_jac_col[i]
-        for j in qd.static(range(i + 1, n_rows)):
-            product = product + cone_H[qd.static(_tri_idx(i, j, n_rows))] * (
-                rows_jac_row[i] * rows_jac_col[j] + rows_jac_row[j] * rows_jac_col[i]
+    for i_r in qd.static(range(n_rows)):
+        product = product + cone_H[qd.static(_tri_idx(i_r, i_r, n_rows))] * rows_jac_row[i_r] * rows_jac_col[i_r]
+        for j_r in qd.static(range(i_r + 1, n_rows)):
+            product = product + cone_H[qd.static(_tri_idx(i_r, j_r, n_rows))] * (
+                rows_jac_row[i_r] * rows_jac_col[j_r] + rows_jac_row[j_r] * rows_jac_col[i_r]
             )
     return product
 
@@ -5133,22 +5124,23 @@ def _func_cone_block_chol(rows_jaref, D0, con_mu, rows_friction, zone, N, T, EPS
     n_rows = qd.static(rows_jaref.n)
     cone_L = qd.Vector.zero(gs.qd_float, n_rows * (n_rows + 1) // 2)
     if zone == 2:
-        _fs, _c, cone_H = _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T)
-        for j in qd.static(range(n_rows)):
-            pivot_sq = cone_H[qd.static(_tri_idx(j, j, n_rows))]
-            for k in qd.static(range(j)):
-                pivot_sq = pivot_sq - cone_L[qd.static(_tri_idx(k, j, n_rows))] ** 2
-            if qd.static(j < n_rows - 1):
-                cone_L[qd.static(_tri_idx(j, j, n_rows))] = qd.sqrt(qd.max(pivot_sq, EPS))
+        _rows_force, _cost, cone_H = _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T)
+        for j_r in qd.static(range(n_rows)):
+            pivot_sq = cone_H[qd.static(_tri_idx(j_r, j_r, n_rows))]
+            for k_r in qd.static(range(j_r)):
+                pivot_sq = pivot_sq - cone_L[qd.static(_tri_idx(k_r, j_r, n_rows))] ** 2
+            if qd.static(j_r < n_rows - 1):
+                cone_L[qd.static(_tri_idx(j_r, j_r, n_rows))] = qd.sqrt(qd.max(pivot_sq, EPS))
             else:
-                cone_L[qd.static(_tri_idx(j, j, n_rows))] = qd.sqrt(qd.max(pivot_sq, 0.0))
-            for i in qd.static(range(j + 1, n_rows)):
-                offdiag = cone_H[qd.static(_tri_idx(j, i, n_rows))]
-                for k in qd.static(range(j)):
+                cone_L[qd.static(_tri_idx(j_r, j_r, n_rows))] = qd.sqrt(qd.max(pivot_sq, 0.0))
+            for i_r in qd.static(range(j_r + 1, n_rows)):
+                offdiag = cone_H[qd.static(_tri_idx(j_r, i_r, n_rows))]
+                for k_r in qd.static(range(j_r)):
                     offdiag = (
-                        offdiag - cone_L[qd.static(_tri_idx(k, i, n_rows))] * cone_L[qd.static(_tri_idx(k, j, n_rows))]
+                        offdiag
+                        - cone_L[qd.static(_tri_idx(k_r, i_r, n_rows))] * cone_L[qd.static(_tri_idx(k_r, j_r, n_rows))]
                     )
-                cone_L[qd.static(_tri_idx(j, i, n_rows))] = offdiag / cone_L[qd.static(_tri_idx(j, j, n_rows))]
+                cone_L[qd.static(_tri_idx(j_r, i_r, n_rows))] = offdiag / cone_L[qd.static(_tri_idx(j_r, j_r, n_rows))]
     return cone_L
 
 
@@ -5176,10 +5168,10 @@ def func_cone_middle_cost(
 def _func_cone_cost_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, con_mu, rows_friction):
     """Exact elliptic-cone cost and its first/second derivatives in the linesearch step alpha (matching MuJoCo).
 
-    Evaluated at jar_k(alpha) = rows_jaref[k] + alpha * rows_jv[k], returning (cost, dcost/dalpha,
-    d2cost/dalpha2). The zone is re-classified at this alpha, so the cost is exact along the whole search line
-    (top: 0; bottom: plain quadratic; middle: the cone potential 0.5*Dm*(N - con_mu*T)^2 differentiated through
-    T = ||rows_friction[1:] * rows_jaref[1:]||).
+    Evaluated at rows_jaref + alpha * rows_jv, returning (cost, dcost/dalpha, d2cost/dalpha2). The zone is
+    re-classified at this alpha, so the cost is exact along the whole search line (top: 0; bottom: plain quadratic;
+    middle: the cone potential 0.5*Dm*(N - con_mu*T)^2 differentiated through T = ||rows_friction[1:] *
+    rows_jaref[1:]||).
     """
     rows_jaref_alpha = rows_jaref + alpha * rows_jv
     zone, N, T = _func_cone_zone(rows_jaref_alpha, con_mu, rows_friction)
@@ -5187,19 +5179,19 @@ def _func_cone_cost_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, con_mu, 
     grad = gs.qd_float(0.0)
     hess = gs.qd_float(0.0)
     if zone == 1:
-        for k in qd.static(range(rows_jaref_alpha.n)):
-            cost = cost + rows_efc_D[k] * rows_jaref_alpha[k] ** 2
-            grad = grad + rows_efc_D[k] * rows_jaref_alpha[k] * rows_jv[k]
-            hess = hess + rows_efc_D[k] * rows_jv[k] ** 2
+        for i_r in qd.static(range(rows_jaref_alpha.n)):
+            cost = cost + rows_efc_D[i_r] * rows_jaref_alpha[i_r] ** 2
+            grad = grad + rows_efc_D[i_r] * rows_jaref_alpha[i_r] * rows_jv[i_r]
+            hess = hess + rows_efc_D[i_r] * rows_jv[i_r] ** 2
         cost = 0.5 * cost
     elif zone == 2:
         Dm = _func_cone_Dm(rows_efc_D[0], con_mu)
         dN = con_mu * rows_jv[0]
         dT_sum = gs.qd_float(0.0)
         d2T_sum = gs.qd_float(0.0)
-        for k in qd.static(range(1, rows_jaref_alpha.n)):
-            u = rows_friction[k] * rows_jaref_alpha[k]
-            du = rows_friction[k] * rows_jv[k]
+        for i_r in qd.static(range(1, rows_jaref_alpha.n)):
+            u = rows_friction[i_r] * rows_jaref_alpha[i_r]
+            du = rows_friction[i_r] * rows_jv[i_r]
             dT_sum = dT_sum + u * du
             d2T_sum = d2T_sum + du**2
         dT = dT_sum / T
@@ -5230,12 +5222,12 @@ def _func_cone_cost_diff_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, con
     cost_diff = gs.qd_float(0.0)
     if zone == zone0:
         if zone == 1:
-            lin = gs.qd_float(0.0)
-            quad = gs.qd_float(0.0)
-            for k in qd.static(range(rows_jaref.n)):
-                lin = lin + rows_efc_D[k] * rows_jv[k] * rows_jaref[k]
-                quad = quad + rows_efc_D[k] * rows_jv[k] ** 2
-            cost_diff = alpha * lin + alpha**2 * (0.5 * quad)
+            dcost_0 = gs.qd_float(0.0)
+            d2cost = gs.qd_float(0.0)
+            for i_r in qd.static(range(rows_jaref.n)):
+                dcost_0 = dcost_0 + rows_efc_D[i_r] * rows_jv[i_r] * rows_jaref[i_r]
+                d2cost = d2cost + rows_efc_D[i_r] * rows_jv[i_r] ** 2
+            cost_diff = alpha * dcost_0 + alpha**2 * (0.5 * d2cost)
         elif zone == 2:
             Dm = _func_cone_Dm(rows_efc_D[0], con_mu)
             g = N - con_mu * T
@@ -5256,35 +5248,33 @@ def func_cone_update_rows(
     constraint_state: array_class.ConstraintState,
     rigid_config: qd.template(),
 ):
-    """Recompute active and efc_force for the rows of the elliptic cone whose head (normal) row is i_c, and
-    return the coupled middle-zone cost contribution (0 outside the middle zone).
+    """Recompute active and efc_force for the rows of the elliptic cone whose head (normal) row is i_c, and return
+    the coupled middle-zone cost contribution (0 outside the middle zone).
 
-    The normal row and its friction rows are one second-order cone (SOC), processed together at the head. The top
-    zone is inactive; the bottom zone reduces to the standard per-row quadratic (active=True lets the shared
-    cost/Hessian passes handle it); the middle zone is the analytic cone projection, excluded from the per-row
-    cost/Hessian (active=False) with its coupled cost returned here and its coupled Hessian block added in assembly.
-    Shared by every force-update path (serial batch, cooperative one-thread-per-row, decomposed) so the cone is
-    resolved identically across arms; per-row callers invoke it from the head thread only, keeping each row written
-    exactly once (race-free).
+    The cone rows are one second-order cone (SOC) processed together at the head: bottom-zone rows keep active=True
+    so the shared per-row cost/Hessian passes handle them, while middle-zone rows are excluded (active=False) with
+    their coupled cost returned here and their coupled Hessian block added in assembly. Shared by every force-update
+    path so the cone resolves identically across arms; per-row callers invoke it from the head thread only, keeping
+    each row written exactly once (race-free).
     """
     n_rows = qd.static(rigid_config.rows_per_contact)
     rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(i_c, i_b, constraint_state, rigid_config)
     zone, N, T = _func_cone_zone(rows_jaref, con_mu, rows_friction)
     cost = gs.qd_float(0.0)
     if zone == 0:  # top: inactive
-        for k in qd.static(range(n_rows)):
-            constraint_state.active[i_c + k, i_b] = False
-            constraint_state.efc_force[i_c + k, i_b] = 0.0
+        for i_r in qd.static(range(n_rows)):
+            constraint_state.active[i_c + i_r, i_b] = False
+            constraint_state.efc_force[i_c + i_r, i_b] = 0.0
     elif zone == 1:  # bottom: plain quadratic on all rows
-        for k in qd.static(range(n_rows)):
-            constraint_state.active[i_c + k, i_b] = True
-            constraint_state.efc_force[i_c + k, i_b] = -rows_jaref[k] * rows_efc_D[k]
+        for i_r in qd.static(range(n_rows)):
+            constraint_state.active[i_c + i_r, i_b] = True
+            constraint_state.efc_force[i_c + i_r, i_b] = -rows_jaref[i_r] * rows_efc_D[i_r]
     else:  # middle: cone boundary. Excluded from the per-row cost/Hessian; handled coupled.
-        rows_force, cost_m, _hs = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
-        for k in qd.static(range(n_rows)):
-            constraint_state.active[i_c + k, i_b] = False
-            constraint_state.efc_force[i_c + k, i_b] = rows_force[k]
-        cost = cost_m
+        rows_force, cost_middle, _cone_H = _func_cone_middle(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
+        for i_r in qd.static(range(n_rows)):
+            constraint_state.active[i_c + i_r, i_b] = False
+            constraint_state.efc_force[i_c + i_r, i_b] = rows_force[i_r]
+        cost = cost_middle
     return cost
 
 
@@ -6186,21 +6176,19 @@ def func_solve_iter(
                         func_update_cone_free_hessian_flip(
                             i_b, constraint_state.incr_changed_idx[idx, i_b], constraint_state, rigid_info, rigid_config
                         )
-                # Count middle-zone cone contacts: each rides 2 rank-1 sweeps per cone row (one per staged factor
-                # column of its downdated + updated blocks) on the incremental factor every iteration regardless of
-                # active-set flips, so it must weigh into the crossover below (and n_changed alone is often 0 while
-                # the cone still moves). The count reads cone_prev_jaref, which only the CPU backend allocates; a GPU
-                # build of this branch (explicit sparse_solve on GPU) rebuilds with the cone baked in each iteration
-                # instead, and the static backend gate keeps the cone helpers out of the GPU compilation. cone_passes
-                # stays 0 for the pyramidal cone.
+                # Each middle-zone cone rides 2 rank-1 sweeps per cone row on the incremental factor every iteration
+                # regardless of active-set flips, so it must weigh into the crossover below (n_changed alone is often
+                # 0 while the cone still moves). The count reads cone_prev_jaref, which only the CPU backend
+                # allocates; a GPU build of this branch rebuilds with the cone baked in instead, the static backend
+                # gate keeping the cone helpers out of the GPU compilation.
                 cone_passes = 0
                 if qd.static(rigid_config.enable_elliptic_friction and rigid_config.backend == gs.cpu):
                     n_rows = qd.static(rigid_config.rows_per_contact)
                     nef = (
                         constraint_state.n_constraints_equality[i_b] + constraint_state.n_constraints_frictionloss[i_b]
                     )
-                    for i_head in range(constraint_state.n_constraints_cone[i_b] // n_rows):
-                        if _func_cone_head_is_middle(nef + i_head * n_rows, i_b, nef, constraint_state, rigid_config):
+                    for i_cone in range(constraint_state.n_constraints_cone[i_b] // n_rows):
+                        if _func_cone_head_is_middle(nef + i_cone * n_rows, i_b, nef, constraint_state, rigid_config):
                             cone_passes = cone_passes + 1
                 need_rebuild = True
                 if n_changed == 0 and cone_passes == 0:

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -5142,8 +5142,11 @@ def _func_cone_middle(rows_jaref, D0, con_mu, rows_friction, N, T):
 
 @qd.func
 def _func_cone_block_product(cone_H, rows_jac_row, rows_jac_col):
-    """One entry J_row^T H_c J_col of the scattered coupled-cone Hessian: the packed symmetric local block H_c (see
-    _tri_idx) contracted with the cone rows' jacobian entries at the Hessian row DOF and column DOF."""
+    """One entry J_row^T H_c J_col of the scattered coupled-cone Hessian.
+
+    The packed symmetric local block H_c (see _tri_idx) is contracted with the cone rows' jacobian entries at the
+    Hessian row DOF and column DOF.
+    """
     n_rows = qd.static(rows_jac_row.n)
     product = gs.qd_float(0.0)
     for i_r in qd.static(range(n_rows)):

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -606,14 +606,15 @@ def _func_contact_row_direction(
     d2,
     friction,
     friction_torsional,
+    friction_rolling,
     rigid_config: qd.template(),
 ):
     """Direction of collision row i_friction, as a translational part n and an angular part n_ang.
 
-    Elliptic rows [normal, t1, t2(, spin)] follow the contact frame unmixed (the cone couples them in the solver; the
-    spin row's friction strength lives in its regularization, see the diag computation in _add_friction_constraint).
-    Pyramidal rows are 2 opposing friction-mixed edges per tangent axis, then the torsional pair mixing the spin axis
-    through the angular jacobian.
+    Elliptic rows [normal, t1, t2(, spin)(, roll1, roll2)] follow the contact frame unmixed (the cone couples them in
+    the solver; the spin and rolling rows' friction strength lives in their regularization, see the diag computation
+    in _add_friction_constraint). Pyramidal rows are 2 opposing friction-mixed edges per tangent axis, then the
+    torsional and rolling pairs mixing the spin and tangent axes through the angular jacobian.
     """
     n = -normal
     n_ang = qd.Vector.zero(gs.qd_float, 3)
@@ -630,6 +631,12 @@ def _func_contact_row_direction(
                 n = qd.Vector.zero(gs.qd_float, 3)
                 if friction_torsional > 0.0:
                     n_ang = -normal
+        if qd.static(rigid_config.enable_rolling_friction):
+            # The rolling axes follow the tangent rows' frame; a zero coefficient zeroes them like the spin row.
+            if i_friction >= 4:
+                n = qd.Vector.zero(gs.qd_float, 3)
+                if friction_rolling > 0.0:
+                    n_ang = d1 if i_friction == 4 else d2
     else:
         d = (2 * (i_friction % 2) - 1) * (d1 if i_friction < 2 else d2)
         n = d * friction - normal
@@ -637,11 +644,18 @@ def _func_contact_row_direction(
             # A zero coefficient zeroes the pair (aref alongside, see _add_friction_constraint): the rows would
             # otherwise degenerate to two extra pure-normal rows that stiffen the normal response and report phantom
             # contact force.
-            if i_friction >= 4:
+            if i_friction >= 4 and i_friction < 6:
                 n = qd.Vector.zero(gs.qd_float, 3)
                 if friction_torsional > 0.0:
                     n = -normal
                     n_ang = ((2 * (i_friction % 2) - 1) * friction_torsional) * normal
+        if qd.static(rigid_config.enable_rolling_friction):
+            # The rolling pairs mix the tangent axes; a zero coefficient zeroes them like the torsional pair.
+            if i_friction >= 6:
+                n = qd.Vector.zero(gs.qd_float, 3)
+                if friction_rolling > 0.0:
+                    n = -normal
+                    n_ang = ((2 * (i_friction % 2) - 1) * friction_rolling) * (d1 if i_friction < 8 else d2)
     return n, n_ang
 
 
@@ -698,6 +712,9 @@ def _add_friction_constraint(
     contact_data_friction_torsional = gs.qd_float(0.0)
     if qd.static(rigid_config.enable_torsional_friction):
         contact_data_friction_torsional = collider_state.contact_data.friction_torsional[i_col, i_b]
+    contact_data_friction_rolling = gs.qd_float(0.0)
+    if qd.static(rigid_config.enable_rolling_friction):
+        contact_data_friction_rolling = collider_state.contact_data.friction_rolling[i_col, i_b]
     n, n_ang = _func_contact_row_direction(
         i_friction,
         contact_data_normal,
@@ -705,6 +722,7 @@ def _add_friction_constraint(
         d2,
         contact_data_friction,
         contact_data_friction_torsional,
+        contact_data_friction_rolling,
         rigid_config,
     )
 
@@ -773,8 +791,8 @@ def _add_friction_constraint(
         diag = invweight * (1 - imp) / imp
         if i_friction > 0:
             diag = diag / rigid_info.impratio[None]
-        # The cone solver reads the contact friction coefficient off the head (normal) row, and the torsional one
-        # off the spin row.
+        # The cone solver reads the contact friction coefficient off the head (normal) row, and the torsional and
+        # rolling ones off their own rows.
         efc_frictionloss = contact_data_friction if i_friction == 0 else gs.qd_float(0.0)
         if qd.static(rigid_config.enable_torsional_friction):
             # The mu ratio lives in the spin row's regularization (jacobian unscaled), matching MuJoCo's elliptic
@@ -784,6 +802,12 @@ def _add_friction_constraint(
                 if contact_data_friction_torsional > 0.0:
                     diag = diag * contact_data_friction**2 / contact_data_friction_torsional**2
                 efc_frictionloss = contact_data_friction_torsional
+        if qd.static(rigid_config.enable_rolling_friction):
+            # The rolling rows carry the mu ratio in their regularization like the spin row.
+            if i_friction >= 4:
+                if contact_data_friction_rolling > 0.0:
+                    diag = diag * contact_data_friction**2 / contact_data_friction_rolling**2
+                efc_frictionloss = contact_data_friction_rolling
         constraint_state.efc_frictionloss[n_con, i_b] = efc_frictionloss
     else:
         imp, aref = gu.imp_aref(contact_data_sol_params, -contact_data_penetration, jac_qvel, -contact_data_penetration)
@@ -796,7 +820,11 @@ def _add_friction_constraint(
         if qd.static(rigid_config.enable_torsional_friction):
             # A zeroed torsional pair (see _func_contact_row_direction) must also drop the positional reference:
             # with it, the zero-jacobian rows would carry a phantom force that pollutes the reported contact force.
-            if i_friction >= 4 and contact_data_friction_torsional <= 0.0:
+            if i_friction >= 4 and i_friction < 6 and contact_data_friction_torsional <= 0.0:
+                aref = gs.qd_float(0.0)
+        if qd.static(rigid_config.enable_rolling_friction):
+            # A zeroed rolling pair drops its positional reference like the torsional pair.
+            if i_friction >= 6 and contact_data_friction_rolling <= 0.0:
                 aref = gs.qd_float(0.0)
     diag = qd.max(diag, EPS)
     constraint_state.diag[n_con, i_b] = diag
@@ -924,6 +952,9 @@ def _add_collision_constraints_per_contact(
             contact_data_friction_torsional = gs.qd_float(0.0)
             if qd.static(rigid_config.enable_torsional_friction):
                 contact_data_friction_torsional = collider_state.contact_data.friction_torsional[i_col, i_b]
+            contact_data_friction_rolling = gs.qd_float(0.0)
+            if qd.static(rigid_config.enable_rolling_friction):
+                contact_data_friction_rolling = collider_state.contact_data.friction_rolling[i_col, i_b]
 
             for i_friction in range(rows_per_contact):
                 n, n_ang = _func_contact_row_direction(
@@ -933,6 +964,7 @@ def _add_collision_constraints_per_contact(
                     d2,
                     contact_data_friction,
                     contact_data_friction_torsional,
+                    contact_data_friction_rolling,
                     rigid_config,
                 )
 
@@ -1006,6 +1038,12 @@ def _add_collision_constraints_per_contact(
                             if contact_data_friction_torsional > 0.0:
                                 diag = diag * contact_data_friction**2 / contact_data_friction_torsional**2
                             efc_frictionloss = contact_data_friction_torsional
+                    if qd.static(rigid_config.enable_rolling_friction):
+                        # Rolling-row regularization and coefficient storage: see _add_friction_constraint.
+                        if i_friction >= 4:
+                            if contact_data_friction_rolling > 0.0:
+                                diag = diag * contact_data_friction**2 / contact_data_friction_rolling**2
+                            efc_frictionloss = contact_data_friction_rolling
                     constraint_state.efc_frictionloss[n_con, i_b] = efc_frictionloss
                 else:
                     imp, aref = gu.imp_aref(
@@ -1018,7 +1056,11 @@ def _add_collision_constraints_per_contact(
                     diag = diag * 2 * friction_sq_reg * (1 - imp) / imp
                     if qd.static(rigid_config.enable_torsional_friction):
                         # A zeroed torsional pair drops its positional reference: see _add_friction_constraint.
-                        if i_friction >= 4 and contact_data_friction_torsional <= 0.0:
+                        if i_friction >= 4 and i_friction < 6 and contact_data_friction_torsional <= 0.0:
+                            aref = gs.qd_float(0.0)
+                    if qd.static(rigid_config.enable_rolling_friction):
+                        # A zeroed rolling pair drops its positional reference: see _add_friction_constraint.
+                        if i_friction >= 6 and contact_data_friction_rolling <= 0.0:
                             aref = gs.qd_float(0.0)
                 diag = qd.max(diag, EPS)
                 constraint_state.diag[n_con, i_b] = diag
@@ -5004,10 +5046,10 @@ def _func_cone_head_load(
     """Load the shared per-contact scalars of the elliptic cone whose head (normal) row is i_c.
 
     Returns (rows_efc_D, rows_friction, con_mu, rows_jaref): the per-row impedances, the per-row friction
-    coefficients (sliding on the head and tangent slots, torsional on the spin slot, see efc_frictionloss in
-    array_class.py), the regularized master coefficient con_mu = friction / sqrt(impratio) (computed as
-    friction * sqrt(rows_efc_D[0] / rows_efc_D[1]) since the friction rows are impratio times stiffer), and the
-    per-row residuals.
+    coefficients (sliding on the head and tangent slots, torsional and rolling on their own slots, see
+    efc_frictionloss in array_class.py), the regularized master coefficient con_mu = friction / sqrt(impratio)
+    (computed as friction * sqrt(rows_efc_D[0] / rows_efc_D[1]) since the friction rows are impratio times stiffer),
+    and the per-row residuals.
     """
     n_rows = qd.static(rigid_config.rows_per_contact)
     rows_efc_D = qd.Vector.zero(gs.qd_float, n_rows)
@@ -5020,7 +5062,8 @@ def _func_cone_head_load(
     for i_r in qd.static(range(n_rows)):
         rows_friction[i_r] = friction
     if qd.static(rigid_config.enable_torsional_friction):
-        rows_friction[n_rows - 1] = constraint_state.efc_frictionloss[i_c + n_rows - 1, i_b]
+        for i_r in qd.static(range(3, n_rows)):
+            rows_friction[i_r] = constraint_state.efc_frictionloss[i_c + i_r, i_b]
     con_mu = friction * qd.sqrt(rows_efc_D[0] / rows_efc_D[1])
     return rows_efc_D, rows_friction, con_mu, rows_jaref
 
@@ -6371,8 +6414,9 @@ def func_update_contact_force(
             force = qd.Vector.zero(gs.qd_float, 3)
             d1, d2 = gu.qd_orthogonals(contact_data_normal)
             if qd.static(rigid_config.enable_elliptic_friction):
-                # Cone rows [normal, t1, t2(, spin)] contiguous in the collision segment; the spin row carries
-                # torque only, so the linear contact force sums the three translational directions.
+                # Cone rows [normal, t1, t2(, spin)(, roll1, roll2)] contiguous in the collision segment; the spin
+                # and rolling rows carry torque only, so the linear contact force sums the three translational
+                # directions.
                 base = i_c * rows_per_contact + const_start
                 force = -contact_data_normal * constraint_state.efc_force[base, i_b]
                 force = force + d1 * constraint_state.efc_force[base + 1, i_b]
@@ -6382,8 +6426,8 @@ def func_update_contact_force(
                     d = (2 * (i_dir % 2) - 1) * (d1 if i_dir < 2 else d2)
                     n = d * contact_data_friction - contact_data_normal
                     force = force + n * constraint_state.efc_force[i_c * rows_per_contact + i_dir + const_start, i_b]
-                # The torsional pyramid pair mixes the spin axis through the angular jacobian; its linear part is the
-                # shared normal opposition.
+                # The torsional and rolling pyramid pairs mix the spin and tangent axes through the angular
+                # jacobian; their linear part is the shared normal opposition.
                 if qd.static(rigid_config.enable_torsional_friction):
                     for i_dir in qd.static(range(4, rows_per_contact)):
                         force = (

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -151,19 +151,20 @@ def _func_decomp_linesearch_p0(
                 i_c = tid
                 while i_c < n_con:
                     if qd.static(rigid_config.enable_elliptic_friction) and (nef <= i_c and i_c < ncone):
-                        # Elliptic cone: the head thread carries the exact coupled grad/hess of the whole triple
+                        # Elliptic cone: the head thread carries the exact coupled grad/hess of the whole cone
                         # (evaluated at alpha=0 through the shared per-alpha routine, matching the serial linesearch);
-                        # the two tangent threads are no-ops so the triple is counted once. The cone cost itself
+                        # the friction-row threads are no-ops so the cone is counted once. The cone cost itself
                         # cancels in the shifted convention (see quad_gauss in array_class.py).
-                        if (i_c - nef) % 3 == 0:
-                            d0, d1v, d2v, friction, con_mu, jar0, jar1, jar2 = solver._func_cone_head_load(
-                                i_c, i_b, constraint_state
+                        if (i_c - nef) % qd.static(rigid_config.rows_per_contact) == 0:
+                            n_rows = qd.static(rigid_config.rows_per_contact)
+                            rows_efc_D, rows_friction, con_mu, rows_jaref = solver._func_cone_head_load(
+                                i_c, i_b, constraint_state, rigid_config
                             )
-                            jv0 = constraint_state.jv[i_c, i_b]
-                            jv1 = constraint_state.jv[i_c + 1, i_b]
-                            jv2 = constraint_state.jv[i_c + 2, i_b]
+                            rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
+                            for k in qd.static(range(n_rows)):
+                                rows_jv[k] = constraint_state.jv[i_c + k, i_b]
                             _c_cost, c_grad, c_hess = solver._func_cone_cost_along_alpha(
-                                jar0, jar1, jar2, jv0, jv1, jv2, 0.0, d0, d1v, d2v, con_mu, friction
+                                rows_jaref, rows_jv, 0.0, rows_efc_D, con_mu, rows_friction
                             )
                             local_constraint_grad += c_grad
                             local_constraint_hess += 0.5 * c_hess
@@ -453,11 +454,11 @@ def _func_update_constraint_forces_body(
         ncone = ncone + constraint_state.n_constraints_cone[i_b]
 
     if qd.static(rigid_config.enable_elliptic_friction) and (nef <= i_c and i_c < ncone):
-        # Elliptic cone (one-thread-per-row): only the head thread resolves the coupled triple and writes all three
-        # rows; the two tangent threads are no-ops (race-free). The coupled middle-zone cost is discarded here; the
+        # Elliptic cone (one-thread-per-row): only the head thread resolves the coupled rows and writes all of
+        # them; the friction-row threads are no-ops (race-free). The coupled middle-zone cost is discarded here; the
         # linesearch evaluates the cone cost delta directly.
-        if (i_c - nef) % 3 == 0:
-            solver.func_cone_update_rows(i_c, i_b, constraint_state)
+        if (i_c - nef) % qd.static(rigid_config.rows_per_contact) == 0:
+            solver.func_cone_update_rows(i_c, i_b, constraint_state, rigid_config)
     else:
         if qd.static(
             rigid_config.solver_type == gs.constraint_solver.Newton and not rigid_config.enable_elliptic_friction
@@ -668,7 +669,7 @@ def _func_newton_only_nt_hessian_and_cholesky(
     in-place.  H patching is not used because the subsequent Cholesky would destroy H anyway.
     """
     solver.func_hessian_direct_tiled(constraint_state, rigid_info)
-    # func_hessian_direct_tiled assembles M + J^T D J only; add the coupled elliptic-cone 3x3 block as an additive
+    # func_hessian_direct_tiled assembles M + J^T D J only; add the coupled elliptic-cone block as an additive
     # post-pass before the factor reads nt_H, matching the monolith tiled path (this path rebuilds every improved env).
     if qd.static(rigid_config.enable_elliptic_friction):
         _B_envs = constraint_state.jac.shape[2]

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -161,8 +161,8 @@ def _func_decomp_linesearch_p0(
                                 i_c, i_b, constraint_state, rigid_config
                             )
                             rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
-                            for k in qd.static(range(n_rows)):
-                                rows_jv[k] = constraint_state.jv[i_c + k, i_b]
+                            for i_r in qd.static(range(n_rows)):
+                                rows_jv[i_r] = constraint_state.jv[i_c + i_r, i_b]
                             _c_cost, c_grad, c_hess = solver._func_cone_cost_along_alpha(
                                 rows_jaref, rows_jv, 0.0, rows_efc_D, con_mu, rows_friction
                             )

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -159,8 +159,10 @@ from .abd.accessor import (
     kernel_set_drone_rpm,
     kernel_update_drone_propeller_vgeoms,
     kernel_set_geom_friction,
+    kernel_set_geom_friction_rolling,
     kernel_set_geom_friction_torsional,
     kernel_set_geoms_friction,
+    kernel_set_geoms_friction_rolling,
     kernel_set_geoms_friction_torsional,
     kernel_adjust_link_inertia,
 )
@@ -538,6 +540,7 @@ class RigidSolver(KinematicSolver):
             enable_mujoco_compatibility=self._enable_mujoco_compatibility,
             enable_elliptic_friction=self._options.friction_cone == gs.friction_cone.elliptic,
             enable_torsional_friction=self._options.enable_torsional_friction,
+            enable_rolling_friction=self._options.enable_rolling_friction,
             enable_multi_contact=self._enable_multi_contact,
             enable_collision=self._enable_collision,
             enable_joint_limit=self._enable_joint_limit,
@@ -1108,6 +1111,7 @@ class RigidSolver(KinematicSolver):
                 np.array([geom.type for geom in geoms], dtype=gs.np_int),
                 np.array([geom.friction for geom in geoms], dtype=gs.np_float),
                 np.array([geom.friction_torsional for geom in geoms], dtype=gs.np_float),
+                np.array([geom.friction_rolling for geom in geoms], dtype=gs.np_float),
                 geoms_sol_params,
                 np.array([geom.data for geom in geoms], dtype=gs.np_float),
                 np.array([geom.is_convex for geom in geoms], dtype=gs.np_bool),
@@ -2936,6 +2940,9 @@ class RigidSolver(KinematicSolver):
     def set_geom_friction_torsional(self, friction_torsional, geoms_idx):
         kernel_set_geom_friction_torsional(geoms_idx, self.dyn_info, friction_torsional)
 
+    def set_geom_friction_rolling(self, friction_rolling, geoms_idx):
+        kernel_set_geom_friction_rolling(geoms_idx, self.dyn_info, friction_rolling)
+
     def set_geoms_friction(self, friction, geoms_idx=None):
         friction, geoms_idx, _ = self._sanitize_io_variables(
             friction, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
@@ -2947,6 +2954,12 @@ class RigidSolver(KinematicSolver):
             friction_torsional, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
         )
         kernel_set_geoms_friction_torsional(geoms_idx, friction_torsional, self.dyn_info, self.rigid_config)
+
+    def set_geoms_friction_rolling(self, friction_rolling, geoms_idx=None):
+        friction_rolling, geoms_idx, _ = self._sanitize_io_variables(
+            friction_rolling, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
+        )
+        kernel_set_geoms_friction_rolling(geoms_idx, friction_rolling, self.dyn_info, self.rigid_config)
 
     def add_weld_constraint(self, link1_idx, link2_idx, envs_idx=None):
         return self.constraint_solver.add_weld_constraint(link1_idx, link2_idx, envs_idx)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -161,6 +161,7 @@ from .abd.accessor import (
     kernel_set_geom_friction,
     kernel_set_geom_friction_torsional,
     kernel_set_geoms_friction,
+    kernel_set_geoms_friction_torsional,
     kernel_adjust_link_inertia,
 )
 from .abd.diff import (
@@ -2940,6 +2941,12 @@ class RigidSolver(KinematicSolver):
             friction, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
         )
         kernel_set_geoms_friction(geoms_idx, friction, self.dyn_info, self.rigid_config)
+
+    def set_geoms_friction_torsional(self, friction_torsional, geoms_idx=None):
+        friction_torsional, geoms_idx, _ = self._sanitize_io_variables(
+            friction_torsional, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
+        )
+        kernel_set_geoms_friction_torsional(geoms_idx, friction_torsional, self.dyn_info, self.rigid_config)
 
     def add_weld_constraint(self, link1_idx, link2_idx, envs_idx=None):
         return self.constraint_solver.add_weld_constraint(link1_idx, link2_idx, envs_idx)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -159,6 +159,7 @@ from .abd.accessor import (
     kernel_set_drone_rpm,
     kernel_update_drone_propeller_vgeoms,
     kernel_set_geom_friction,
+    kernel_set_geom_friction_torsional,
     kernel_set_geoms_friction,
     kernel_adjust_link_inertia,
 )
@@ -535,6 +536,7 @@ class RigidSolver(KinematicSolver):
             batch_joints_info=self._options.batch_joints_info,
             enable_mujoco_compatibility=self._enable_mujoco_compatibility,
             enable_elliptic_friction=self._options.friction_cone == gs.friction_cone.elliptic,
+            enable_torsional_friction=self._options.enable_torsional_friction,
             enable_multi_contact=self._enable_multi_contact,
             enable_collision=self._enable_collision,
             enable_joint_limit=self._enable_joint_limit,
@@ -1104,6 +1106,7 @@ class RigidSolver(KinematicSolver):
                 np.array([geom.init_quat for geom in geoms], dtype=gs.np_float),
                 np.array([geom.type for geom in geoms], dtype=gs.np_int),
                 np.array([geom.friction for geom in geoms], dtype=gs.np_float),
+                np.array([geom.friction_torsional for geom in geoms], dtype=gs.np_float),
                 geoms_sol_params,
                 np.array([geom.data for geom in geoms], dtype=gs.np_float),
                 np.array([geom.is_convex for geom in geoms], dtype=gs.np_bool),
@@ -2928,6 +2931,9 @@ class RigidSolver(KinematicSolver):
 
     def set_geom_friction(self, friction, geoms_idx):
         kernel_set_geom_friction(geoms_idx, self.dyn_info, friction)
+
+    def set_geom_friction_torsional(self, friction_torsional, geoms_idx):
+        kernel_set_geom_friction_torsional(geoms_idx, self.dyn_info, friction_torsional)
 
     def set_geoms_friction(self, friction, geoms_idx=None):
         friction, geoms_idx, _ = self._sanitize_io_variables(

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -420,8 +420,8 @@ class RigidOptions(Options):
         Maximum number of collision pairs. Defaults to 100.
     max_contacts : int, optional
         Maximum number of simultaneous contact points per environment that the constraint solver can handle, which
-        determines the size of the contact constraint buffers (3 to 6 constraint rows per contact point depending on
-        'friction_cone' and 'enable_torsional_friction'). Defaults to None.
+        determines the size of the contact constraint buffers (3 to 10 constraint rows per contact point depending on
+        'friction_cone', 'enable_torsional_friction', and 'enable_rolling_friction'). Defaults to None.
 
         This limit applies to the final contact points after pruning, not to the candidate contact points that
         collision detection can emit (see 'max_collision_pairs'). Exceeding it at runtime halts the simulation with
@@ -471,6 +471,12 @@ class RigidOptions(Options):
         object twisting in a gripper, a top spinning in place - motions a point contact transmits no torque against,
         so they persist indefinitely otherwise. The extra spin resistance slows down the constraint solve on every
         contact, including those where spin is irrelevant. Defaults to False.
+    enable_rolling_friction : bool, optional
+        Whether contacts also resist rolling, with strength set per geometry by the material option 'friction_rolling'
+        (see 'gs.materials.Rigid'). Enable it when rolling resistance matters - a ball or wheel coasting to rest, a
+        cylinder settling on a slope - motions a point contact otherwise never slows down. The extra rolling
+        resistance slows down the constraint solve on every contact, more so than torsional friction (two extra axes),
+        and requires 'enable_torsional_friction'. Defaults to False.
     impratio : float, optional
         Ratio of tangential (friction) to normal constraint impedance at contacts. Raising it above 1 stiffens
         friction so resting stacks and piles hold their pose under sustained shear, at the cost of a slower solve that
@@ -549,6 +555,7 @@ class RigidOptions(Options):
     noslip_tolerance: PositiveFloat = 1e-6
     friction_cone: gs.friction_cone = gs.friction_cone.pyramidal
     enable_torsional_friction: StrictBool = False
+    enable_rolling_friction: StrictBool = False
     impratio: PositiveFloat | None = None
     contact_pruning_tolerance: PositiveFloat | None = 0.02
     sparse_solve: StrictBool | None = None
@@ -589,6 +596,8 @@ class RigidOptions(Options):
             self.contact_pruning_tolerance = None
         if self.friction_cone == gs.friction_cone.elliptic and self.noslip_iterations > 0:
             gs.raise_exception("The elliptic friction cone is not supported with the noslip solver.")
+        if self.enable_rolling_friction and not self.enable_torsional_friction:
+            gs.raise_exception("'enable_rolling_friction' requires 'enable_torsional_friction'.")
 
 
 class MPMOptions(Options):

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -420,7 +420,8 @@ class RigidOptions(Options):
         Maximum number of collision pairs. Defaults to 100.
     max_contacts : int, optional
         Maximum number of simultaneous contact points per environment that the constraint solver can handle, which
-        determines the size of the contact constraint buffers (4 constraints per contact point). Defaults to None.
+        determines the size of the contact constraint buffers (3 to 6 constraint rows per contact point depending on
+        'friction_cone' and 'enable_torsional_friction'). Defaults to None.
 
         This limit applies to the final contact points after pruning, not to the candidate contact points that
         collision detection can emit (see 'max_collision_pairs'). Exceeding it at runtime halts the simulation with
@@ -464,6 +465,12 @@ class RigidOptions(Options):
         (default) is robust and easy to solve; 'gs.friction_cone.elliptic' is the exact isotropic cone, harder to solve
         but paired with a high 'impratio' it holds resting stacks without slow tangential creep. See 'gs.friction_cone'
         for the description of each model. Unsupported with the noslip solver or differentiable simulation.
+    enable_torsional_friction : bool, optional
+        Whether contacts also resist relative spin about their normal, with strength set per geometry by the material
+        option 'friction_torsional' (see 'gs.materials.Rigid'). Enable it when spin resistance matters - a grasped
+        object twisting in a gripper, a top spinning in place - which a point contact otherwise never slows down since
+        it transmits no spin torque. Every contact carries extra constraint rows to do so, slowing down the constraint
+        solve even where spin is irrelevant. Defaults to False.
     impratio : float, optional
         Ratio of tangential (friction) to normal constraint impedance at contacts. Raising it above 1 stiffens
         friction so resting stacks and piles hold their pose under sustained shear, at the cost of a slower solve that
@@ -541,6 +548,7 @@ class RigidOptions(Options):
     noslip_iterations: NonNegativeInt = 0
     noslip_tolerance: PositiveFloat = 1e-6
     friction_cone: gs.friction_cone = gs.friction_cone.pyramidal
+    enable_torsional_friction: StrictBool = False
     impratio: PositiveFloat | None = None
     contact_pruning_tolerance: PositiveFloat | None = 0.02
     sparse_solve: StrictBool | None = None

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -468,9 +468,9 @@ class RigidOptions(Options):
     enable_torsional_friction : bool, optional
         Whether contacts also resist relative spin about their normal, with strength set per geometry by the material
         option 'friction_torsional' (see 'gs.materials.Rigid'). Enable it when spin resistance matters - a grasped
-        object twisting in a gripper, a top spinning in place - which a point contact otherwise never slows down since
-        it transmits no spin torque. Every contact carries extra constraint rows to do so, slowing down the constraint
-        solve even where spin is irrelevant. Defaults to False.
+        object twisting in a gripper, a top spinning in place - motions a point contact transmits no torque against,
+        so they persist indefinitely otherwise. The extra spin resistance slows down the constraint solve on every
+        contact, including those where spin is irrelevant. Defaults to False.
     impratio : float, optional
         Ratio of tangential (friction) to normal constraint impedance at contacts. Raising it above 1 stiffens
         friction so resting stacks and piles hold their pose under sustained shear, at the cost of a slower solve that

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -425,8 +425,9 @@ class ConstraintState:
     jac_n_dofs: qd.Tensor
     n_constraints_equality: qd.Tensor
     n_constraints_frictionloss: qd.Tensor
-    # Number of elliptic-cone contact rows (3 per contact), laid out contiguously at the start of the collision
-    # segment. Zero for the pyramidal cone. The cone rows occupy [ne + n_frictionloss, ne + n_frictionloss + n_cone).
+    # Number of elliptic-cone contact rows (rows_per_contact per contact), laid out contiguously at the start of the
+    # collision segment. Zero for the pyramidal cone. The cone rows occupy
+    # [ne + n_frictionloss, ne + n_frictionloss + n_cone).
     n_constraints_cone: qd.Tensor
     improved: qd.Tensor
     Jaref: qd.Tensor
@@ -440,7 +441,8 @@ class ConstraintState:
     cone_prev_jaref: qd.Tensor
     efc_D: qd.Tensor
     # Frictionloss rows store their friction loss; elliptic-cone head (normal) rows reuse the field to carry the
-    # contact friction coefficient read by the cone solver (their tangent rows hold 0).
+    # contact sliding friction coefficient read by the cone solver, and with torsional friction the spin row carries
+    # the torsional coefficient the same way (the tangent rows hold 0).
     efc_frictionloss: qd.Tensor
     efc_force: qd.Tensor
     active: qd.Tensor
@@ -696,6 +698,7 @@ class ContactData:
     normal: qd.Tensor
     pos: qd.Tensor
     friction: qd.Tensor
+    friction_torsional: qd.Tensor
     sol_params: qd.Tensor
     force: qd.Tensor
     link_a: qd.Tensor
@@ -714,6 +717,7 @@ def get_contact_data(solver, max_candidate_contacts, requires_grad):
         pos=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
         penetration=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
         friction=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
+        friction_torsional=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
         sol_params=V_VEC(7, dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
         force=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B)),
         link_a=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
@@ -1950,6 +1954,7 @@ class GeomsInfo:
     link_idx: qd.Tensor
     type: qd.Tensor
     friction: qd.Tensor
+    friction_torsional: qd.Tensor
     sol_params: qd.Tensor
     vert_num: qd.Tensor
     vert_start: qd.Tensor
@@ -1985,6 +1990,7 @@ def get_geoms_info(solver, is_active=True):
         link_idx=V(dtype=gs.qd_int, shape=shape),
         type=V(dtype=gs.qd_int, shape=shape),
         friction=V(dtype=gs.qd_float, shape=shape),
+        friction_torsional=V(dtype=gs.qd_float, shape=shape),
         sol_params=V(dtype=gs.qd_vec7, shape=shape),
         vert_num=V(dtype=gs.qd_int, shape=shape),
         vert_start=V(dtype=gs.qd_int, shape=shape),
@@ -2404,6 +2410,9 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # Whether the cone-free assembled Hessian is persisted in nt_H's mirror slots (diagonal in nt_H_cone_free_diag);
     # see the nt_H declaration for the packed-storage mechanics and the rigid solver's resolution for the gating.
     enable_cone_free_hessian_reuse: bool = False
+    # Whether contacts carry torsional friction rows resisting relative spin about the contact normal: one extra
+    # opposing pyramid pair per contact with the pyramidal cone, one extra cone row with the elliptic cone.
+    enable_torsional_friction: bool = False
     # Consecutive sub-tolerance steps a body's max DOF velocity must hold before it is ready to hibernate. Guards
     # against a body that is only momentarily slow (e.g. at the apex of a toss) sleeping prematurely.
     hibernation_min_steps: int = 10
@@ -2463,6 +2472,14 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     n_entities: int = -1
     n_links: int = -1
     n_geoms: int = -1
+
+    @property
+    def rows_per_contact(self) -> int:
+        """Constraint rows per contact: 2 opposing pyramid edges per friction axis with the pyramidal cone, or the
+        normal row plus one row per friction axis with the elliptic cone; torsional friction adds the spin axis."""
+        if self.enable_elliptic_friction:
+            return 4 if self.enable_torsional_friction else 3
+        return 6 if self.enable_torsional_friction else 4
 
 
 # =========================================== DataManager ===========================================

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -2480,9 +2480,12 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
 
     @property
     def rows_per_contact(self) -> int:
-        """Constraint rows per contact: 2 opposing pyramid edges per friction axis with the pyramidal cone, or the
-        normal row plus one row per friction axis with the elliptic cone; torsional friction adds the spin axis and
-        rolling friction the two tangent axes."""
+        """Constraint rows per contact.
+
+        The pyramidal cone carries 2 opposing friction-mixed edges per friction axis, the elliptic cone the normal
+        row plus one row per friction axis; torsional friction adds the spin axis and rolling friction the two
+        tangent axes.
+        """
         n_extra_axes = int(self.enable_torsional_friction) + 2 * int(self.enable_rolling_friction)
         if self.enable_elliptic_friction:
             return 3 + n_extra_axes
@@ -2490,10 +2493,12 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
 
     @property
     def hessian_rank_update_batch(self) -> int:
-        """Number of rank-1 Cholesky updates fused into one column sweep by the CPU per-island incremental factor
-        (func_rank_batch_update_island). Sizes the nt_vec slots and the static per-column unroll: 8 amortizes the
+        """Number of rank-1 Cholesky updates fused into one column sweep by the CPU incremental factor.
+
+        Sizes the nt_vec slots and the static per-column unroll of func_rank_batch_update_island: 8 amortizes the
         active-set flip batching, widened when the coupled elliptic-cone update must stage 2 slots per cone row
-        (see func_cone_rank_update_island)."""
+        (see func_cone_rank_update_island).
+        """
         return max(8, 2 * self.rows_per_contact)
 
 

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -377,11 +377,16 @@ def get_island_state(solver, collider):
         and not solver.rigid_config.sparse_envelope
     )
     max_candidate_contacts = max(collider._collider_info.max_candidate_contacts[None], 1)
-    # Safe upper bound on active constraints, mirroring ConstraintSolver.len_constraints: 4 per contact +
-    # joint-limit/frictionloss (<= n_dofs each) + equality rows (<= 6 each). The equality term must use the candidate
-    # count (model equalities plus the dynamic-weld budget), not just the model equalities, otherwise constraint_id is
-    # undersized once dynamic welds are added and the per-island grouping writes out of bounds.
-    n_constraints_max = max(max_candidate_contacts * 4 + 2 * n_dofs + max(solver.n_candidate_equalities_, 1) * 6, 1)
+    # Safe upper bound on active constraints, mirroring ConstraintSolver.len_constraints: rows_per_contact per
+    # contact + joint-limit/frictionloss (<= n_dofs each) + equality rows (<= 6 each). The equality term must use the
+    # candidate count (model equalities plus the dynamic-weld budget), not just the model equalities, otherwise
+    # constraint_id is undersized once dynamic welds are added and the per-island grouping writes out of bounds.
+    n_constraints_max = max(
+        max_candidate_contacts * solver.rigid_config.rows_per_contact
+        + 2 * n_dofs
+        + max(solver.n_candidate_equalities_, 1) * 6,
+        1,
+    )
     return IslandState(
         links_parent_idx=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), is_active)),
         links_island_idx=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), is_active)),

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -699,6 +699,7 @@ class ContactData:
     pos: qd.Tensor
     friction: qd.Tensor
     friction_torsional: qd.Tensor
+    friction_rolling: qd.Tensor
     sol_params: qd.Tensor
     force: qd.Tensor
     link_a: qd.Tensor
@@ -718,6 +719,7 @@ def get_contact_data(solver, max_candidate_contacts, requires_grad):
         penetration=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
         friction=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
         friction_torsional=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
+        friction_rolling=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
         sol_params=V_VEC(7, dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
         force=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B)),
         link_a=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
@@ -1955,6 +1957,7 @@ class GeomsInfo:
     type: qd.Tensor
     friction: qd.Tensor
     friction_torsional: qd.Tensor
+    friction_rolling: qd.Tensor
     sol_params: qd.Tensor
     vert_num: qd.Tensor
     vert_start: qd.Tensor
@@ -1991,6 +1994,7 @@ def get_geoms_info(solver, is_active=True):
         type=V(dtype=gs.qd_int, shape=shape),
         friction=V(dtype=gs.qd_float, shape=shape),
         friction_torsional=V(dtype=gs.qd_float, shape=shape),
+        friction_rolling=V(dtype=gs.qd_float, shape=shape),
         sol_params=V(dtype=gs.qd_vec7, shape=shape),
         vert_num=V(dtype=gs.qd_int, shape=shape),
         vert_start=V(dtype=gs.qd_int, shape=shape),
@@ -2413,6 +2417,10 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # Whether contacts carry torsional friction rows resisting relative spin about the contact normal: one extra
     # opposing pyramid pair per contact with the pyramidal cone, one extra cone row with the elliptic cone.
     enable_torsional_friction: bool = False
+    # Whether contacts also carry rolling friction rows resisting relative rotation about the two tangent axes: two
+    # extra opposing pyramid pairs per contact with the pyramidal cone, two extra cone rows with the elliptic cone.
+    # Requires enable_torsional_friction (the rolling rows sit after the spin row in the contact row layout).
+    enable_rolling_friction: bool = False
     # Consecutive sub-tolerance steps a body's max DOF velocity must hold before it is ready to hibernate. Guards
     # against a body that is only momentarily slow (e.g. at the apex of a toss) sleeping prematurely.
     hibernation_min_steps: int = 10
@@ -2426,9 +2434,6 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     # based on n_dofs: 32 wins for large problems (e.g. dex_hand, n_dofs=62); 16 wins when n_dofs is small or lands in a
     # padding-unfavorable band (e.g. g1_fall, n_dofs=35).
     cholesky_tile_size: int = 32
-    # Number of rank-1 Cholesky updates fused into one column sweep by the CPU per-island incremental factor
-    # (func_rank_batch_update_island). Sizes the nt_vec slots and the static per-column unroll.
-    hessian_rank_update_batch: int = 8
     # Register-streaming tiled per-entity mass factor for the >shared-cap branch of func_factor_mass (GPU forward
     # only). When True, each entity's single-mass-block submatrix factors in registers via the same TileNxN Cholesky
     # primitive as the Hessian, instead of the shared-pivot cooperative LDL^T. Only enabled when every entity is a
@@ -2476,10 +2481,20 @@ class RigidSimStaticConfig(metaclass=AutoInitMeta):
     @property
     def rows_per_contact(self) -> int:
         """Constraint rows per contact: 2 opposing pyramid edges per friction axis with the pyramidal cone, or the
-        normal row plus one row per friction axis with the elliptic cone; torsional friction adds the spin axis."""
+        normal row plus one row per friction axis with the elliptic cone; torsional friction adds the spin axis and
+        rolling friction the two tangent axes."""
+        n_extra_axes = int(self.enable_torsional_friction) + 2 * int(self.enable_rolling_friction)
         if self.enable_elliptic_friction:
-            return 4 if self.enable_torsional_friction else 3
-        return 6 if self.enable_torsional_friction else 4
+            return 3 + n_extra_axes
+        return 4 + 2 * n_extra_axes
+
+    @property
+    def hessian_rank_update_batch(self) -> int:
+        """Number of rank-1 Cholesky updates fused into one column sweep by the CPU per-island incremental factor
+        (func_rank_batch_update_island). Sizes the nt_vec slots and the static per-column unroll: 8 amortizes the
+        active-set flip batching, widened when the coupled elliptic-cone update must stage 2 slots per cone row
+        (see func_cone_rank_update_island)."""
+        return max(8, 2 * self.rows_per_contact)
 
 
 # =========================================== DataManager ===========================================

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -2189,6 +2189,10 @@ def default_friction_torsional():
     return 0.005
 
 
+def default_friction_rolling():
+    return 0.0001
+
+
 def default_dofs_kp(n=6):
     return np.full((n,), fill_value=100.0, dtype=gs.np_float)
 

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -2185,6 +2185,10 @@ def default_friction():
     return 1.0
 
 
+def default_friction_torsional():
+    return 0.005
+
+
 def default_dofs_kp(n=6):
     return np.full((n,), fill_value=100.0, dtype=gs.np_float)
 

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -733,8 +733,11 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
         "group": mj_geom.group[0],
         "data": geom_data,
         "friction": mj_geom.friction[0],
-        "friction_torsional": mj_geom.friction[1],
-        "friction_rolling": mj_geom.friction[2],
+        # MuJoCo only applies torsional friction from condim 4 and rolling friction from condim 6 onward, and the
+        # friction vector carries its defaults on every geom regardless, so the coefficients of a lower-condim geom
+        # must parse as inert or the geom would resist spin or rolling that MuJoCo leaves free.
+        "friction_torsional": mj_geom.friction[1] if mj_geom.condim[0] >= 4 else 0.0,
+        "friction_rolling": mj_geom.friction[2] if mj_geom.condim[0] >= 6 else 0.0,
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
     if is_col:

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -712,6 +712,7 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
         "group": mj_geom.group[0],
         "data": geom_data,
         "friction": mj_geom.friction[0],
+        "friction_torsional": mj_geom.friction[1],
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
     if is_col:

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -713,6 +713,7 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
         "data": geom_data,
         "friction": mj_geom.friction[0],
         "friction_torsional": mj_geom.friction[1],
+        "friction_rolling": mj_geom.friction[2],
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
     if is_col:

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -249,7 +249,7 @@ def build_model(
     return mj
 
 
-def parse_xml(morph, surface):
+def parse_xml(morph, surface, rigid_options=None):
     # Always merge fixed links unless explicitly asked not to do so
     merge_fixed_links, links_to_keep = False, ()
     if isinstance(morph, (gs.morphs.URDF, gs.morphs.Drone)):
@@ -283,6 +283,27 @@ def parse_xml(morph, surface):
 
     # Parsing all equality constraints
     eqs_info = parse_equalities(mj, morph.scale)
+
+    # Friction features the model declares but the rigid options leave disabled parse to inert values; warn so their
+    # absence in the simulation is no surprise. rigid_options is None on the secondary URDF parse, whose compiled
+    # model only carries MuJoCo defaults.
+    if rigid_options is not None:
+        if mj.opt.cone == mujoco.mjtCone.mjCONE_ELLIPTIC and rigid_options.friction_cone != gs.friction_cone.elliptic:
+            gs.logger.warning(
+                "(MJCF) The model declares the elliptic friction cone; set 'friction_cone' to "
+                "'gs.friction_cone.elliptic' to honor it."
+            )
+        geoms_max_condim = mj.geom_condim.max() if mj.ngeom else 3
+        if geoms_max_condim >= 4 and not rigid_options.enable_torsional_friction:
+            gs.logger.warning(
+                "(MJCF) The model declares torsional friction (geom condim >= 4); enable "
+                "'enable_torsional_friction' to honor the parsed coefficients."
+            )
+        if geoms_max_condim >= 6 and not rigid_options.enable_rolling_friction:
+            gs.logger.warning(
+                "(MJCF) The model declares rolling friction (geom condim >= 6); enable "
+                "'enable_rolling_friction' to honor the parsed coefficients."
+            )
 
     return l_infos, links_j_infos, links_g_infos, eqs_info
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -891,8 +891,8 @@ def gs_sim(
         gjk_collision,
         show_viewer,
         mj_sim,
-        torsional_friction=torsional_friction,
         friction_cone=friction_cone,
+        torsional_friction=torsional_friction,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -660,6 +660,19 @@ def gjk_collision(request):
 
 
 @pytest.fixture
+def torsional_friction(request):
+    torsional_friction = None
+    for mark in request.node.iter_markers("torsional_friction"):
+        if mark.args:
+            if torsional_friction is not None:
+                pytest.fail("'torsional_friction' can only be specified once.")
+            (torsional_friction,) = mark.args
+    if torsional_friction is None:
+        torsional_friction = False
+    return torsional_friction
+
+
+@pytest.fixture
 def merge_fixed_links(request):
     merge_fixed_links = None
     for mark in request.node.iter_markers("merge_fixed_links"):
@@ -861,6 +874,7 @@ def gs_sim(
     adjacent_collision,
     gjk_collision,
     friction_cone,
+    torsional_friction,
     show_viewer,
     mj_sim,
 ):
@@ -877,6 +891,7 @@ def gs_sim(
         gjk_collision,
         show_viewer,
         mj_sim,
+        torsional_friction=torsional_friction,
         friction_cone=friction_cone,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -660,16 +660,29 @@ def gjk_collision(request):
 
 
 @pytest.fixture
-def torsional_friction(request):
-    torsional_friction = None
-    for mark in request.node.iter_markers("torsional_friction"):
+def friction_torsional(request):
+    friction_torsional = None
+    for mark in request.node.iter_markers("friction_torsional"):
         if mark.args:
-            if torsional_friction is not None:
-                pytest.fail("'torsional_friction' can only be specified once.")
-            (torsional_friction,) = mark.args
-    if torsional_friction is None:
-        torsional_friction = False
-    return torsional_friction
+            if friction_torsional is not None:
+                pytest.fail("'friction_torsional' can only be specified once.")
+            (friction_torsional,) = mark.args
+    if friction_torsional is None:
+        friction_torsional = False
+    return friction_torsional
+
+
+@pytest.fixture
+def friction_rolling(request):
+    friction_rolling = None
+    for mark in request.node.iter_markers("friction_rolling"):
+        if mark.args:
+            if friction_rolling is not None:
+                pytest.fail("'friction_rolling' can only be specified once.")
+            (friction_rolling,) = mark.args
+    if friction_rolling is None:
+        friction_rolling = False
+    return friction_rolling
 
 
 @pytest.fixture
@@ -874,7 +887,8 @@ def gs_sim(
     adjacent_collision,
     gjk_collision,
     friction_cone,
-    torsional_friction,
+    friction_torsional,
+    friction_rolling,
     show_viewer,
     mj_sim,
 ):
@@ -892,7 +906,8 @@ def gs_sim(
         show_viewer,
         mj_sim,
         friction_cone=friction_cone,
-        torsional_friction=torsional_friction,
+        friction_torsional=friction_torsional,
+        friction_rolling=friction_rolling,
     )
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -18,48 +18,49 @@ def xml_path(request, tmp_path, model_name):
     return file_path
 
 
+def _build_plane_contact_model(model_name, condim, friction, plane_size):
+    """Generate the shared skeleton of the plane-contact MJCF models: one contact default applying to every geom and
+    a plane floor, with the free bodies appended by _add_free_body."""
+    mjcf = ET.Element("mujoco", model=model_name)
+    ET.SubElement(mjcf, "option", timestep="0.01")
+    default = ET.SubElement(mjcf, "default")
+    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim=condim, friction=friction)
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size=plane_size)
+    return mjcf
+
+
+def _add_free_body(mjcf, name, geom_type, geom_size, pos, rgba=None):
+    """Append a free-floating body with a single geom to a plane-contact MJCF model."""
+    body = ET.SubElement(mjcf.find("worldbody"), "body", name=name, pos=pos)
+    geom_kwargs = {} if rgba is None else {"rgba": rgba}
+    ET.SubElement(body, "geom", type=geom_type, size=geom_size, pos="0. 0. 0.", **geom_kwargs)
+    ET.SubElement(body, "joint", name=f"{name}_root", type="free")
+
+
 @pytest.fixture(scope="session")
 def box_plan():
     """Generate an MJCF model for a box on a plane."""
-    mjcf = ET.Element("mujoco", model="one_box")
-    ET.SubElement(mjcf, "option", timestep="0.01")
-    default = ET.SubElement(mjcf, "default")
-    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="3", friction="1. 0.5 0.5")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size="40. 40. 40.")
-    box_body = ET.SubElement(worldbody, "body", name="box", pos="0. 0. 0.3")
-    ET.SubElement(box_body, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.")
-    ET.SubElement(box_body, "joint", name="root", type="free")
+    mjcf = _build_plane_contact_model("box_plan", condim="3", friction="1. 0.5 0.5", plane_size="40. 40. 40.")
+    _add_free_body(mjcf, name="box", geom_type="box", geom_size="0.2 0.2 0.2", pos="0. 0. 0.3")
     return mjcf
 
 
 @pytest.fixture(scope="session")
 def sphere_plane_roll():
     """Generate an MJCF model for a sphere rolling on a plane, with torsional and rolling friction (condim=6)."""
-    mjcf = ET.Element("mujoco", model="sphere_plane_roll")
-    ET.SubElement(mjcf, "option", timestep="0.01")
-    default = ET.SubElement(mjcf, "default")
-    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="6", friction="1. 0.005 0.002")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size="10. 10. 10.")
-    sphere_body = ET.SubElement(worldbody, "body", name="sphere", pos="0. 0. 0.1")
-    ET.SubElement(sphere_body, "geom", type="sphere", size="0.1", pos="0. 0. 0.")
-    ET.SubElement(sphere_body, "joint", name="root", type="free")
+    mjcf = _build_plane_contact_model(
+        "sphere_plane_roll", condim="6", friction="1. 0.005 0.002", plane_size="10. 10. 10."
+    )
+    _add_free_body(mjcf, name="sphere", geom_type="sphere", geom_size="0.1", pos="0. 0. 0.1")
     return mjcf
 
 
 @pytest.fixture(scope="session")
 def sphere_plane_spin():
     """Generate an MJCF model for a sphere spinning in place on a plane, with torsional friction (condim=4)."""
-    mjcf = ET.Element("mujoco", model="sphere_plane_spin")
-    ET.SubElement(mjcf, "option", timestep="0.01")
-    default = ET.SubElement(mjcf, "default")
-    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="4", friction="1. 0.005 0.")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size="10. 10. 10.")
-    sphere_body = ET.SubElement(worldbody, "body", name="sphere", pos="0. 0. 0.1")
-    ET.SubElement(sphere_body, "geom", type="sphere", size="0.1", pos="0. 0. 0.")
-    ET.SubElement(sphere_body, "joint", name="root", type="free")
+    mjcf = _build_plane_contact_model("sphere_plane_spin", condim="4", friction="1. 0.005 0.", plane_size="10. 10. 10.")
+    _add_free_body(mjcf, name="sphere", geom_type="sphere", geom_size="0.1", pos="0. 0. 0.1")
     return mjcf
 
 
@@ -83,19 +84,10 @@ def mimic_hinges():
 
 @pytest.fixture(scope="session")
 def box_box():
-    """Generate an MJCF model for two boxes."""
-    mjcf = ET.Element("mujoco", model="one_box")
-    ET.SubElement(mjcf, "option", timestep="0.01")
-    default = ET.SubElement(mjcf, "default")
-    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="3", friction="1. 0.5 0.5")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size="40. 40. 40.")
-    box1_body = ET.SubElement(worldbody, "body", name="box1", pos="0. 0. 0.2")
-    ET.SubElement(box1_body, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.", rgba="0 1 0 0.4")
-    ET.SubElement(box1_body, "joint", name="root1", type="free")
-    box2_body = ET.SubElement(worldbody, "body", name="box2", pos="0. 0. 0.8")
-    ET.SubElement(box2_body, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.", rgba="0 0 1 0.4")
-    ET.SubElement(box2_body, "joint", name="root2", type="free")
+    """Generate an MJCF model for two boxes stacked on a plane."""
+    mjcf = _build_plane_contact_model("box_box", condim="3", friction="1. 0.5 0.5", plane_size="40. 40. 40.")
+    _add_free_body(mjcf, name="box1", geom_type="box", geom_size="0.2 0.2 0.2", pos="0. 0. 0.2", rgba="0 1 0 0.4")
+    _add_free_body(mjcf, name="box2", geom_type="box", geom_size="0.2 0.2 0.2", pos="0. 0. 0.8", rgba="0 0 1 0.4")
     return mjcf
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -34,6 +34,21 @@ def box_plan():
 
 
 @pytest.fixture(scope="session")
+def sphere_plane_roll():
+    """Generate an MJCF model for a sphere rolling on a plane, with torsional and rolling friction (condim=6)."""
+    mjcf = ET.Element("mujoco", model="sphere_plane_roll")
+    ET.SubElement(mjcf, "option", timestep="0.01")
+    default = ET.SubElement(mjcf, "default")
+    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="6", friction="1. 0.005 0.002")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size="10. 10. 10.")
+    sphere_body = ET.SubElement(worldbody, "body", name="sphere", pos="0. 0. 0.1")
+    ET.SubElement(sphere_body, "geom", type="sphere", size="0.1", pos="0. 0. 0.")
+    ET.SubElement(sphere_body, "joint", name="root", type="free")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def sphere_plane_spin():
     """Generate an MJCF model for a sphere spinning in place on a plane, with torsional friction (condim=4)."""
     mjcf = ET.Element("mujoco", model="sphere_plane_spin")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -34,6 +34,21 @@ def box_plan():
 
 
 @pytest.fixture(scope="session")
+def sphere_plane_spin():
+    """Generate an MJCF model for a sphere spinning in place on a plane, with torsional friction (condim=4)."""
+    mjcf = ET.Element("mujoco", model="sphere_plane_spin")
+    ET.SubElement(mjcf, "option", timestep="0.01")
+    default = ET.SubElement(mjcf, "default")
+    ET.SubElement(default, "geom", contype="1", conaffinity="1", condim="4", friction="1. 0.005 0.")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    ET.SubElement(worldbody, "geom", type="plane", name="floor", pos="0. 0. 0.", size="10. 10. 10.")
+    sphere_body = ET.SubElement(worldbody, "body", name="sphere", pos="0. 0. 0.1")
+    ET.SubElement(sphere_body, "geom", type="sphere", size="0.1", pos="0. 0. 0.")
+    ET.SubElement(sphere_body, "joint", name="root", type="free")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def mimic_hinges():
     mjcf = ET.Element("mujoco", model="mimic_hinges")
     ET.SubElement(mjcf, "compiler", angle="degree")

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -426,6 +426,16 @@ def test_torsional_friction_spin_down_rate(friction_cone, n_envs, show_viewer):
         rtol=0.01,
     )
 
+    # A runtime coefficient update takes effect immediately: the zero-coefficient sphere, still spinning at W0, now
+    # decays exactly like the sphere that carried the same coefficient from the start.
+    spheres[0].set_friction_torsional(spheres_friction_torsional[-1])
+    for _ in range(5):
+        scene.step()
+    w_runtime_start = spheres[0].get_dofs_velocity()[..., 5]
+    for _ in range(10):
+        scene.step()
+    assert_allclose(w_runtime_start - spheres[0].get_dofs_velocity()[..., 5], spin_downs[-1], rtol=0.05, atol=1e-3)
+
 
 @pytest.mark.required
 def test_elliptic_cone_push_isotropy(show_viewer):

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -351,6 +351,107 @@ def test_elliptic_cone_coulomb_isotropy(sparse_solve, use_contact_island, show_v
 
 
 @pytest.mark.required
+@pytest.mark.torsional_friction(True)
+@pytest.mark.parametrize("model_name", ["sphere_plane_spin"])
+@pytest.mark.parametrize(
+    "gs_solver, gs_integrator",
+    [
+        (gs.constraint_solver.Newton, gs.integrator.Euler),
+        pytest.param(
+            gs.constraint_solver.Newton,
+            gs.integrator.Euler,
+            marks=pytest.mark.friction_cone(gs.friction_cone.elliptic),
+            id="Newton-Euler-elliptic",
+        ),
+    ],
+)
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_torsional_friction_mujoco_consistency(gs_sim, mj_sim, tol):
+    # Sliding while spinning couples the tangential and spin axes of the friction cone, so both the pyramidal
+    # torsional pair and the elliptic cone's coupled middle zone are exercised through slip, stick, and rest. The
+    # sphere starts slightly penetrated so the contact exists unambiguously from the first step.
+    qpos = np.array([0.0, 0.0, 0.0999, 1.0, 0.0, 0.0, 0.0])
+    qvel = np.array([0.5, 0.0, 0.0, 0.0, 0.0, 3.0])
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=qpos, qvel=qvel, num_steps=60, tol=tol)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("friction_cone", [gs.friction_cone.pyramidal, gs.friction_cone.elliptic])
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_torsional_friction_spin_down_rate(friction_cone, n_envs, show_viewer):
+    # A sphere spinning about the vertical axis on a plane has a single contact whose only braking torque is
+    # torsional friction: I * dw/dt = -friction_torsional * m * g with I = 2/5 m r^2, so the saturated spin-down
+    # rate is friction_torsional * g / (0.4 r^2), independent of the mass. The elliptic cone at the default
+    # impratio tracks the exact Coulomb bound once fully slipping, including for coefficients far below the
+    # tangential ones; the pyramidal cone's regularized friction decays below that bound, so it asserts the
+    # coefficient ordering of the rates. Coefficients pair by maximum, so the plane's zero coefficient leaves each
+    # sphere decaying at its own rate, and a zero-coefficient sphere never slows down and keeps the normal contact
+    # response of a torsional-free scene (weight-only reported contact force).
+    GRAVITY = 9.81
+    DT = 0.01
+    RADIUS = 0.1
+    W0 = 3.0
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+            gravity=(0.0, 0.0, -GRAVITY),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=friction_cone,
+            enable_torsional_friction=True,
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+        material=gs.materials.Rigid(
+            friction_torsional=0.0,
+        ),
+    )
+    spheres_friction_torsional = (0.0, 0.0001, 0.002, 0.005)
+    spheres = []
+    for i_s, friction_torsional in enumerate(spheres_friction_torsional):
+        spheres.append(
+            scene.add_entity(
+                gs.morphs.Sphere(
+                    radius=RADIUS,
+                    pos=(0.5 * i_s, 0.0, RADIUS),
+                ),
+                material=gs.materials.Rigid(
+                    friction_torsional=friction_torsional,
+                ),
+            )
+        )
+    scene.build(n_envs=n_envs)
+
+    for _ in range(10):
+        scene.step()
+    for sphere in spheres:
+        sphere.set_dofs_velocity([0.0, 0.0, 0.0, 0.0, 0.0, W0])
+    # Let the contact reference dynamics settle into the fully slipping regime before measuring the rate.
+    for _ in range(5):
+        scene.step()
+    w_start = [sphere.get_dofs_velocity()[..., 5] for sphere in spheres]
+    for _ in range(10):
+        scene.step()
+    spin_downs = []
+    for sphere, friction_torsional, w_0 in zip(spheres, spheres_friction_torsional, w_start):
+        spin_down = w_0 - sphere.get_dofs_velocity()[..., 5]
+        spin_downs.append(spin_down)
+        if friction_cone == gs.friction_cone.elliptic or friction_torsional == 0.0:
+            spin_down_rate = friction_torsional * GRAVITY / (0.4 * RADIUS**2)
+            assert_allclose(spin_down, spin_down_rate * 10 * DT, rtol=0.05, atol=1e-3)
+    for spin_down_slow, spin_down_fast in zip(spin_downs[1:], spin_downs[2:]):
+        assert (spin_down_slow < spin_down_fast).all()
+    assert_allclose(
+        torch.linalg.norm(spheres[0].get_links_net_contact_force(), dim=-1).sum(dim=-1),
+        spheres[0].get_mass() * GRAVITY,
+        rtol=0.01,
+    )
+
+
+@pytest.mark.required
 def test_elliptic_cone_push_isotropy(show_viewer):
     N_ENVS = 8
     FRICTION = 0.5

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -438,6 +438,85 @@ def test_torsional_friction_spin_down_rate(friction_cone, n_envs, show_viewer):
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("friction_cone", [gs.friction_cone.pyramidal, gs.friction_cone.elliptic])
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_rolling_friction_deceleration_rate(friction_cone, n_envs, show_viewer):
+    # A sphere rolling without slipping decelerates only through the rolling resistance torque friction_rolling *
+    # m * g: with the rolling constraint v = w * r and I = 2/5 m r^2, dv/dt = -(5/7) * friction_rolling * g / r,
+    # mass-independent. The elliptic cone tracks this exact Coulomb bound; the pyramidal cone decays below it, so
+    # only the rate ordering is asserted. The plane's zero coefficient is inert under the pair-by-maximum rule, and
+    # a zero-coefficient sphere keeps rolling freely with the weight-only contact force of a rolling-free scene.
+    GRAVITY = 9.81
+    DT = 0.01
+    RADIUS = 0.1
+    V0 = 0.5
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+            gravity=(0.0, 0.0, -GRAVITY),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=friction_cone,
+            enable_torsional_friction=True,
+            enable_rolling_friction=True,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.75, -1.8, 0.8),
+            camera_lookat=(0.75, 0.0, 0.1),
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+        material=gs.materials.Rigid(
+            friction_torsional=0.0,
+            friction_rolling=0.0,
+        ),
+    )
+    spheres_friction_rolling = (0.0, 0.001, 0.004)
+    spheres = []
+    for i_s, friction_rolling in enumerate(spheres_friction_rolling):
+        spheres.append(
+            scene.add_entity(
+                gs.morphs.Sphere(
+                    radius=RADIUS,
+                    pos=(0.5 * i_s, 0.0, RADIUS),
+                ),
+                material=gs.materials.Rigid(
+                    friction_rolling=friction_rolling,
+                ),
+            )
+        )
+    scene.build(n_envs=n_envs)
+
+    for _ in range(10):
+        scene.step()
+    for sphere in spheres:
+        sphere.set_dofs_velocity([V0, 0.0, 0.0, 0.0, V0 / RADIUS, 0.0])
+    # Let the contact settle into steady rolling before measuring the deceleration.
+    for _ in range(5):
+        scene.step()
+    v_start = [sphere.get_dofs_velocity()[..., 0] for sphere in spheres]
+    for _ in range(10):
+        scene.step()
+    slow_downs = []
+    for sphere, friction_rolling, v_0 in zip(spheres, spheres_friction_rolling, v_start):
+        slow_down = v_0 - sphere.get_dofs_velocity()[..., 0]
+        slow_downs.append(slow_down)
+        if friction_cone == gs.friction_cone.elliptic or friction_rolling == 0.0:
+            deceleration = (5.0 / 7.0) * friction_rolling * GRAVITY / RADIUS
+            assert_allclose(slow_down, deceleration * 10 * DT, rtol=0.05, atol=1e-3)
+    for slow_down_slow, slow_down_fast in zip(slow_downs[:-1], slow_downs[1:]):
+        assert (slow_down_slow < slow_down_fast).all()
+    assert_allclose(
+        torch.linalg.norm(spheres[0].get_links_net_contact_force(), dim=-1).sum(dim=-1),
+        spheres[0].get_mass() * GRAVITY,
+        rtol=0.01,
+    )
+
+
+@pytest.mark.required
 def test_elliptic_cone_push_isotropy(show_viewer):
     N_ENVS = 8
     FRICTION = 0.5

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -351,42 +351,14 @@ def test_elliptic_cone_coulomb_isotropy(sparse_solve, use_contact_island, show_v
 
 
 @pytest.mark.required
-@pytest.mark.torsional_friction(True)
-@pytest.mark.parametrize("model_name", ["sphere_plane_spin"])
-@pytest.mark.parametrize(
-    "gs_solver, gs_integrator",
-    [
-        (gs.constraint_solver.Newton, gs.integrator.Euler),
-        pytest.param(
-            gs.constraint_solver.Newton,
-            gs.integrator.Euler,
-            marks=pytest.mark.friction_cone(gs.friction_cone.elliptic),
-            id="Newton-Euler-elliptic",
-        ),
-    ],
-)
-@pytest.mark.parametrize("backend", [gs.cpu])
-def test_torsional_friction_mujoco_consistency(gs_sim, mj_sim, tol):
-    # Sliding while spinning couples the tangential and spin axes of the friction cone, so both the pyramidal
-    # torsional pair and the elliptic cone's coupled middle zone are exercised through slip, stick, and rest. The
-    # sphere starts slightly penetrated so the contact exists unambiguously from the first step.
-    qpos = np.array([0.0, 0.0, 0.0999, 1.0, 0.0, 0.0, 0.0])
-    qvel = np.array([0.5, 0.0, 0.0, 0.0, 0.0, 3.0])
-    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=qpos, qvel=qvel, num_steps=60, tol=tol)
-
-
-@pytest.mark.required
 @pytest.mark.parametrize("friction_cone", [gs.friction_cone.pyramidal, gs.friction_cone.elliptic])
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_torsional_friction_spin_down_rate(friction_cone, n_envs, show_viewer):
-    # A sphere spinning about the vertical axis on a plane has a single contact whose only braking torque is
-    # torsional friction: I * dw/dt = -friction_torsional * m * g with I = 2/5 m r^2, so the saturated spin-down
-    # rate is friction_torsional * g / (0.4 r^2), independent of the mass. The elliptic cone at the default
-    # impratio tracks the exact Coulomb bound once fully slipping, including for coefficients far below the
-    # tangential ones; the pyramidal cone's regularized friction decays below that bound, so it asserts the
-    # coefficient ordering of the rates. Coefficients pair by maximum, so the plane's zero coefficient leaves each
-    # sphere decaying at its own rate, and a zero-coefficient sphere never slows down and keeps the normal contact
-    # response of a torsional-free scene (weight-only reported contact force).
+    # I * dw/dt = -friction_torsional * m * g with I = 2/5 m r^2: the saturated spin-down rate is
+    # friction_torsional * g / (0.4 r^2), mass-independent. The elliptic cone tracks this exact Coulomb bound once
+    # fully slipping; the pyramidal cone's regularized friction decays below it, so only the rate ordering is
+    # asserted. The plane's zero coefficient is inert under the pair-by-maximum rule, and a zero-coefficient sphere
+    # keeps the weight-only contact force of a torsional-free scene.
     GRAVITY = 9.81
     DT = 0.01
     RADIUS = 0.1
@@ -400,6 +372,10 @@ def test_torsional_friction_spin_down_rate(friction_cone, n_envs, show_viewer):
         rigid_options=gs.options.RigidOptions(
             friction_cone=friction_cone,
             enable_torsional_friction=True,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.75, -1.8, 0.8),
+            camera_lookat=(0.75, 0.0, 0.1),
         ),
         show_viewer=show_viewer,
     )

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -39,6 +39,33 @@ def multi_free_body_path(tmp_path):
 
 
 @pytest.mark.required
+def test_constraint_capacity_covers_friction_rows(show_viewer):
+    # The island grouping writes one entry per assembled constraint, so its buffers must cover the same bound as
+    # the constraint solver, including the extra torsional and rolling rows per contact.
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            use_contact_island=True,
+            enable_torsional_friction=True,
+            enable_rolling_friction=True,
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    for i_box in range(2):
+        scene.add_entity(
+            gs.morphs.Box(
+                size=(0.2, 0.2, 0.2),
+                pos=(0.0, 0.0, 0.2 + 0.4 * i_box),
+            ),
+        )
+    scene.build()
+    constraint_solver = scene.sim.rigid_solver.constraint_solver
+    assert constraint_solver.constraint_state.island.constraint_id.shape[0] >= constraint_solver.len_constraints
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_partition_logics(show_viewer, n_envs, multi_free_body_path, monkeypatch):
     # The welded pair never touches, so only the equality edge couples them: without it the partition would split them

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -54,6 +54,30 @@ def test_box_plane_dynamics(gs_sim, mj_sim, tol):
 
 
 @pytest.mark.required
+@pytest.mark.torsional_friction(True)
+@pytest.mark.parametrize("model_name", ["sphere_plane_spin"])
+@pytest.mark.parametrize(
+    "gs_solver, gs_integrator",
+    [
+        (gs.constraint_solver.Newton, gs.integrator.Euler),
+        pytest.param(
+            gs.constraint_solver.Newton,
+            gs.integrator.Euler,
+            marks=pytest.mark.friction_cone(gs.friction_cone.elliptic),
+            id="Newton-Euler-elliptic",
+        ),
+    ],
+)
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_torsional_friction(gs_sim, mj_sim, tol):
+    # Sliding while spinning couples the tangential and spin friction axes through slip, stick, and rest. The slight
+    # initial penetration makes the contact exist from the first step.
+    qpos = np.array([0.0, 0.0, 0.0999, 1.0, 0.0, 0.0, 0.0])
+    qvel = np.array([0.5, 0.0, 0.0, 0.0, 0.0, 3.0])
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=qpos, qvel=qvel, num_steps=60, tol=tol)
+
+
+@pytest.mark.required
 @pytest.mark.adjacent_collision(True)
 @pytest.mark.parametrize("model_name", ["chain_capsule_hinge_mesh"])  # FIXME: , "chain_capsule_hinge_capsule"])
 @pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -54,8 +54,14 @@ def test_box_plane_dynamics(gs_sim, mj_sim, tol):
 
 
 @pytest.mark.required
-@pytest.mark.torsional_friction(True)
-@pytest.mark.parametrize("model_name", ["sphere_plane_spin"])
+@pytest.mark.friction_torsional(True)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "sphere_plane_spin",
+        pytest.param("sphere_plane_roll", marks=pytest.mark.friction_rolling(True)),
+    ],
+)
 @pytest.mark.parametrize(
     "gs_solver, gs_integrator",
     [
@@ -69,11 +75,11 @@ def test_box_plane_dynamics(gs_sim, mj_sim, tol):
     ],
 )
 @pytest.mark.parametrize("backend", [gs.cpu])
-def test_torsional_friction(gs_sim, mj_sim, tol):
-    # Sliding while spinning couples the tangential and spin friction axes through slip, stick, and rest. The slight
+def test_torsional_and_rolling_friction(gs_sim, mj_sim, tol):
+    # Sliding while spinning and rolling couples every friction axis through slip, stick, and rest. The slight
     # initial penetration makes the contact exist from the first step.
     qpos = np.array([0.0, 0.0, 0.0999, 1.0, 0.0, 0.0, 0.0])
-    qvel = np.array([0.5, 0.0, 0.0, 0.0, 0.0, 3.0])
+    qvel = np.array([0.5, 0.0, 0.0, 0.0, 4.0, 3.0])
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=qpos, qvel=qvel, num_steps=60, tol=tol)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -690,6 +690,7 @@ def build_genesis_sim(
     mj_sim,
     *,
     friction_cone,
+    torsional_friction=False,
 ):
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
@@ -708,6 +709,7 @@ def build_genesis_sim(
             constraint_solver=gs_solver,
             enable_mujoco_compatibility=mujoco_compatibility,
             friction_cone=friction_cone,
+            enable_torsional_friction=torsional_friction,
             box_box_detection=True,
             enable_self_collision=True,
             enable_adjacent_collision=adjacent_collision,
@@ -1078,8 +1080,28 @@ def check_mujoco_data_consistency(
 
             # Note that 'constraint_solver.active' refers to whether the quadratic part of a constraint is active,
             # unlike Mujoco that defines 'nactive' as the number of active constraints regardless of its type.
-            # In practice, this only makes a difference if frictionloss is enabled.
-            gs_nactive = sum(gs_sim.rigid_solver.constraint_solver.active.to_numpy()[:gs_n_constraints, 0])
+            # In practice, this only makes a difference if frictionloss is enabled. Middle-zone (slipping) elliptic
+            # cone rows are excluded from the per-row quadratic (handled as a coupled block) yet count as active in
+            # Mujoco's stat, which engages a cone as a whole; counting every row of a cone that carries any force
+            # translates Genesis's convention into Mujoco's.
+            gs_counted = gs_sim.rigid_solver.constraint_solver.active.to_numpy()[:gs_n_constraints, 0].copy()
+            gs_n_cone = gs_sim.rigid_solver.constraint_solver.constraint_state.n_constraints_cone.to_numpy()[0]
+            if gs_n_cone:
+                gs_nef = (
+                    gs_sim.rigid_solver.constraint_solver.n_constraints_equality.to_numpy()[0]
+                    + gs_sim.rigid_solver.constraint_solver.n_constraints_frictionloss.to_numpy()[0]
+                )
+                rows_per_contact = gs_sim.rigid_solver.rigid_config.rows_per_contact
+                gs_cones_counted = (
+                    (
+                        gs_counted[gs_nef : gs_nef + gs_n_cone]
+                        | (np.abs(gs_efc_force[gs_nef : gs_nef + gs_n_cone]) > 0.0)
+                    )
+                    .reshape(-1, rows_per_contact)
+                    .any(axis=1)
+                )
+                gs_counted[gs_nef : gs_nef + gs_n_cone] = np.repeat(gs_cones_counted, rows_per_contact)
+            gs_nactive = gs_counted.sum()
             mj_native = mj_sim.data.solver.nactive[mj_iter]
             if not (gs_sim.rigid_solver.dyn_info.dofs.frictionloss.to_numpy() > gs.EPS).any():
                 assert mj_native == gs_nactive

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1092,15 +1092,10 @@ def check_mujoco_data_consistency(
                     + gs_sim.rigid_solver.constraint_solver.n_constraints_frictionloss.to_numpy()[0]
                 )
                 rows_per_contact = gs_sim.rigid_solver.rigid_config.rows_per_contact
-                gs_cones_counted = (
-                    (
-                        gs_counted[gs_nef : gs_nef + gs_n_cone]
-                        | (np.abs(gs_efc_force[gs_nef : gs_nef + gs_n_cone]) > 0.0)
-                    )
-                    .reshape(-1, rows_per_contact)
-                    .any(axis=1)
-                )
-                gs_counted[gs_nef : gs_nef + gs_n_cone] = np.repeat(gs_cones_counted, rows_per_contact)
+                gs_cone_rows = slice(gs_nef, gs_nef + gs_n_cone)
+                gs_cone_rows_counted = gs_counted[gs_cone_rows] | (np.abs(gs_efc_force[gs_cone_rows]) > 0.0)
+                gs_cones_counted = gs_cone_rows_counted.reshape(-1, rows_per_contact).any(axis=1)
+                gs_counted[gs_cone_rows] = np.repeat(gs_cones_counted, rows_per_contact)
             gs_nactive = gs_counted.sum()
             mj_native = mj_sim.data.solver.nactive[mj_iter]
             if not (gs_sim.rigid_solver.dyn_info.dofs.frictionloss.to_numpy() > gs.EPS).any():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -690,7 +690,8 @@ def build_genesis_sim(
     mj_sim,
     *,
     friction_cone,
-    torsional_friction,
+    friction_torsional,
+    friction_rolling,
 ):
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
@@ -709,7 +710,8 @@ def build_genesis_sim(
             constraint_solver=gs_solver,
             enable_mujoco_compatibility=mujoco_compatibility,
             friction_cone=friction_cone,
-            enable_torsional_friction=torsional_friction,
+            enable_torsional_friction=friction_torsional,
+            enable_rolling_friction=friction_rolling,
             box_box_detection=True,
             enable_self_collision=True,
             enable_adjacent_collision=adjacent_collision,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -690,7 +690,7 @@ def build_genesis_sim(
     mj_sim,
     *,
     friction_cone,
-    torsional_friction=False,
+    torsional_friction,
 ):
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
@@ -1085,7 +1085,7 @@ def check_mujoco_data_consistency(
             # Mujoco's stat, which engages a cone as a whole; counting every row of a cone that carries any force
             # translates Genesis's convention into Mujoco's.
             gs_counted = gs_sim.rigid_solver.constraint_solver.active.to_numpy()[:gs_n_constraints, 0].copy()
-            gs_n_cone = gs_sim.rigid_solver.constraint_solver.constraint_state.n_constraints_cone.to_numpy()[0]
+            gs_n_cone = gs_sim.rigid_solver.constraint_solver.n_constraints_cone.to_numpy()[0]
             if gs_n_cone:
                 gs_nef = (
                     gs_sim.rigid_solver.constraint_solver.n_constraints_equality.to_numpy()[0]


### PR DESCRIPTION
## Description

Add opt-in torsional and rolling friction to rigid contacts: every contact can also resist relative spin about its normal (`RigidOptions.enable_torsional_friction`) and rolling about its tangent axes (`RigidOptions.enable_rolling_friction`).

- Per-geom coefficients `gs.materials.Rigid.friction_torsional` / `friction_rolling` (meters, the effective contact patch radius), parsed from MJCF geom `friction[1]` / `friction[2]` (on condim >= 4 / >= 6 geoms, matching when MuJoCo applies them), combined per contact by elementwise maximum, and settable at runtime at geom/link/entity level.
- Parsing an MJCF model that relies on the elliptic cone or condim >= 4 friction while the matching option is disabled fires a warning.
- The pyramidal cone gains one opposing pyramid pair per friction axis (4 -> 6 -> 10 rows per contact); the elliptic cone gains one row per axis (3 -> 4 -> 6) whose regularization carries the squared sliding-to-axis coefficient ratio, with the whole cone machinery made dimension-generic over the cone rows.
- Row construction matches MuJoCo condim=4 and condim=6 to machine precision.
- Three examples document the friction models: `friction_breakaway.py` sweeps constant tangential, torsional, and rolling loads across the analytic Coulomb limits under both cones (documenting the pyramidal cone's limitations at its default `impratio` of 1), `torsional_grasp.py` shows in-hand pivoting, and `rolling_coast.py` a ball coasting to rest.

| `friction_breakaway.py` (pyramidal left, elliptic right) | `torsional_grasp.py` | `rolling_coast.py` |
| :---: | :---: | :---: |
| ![friction breakaway](https://raw.githubusercontent.com/duburcqa/Genesis/4ca9426c46cfa577cc9f87b3b62e4d324e457423/breakaway.gif) | ![torsional grasp](https://raw.githubusercontent.com/duburcqa/Genesis/4ca9426c46cfa577cc9f87b3b62e4d324e457423/torsional_grasp.gif) | ![rolling coast](https://raw.githubusercontent.com/duburcqa/Genesis/4ca9426c46cfa577cc9f87b3b62e4d324e457423/rolling_coast.gif) |

## Motivation and Context

Point contacts transmit no spin or rolling torque, so anything relying on them (a grasped object twisting in a gripper, a ball rolling to rest) moves freely forever; the MJCF torsional and rolling coefficients were silently dropped at parsing. With the option off (default), behavior and performance are unchanged (interleaved A/B benchmark on a contact-dense pile: within noise); enabled, the same scene costs ~12% (elliptic) / ~14% (pyramidal) per step on CPU for torsional friction, and ~28% / ~41% with rolling friction on top, from the extra contact rows, with the Cholesky factor unaffected.

## Related Issue

Addresses the torsional and rolling friction half of https://github.com/Genesis-Embodied-AI/genesis-world/issues/2718 (the per-geom friction priority field remains open).

## How Has This Been / Can This Be Tested?

`pytest tests/rigid/test_friction.py tests/rigid/test_mujoco_parity.py --backend cpu` covers the new tests: MuJoCo condim=4 and condim=6 consistency through slip, stick, and rest for both cones (60-step slide+spin+roll trajectories match at the suite's 64-bit tolerance of 1e-9), the analytic sphere spin-down rate `friction_torsional * g / (0.4 r^2)` including a coefficient far below the tangential ones, zero-coefficient inertness, and runtime coefficient updates, and the analytic rolling deceleration `(5/7) * friction_rolling * g / r`.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


