### PR TITLE
[BUG FIX] Release the offscreen EGL context before destroying it during teardown.

### DIFF
--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -281,12 +281,16 @@ class EGLPlatform(Platform):
         from OpenGL.EGL import eglDestroyContext, eglGetCurrentContext
 
         if self._egl_display is not None:
-            # The EGL current context is per-thread and shared across renderers. Only release it if it is ours;
-            # otherwise another renderer (possibly mid-render) is current and tearing down this context must not
-            # strand it with no current context.
-            if self._egl_context is not None and eglGetCurrentContext() == self._egl_context:
-                self.make_uncurrent()
             if self._egl_context is not None:
+                # The EGL current context is per-thread and shared across renderers. Only release it if it is
+                # ours; otherwise another renderer (possibly mid-render) is current and tearing down this context
+                # must not strand it with no current context. eglGetCurrentContext returns a fresh pointer object
+                # each call that never compares equal to the stored handle by identity, so compare the underlying
+                # addresses instead of the pointer objects.
+                current_addr = ctypes.cast(eglGetCurrentContext(), ctypes.c_void_p).value
+                own_addr = ctypes.cast(self._egl_context, ctypes.c_void_p).value
+                if current_addr == own_addr:
+                    self.make_uncurrent()
                 eglDestroyContext(self._egl_display, self._egl_context)
                 self._egl_context = None
             # NOTE: intentionally not calling eglTerminate here. The NVIDIA EGL


### PR DESCRIPTION
## Description

`EGLPlatform.delete_context` gates releasing the current context on `eglGetCurrentContext() == self._egl_context`. PyOpenGL's EGL context pointers compare by object identity and `eglGetCurrentContext()` returns a fresh object each call, so that equality is never true and the context is never released before `eglDestroyContext`. Comparing the underlying handle addresses makes the guard fire when our own context is the one currently bound, so it is released before being destroyed, while a foreign renderer's current context is still left untouched.

## Related Issue

Related to the offscreen GL context isolation work in #2951, and a minimal alternative to #3075.

## Motivation and Context

The intended "release our context before destroying it" behavior is currently dead code; this restores it. I could not reproduce any crash or corruption from the current behavior (stress-tested destroy-while-current single- and multi-threaded, and through the full render path, on NVIDIA EGL), so this is a correctness fix rather than a fix for a demonstrated failure.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
