### PR TITLE
[BUG FIX] Fix host-heap corruption tearing down offscreen EGL context while another renderer is current (#2951 regression)

### DIFF
--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -251,10 +251,9 @@ class OffscreenRenderer(object):
 
     def delete(self):
         """Free all OpenGL resources."""
-        # Do not force this context current before deleting it. The platforms' current-context state is
-        # process/thread-global, so making it current here would clobber the context another renderer may be
-        # using (e.g. while it is mid-render, when this renderer is being torn down by garbage collection).
-        # 'delete_context' makes itself current only when the platform requires it.
+        # The platforms' current-context state is process/thread-global, so 'delete_context' handles the
+        # current-context safety itself: it saves and restores any foreign context (e.g. another renderer
+        # mid-render, when this one is torn down by garbage collection) around destroying its own.
         self._platform.delete_context()
         del self._platform
         self._platform = None

--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -281,14 +281,27 @@ class EGLPlatform(Platform):
         from OpenGL.EGL import eglDestroyContext, eglGetCurrentContext
 
         if self._egl_display is not None:
-            # The EGL current context is per-thread and shared across renderers. Only release it if it is ours;
-            # otherwise another renderer (possibly mid-render) is current and tearing down this context must not
-            # strand it with no current context.
-            if self._egl_context is not None and eglGetCurrentContext() == self._egl_context:
-                self.make_uncurrent()
             if self._egl_context is not None:
+                # All offscreen renderers on a device share one EGLDisplay, and the EGL current context is
+                # per-thread. Calling eglDestroyContext while a *foreign* renderer's context is current on the
+                # shared display corrupts the driver's shared per-display state (observed as a host-heap
+                # use-after-free during GC-triggered teardown, when a renderer is deleted while another is
+                # mid-render). Destroy our context with a well-defined current binding instead: remember any
+                # foreign current context, make ours current, release it (NO_CONTEXT) so it is current to no
+                # thread, destroy it, then restore the foreign context. This neither strands nor clobbers
+                # another renderer's context.
+                current_context = eglGetCurrentContext()
+                restore_context = (
+                    self.save_current_context()
+                    if current_context and current_context != self._egl_context
+                    else None
+                )
+                self.make_current()
+                self.make_uncurrent()
                 eglDestroyContext(self._egl_display, self._egl_context)
                 self._egl_context = None
+                if restore_context is not None:
+                    restore_context()
             # NOTE: intentionally not calling eglTerminate here. The NVIDIA EGL
             # driver does not support terminate/re-initialize cycles on the same
             # device (returns EGL_BAD_ACCESS), which breaks multi-scene workflows.


### PR DESCRIPTION
# Fix host-heap corruption tearing down an offscreen EGL context while another renderer is current (#2951 regression)

## Motivation

(datagen → CUDA-train) crashes non-deterministically
(~50%) with a hard `SIGSEGV` in glibc's allocator (`unlink_chunk` / `_int_malloc`).
The victim wanders run to run — Python GC `visit_decref` at startup, or the NVIDIA
`libcudart` fat-binary/module registry at process exit — the signature of a stray
heap write whose blast radius is "whatever chunk was adjacent."

`git bisect` (v1.1.1..v1.2.0)  pins the first-bad commit to **289af1a4 (#2951 "isolate offscreen GL contexts")** 
The bug is still present on `main` and in v1.2.2.

## Root cause

#2951 changed `EGLPlatform.delete_context()` to call `eglDestroyContext` **cold** —
it releases the current binding only when *our own* context is the one bound on the
calling thread (`eglGetCurrentContext() == self._egl_context`), otherwise it destroys
the context while a **foreign** renderer's context is still current.

But all offscreen renderers on a device share a single `EGLDisplay`
(`eglGetPlatformDisplayEXT(device)` returns the same handle), and the EGL current
context is per-thread. Destroying a context while a foreign context is current on
that shared display drives the driver into a **use-after-free of its shared
per-display bookkeeping**, which lives in the process heap → the stray write.

It's a timing race — whether a foreign renderer is mid-render (its context current)
when GC frees another renderer — hence the ~50% flakiness. It reproduces in datagen
pipelines that render an offscreen camera every step and rebuild scenes across
episodes. Sanitizers miss it because the write lands in a valid heap allocation, and
any timing perturbation (a debugger, single-threading, a faster loop) hides it.

The tell: the **render** path already guards this correctly
(`Rasterizer` uses `save_current_context()` … `restore_context()`); only the
**teardown** path was left destroying a context out from under a foreign binding.

## Solution

Destroy our context with a well-defined current binding: remember any foreign
current context, make ours current, release it (`NO_CONTEXT`) so it is current to no
thread, destroy it, then restore the foreign context. This never strands nor
clobbers another renderer's context — so it also preserves #2951's original intent
(don't disturb a mid-render renderer) while removing the memory corruption.

Only `EGLPlatform` is affected (the pyglet/osmesa platforms are untouched).

## Tests

Validated on the known-failure datagen config (offscreen camera every step + train):

