### PR TITLE
[BUG FIX] Preserve joint armature values specified in MJCF files.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -495,6 +495,16 @@ class Scene(RBC):
                 # watertightening (already-watertight inputs); watertighten does its own feature-preserving QEM.
                 if morph_variant.decimate is None:
                     morph_variant.decimate = morph_variant.convexify
+                # Genesis fills in a default rotor armature for joints whose armature is not specified in the model
+                # file, while MuJoCo's own default may differ. Under MuJoCo compatibility, the default is dropped
+                # unless set manually, deferring to MuJoCo. USD keeps the Genesis default since MuJoCo is not
+                # involved in its parsing.
+                if (
+                    isinstance(morph_variant, (gs.morphs.MJCF, gs.morphs.URDF, gs.morphs.Drone))
+                    and "default_armature" not in morph_variant.model_fields_set
+                    and self._sim.rigid_solver._enable_mujoco_compatibility
+                ):
+                    morph_variant.default_armature = None
 
         entity = self._sim._add_entity(morph, material, surface, visualize_contact, name)
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -989,8 +989,9 @@ class MJCF(FileMorph):
         aligned with the principal axes of inertia. Only applies to root (floating-base) links. Default to False.
         **This is only used for RigidEntity.**
     default_armature : float, optional
-        Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
-        actuated. None to disable. Default to 0.1.
+        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
+        file, regardless of whether it is actuated. None to disable. Defaults to 0.1 if MuJoCo compatibility is
+        disabled on the rigid solver, None otherwise.
     exclude_ground_plane : bool, optional
         Whether to exclude plane geometries authored directly under the MJCF worldbody if any. Defaults to False.
     """
@@ -1130,8 +1131,9 @@ class URDF(FileMorph):
         aligned with the principal axes of inertia. Only applies to root (floating-base) links. Default to False.
         **This is only used for RigidEntity.**
     default_armature : float, optional
-        Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
-        actuated. None to disable. Default to 0.1.
+        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
+        file, regardless of whether it is actuated. None to disable. Defaults to 0.1 if MuJoCo compatibility is
+        disabled on the rigid solver, None otherwise.
     xacro_args : dict, optional
         Key-value pairs to override ``xacro:arg`` declarations in the xacro file
         (e.g. ``{"use_sim": "true", "arm_length": "0.5"}``). Only used for ``.xacro`` files. Defaults to ``{}``.
@@ -1271,8 +1273,9 @@ class Drone(FileMorph):
     links_to_keep : list of str, optional
         A list of link names that should not be skipped during link merging. Defaults to ().
     default_armature : float, optional
-        Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
-        actuated. None to disable. Default to 0.1.
+        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
+        file, regardless of whether it is actuated. None to disable. Defaults to 0.1 if MuJoCo compatibility is
+        disabled on the rigid solver, None otherwise.
     default_base_ang_damping_scale : float, optional
         Default angular damping applied on the floating base that will be rescaled by the total mass.
         None to disable. Default to 1e-5.
@@ -1611,8 +1614,8 @@ class USD(FileMorph):
         Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
         **This is only used for RigidEntity.**
     default_armature : float, optional
-        Default rotor inertia of the actuators. In practice it is applied to all joints regardless of whether they are
-        actuated. None to disable. Default to 0.1.
+        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
+        file, regardless of whether it is actuated. None to disable. Default to 0.1.
 
     Joint Dynamics Options
     ----------------------

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -159,8 +159,11 @@ def build_model(
                 has_armature_by_class[default_elem.attrib.get("class", "main")] = has_armature
                 default_stack.extend((child, has_armature) for child in default_elem.findall("default"))
             # Then walk the kinematic tree while tracking the childclass in effect to resolve each joint's class.
+            # Bodies may be nested under grouping meta-elements (frame, replicate) at any depth.
             for worldbody in mjcf.findall("worldbody"):
-                body_stack = [(elem, "main") for tag in ("body", "frame") for elem in worldbody.findall(tag)]
+                body_stack = [
+                    (elem, "main") for tag in ("body", "frame", "replicate") for elem in worldbody.findall(tag)
+                ]
                 while body_stack:
                     body_elem, childclass = body_stack.pop()
                     childclass = body_elem.attrib.get("childclass", childclass)
@@ -171,7 +174,7 @@ def build_model(
                         if not has_armature_by_class.get(joint_class, False):
                             joint_elem.attrib.setdefault("armature", str(default_armature))
                     body_stack.extend(
-                        (elem, childclass) for tag in ("body", "frame") for elem in body_elem.findall(tag)
+                        (elem, childclass) for tag in ("body", "frame", "replicate") for elem in body_elem.findall(tag)
                     )
 
         # Must pre-process URDF to overwrite default Mujoco compile flags

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -159,10 +159,13 @@ def build_model(
                 has_armature_by_class[default_elem.attrib.get("class", "main")] = has_armature
                 default_stack.extend((child, has_armature) for child in default_elem.findall("default"))
             # Then walk the kinematic tree while tracking the childclass in effect to resolve each joint's class.
-            # Bodies may be nested under grouping meta-elements (frame, replicate) at any depth.
+            # Bodies may be nested under grouping meta-elements (frame, replicate) at any depth, and composite
+            # elements hold joint configuration subelements that take armature like regular joints.
             for worldbody in mjcf.findall("worldbody"):
                 body_stack = [
-                    (elem, "main") for tag in ("body", "frame", "replicate") for elem in worldbody.findall(tag)
+                    (elem, "main")
+                    for tag in ("body", "frame", "replicate", "composite")
+                    for elem in worldbody.findall(tag)
                 ]
                 while body_stack:
                     body_elem, childclass = body_stack.pop()
@@ -174,7 +177,9 @@ def build_model(
                         if not has_armature_by_class.get(joint_class, False):
                             joint_elem.attrib.setdefault("armature", str(default_armature))
                     body_stack.extend(
-                        (elem, childclass) for tag in ("body", "frame", "replicate") for elem in body_elem.findall(tag)
+                        (elem, childclass)
+                        for tag in ("body", "frame", "replicate", "composite")
+                        for elem in body_elem.findall(tag)
                     )
 
         # Must pre-process URDF to overwrite default Mujoco compile flags

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -147,12 +147,32 @@ def build_model(
                 # default value...
                 group.attrib.setdefault(param_name, str(MIN_TIMECONST))
         if default_armature is not None:
-            worldbody = mjcf.find("worldbody")
-            if worldbody is not None:
-                for joint_elem in worldbody.findall(".//joint"):
-                    if joint_elem.attrib.get("type") == "free":
-                        continue
-                    joint_elem.attrib.setdefault("armature", str(default_armature))
+            # The default rotor armature only fills in joints whose armature is authored neither on the element nor
+            # anywhere in their default class chain, so the values authored in the model file are always preserved.
+            # First scan the nested default classes: a class authors armature if itself or any ancestor class sets it.
+            has_armature_by_class = {}
+            default_stack = [(elem, False) for elem in mjcf.findall("default")]
+            while default_stack:
+                default_elem, has_armature = default_stack.pop()
+                joint_elem = default_elem.find("joint")
+                has_armature |= joint_elem is not None and "armature" in joint_elem.attrib
+                has_armature_by_class[default_elem.attrib.get("class", "main")] = has_armature
+                default_stack.extend((child, has_armature) for child in default_elem.findall("default"))
+            # Then walk the kinematic tree while tracking the childclass in effect to resolve each joint's class.
+            for worldbody in mjcf.findall("worldbody"):
+                body_stack = [(elem, "main") for tag in ("body", "frame") for elem in worldbody.findall(tag)]
+                while body_stack:
+                    body_elem, childclass = body_stack.pop()
+                    childclass = body_elem.attrib.get("childclass", childclass)
+                    for joint_elem in body_elem.findall("joint"):
+                        if joint_elem.attrib.get("type") == "free":
+                            continue
+                        joint_class = joint_elem.attrib.get("class", childclass)
+                        if not has_armature_by_class.get(joint_class, False):
+                            joint_elem.attrib.setdefault("armature", str(default_armature))
+                    body_stack.extend(
+                        (elem, childclass) for tag in ("body", "frame") for elem in body_elem.findall(tag)
+                    )
 
         # Must pre-process URDF to overwrite default Mujoco compile flags
         if is_urdf_file:

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -579,6 +579,9 @@ def box_freejoint_offset():
 @pytest.fixture(scope="session")
 def freeflyer_mjcf():
     mjcf = ET.Element("mujoco", model="freeflyer")
+    default = ET.SubElement(mjcf, "default")
+    default_authored = ET.SubElement(default, "default", {"class": "authored"})
+    ET.SubElement(default_authored, "joint", armature="0.0002")
     worldbody = ET.SubElement(mjcf, "worldbody")
     body = ET.SubElement(worldbody, "body", name="base", pos="0 0 1")
     ET.SubElement(body, "joint", type="free")
@@ -592,6 +595,10 @@ def freeflyer_mjcf():
     ET.SubElement(grandchild, "joint", type="slide", axis="1 0 0", armature="42.0")
     ET.SubElement(grandchild, "inertial", pos="0 0 0", mass="0.1", diaginertia="0.0001 0.0001 0.0001")
     ET.SubElement(grandchild, "geom", type="sphere", size="0.01")
+    greatgrandchild = ET.SubElement(grandchild, "body", name="greatgrandchild", pos="0 0 0.1")
+    ET.SubElement(greatgrandchild, "joint", {"type": "slide", "axis": "0 1 0", "class": "authored"})
+    ET.SubElement(greatgrandchild, "inertial", pos="0 0 0", mass="0.1", diaginertia="0.0001 0.0001 0.0001")
+    ET.SubElement(greatgrandchild, "geom", type="sphere", size="0.01")
     return mjcf
 
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -422,8 +422,9 @@ def test_default_armature_freeflyer(xml_path):
     armature = robot.get_dofs_armature()
     assert_allclose(armature[:6], 0.0, tol=gs.EPS)
     assert_allclose(armature[6], DEFAULT_ARMATURE, tol=gs.EPS)
-    if xml_path.endswith(".mjcf"):
-        assert abs(armature[7]) > gs.EPS and abs(armature[7] - DEFAULT_ARMATURE) > gs.EPS
+    if xml_path.endswith(".xml"):
+        assert_allclose(armature[7], 42.0, tol=gs.EPS)
+        assert_allclose(armature[8], 0.0002, tol=gs.EPS)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -678,7 +678,6 @@ def build_genesis_sim(
         file=file,
         convexify=True,
         decompose_robot_error_threshold=float("inf"),
-        default_armature=None,
         align=False,
     )
     if xml_path.endswith(".xml"):


### PR DESCRIPTION
## Description

MJCF/URDF loading injects the default rotor armature (0.1) as an element-level attribute on every joint lacking one. In MJCF, an element attribute takes precedence over `<default>` classes, so armature authored through default classes was silently overridden (e.g. the MuJoCo Menagerie Shadow Hand authors 0.0002 and was simulated with 0.1, a 500x inflation). The injection is now aware of the default class chain (explicit `class`, ancestor `childclass`, nested class inheritance): the default only fills in joints whose armature is authored nowhere in the model file. In addition, when MuJoCo compatibility is enabled, an unset `default_armature` now resolves to None so that MuJoCo's own default applies; a value set manually is honored. USD morphs keep the Genesis default since MuJoCo is not involved in their parsing.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3051

## Motivation and Context

The issue reports an 18x success-rate gap vs MuJoCo on a Shadow Hand in-hand reorientation benchmark with a byte-identical MJCF. The root cause is the armature override: 0.1 instead of the authored 0.0002 amounts to roughly 100 kg of reflected inertia at a fingertip, so the cube cannot back-drive the fingers. It is invisible in quasi-static checks (stick phase, breakaway threshold, settled forces all match MuJoCo bit-for-bit) and only shows in accelerating phases, which is why it survived all the reconciliation attempts reported in the issue, including `enable_mujoco_compatibility=True`.

## How Has This Been / Can This Be Tested?

`test_default_armature_freeflyer` now asserts that armature authored through a default class survives an active `default_armature` injection (fails without this fix), on top of the element-level case. `build_genesis_sim` no longer neutralizes `default_armature`, so the MuJoCo parity suite covers the resolution: compat tests (e.g. `test_walker`) fail on main because the default was injected on top of the model, and `test_stickman` checks the default-class preservation with the default active. The kinetic slip microbenchmark from the issue now matches MuJoCo through breakaway and slip.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
