### PR TITLE
[MISC] Speed up raycast sensors by splitting the rigid collision BVH into static and dynamic subsets.

### DIFF
--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -541,9 +541,11 @@ def _func_query_contact_depth_penetration_bvh(
     negative when the probe is inside the surface, like ``_func_elastomer_min_signed_dist_bvh``) and returns
     ``max(0, R - sd)`` per radius. This matches the SDF path's ``pen = R - sd`` -- in particular it keeps growing as
     the probe penetrates, rather than folding back at ``R`` like an unsigned closest-point distance. Mirrors
-    ``_func_query_contact_depth_penetration``'s return.
+    ``_func_query_contact_depth_penetration``'s return, with the nearest triangle's signed distance appended so a
+    split-tree caller can select the globally nearest answer (see the kernels' fold).
     """
-    n_triangles = dyn_info.faces.verts_idx.shape[0]
+    # The tree's own leaf count: a compacted-subset tree (see RaycastContext.activate) has fewer leaves than faces.
+    n_triangles = bvh_morton_codes.shape[1]
     radius_query = qd.max(probe_radius_gt, probe_radius_m)
     best_dist_sq = radius_query * radius_query
     best_signed = radius_query
@@ -589,7 +591,7 @@ def _func_query_contact_depth_penetration_bvh(
 
     max_pen_gt = qd.max(gs.qd_float(0.0), probe_radius_gt - best_signed)
     max_pen_m = qd.max(gs.qd_float(0.0), probe_radius_m - best_signed)
-    return max_pen_gt, max_pen_m
+    return max_pen_gt, max_pen_m, best_signed
 
 
 @qd.func
@@ -610,9 +612,11 @@ def _func_query_contact_depth_bvh(
 
     Finds the nearest candidate triangle and its signed distance (sign from the face normal; negative when the probe
     is inside the surface), yielding ``pen = R - sd`` to match the SDF path. The returned contact normal is the
-    nearest triangle's outward face normal, which the spring-damper model uses as the surface normal.
+    nearest triangle's outward face normal, which the spring-damper model uses as the surface normal. The signed
+    distance is appended so a split-tree caller can select the globally nearest answer (see the kernels' fold).
     """
-    n_triangles = dyn_info.faces.verts_idx.shape[0]
+    # The tree's own leaf count: a compacted-subset tree (see RaycastContext.activate) has fewer leaves than faces.
+    n_triangles = bvh_morton_codes.shape[1]
     radius_query = qd.max(probe_radius_gt, probe_radius_m)
     best_dist_sq = radius_query * radius_query
     best_signed = radius_query
@@ -667,7 +671,7 @@ def _func_query_contact_depth_bvh(
     contact_link_m = contact_link if max_pen_m > gs.qd_float(0.0) else gs.qd_int(-1)
     contact_normal_gt = contact_normal if max_pen_gt > gs.qd_float(0.0) else qd.Vector.zero(gs.qd_float, 3)
     contact_normal_m = contact_normal if max_pen_m > gs.qd_float(0.0) else qd.Vector.zero(gs.qd_float, 3)
-    return max_pen_gt, contact_link_gt, contact_normal_gt, max_pen_m, contact_link_m, contact_normal_m
+    return max_pen_gt, contact_link_gt, contact_normal_gt, max_pen_m, contact_link_m, contact_normal_m, best_signed
 
 
 @qd.kernel(fastcache=False)
@@ -681,12 +685,15 @@ def _kernel_contact_depth_probe_bvh(
     probe_radii_noise: qd.types.ndarray(),
     probe_gains: qd.types.ndarray(),
     sensor_candidate_geom_mask: qd.types.ndarray(),
-    bvh_nodes: qd.template(),
-    bvh_morton_codes: qd.template(),
+    bvh_nodes_a: qd.template(),
+    bvh_morton_codes_a: qd.template(),
+    bvh_nodes_b: qd.template(),
+    bvh_morton_codes_b: qd.template(),
     output_gt: qd.types.ndarray(),
     output_measured: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
+    is_split: qd.template(),
 ):
     total_n_probes = probe_positions_local.shape[0]
     n_batches = output_gt.shape[-1]
@@ -716,18 +723,38 @@ def _kernel_contact_depth_probe_bvh(
             func_noised_probe_radius(probe_radius, probe_radius_noise) if probe_radius_noise > gs.EPS else probe_radius
         )
 
-        max_penetration_gt, max_penetration_m = _func_query_contact_depth_penetration_bvh(
+        max_penetration_gt, max_penetration_m, signed_dist = _func_query_contact_depth_penetration_bvh(
             i_b,
             i_s,
             probe_pos,
             probe_radius,
             probe_radius_m,
-            bvh_nodes,
-            bvh_morton_codes,
+            bvh_nodes_a,
+            bvh_morton_codes_a,
             sensor_candidate_geom_mask,
             dyn_state,
             dyn_info,
         )
+        if is_split:
+            # The collision faces are partitioned over two trees (see RaycastContext.activate). Each query answers
+            # for its own nearest triangle, and penetration alone cannot decide between them - a farther inside
+            # triangle out-penetrates a nearer outside one - so the globally nearest answer is the one with the
+            # smaller signed-distance magnitude, taken wholesale.
+            max_penetration_gt_b, max_penetration_m_b, signed_dist_b = _func_query_contact_depth_penetration_bvh(
+                i_b,
+                i_s,
+                probe_pos,
+                probe_radius,
+                probe_radius_m,
+                bvh_nodes_b,
+                bvh_morton_codes_b,
+                sensor_candidate_geom_mask,
+                dyn_state,
+                dyn_info,
+            )
+            if qd.abs(signed_dist_b) < qd.abs(signed_dist):
+                max_penetration_gt = max_penetration_gt_b
+                max_penetration_m = max_penetration_m_b
         max_penetration_m = max_penetration_m * probe_gains[i_b, i_p]
         cache_idx = sensor_cache_start[i_s] + i_p - sensor_probe_start[i_s]
         output_gt[cache_idx, i_b] = max_penetration_gt
@@ -751,13 +778,16 @@ def _kernel_kinematic_taxel_bvh(
     twist_scalar: qd.types.ndarray(),
     n_probes_per_sensor: qd.types.ndarray(),
     sensor_candidate_geom_mask: qd.types.ndarray(),
-    bvh_nodes: qd.template(),
-    bvh_morton_codes: qd.template(),
+    bvh_nodes_a: qd.template(),
+    bvh_morton_codes_a: qd.template(),
+    bvh_nodes_b: qd.template(),
+    bvh_morton_codes_b: qd.template(),
     output_gt: qd.types.ndarray(),
     output_measured: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
     measured_equals_gt: int,
+    is_split: qd.template(),
 ):
     total_n_probes = probe_positions_local.shape[0]
     n_batches = output_gt.shape[-1]
@@ -802,18 +832,49 @@ def _kernel_kinematic_taxel_bvh(
             max_penetration_m,
             contact_link_m,
             contact_normal_m,
+            signed_dist,
         ) = _func_query_contact_depth_bvh(
             i_b,
             i_s,
             probe_pos,
             probe_radius,
             probe_radius_m,
-            bvh_nodes,
-            bvh_morton_codes,
+            bvh_nodes_a,
+            bvh_morton_codes_a,
             sensor_candidate_geom_mask,
             dyn_state,
             dyn_info,
         )
+        if is_split:
+            # See _kernel_contact_depth_probe_bvh for the two-tree fold: the globally nearest answer is the one
+            # with the smaller signed-distance magnitude, taken wholesale so link and normal stay consistent.
+            (
+                max_penetration_gt_b,
+                contact_link_gt_b,
+                contact_normal_gt_b,
+                max_penetration_m_b,
+                contact_link_m_b,
+                contact_normal_m_b,
+                signed_dist_b,
+            ) = _func_query_contact_depth_bvh(
+                i_b,
+                i_s,
+                probe_pos,
+                probe_radius,
+                probe_radius_m,
+                bvh_nodes_b,
+                bvh_morton_codes_b,
+                sensor_candidate_geom_mask,
+                dyn_state,
+                dyn_info,
+            )
+            if qd.abs(signed_dist_b) < qd.abs(signed_dist):
+                max_penetration_gt = max_penetration_gt_b
+                contact_link_gt = contact_link_gt_b
+                contact_normal_gt = contact_normal_gt_b
+                max_penetration_m = max_penetration_m_b
+                contact_link_m = contact_link_m_b
+                contact_normal_m = contact_normal_m_b
 
         gained_pen_m = max_penetration_m * probe_gains[i_b, i_p]
 
@@ -969,6 +1030,8 @@ class ContactDepthProbeSensor(
                 shared_metadata.sensor_candidate_geom_mask,
                 solver.collider._collider_state,
             )
+            collision_bvh_contexts = shared_context.collision_bvh_contexts
+            entry_a, entry_b = collision_bvh_contexts[0], collision_bvh_contexts[-1]
             _kernel_contact_depth_probe_bvh(
                 shared_metadata.probe_sensor_idx,
                 shared_metadata.links_idx,
@@ -979,12 +1042,15 @@ class ContactDepthProbeSensor(
                 shared_metadata.probe_radii_noise,
                 shared_metadata.probe_gains,
                 shared_metadata.sensor_candidate_geom_mask,
-                shared_context.collision_bvh_context.bvh.nodes,
-                shared_context.collision_bvh_context.bvh.morton_codes,
+                entry_a.bvh.nodes,
+                entry_a.bvh.morton_codes,
+                entry_b.bvh.nodes,
+                entry_b.bvh.morton_codes,
                 current_ground_truth_data_T,
                 measured_cols_b,
                 solver.dyn_state,
                 solver.dyn_info,
+                is_split=entry_b is not entry_a,
             )
         if ground_truth_data_timeline is not None:
             ground_truth_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)
@@ -1242,6 +1308,8 @@ class KinematicTaxelSensor(
                 shared_metadata.sensor_candidate_geom_mask,
                 solver.collider._collider_state,
             )
+            collision_bvh_contexts = shared_context.collision_bvh_contexts
+            entry_a, entry_b = collision_bvh_contexts[0], collision_bvh_contexts[-1]
             _kernel_kinematic_taxel_bvh(
                 shared_metadata.probe_sensor_idx,
                 shared_metadata.links_idx,
@@ -1258,13 +1326,16 @@ class KinematicTaxelSensor(
                 shared_metadata.twist_scalar,
                 shared_metadata.n_probes_per_sensor,
                 shared_metadata.sensor_candidate_geom_mask,
-                shared_context.collision_bvh_context.bvh.nodes,
-                shared_context.collision_bvh_context.bvh.morton_codes,
+                entry_a.bvh.nodes,
+                entry_a.bvh.morton_codes,
+                entry_b.bvh.nodes,
+                entry_b.bvh.morton_codes,
                 current_ground_truth_data_T,
                 measured_cols_b,
                 solver.dyn_state,
                 solver.dyn_info,
                 measured_equals_gt,
+                is_split=entry_b is not entry_a,
             )
         if ground_truth_data_timeline is not None:
             ground_truth_data_timeline.at(0, copy=False).copy_(current_ground_truth_data_T.T)

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -1068,7 +1068,8 @@ def _func_elastomer_min_signed_dist_bvh(
     Uses ``max_query_dist`` as the BVH cull radius: probes farther than that from every candidate triangle are
     treated as fully outside (returns ``+max_query_dist``), which downstream maps to depth = 0.
     """
-    n_triangles = dyn_info.faces.verts_idx.shape[0]
+    # The tree's own leaf count: a compacted-subset tree (see RaycastContext.activate) has fewer leaves than faces.
+    n_triangles = bvh_morton_codes.shape[1]
     best_dist = max_query_dist
     best_dist_sq = best_dist * best_dist
     best_signed = max_query_dist
@@ -1123,15 +1124,19 @@ def _kernel_elastomer_probe_depth_bvh(
     probe_positions_local: qd.types.ndarray(),
     probe_radii: qd.types.ndarray(),
     track_geom_mask: qd.types.ndarray(),
-    bvh_nodes: qd.template(),
-    bvh_morton_codes: qd.template(),
+    bvh_nodes_a: qd.template(),
+    bvh_morton_codes_a: qd.template(),
+    bvh_nodes_b: qd.template(),
+    bvh_morton_codes_b: qd.template(),
     probe_depth_buf: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
     max_query_dist: float,
+    is_split: qd.template(),
 ):
     """
-    Per-probe contact depth from the rigid solver's global collision BVH, gated by ``track_geom_mask``.
+    Per-probe contact depth from the rigid solver's collision BVH entries (folded when split), gated by
+    ``track_geom_mask``.
 
     Mirrors ``_kernel_elastomer_probe_depth``'s output contract (write into ``probe_depth_buf``); the dilate
     accumulator consumes the same buffer downstream.
@@ -1151,8 +1156,24 @@ def _kernel_elastomer_probe_depth_bvh(
         probe_world = link_pos + gu.qd_transform_by_quat(probe_local, link_quat)
 
         signed = _func_elastomer_min_signed_dist_bvh(
-            i_b, i_s, probe_world, bvh_nodes, bvh_morton_codes, track_geom_mask, dyn_state, dyn_info, max_query_dist
+            i_b, i_s, probe_world, bvh_nodes_a, bvh_morton_codes_a, track_geom_mask, dyn_state, dyn_info, max_query_dist
         )
+        if is_split:
+            # The collision faces are partitioned over two trees (see RaycastContext.activate); |signed| is the
+            # distance the query minimizes, so the smaller magnitude is the globally nearest triangle's answer.
+            signed_b = _func_elastomer_min_signed_dist_bvh(
+                i_b,
+                i_s,
+                probe_world,
+                bvh_nodes_b,
+                bvh_morton_codes_b,
+                track_geom_mask,
+                dyn_state,
+                dyn_info,
+                max_query_dist,
+            )
+            if qd.abs(signed_b) < qd.abs(signed):
+                signed = signed_b
         probe_depth_buf[i_b, i_p] = qd.max(gs.qd_float(0.0), -signed)
 
 
@@ -1453,8 +1474,10 @@ def _kernel_elastomer_surface_state_via_global_bvh(
     pc_active_envs_mask: qd.types.ndarray(),
     sdf_enter: qd.types.ndarray(),
     sdf_exit: qd.types.ndarray(),
-    global_bvh_nodes: qd.template(),
-    global_bvh_morton_codes: qd.template(),
+    global_bvh_nodes_a: qd.template(),
+    global_bvh_morton_codes_a: qd.template(),
+    global_bvh_nodes_b: qd.template(),
+    global_bvh_morton_codes_b: qd.template(),
     surface_pos_sensor_buf: qd.types.ndarray(),
     surface_entry_pos_sensor_buf: qd.types.ndarray(),
     surface_depth_buf: qd.types.ndarray(),
@@ -1464,13 +1487,14 @@ def _kernel_elastomer_surface_state_via_global_bvh(
     dyn_info: array_class.DynInfo,
     aabb_margin: float,
     max_query_dist: float,
+    is_split: qd.template(),
 ):
     """
     Raycast variant of ``_kernel_elastomer_surface_state_bvh``.
 
     Same outer (env, chunk) traversal over the point-cloud BVH per tracked link, but the inner signed-distance query
-    at each PC point uses ``_func_elastomer_min_signed_dist_bvh`` over the rigid solver's global collision BVH (gated
-    by ``elastomer_candidate_geom_mask``) instead of the analytic SDF. Output contract matches the SDF variant so the
+    at each PC point uses ``_func_elastomer_min_signed_dist_bvh`` over the rigid solver's collision BVH entries
+    (folded when split, gated by ``elastomer_candidate_geom_mask``) instead of the analytic SDF. Output contract matches the SDF variant so the
     dilate / shear pipeline downstream is unchanged.
     """
     n_batches = surface_pos_sensor_buf.shape[0]
@@ -1563,13 +1587,28 @@ def _kernel_elastomer_surface_state_via_global_bvh(
                         i_b,
                         i_s,
                         point_world,
-                        global_bvh_nodes,
-                        global_bvh_morton_codes,
+                        global_bvh_nodes_a,
+                        global_bvh_morton_codes_a,
                         elastomer_candidate_geom_mask,
                         dyn_state,
                         dyn_info,
                         max_query_dist,
                     )
+                    if is_split:
+                        # See _kernel_elastomer_probe_depth_bvh for the two-tree fold.
+                        min_sdf_b = _func_elastomer_min_signed_dist_bvh(
+                            i_b,
+                            i_s,
+                            point_world,
+                            global_bvh_nodes_b,
+                            global_bvh_morton_codes_b,
+                            elastomer_candidate_geom_mask,
+                            dyn_state,
+                            dyn_info,
+                            max_query_dist,
+                        )
+                        if qd.abs(min_sdf_b) < qd.abs(min_sdf):
+                            min_sdf = min_sdf_b
 
                     surface_depth_buf[i_b, i_o] = qd.max(gs.qd_float(0.0), -min_sdf)
 
@@ -2180,18 +2219,23 @@ class ElastomerTaxelSensor(
                 solver.collider._collider_info,
             )
         else:
+            collision_bvh_contexts = shared_context.collision_bvh_contexts
+            entry_a, entry_b = collision_bvh_contexts[0], collision_bvh_contexts[-1]
             _kernel_elastomer_probe_depth_bvh(
                 shared_metadata.probe_sensor_idx,
                 shared_metadata.links_idx,
                 shared_metadata.probe_positions,
                 shared_metadata.probe_radii,
                 shared_metadata.sensor_candidate_geom_mask,
-                shared_context.collision_bvh_context.bvh.nodes,
-                shared_context.collision_bvh_context.bvh.morton_codes,
+                entry_a.bvh.nodes,
+                entry_a.bvh.morton_codes,
+                entry_b.bvh.nodes,
+                entry_b.bvh.morton_codes,
                 shared_metadata.probe_depth_buf,
                 solver.dyn_state,
                 solver.dyn_info,
                 _ELASTOMER_RAYCAST_QUERY_DIST,
+                is_split=entry_b is not entry_a,
             )
         _kernel_elastomer_dilate_accumulate(
             shared_metadata.probe_sensor_idx,
@@ -2254,6 +2298,8 @@ class ElastomerTaxelSensor(
                     BVH_STACK_SIZE,
                 )
             else:
+                collision_bvh_contexts = shared_context.collision_bvh_contexts
+                entry_a, entry_b = collision_bvh_contexts[0], collision_bvh_contexts[-1]
                 _kernel_elastomer_surface_state_via_global_bvh(
                     shared_metadata.links_idx,
                     shared_metadata.sensor_elastomer_geom_start,
@@ -2267,8 +2313,10 @@ class ElastomerTaxelSensor(
                     shared_metadata.pc_active_envs_mask,
                     shared_metadata.shear_anchor_sd_enter,
                     shared_metadata.shear_anchor_sd_exit,
-                    shared_context.collision_bvh_context.bvh.nodes,
-                    shared_context.collision_bvh_context.bvh.morton_codes,
+                    entry_a.bvh.nodes,
+                    entry_a.bvh.morton_codes,
+                    entry_b.bvh.nodes,
+                    entry_b.bvh.morton_codes,
                     shared_metadata.surface_pos_sensor_buf,
                     shared_metadata.surface_entry_pos_sensor_buf,
                     shared_metadata.surface_depth_buf,
@@ -2278,6 +2326,7 @@ class ElastomerTaxelSensor(
                     solver.dyn_info,
                     _ELASTOMER_QUERY_AABB_MARGIN,
                     _ELASTOMER_RAYCAST_QUERY_DIST,
+                    is_split=entry_b is not entry_a,
                 )
             # Invalidate stale surface state for points the BVH did not visit. surface_initialized
             # and entry-pos survive across steps; depth/pos are gated by initialized downstream so

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -16,8 +16,11 @@ from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_nump
 from genesis.utils.raycast_qd import (
     kernel_cast_rays,
     kernel_cast_rays_visual,
-    kernel_update_visual_aabbs,
+    kernel_remap_leaf_faces,
+    kernel_update_subset_aabbs,
     kernel_update_verts_and_aabbs,
+    kernel_update_verts_and_subset_aabbs,
+    kernel_update_visual_aabbs,
 )
 from genesis.vis.rasterizer_context import RasterizerContext
 
@@ -48,37 +51,49 @@ class BVHContext:
     # which visual faces contribute.
     raycast_mask: np.ndarray | None = None
 
-    # True when no link in the solver can be moved by the physics (all links fixed), so its geometry only ever changes
-    # through an explicit set_pos/set_quat (collision) or set_vverts (visual) - all GEOMETRY mutations the subscription
-    # catches. Such an entry skips the per-step rebuild - the dominant cost for static raycasting - and rebuilds only
-    # when flagged.
+    # True when the physics cannot move any of the geometry this BVH covers (every covered collision face sits on a
+    # fixed link; for a visual BVH, all links in the solver are fixed), so that geometry only ever changes through an
+    # explicit set_pos/set_quat (collision) or set_vverts (visual) - all GEOMETRY mutations the subscription catches.
+    # Such an entry skips the per-step rebuild - the dominant cost for static raycasting - and rebuilds only when
+    # flagged.
     maybe_static: bool = False
     # Lazy GEOMETRY subscriber for a static entry, registered on its solver; None for a movable entry (which rebuilds
     # every step regardless). RaycastContext.update polls it: a pending set_pos/set_quat/set_vverts flags for rebuild.
+    # Static collision entries filter it on the fixed links owning their faces, so mutations that cannot move those
+    # links (movable-link teleports, configuration-space setters) never flag a rebuild.
     rebuild_subscriber: Subscriber | None = None
     # Set whenever this entry must rebuild before the next cast: at init, on reset, and when its rebuild_subscriber
     # reveals a set_pos/set_quat/set_vverts since the last build. Ignored by non-static entries, which rebuild every
     # step regardless.
     needs_rebuild: bool = True
     # True when the geometry is bit-identical across envs, so the cast reads one shared copy (batch 0) with coalesced
-    # node loads instead of scattering over n_env identical trees. Recomputed on every rebuild.
+    # node loads instead of scattering over n_env identical trees. Recomputed on every rebuild, except for entries
+    # holding it by construction (see is_env_uniform).
     shared_across_envs: bool = False
+    # True when every build input of this BVH is environment-independent: all covered faces read unbatched fixed
+    # vertices (their links are fixed with batch_fixed_verts=False, so even an explicit env-specific pose is
+    # rejected) and no per-env geom range applies (heterogeneous entities). The per-env trees are then bit-identical
+    # by construction, so shared_across_envs holds permanently and update() spares the AABB comparison.
+    is_env_uniform: bool = False
+    # Global face index at each AABB slot, for a collision BVH over a compacted face subset (see
+    # RaycastContext.activate for the static/dynamic face split); update() rewrites the sorted leaf payloads with it
+    # after every build, so traversals read global faces directly. None when the BVH covers every face in order and
+    # for visual entries.
+    faces_idx: torch.Tensor | None = None
 
 
 class RaycastContext(SharedSensorContext):
     """
     Per-simulator collision/visual raycast BVHs, shared across sensor types that cast rays.
 
-    Holds one ``BVHContext`` per (active solver, mesh type): a collision BVH over a rigid solver's faces and a visual
-    BVH over the vfaces opted into ``material.use_visual_raycasting``.
+    Holds one ``BVHContext`` per (active solver, mesh type): one or two collision BVHs over a rigid solver's faces
+    (see ``activate`` for the static/dynamic face split) and a visual BVH over the vfaces opted into
+    ``material.use_visual_raycasting``.
     """
 
     def __init__(self, sim):
         super().__init__(sim)
         self._bvh_contexts: list[BVHContext] = []
-        # The rigid collision BVH context -- the single entry with no per-vface raycast mask (raycast_mask is None).
-        # Resolved once in ``activate`` (the entry list is fixed after that); ``None`` until then / if no rigid solver.
-        self.collision_bvh_context: BVHContext | None = None
 
     @property
     def bvh_contexts(self) -> list[BVHContext]:
@@ -89,6 +104,13 @@ class RaycastContext(SharedSensorContext):
         if not self._active:
             raise gs.GenesisException("RaycastContext queried before activation; no sensor declared a raycast need.")
         return self._bvh_contexts
+
+    @property
+    def collision_bvh_contexts(self) -> list[BVHContext]:
+        """The rigid solver's collision BVH entries: one or two trees jointly covering every collision face, with
+        global-face leaf payloads (see activate). Empty if no rigid solver is active.
+        """
+        return [entry for entry in self.bvh_contexts if entry.raycast_mask is None]
 
     @staticmethod
     def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
@@ -112,9 +134,16 @@ class RaycastContext(SharedSensorContext):
         """
         Build the per-(solver, mesh-type) BVHs on first activation; idempotent.
 
-        Rigid solvers get a collision BVH covering all collision faces; any solver with entities opting in via
-        ``material.use_visual_raycasting`` gets a visual BVH masked to those vfaces. Collision and visual entries
-        coexist (the cast kernels merge in place).
+        Rigid solvers get collision BVHs over their collision faces, partitioned by owning-link fixedness: faces on
+        fixed links move only on an explicit set_pos/set_quat while faces on movable links move on every step, so
+        giving each group its own tree keeps the static-rebuild skip (and the shared read across envs) available even
+        when movable links share the solver, and scales the per-step rebuild with the movable face count alone. The
+        subsets are cast separately and merged in place, giving the same result as one combined tree; sphere-query
+        consumers (tactile probes) fold both trees the same way. A solver whose faces are all static or all movable
+        keeps a single tree.
+
+        Any solver with entities opting in via ``material.use_visual_raycasting`` gets a visual BVH masked to those
+        vfaces. Collision and visual entries coexist (the cast kernels merge in place).
         """
         if self._active:
             return
@@ -123,45 +152,103 @@ class RaycastContext(SharedSensorContext):
             if not solver.is_active:
                 continue
             n_envs = solver._B
-            # A solver's geometry is static when no link can be moved by the physics (all links fixed); it then changes
-            # only through an explicit set_pos/set_quat/set_vverts, all GEOMETRY mutations the subscription catches.
-            # Applies to both the collision and the visual BVH.
+            # A solver's visual geometry is static when no link can be moved by the physics (all links fixed); it then
+            # changes only through an explicit set_pos/set_quat/set_vverts, all GEOMETRY mutations the subscription
+            # catches. Collision entries refine this to a per-face criterion below.
             maybe_static = all(link.is_fixed for link in solver.links)
             if isinstance(solver, RigidSolver):
                 n_faces = solver.dyn_info.faces.geom_idx.shape[0]
-                aabb = AABB(n_batches=n_envs, n_aabbs=n_faces)
-                bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                self._bvh_contexts.append(BVHContext(solver, bvh, aabb, None, maybe_static))
+                # Fixedness per face, from its owning link. A movable link without collision geoms leaves the tree
+                # unaffected, so a per-face criterion catches static collision meshes the per-link one misses.
+                faces_geom_idx = qd_to_numpy(solver.dyn_info.faces.geom_idx)
+                geoms_link_idx = qd_to_numpy(solver.dyn_info.geoms.link_idx)
+                faces_link_idx = geoms_link_idx[faces_geom_idx]
+                links_is_fixed = np.array([link.is_fixed for link in solver.links])
+                faces_is_static = links_is_fixed[faces_link_idx]
+                # A face whose three vertices live in the unbatched fixed-verts buffer reads env-independent build
+                # inputs; see BVHContext.is_env_uniform.
+                verts_is_fixed = qd_to_numpy(solver.dyn_info.verts.is_fixed)
+                faces_is_env_uniform = verts_is_fixed[qd_to_numpy(solver.dyn_info.faces.verts_idx)].all(axis=1)
+                # Each subset is (faces_idx, is_static), with faces_idx None when the subset covers every face in
+                # order (leaf slot == face index, no remap needed).
+                if faces_is_static.all() or not faces_is_static.any():
+                    subsets = [(None, faces_is_static.all())]
+                else:
+                    subsets = [
+                        (np.nonzero(faces_is_static)[0], True),
+                        (np.nonzero(~faces_is_static)[0], False),
+                    ]
+                for subset_faces_idx, is_subset_static in subsets:
+                    is_env_uniform = not solver._enable_heterogeneous and bool(
+                        faces_is_env_uniform.all()
+                        if subset_faces_idx is None
+                        else faces_is_env_uniform[subset_faces_idx].all()
+                    )
+                    aabb = AABB(
+                        n_batches=n_envs, n_aabbs=n_faces if subset_faces_idx is None else subset_faces_idx.shape[0]
+                    )
+                    bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
+                    faces_idx = None
+                    if subset_faces_idx is not None:
+                        faces_idx = torch.as_tensor(subset_faces_idx, dtype=gs.tc_int, device=gs.device)
+                    # Watch GEOMETRY changes that can reach this entry's faces: filtering the subscription on the
+                    # fixed links owning them keeps movable-link mutations (e.g. a per-step robot teleport) from
+                    # flagging a rebuild, so the static skip survives them.
+                    rebuild_subscriber = None
+                    if is_subset_static:
+                        rebuild_subscriber = Subscriber(
+                            to=frozenset({StateChange.GEOMETRY}),
+                            links_filter=np.unique(
+                                faces_link_idx if subset_faces_idx is None else faces_link_idx[subset_faces_idx]
+                            ),
+                        )
+                        solver.subscribe(rebuild_subscriber)
+                    self._bvh_contexts.append(
+                        BVHContext(
+                            solver,
+                            bvh,
+                            aabb,
+                            raycast_mask=None,
+                            maybe_static=is_subset_static,
+                            shared_across_envs=is_env_uniform and n_envs > 1,
+                            faces_idx=faces_idx,
+                            rebuild_subscriber=rebuild_subscriber,
+                            is_env_uniform=is_env_uniform,
+                        )
+                    )
             n_vfaces = solver.dyn_info.vfaces.vgeom_idx.shape[0]
             if n_vfaces > 0:
                 mask = self._compute_visual_raycast_mask(solver)
                 if mask.any():
                     aabb = AABB(n_batches=n_envs, n_aabbs=n_vfaces)
                     bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                    self._bvh_contexts.append(BVHContext(solver, bvh, aabb, mask, maybe_static))
-
-        self.collision_bvh_context = next((c for c in self._bvh_contexts if c.raycast_mask is None), None)
-
-        # Lazily watch each static BVH (collision or visual) for GEOMETRY changes. ``update`` polls its
-        # rebuild_subscriber so an explicit set_pos / set_quat / set_vverts on the otherwise-immovable geometry forces
-        # the (normally skipped) rebuild before the next cast.
-        for entry in self._bvh_contexts:
-            if entry.maybe_static:
-                entry.rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
-                entry.solver.subscribe(entry.rebuild_subscriber)
+                    # A static visual entry watches every GEOMETRY change: an explicit set_vverts can reshape any
+                    # opted-in vgeom, so its subscription carries no links filter.
+                    rebuild_subscriber = None
+                    if maybe_static:
+                        rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
+                        solver.subscribe(rebuild_subscriber)
+                    self._bvh_contexts.append(
+                        BVHContext(solver, bvh, aabb, mask, maybe_static, rebuild_subscriber=rebuild_subscriber)
+                    )
 
         self.update()
 
     def update(self):
         """Rebuild every BVH whose geometry may have changed since the last cast.
 
-        A static entry (maybe_static: no link the physics can move) is skipped while it is not flagged for rebuild,
-        since its tree would come out unchanged. Its rebuild_subscriber flags it after an explicit
-        set_pos/set_quat/set_vverts, and ``reset`` flags every entry, so a re-randomized terrain or teleported obstacle
-        still rebuilds. Movable entries are never static, so they rebuild on every call.
+        A static entry (maybe_static: the physics cannot move its geometry) is skipped while it is not flagged for
+        rebuild, since its tree would come out unchanged. Its rebuild_subscriber flags it after an explicit
+        set_pos/set_quat/set_vverts that can reach its geometry (see BVHContext.rebuild_subscriber), and ``reset``
+        flags every entry, so a re-randomized terrain or teleported obstacle still rebuilds. Movable entries are
+        never static, so they rebuild on every call.
         """
         if not self._active:
             return
+        # When several collision entries of one rigid solver rebuild in the same call (e.g. after a reset), the
+        # world-space vertices only need refreshing once: the first entry runs the fused verts+AABBs kernel, the
+        # rest fit their AABBs over the already-updated vertices.
+        verts_updated_solver = None
         for entry in self._bvh_contexts:
             # A pending GEOMETRY change means a set_pos/set_quat/set_vverts hit this otherwise-static geometry since the
             # last build; flag it for rebuild and clear the subscriber so the next idle update skips again.
@@ -171,10 +258,29 @@ class RaycastContext(SharedSensorContext):
             if entry.maybe_static and not entry.needs_rebuild:
                 continue
             if entry.raycast_mask is None:
-                kernel_update_verts_and_aabbs(
-                    entry.solver.dyn_state, entry.aabb, entry.solver.dyn_info, entry.solver.rigid_config
-                )
-                entry.bvh.build()
+                if entry.faces_idx is None:
+                    kernel_update_verts_and_aabbs(
+                        entry.solver.dyn_state, entry.aabb, entry.solver.dyn_info, entry.solver.rigid_config
+                    )
+                    entry.bvh.build()
+                else:
+                    subset_aabbs_kernel = (
+                        kernel_update_subset_aabbs
+                        if entry.solver is verts_updated_solver
+                        else kernel_update_verts_and_subset_aabbs
+                    )
+                    subset_aabbs_kernel(
+                        entry.faces_idx,
+                        entry.solver.dyn_state,
+                        entry.aabb,
+                        entry.solver.dyn_info,
+                        entry.solver.rigid_config,
+                    )
+                    entry.bvh.build()
+                    # build() resets the leaf payloads to subset slots; rewrite them to global faces (see
+                    # kernel_remap_leaf_faces) so every traversal is subset-agnostic.
+                    kernel_remap_leaf_faces(entry.faces_idx, entry.bvh.morton_codes)
+                verts_updated_solver = entry.solver
             else:
                 # Reads vverts_state.pos as the source of vvert positions. The buffer is seeded by FK at scene.build()
                 # and refreshed for each user-driven entity via set_vverts; entries set via set_vverts survive across
@@ -190,16 +296,18 @@ class RaycastContext(SharedSensorContext):
             # The per-env trees are bit-identical - so the cast can read one shared copy (batch 0) - exactly when the
             # per-face AABBs they are built from match across envs. Comparing that build input directly (rather than a
             # proxy like link poses or raw verts) captures per-env pose, batched verts, and any per-env geometry
-            # selection at once - so it stays correct whatever feeds the AABBs. A single-env solver gains nothing.
-            if entry.maybe_static and entry.aabb.n_batches > 1:
-                aabb_min = qd_to_torch(entry.aabb.aabbs.min)
-                aabb_max = qd_to_torch(entry.aabb.aabbs.max)
-                entry.shared_across_envs = bool(
-                    torch.equal(aabb_min, aabb_min[:1].expand_as(aabb_min))
-                    and torch.equal(aabb_max, aabb_max[:1].expand_as(aabb_max))
-                )
-            else:
-                entry.shared_across_envs = False
+            # selection at once - so it stays correct whatever feeds the AABBs. A single-env solver gains nothing, and
+            # an env-uniform entry holds the property by construction (see is_env_uniform), sparing the comparison.
+            if not entry.is_env_uniform:
+                if entry.maybe_static and entry.aabb.n_batches > 1:
+                    aabb_min = qd_to_torch(entry.aabb.aabbs.min)
+                    aabb_max = qd_to_torch(entry.aabb.aabbs.max)
+                    entry.shared_across_envs = bool(
+                        torch.equal(aabb_min, aabb_min[:1].expand_as(aabb_min))
+                        and torch.equal(aabb_max, aabb_max[:1].expand_as(aabb_max))
+                    )
+                else:
+                    entry.shared_across_envs = False
 
     def reset(self, envs_idx):
         # A reset may change otherwise-static geometry (re-randomized terrain, teleported obstacles), so force every
@@ -216,8 +324,8 @@ class RaycastContext(SharedSensorContext):
 @dataclass
 class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata):
     # The BVHs cast against each frame live on the shared ``RaycastContext`` (one per active solver per mesh type),
-    # so a Raycaster and a DepthCamera share one set of trees. The first cast entry initializes the output cache
-    # (is_merge=False), the rest merge in closer hits. Per-sensor link poses are gathered via
+    # so a Raycaster and a DepthCamera share one set of trees. The cast entries chain into the output cache; see
+    # write_ray_hit in raycast_qd.py for the merge scheme. Per-sensor link poses are gathered via
     # KinematicSensorMetadataMixin.solver_groups, independent of which BVH is being cast.
 
     # Per-step scratch tensors for sensor link poses, lazily allocated on the first cast (B and n_sensors known).
@@ -321,14 +429,6 @@ class RaycasterSensor(
             self._shared_metadata.no_hit_values, self._options.no_hit_value
         )
 
-        # Multi-BVH merge passes use raw distance comparison to pick the closer hit; this only works if no_hit_value >=
-        # max_range. The negated form also rejects NaN (every IEEE 754 comparison with NaN is False).
-        if len(self._shared_context.bvh_contexts) > 1 and not (self._options.no_hit_value >= self._options.max_range):
-            gs.raise_exception(
-                f"no_hit_value ({self._options.no_hit_value}) must be >= max_range ({self._options.max_range}) "
-                f"when multiple BVHs are active (the merge step compares raw distances)."
-            )
-
     def _get_return_format(self) -> tuple[tuple[int, ...], ...]:
         shape = self._options.pattern.return_shape
         # Distances-only: drop the (*shape, 3) points field so the cache holds just the distances.
@@ -381,8 +481,8 @@ class RaycasterSensor(
             links_pos[:, group.sensor_cols, :] = pos
             links_quat[:, group.sensor_cols, :] = quat
 
-        # First entry initializes the cache (is_merge=False, writes a hit or no_hit_value into every slot). Each
-        # subsequent entry merges in place (is_merge=True, writes only where it found a closer hit).
+        # The entries chain into one output buffer: the first initializes every slot (is_merge=False), each subsequent
+        # one merges in closer hits, and the final one (is_last) settles misses to no_hit_value - see write_ray_hit.
         for i, entry in enumerate(bvh_contexts):
             solver = entry.solver
             args_common = (
@@ -409,6 +509,7 @@ class RaycasterSensor(
                     solver.dyn_info,
                     eps=gs.EPS,
                     is_merge=i > 0,
+                    is_last=i == len(bvh_contexts) - 1,
                     shared_bvh=entry.shared_across_envs,
                 )
             else:
@@ -418,6 +519,7 @@ class RaycasterSensor(
                     solver.dyn_info,
                     eps=gs.EPS,
                     is_merge=i > 0,
+                    is_last=i == len(bvh_contexts) - 1,
                     shared_bvh=entry.shared_across_envs,
                 )
 
@@ -443,11 +545,12 @@ class RaycasterSensor(
             if not self._options.return_world_frame:
                 points = transform_by_trans_quat(points + self.ray_starts, pos, quat)
         else:
-            # Reconstruct the local-frame hit points as distance * unit ray_dir. Missed rays carry no_hit_value as
-            # distance and collapse onto the ray start, matching the (0, 0, 0) stored for them when points are enabled.
+            # Reconstruct the local-frame hit points as distance * unit ray_dir. Missed rays carry exactly
+            # no_hit_value as distance (which may lie below max_range, so an ordering test cannot discriminate) and
+            # collapse onto the ray start, matching the (0, 0, 0) stored for them when points are enabled.
             distances = data.distances.reshape((-1, 1))
             hit_points_local = torch.where(
-                distances < self._options.no_hit_value, distances * normalize(self.ray_dirs), 0.0
+                distances != self._options.no_hit_value, distances * normalize(self.ray_dirs), 0.0
             )
             points = transform_by_trans_quat(hit_points_local + self.ray_starts, pos, quat)
 

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -10,7 +10,7 @@ import torch
 
 import genesis as gs
 import genesis.utils.array_class as array_class
-from genesis.utils.misc import qd_to_torch
+from genesis.utils.misc import qd_to_torch, sanitize_index, tensor_to_array
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.states import QueriedStates
 from genesis.repr_base import RBC
@@ -34,7 +34,38 @@ class StateChange(enum.Enum):
     DYNAMICS = enum.auto()
 
 
-def mutates(*changes: StateChange) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+class MutatedLinks(enum.Enum):
+    """Which links a @mutates-tagged method can affect, consumed by link-filtered subscribers (see Subscriber).
+
+    ALL: any link (the conservative default). ARTICULATED: only links whose pose is a function of the configuration
+    - a configuration-space setter (qpos, dofs) can never displace a fixed link, which carries no degree of freedom
+    (fixed links move only through explicit base-pose setters, whose reach is their link selection). A method whose
+    reach is an explicit link selection instead declares the name of its links-index argument.
+    """
+
+    ALL = enum.auto()
+    ARTICULATED = enum.auto()
+
+
+def _expand_links_subtree(links_idx: np.ndarray, links_parent_idx: np.ndarray) -> np.ndarray:
+    """Close a set of global link indices over their kinematic subtrees: every descendant of a member is a member.
+
+    Iterates one tree level per pass (a link joins when its parent is a member), so it terminates after at most the
+    tree depth."""
+    is_affected = np.zeros(links_parent_idx.shape[0], dtype=bool)
+    is_affected[links_idx] = True
+    has_parent = links_parent_idx >= 0
+    while True:
+        is_expanded = is_affected.copy()
+        is_expanded[has_parent] |= is_affected[links_parent_idx[has_parent]]
+        if (is_expanded == is_affected).all():
+            return np.flatnonzero(is_affected)
+        is_affected = is_expanded
+
+
+def mutates(
+    *changes: StateChange, links: str | MutatedLinks = MutatedLinks.ALL
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Tag a solver state-mutating method with the StateChange categories it produces (one method may produce several,
     e.g. set_state changes both GEOMETRY and DYNAMICS).
 
@@ -42,28 +73,63 @@ def mutates(*changes: StateChange) -> Callable[[Callable[..., Any]], Callable[..
     single notification per StateChange that occurred, when the outermost call returns, rather than one per nested
     call. The outermost call's `envs_idx` (None meaning all envs) is forwarded. Untagged methods, reads included, never
     notify, so a subscriber only ever wakes on a genuine mutation.
+
+    `links` declares which links the method can affect, so link-filtered subscribers can drop notifications that
+    cannot concern them: the name of the argument holding the targeted global link indices (e.g. "links_idx") - the
+    reach then closes over their kinematic subtrees, since forward kinematics carries a new pose to every descendant,
+    fixed children included - MutatedLinks.ARTICULATED for configuration-space setters, or MutatedLinks.ALL when any
+    link may change. Nested tagged calls union their mutated links, an unbounded reach absorbing the rest.
     """
     triggered = frozenset(changes)
 
     def decorator(method: Callable[..., Any]) -> Callable[..., Any]:
         signature = inspect.signature(method)
 
+        def resolve_mutated_links_idx(self: "Solver", bound_arguments) -> np.ndarray | None:
+            if links is MutatedLinks.ARTICULATED:
+                return self._articulated_links_idx
+            if links is MutatedLinks.ALL:
+                return None
+            links_idx = bound_arguments.get(links)
+            if links_idx is None or self._links_parent_idx is None:
+                # The setter substitutes its own default selection (potentially reaching any link), or the solver
+                # exposes no kinematic structure to close the reach over: stay unbounded.
+                return None
+            # sanitize_index covers every index form the setters accept (int, sequence, slice, bool mask, tensor);
+            # the reach set lives host-side, where the subscriber filters compare.
+            links_idx = tensor_to_array(sanitize_index(links_idx, -1, self.n_links, 0, links))
+            return _expand_links_subtree(links_idx, self._links_parent_idx)
+
         @functools.wraps(method)
         def wrapper(self: "Solver", *args: Any, **kwargs: Any) -> Any:
             if not self._subscribers:
                 return method(self, *args, **kwargs)
+            bound_arguments = signature.bind(self, *args, **kwargs).arguments
+            mutated_links_idx = resolve_mutated_links_idx(self, bound_arguments)
             if self._is_mutating:
-                # Nested tagged call: record the changes, let the outermost call do the single notification.
+                # Nested tagged call: record the changes and mutated links, let the outermost call do the single
+                # notification.
                 self._mutation_changes |= triggered
+                if self._mutation_links_idx_list is not None:
+                    if mutated_links_idx is None:
+                        self._mutation_links_idx_list = None
+                    else:
+                        self._mutation_links_idx_list.append(mutated_links_idx)
                 return method(self, *args, **kwargs)
             self._is_mutating = True
             self._mutation_changes = set(triggered)
+            self._mutation_links_idx_list = None if mutated_links_idx is None else [mutated_links_idx]
             try:
                 result = method(self, *args, **kwargs)
             finally:
                 self._is_mutating = False
-            envs_idx = signature.bind(self, *args, **kwargs).arguments.get("envs_idx")
+            envs_idx = bound_arguments.get("envs_idx")
+            links_idx = None
+            if self._mutation_links_idx_list is not None:
+                links_idx = np.concatenate(self._mutation_links_idx_list)
             for subscriber in self._subscribers:
+                if not subscriber.is_watching(links_idx):
+                    continue
                 for changed in self._mutation_changes & subscriber.to:
                     if subscriber.callback is None:
                         subscriber._pending.add(changed)
@@ -84,12 +150,28 @@ class Subscriber:
       - eager (callback given): each matching change immediately calls callback(change, envs_idx);
       - lazy (no callback): matching changes accumulate into `pending` until the owner calls clear() - e.g. a sensor
         that rebuilds a cache on its next update rather than on every set_pos.
+
+    `links_filter` (global link indices, normalized by Solver.subscribe) restricts the subscription to changes that
+    can affect those links: a notification whose mutated links (see mutates) are disjoint from the filter is dropped;
+    a notification with an unbounded reach always passes.
     """
 
-    def __init__(self, to: frozenset[StateChange], callback: Callable[[StateChange, object], None] | None = None):
+    def __init__(
+        self,
+        to: frozenset[StateChange],
+        callback: Callable[[StateChange, object], None] | None = None,
+        links_filter: "np.typing.ArrayLike | None" = None,
+    ):
         self.to = to
         self.callback = callback
+        self.links_filter = links_filter
         self._pending: set[StateChange] = set()
+
+    def is_watching(self, links_idx: np.ndarray | None) -> bool:
+        """Whether a change affecting `links_idx` (None meaning possibly any link) concerns this subscriber."""
+        if self.links_filter is None or links_idx is None:
+            return True
+        return bool(np.isin(links_idx, self.links_filter).any())
 
     @property
     def pending(self) -> frozenset[StateChange]:
@@ -129,12 +211,23 @@ class Solver(RBC):
         self._subscribers: set[Subscriber] = set()
         self._is_mutating = False
         self._mutation_changes: set[StateChange] = set()
+        self._mutation_links_idx_list: list[np.ndarray] | None = None
+        # Global indices of the links whose pose is a function of the configuration, resolving
+        # MutatedLinks.ARTICULATED notifications, and the per-link parent indices (-1 for roots) closing named-links
+        # reaches over kinematic subtrees; None keeps the corresponding notifications unbounded. Set at build by
+        # solvers that expose a kinematic structure (see KinematicSolver).
+        self._articulated_links_idx: np.ndarray | None = None
+        self._links_parent_idx: np.ndarray | None = None
 
     def _add_force_field(self, force_field):
         self._ffs.append(force_field)
 
     def subscribe(self, subscriber: Subscriber):
         """Register a Subscriber to be notified after any @mutates-tagged method whose change is in its filter."""
+        if subscriber.links_filter is not None:
+            subscriber.links_filter = tensor_to_array(
+                sanitize_index(subscriber.links_filter, -1, self.n_links, 0, "links_filter")
+            )
         self._subscribers.add(subscriber)
 
     def build(self):

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -18,7 +18,7 @@ from genesis.utils.misc import (
     assign_indexed_tensor,
 )
 
-from .base_solver import Solver, StateChange, mutates
+from .base_solver import MutatedLinks, Solver, StateChange, mutates
 from .rigid.abd.misc import (
     kernel_init_dof_fields,
     kernel_init_link_fields,
@@ -214,6 +214,10 @@ class KinematicSolver(Solver):
 
         for entity in self._entities:
             entity._build()
+
+        # Resolve the link-reach structures of @mutates notifications; see Solver.__init__.
+        self._articulated_links_idx = np.array([link.idx for link in self.links if not link.is_fixed])
+        self._links_parent_idx = np.array([link.parent_idx for link in self.links])
 
         self._n_qs = self.n_qs
         self._n_dofs = self.n_dofs
@@ -771,7 +775,7 @@ class KinematicSolver(Solver):
 
         return tensor_, inputs_idx_, envs_idx_
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links="links_idx")
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -827,7 +831,7 @@ class KinematicSolver(Solver):
             links_idx, envs_idx, pos_grad_, self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config
         )
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links="links_idx")
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -895,7 +899,7 @@ class KinematicSolver(Solver):
             links_idx, envs_idx, quat_grad_, self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config
         )
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links=MutatedLinks.ARTICULATED)
     def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, skip_forward=False):
         if gs.use_zerocopy:
             data = qd_to_torch(self.rigid_info.qpos, transpose=True, copy=False)
@@ -941,7 +945,7 @@ class KinematicSolver(Solver):
             self._is_forward_pos_updated = False
             self._is_forward_vel_updated = False
 
-    @mutates(StateChange.DYNAMICS)
+    @mutates(StateChange.DYNAMICS, links=MutatedLinks.ARTICULATED)
     def set_dofs_velocity(self, velocity, dofs_idx=None, envs_idx=None, *, skip_forward=False):
         if gs.use_zerocopy:
             vel = qd_to_torch(self.dyn_state.dofs.vel, transpose=True, copy=False)
@@ -1008,7 +1012,7 @@ class KinematicSolver(Solver):
             velocity_grad_ = velocity_grad_.unsqueeze(0)
         kernel_set_dofs_velocity_grad(dofs_idx, envs_idx, velocity_grad_, self.dyn_state, self.rigid_config)
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links=MutatedLinks.ARTICULATED)
     def set_dofs_position(self, position, dofs_idx=None, envs_idx=None):
         position, dofs_idx, envs_idx = self._sanitize_io_variables(
             position, dofs_idx, self.n_dofs, "dofs_idx", envs_idx, skip_allocation=True

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -28,7 +28,7 @@ from genesis.utils.misc import (
 )
 from genesis.utils.sdf import SDF
 
-from ..base_solver import Solver, StateChange, mutates
+from ..base_solver import MutatedLinks, Solver, StateChange, mutates
 from ..kinematic_solver import KinematicSolver, _select_links_offset, _offset_world_shift, _fill_base_link_geom_offsets
 from .collider import Collider
 from .constraint import ConstraintSolver
@@ -1846,7 +1846,7 @@ class RigidSolver(KinematicSolver):
     def set_links_pos(self, pos, links_idx=None, envs_idx=None):
         raise DeprecationError("This method has been removed. Please use 'set_base_links_pos' instead.")
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links="links_idx")
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -1968,7 +1968,7 @@ class RigidSolver(KinematicSolver):
     def set_links_quat(self, quat, links_idx=None, envs_idx=None):
         raise DeprecationError("This method has been removed. Please use 'set_base_links_quat' instead.")
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links="links_idx")
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
@@ -2165,7 +2165,7 @@ class RigidSolver(KinematicSolver):
             friction_ratio = friction_ratio[None]
         kernel_set_geoms_friction_ratio(geoms_idx, envs_idx, friction_ratio, self.dyn_state, self.rigid_config)
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links=MutatedLinks.ARTICULATED)
     def set_qpos(self, qpos, qs_idx=None, envs_idx=None, *, skip_forward=False):
         if self.collider is not None:
             self.collider.reset(envs_idx)
@@ -2409,7 +2409,7 @@ class RigidSolver(KinematicSolver):
     def set_dofs_limit(self, lower, upper, dofs_idx=None, envs_idx=None):
         self._set_dofs_info([lower, upper], dofs_idx, "limit", envs_idx)
 
-    @mutates(StateChange.GEOMETRY)
+    @mutates(StateChange.GEOMETRY, links=MutatedLinks.ARTICULATED)
     def set_dofs_position(self, position, dofs_idx=None, envs_idx=None):
         self.collider.reset(envs_idx)
         self.constraint_solver.reset(envs_idx)

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -55,13 +55,14 @@ def bvh_ray_cast(
     Returns
     -------
     hit_face : gs.qd_int
-        index of the hit triangle (-1 if no hit)
+        index of the hit (global) triangle (-1 if no hit)
     hit_distance : gs.qd_float
         distance to hit point (unchanged max_range if no hit)
     hit_normal : qd.math.vec3
         normal vector at hit point (zero vector if no hit)
     """
-    n_triangles = dyn_info.faces.verts_idx.shape[0]
+    # The BVH's own leaf count. For a subset BVH this is the subset size, smaller than the solver's face count.
+    n_triangles = bvh_morton_codes.shape[1]
 
     hit_face = -1
     closest_distance = gs.qd_float(max_range)
@@ -83,7 +84,7 @@ def bvh_ray_cast(
 
         if aabb_t >= 0.0 and aabb_t < closest_distance:
             if node.left == -1:  # Leaf node
-                # Get original triangle/face index
+                # The leaf payload carries the global face index; see kernel_remap_leaf_faces.
                 sorted_leaf_idx = node_idx - (n_triangles - 1)
                 i_f = qd.cast(bvh_morton_codes[i_b, sorted_leaf_idx][1], gs.qd_int)
 
@@ -277,13 +278,16 @@ def triangle_face_normal(v0: qd.types.vector(3), v1: qd.types.vector(3), v2: qd.
 
 
 @qd.func
-def update_aabbs(
+def update_face_aabb(
+    i_a: int,
+    i_f: int,
+    i_b: int,
     dyn_state: array_class.DynState,
     aabb_state: qd.template(),
     dyn_info: array_class.DynInfo,
     rigid_config: qd.template(),
 ):
-    """Update per-face collision AABBs from current vertex positions.
+    """Fit AABB slot i_a to face i_f from current vertex positions.
 
     A face contributes to env i_b only if its geom lies in that env's active geom range (links_info.geom_start /
     geom_end); otherwise its AABB is left inverted (unhittable) and skipped by ray queries. For a homogeneous solver
@@ -291,25 +295,50 @@ def update_aabbs(
     one vertex buffer but activate different per-env geom ranges, it makes each env cast against only its own variant
     instead of the union of every variant.
     """
-    for i_b, i_f in qd.ndrange(dyn_state.free_verts.pos.shape[1], dyn_info.faces.verts_idx.shape[0]):
-        aabb_state.aabbs[i_b, i_f].min.fill(qd.math.inf)
-        aabb_state.aabbs[i_b, i_f].max.fill(-qd.math.inf)
+    aabb_state.aabbs[i_b, i_a].min.fill(qd.math.inf)
+    aabb_state.aabbs[i_b, i_a].max.fill(-qd.math.inf)
 
-        i_g = dyn_info.faces.geom_idx[i_f]
-        i_l = dyn_info.geoms.link_idx[i_g]
-        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
-        if dyn_info.links.geom_start[I_l] <= i_g and i_g < dyn_info.links.geom_end[I_l]:
-            for i in qd.static(range(3)):
-                i_v = dyn_info.faces.verts_idx[i_f][i]
-                i_fv = dyn_info.verts.verts_state_idx[i_v]
-                if dyn_info.verts.is_fixed[i_v]:
-                    pos_v = dyn_state.fixed_verts.pos[i_fv]
-                    aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                    aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
-                else:
-                    pos_v = dyn_state.free_verts.pos[i_fv, i_b]
-                    aabb_state.aabbs[i_b, i_f].min = qd.min(aabb_state.aabbs[i_b, i_f].min, pos_v)
-                    aabb_state.aabbs[i_b, i_f].max = qd.max(aabb_state.aabbs[i_b, i_f].max, pos_v)
+    i_g = dyn_info.faces.geom_idx[i_f]
+    i_l = dyn_info.geoms.link_idx[i_g]
+    I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+    if dyn_info.links.geom_start[I_l] <= i_g and i_g < dyn_info.links.geom_end[I_l]:
+        for i in qd.static(range(3)):
+            i_v = dyn_info.faces.verts_idx[i_f][i]
+            i_fv = dyn_info.verts.verts_state_idx[i_v]
+            if dyn_info.verts.is_fixed[i_v]:
+                pos_v = dyn_state.fixed_verts.pos[i_fv]
+                aabb_state.aabbs[i_b, i_a].min = qd.min(aabb_state.aabbs[i_b, i_a].min, pos_v)
+                aabb_state.aabbs[i_b, i_a].max = qd.max(aabb_state.aabbs[i_b, i_a].max, pos_v)
+            else:
+                pos_v = dyn_state.free_verts.pos[i_fv, i_b]
+                aabb_state.aabbs[i_b, i_a].min = qd.min(aabb_state.aabbs[i_b, i_a].min, pos_v)
+                aabb_state.aabbs[i_b, i_a].max = qd.max(aabb_state.aabbs[i_b, i_a].max, pos_v)
+
+
+@qd.func
+def update_aabbs(
+    dyn_state: array_class.DynState,
+    aabb_state: qd.template(),
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    """Update the per-face collision AABBs of a BVH covering every face in order. See update_face_aabb."""
+    for i_b, i_f in qd.ndrange(dyn_state.free_verts.pos.shape[1], dyn_info.faces.verts_idx.shape[0]):
+        update_face_aabb(i_f, i_f, i_b, dyn_state, aabb_state, dyn_info, rigid_config)
+
+
+@qd.func
+def update_subset_aabbs(
+    faces_idx: qd.types.ndarray(ndim=1),
+    dyn_state: array_class.DynState,
+    aabb_state: qd.template(),
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    """Update the per-face collision AABBs of a BVH covering the compacted face subset `faces_idx` (slot i_a holds
+    face faces_idx[i_a]), so the rebuild scales with the subset size. See update_face_aabb."""
+    for i_b, i_a in qd.ndrange(dyn_state.free_verts.pos.shape[1], faces_idx.shape[0]):
+        update_face_aabb(i_a, faces_idx[i_a], i_b, dyn_state, aabb_state, dyn_info, rigid_config)
 
 
 @qd.kernel
@@ -321,6 +350,42 @@ def kernel_update_verts_and_aabbs(
 ):
     func_update_all_verts(dyn_state, dyn_info, rigid_config)
     update_aabbs(dyn_state, aabb_state, dyn_info, rigid_config)
+
+
+@qd.kernel
+def kernel_update_verts_and_subset_aabbs(
+    faces_idx: qd.types.ndarray(ndim=1),
+    dyn_state: array_class.DynState,
+    aabb_state: qd.template(),
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    func_update_all_verts(dyn_state, dyn_info, rigid_config)
+    update_subset_aabbs(faces_idx, dyn_state, aabb_state, dyn_info, rigid_config)
+
+
+@qd.kernel
+def kernel_update_subset_aabbs(
+    faces_idx: qd.types.ndarray(ndim=1),
+    dyn_state: array_class.DynState,
+    aabb_state: qd.template(),
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    update_subset_aabbs(faces_idx, dyn_state, aabb_state, dyn_info, rigid_config)
+
+
+@qd.kernel
+def kernel_remap_leaf_faces(faces_idx: qd.types.ndarray(ndim=1), bvh_morton_codes: qd.template()):
+    """Rewrite the sorted leaf payloads of a compacted-subset BVH from subset slots to global face indices.
+
+    Run once after each such build (build() recomputes the payloads); every traversal then reads global faces
+    directly, with no per-leaf indirection and no knowledge of the subset. A zero-copy view write would be preferred
+    for a pure accessor like this, but quadrants' DLPack export does not support u32 fields, so the kernel is the
+    only implementation.
+    """
+    for i_b, i in qd.ndrange(bvh_morton_codes.shape[0], bvh_morton_codes.shape[1]):
+        bvh_morton_codes[i_b, i][1] = qd.cast(faces_idx[qd.cast(bvh_morton_codes[i_b, i][1], gs.qd_int)], qd.u32)
 
 
 # =========================================== Visual Mesh Raycasting ===========================================
@@ -510,18 +575,23 @@ def write_ray_hit(
     ray_direction_world,
     ray_dir_local,
     is_world_frame: qd.types.ndarray(ndim=1),
+    max_ranges: qd.types.ndarray(ndim=1),
     no_hit_values: qd.types.ndarray(ndim=1),
     sensor_return_points: qd.types.ndarray(ndim=1),
     output_hits: qd.types.ndarray(ndim=2),
     eps: float,
     is_merge: qd.template(),
+    is_last: qd.template(),
 ):
     """Common post-BVH write block for both collision and visual cast kernels.
 
-    `is_merge` is a compile-time flag. When False the function writes a value into every output slot (hit or
-    no_hit_value), initializing the cache. When True the function only writes when it found a closer hit than what
-    is already in the cache, so multiple BVH casts can be composed by chaining calls (first with is_merge=False,
-    subsequent with is_merge=True) into the same output buffer with no scratch storage.
+    `is_merge` and `is_last` are compile-time flags marking a cast's position in a chain of BVH passes sharing one
+    output buffer (first pass is_merge=False, subsequent passes is_merge=True, final pass is_last=True): the first
+    pass writes a value into every slot, and each later pass only overwrites a slot when it found a closer hit, so
+    the chain composes with no scratch storage. A miss must not beat a real hit from another pass whatever the
+    sensor's ``no_hit_value`` (it may be below max_range, e.g. 0 or -1): a miss on a non-final pass seeds the slot
+    with ``max_range`` - a hit is always strictly below it, so a hit wins every distance comparison - and
+    ``no_hit_value`` is stamped only by the final pass, over any slot still holding that sentinel.
 
     `sensor_return_points[i_s]` gates the hit-point writes; a distances-only sensor skips them.
     """
@@ -540,12 +610,20 @@ def write_ray_hit(
             output_hits[i_p_offset + i_p_sensor * 3 + 1, i_b] = hit_point.y
             output_hits[i_p_offset + i_p_sensor * 3 + 2, i_b] = hit_point.z
     elif not is_merge:
-        # No hit
+        # First-pass miss: zero the point and seed the distance - no_hit_value if this pass is also the last (single
+        # BVH), else the max_range sentinel so a later pass's hit wins.
         if sensor_return_points[i_s]:
             output_hits[i_p_offset + i_p_sensor * 3 + 0, i_b] = 0.0
             output_hits[i_p_offset + i_p_sensor * 3 + 1, i_b] = 0.0
             output_hits[i_p_offset + i_p_sensor * 3 + 2, i_b] = 0.0
-        output_hits[i_p_dist, i_b] = no_hit_values[i_s]
+        if is_last:
+            output_hits[i_p_dist, i_b] = no_hit_values[i_s]
+        else:
+            output_hits[i_p_dist, i_b] = max_ranges[i_s]
+    elif is_last:
+        # Final-pass miss: a slot still at the sentinel means every pass missed, so stamp no_hit_value.
+        if output_hits[i_p_dist, i_b] >= max_ranges[i_s]:
+            output_hits[i_p_dist, i_b] = no_hit_values[i_s]
 
 
 @qd.kernel
@@ -569,13 +647,15 @@ def kernel_cast_rays(
     dyn_info: array_class.DynInfo,
     eps: float,
     is_merge: qd.template(),
+    is_last: qd.template(),
     shared_bvh: qd.template(),
 ):
     """Cast rays against a collision-mesh BVH.
 
-    See write_ray_hit for `is_merge` semantics. The result `output_hits` is a 2D array of shape (total_cache_size,
-    n_env) where in the first dimension each sensor's data is stored as [sensor_points (n_points * 3), sensor_ranges
-    (n_points)], the point block being present only for sensors with sensor_return_points set.
+    See write_ray_hit for `is_merge` / `is_last` semantics. The result `output_hits` is a 2D array of shape
+    (total_cache_size, n_env) where in the first dimension each sensor's data is stored as [sensor_points
+    (n_points * 3), sensor_ranges (n_points)], the point block being present only for sensors with
+    sensor_return_points set.
 
     shared_bvh is a compile-time flag set when the collision geometry is identical across envs; the cast then reads a
     single BVH copy (batch 0) for every env. It also selects the thread -> (ray, env) mapping below, so the homogeneous
@@ -639,11 +719,13 @@ def kernel_cast_rays(
             ray_direction_world,
             ray_dir_local,
             is_world_frame,
+            max_ranges,
             no_hit_values,
             sensor_return_points,
             output_hits,
             eps,
             is_merge,
+            is_last,
         )
 
 
@@ -668,6 +750,7 @@ def kernel_cast_rays_visual(
     dyn_info: array_class.DynInfo,
     eps: float,
     is_merge: qd.template(),
+    is_last: qd.template(),
     shared_bvh: qd.template(),
 ):
     """Visual-mesh variant of kernel_cast_rays.
@@ -727,9 +810,11 @@ def kernel_cast_rays_visual(
             ray_direction_world,
             ray_dir_local,
             is_world_frame,
+            max_ranges,
             no_hit_values,
             sensor_return_points,
             output_hits,
             eps,
             is_merge,
+            is_last,
         )

--- a/tests/core/test_misc.py
+++ b/tests/core/test_misc.py
@@ -1,6 +1,7 @@
 """Tests for the entity naming system."""
 
 import os
+import xml.etree.ElementTree as ET
 
 import numpy as np
 import pytest
@@ -401,13 +402,38 @@ def test_gs_mesh_sample_point_cloud_wrapper():
     assert_allclose(np.linalg.norm(normals, axis=1), 1.0, tol=1e-5)
 
 
+@pytest.fixture
+def two_link_fixed_urdf():
+    robot = ET.Element("robot", name="two_link_fixed")
+    ET.SubElement(robot, "link", name="base")
+    child = ET.SubElement(robot, "link", name="child")
+    collision = ET.SubElement(child, "collision")
+    geometry = ET.SubElement(collision, "geometry")
+    ET.SubElement(geometry, "box", size="0.1 0.1 0.1")
+    joint = ET.SubElement(robot, "joint", name="weld", type="fixed")
+    ET.SubElement(joint, "parent", link="base")
+    ET.SubElement(joint, "child", link="child")
+    ET.SubElement(joint, "origin", xyz="0 0 0.1")
+    return ET.tostring(robot, encoding="unicode")
+
+
 @pytest.mark.required
-def test_solver_state_change_subscribers(show_viewer):
+def test_solver_state_change_subscribers(show_viewer, two_link_fixed_urdf):
     # Imported lazily: the solver package pulls in quadrants kernels that need gs.qd_float, set only by gs.init.
     from genesis.engine.solvers.base_solver import StateChange, Subscriber
 
     scene = gs.Scene(show_viewer=show_viewer)
-    scene.add_entity(gs.morphs.Plane())
+    plane = scene.add_entity(gs.morphs.Plane())
+    # A fixed entity whose collision geometry lives on a fixed child link, the common URDF/MJCF layout: teleporting
+    # it through its base link must reach subscribers watching the child.
+    tower = scene.add_entity(
+        gs.morphs.URDF(
+            file=two_link_fixed_urdf,
+            pos=(2.0, 0.0, 0.0),
+            fixed=True,
+            merge_fixed_links=False,
+        )
+    )
     cube = scene.add_entity(
         gs.morphs.Box(
             size=(0.2, 0.2, 0.2),
@@ -479,6 +505,38 @@ def test_solver_state_change_subscribers(show_viewer):
     solver.subscribe(both)
     cube.set_pos([[0.0, 0.0, 4.0], [0.0, 0.0, 5.0]])
     assert both.pending == frozenset({StateChange.GEOMETRY, StateChange.DYNAMICS})
+
+    # A link-filtered subscriber only wakes on changes that can affect its links. The plane's base link is fixed, so
+    # the cube's base-pose setter (an explicit, disjoint link selection) and its configuration-space setters (which
+    # can never displace a link without degrees of freedom) both stay silent.
+    plane_watcher = Subscriber(to=frozenset({StateChange.GEOMETRY}), links_filter=[plane.base_link_idx])
+    solver.subscribe(plane_watcher)
+    cube.set_pos([[0.0, 0.0, 6.0], [0.0, 0.0, 7.0]], zero_velocity=False)
+    cube.set_qpos([[0.0, 0.0, 8.0, 1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 9.0, 1.0, 0.0, 0.0, 0.0]])
+    assert plane_watcher.pending == frozenset()
+    # A base-pose setter naming a watched link wakes it.
+    plane.set_pos((0.0, 0.0, -0.1))
+    assert plane_watcher.pending == frozenset({StateChange.GEOMETRY})
+    plane_watcher.clear()
+    # A base-pose setter with the implicit selection (every base link, the watched fixed one included) wakes it
+    # too. The pose is env-agnostic: an env-specific pose on a fixed link would require batch_fixed_verts.
+    solver.set_base_links_pos(solver.get_links_pos(links_idx=solver._base_links_idx)[0])
+    assert plane_watcher.pending == frozenset({StateChange.GEOMETRY})
+    plane_watcher.clear()
+    # A base-pose setter reaches the named links' whole kinematic subtree (forward kinematics carries the new pose
+    # to every descendant): teleporting the fixed tower through its base link wakes a watcher of its fixed child
+    # link, where the collision geometry lives.
+    child_link = next(link for link in tower.links if link.name == "child")
+    child_watcher = Subscriber(to=frozenset({StateChange.GEOMETRY}), links_filter=[child_link.idx])
+    solver.subscribe(child_watcher)
+    cube.set_pos([[0.0, 0.0, 10.0], [0.0, 0.0, 11.0]], zero_velocity=False)
+    assert child_watcher.pending == frozenset()
+    tower.set_pos((2.0, 1.0, 0.0))
+    assert child_watcher.pending == frozenset({StateChange.GEOMETRY})
+
+    # A whole-state restore may move any link, so the unbounded reach always passes the filter.
+    scene.reset()
+    assert plane_watcher.pending == frozenset({StateChange.GEOMETRY})
 
 
 @pytest.mark.parametrize("backend", [None])

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -581,11 +581,13 @@ def test_shared_context(show_viewer):
     assert len(contexts) == 1
     assert isinstance(contexts[0], RaycastContext)
     # Both raycast-casting sensor types resolve to that single instance, so they cast against the very same BVH list
-    # (one collision BVH, not one built per sensor type).
+    # instead of one built per sensor type.
     assert raycaster._shared_context is contexts[0]
     assert depth_camera._shared_context is contexts[0]
     assert raycaster._shared_context.bvh_contexts is depth_camera._shared_context.bvh_contexts
-    assert len(raycaster._shared_context.bvh_contexts) == 1
+    # The plane+box scene mixes static and dynamic collision faces, so the shared collision mesh is split into a
+    # static and a dynamic BVH - two entries, both shared by the two sensor types.
+    assert len(raycaster._shared_context.bvh_contexts) == 2
     # A sensor type that declares no context resolves to None.
     assert imu._shared_context is None
 

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -518,6 +518,14 @@ def test_heterogeneous_object(show_viewer, tol):
             gs.morphs.Box(size=(0.6, 0.6, 0.6), pos=(1.0, 0.0, 0.5), fixed=True),
         ),
     )
+    # A movable entity parked off the ray's path: it makes the solver mixed, so the heterogeneous variants are served
+    # through the static subset of the split collision BVH.
+    movable_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.05, 0.4, 0.4),
+            pos=(3.0, 2.0, 0.5),
+        )
+    )
     lidar = scene.add_sensor(
         gs.sensors.Lidar(
             entity_idx=sensor_mount.idx,
@@ -533,15 +541,282 @@ def test_heterogeneous_object(show_viewer, tol):
     distances = lidar.read().distances[:, 0, 0]
     assert_allclose(distances, (0.9, 0.8, 0.7), tol=5e-3)
 
-    # The per-env trees differ (each masks the other variant), so the cast must not share one tree across envs.
-    collision_bvh = next(entry for entry in lidar._shared_context.bvh_contexts if entry.raycast_mask is None)
-    assert collision_bvh.maybe_static
-    assert not collision_bvh.shared_across_envs
+    # The per-env trees differ (each masks the other variant), so the static subset must not share one tree across
+    # envs, while still keeping the rebuild skip.
+    collision_entries = [entry for entry in lidar._shared_context.bvh_contexts if entry.raycast_mask is None]
+    assert len(collision_entries) == 2
+    static_bvh = next(entry for entry in collision_entries if entry.maybe_static)
+    assert not static_bvh.shared_across_envs
 
     # The static BVH is rebuilt only when its geometry actually changes - exactly what is necessary, nothing more: an
     # idle step records no change (rebuild skipped), while a set_pos records a pending change (rebuild scheduled).
-    subscriber = collision_bvh.rebuild_subscriber
+    subscriber = static_bvh.rebuild_subscriber
     scene.step()
     assert not subscriber.pending
     het_obstacle.set_pos((1.0, 0.0, 0.5))
     assert subscriber.pending
+
+    # The movable box slides into the ray's path: the dynamic subset merges its closer hit identically in every env,
+    # in front of each env's own static variant.
+    movable_box.set_pos((0.5, 0.0, 0.5))
+    scene.step()
+    assert_allclose(lidar.read().distances[:, 0, 0], 0.475, tol=5e-3)
+
+    # And back out: each env again sees exactly its own variant through the (skipped) static subset.
+    movable_box.set_pos((3.0, 2.0, 0.5))
+    scene.step()
+    assert_allclose(lidar.read().distances[:, 0, 0], (0.9, 0.8, 0.7), tol=5e-3)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_static_dynamic_bvh_split_merge(show_viewer, n_envs, tol, monkeypatch):
+    MOUNT_Z = 3.0
+    STATIC_TOP_Z = 1.0
+    VISUAL_TOP_Z = 0.5
+    DYNAMIC_TOP_Z = 2.4  # dynamic box (edge 0.4) centered at z=2.2
+    FAR_POS = (5.0, 5.0, 0.2)
+    NO_HIT = -1.0  # below max_range on purpose: a miss must still lose the merge against any real hit
+    DT = 0.01
+    TACTILE_POS = (10.0, 0.0)  # tactile cluster, laterally away from the ray corridor
+    PAD_POS_Z = 0.0025  # pad half-height 0.003: rests 0.5mm into the table so the table becomes a probe candidate
+    TACTILE_BOX_BOTTOM_Z = -0.001
+    PROBE_RADIUS = 0.005
+    PROBE_1_LOCAL_Z = -0.002  # world z=0.0005: 0.5mm above the table top, 1.5mm inside the box above its bottom face
+    PROBE_2_LOCAL = (0.018, 0.0, 0.002)  # world z=0.0045: 2mm inside the box's x side face, the nearest face overall
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+            gravity=(0.0, 0.0, 0.0),
+        ),
+        show_viewer=show_viewer,
+    )
+    static_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(1.0, 1.0, 1.0),
+            pos=(0.0, 0.0, 0.5),
+            fixed=True,
+            batch_fixed_verts=False,
+        )
+    )
+    visual_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(1.0, 1.0, 0.5),
+            pos=(0.0, 0.0, 0.25),
+            fixed=True,
+            collision=False,
+        ),
+        material=gs.materials.Rigid(
+            use_visual_raycasting=True,
+        ),
+    )
+    mount = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.05, 0.05, 0.05),
+            pos=(0.0, 0.0, MOUNT_Z),
+            fixed=True,
+            collision=False,
+        )
+    )
+    dynamic_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.4, 0.4, 0.4),
+            pos=FAR_POS,
+        )
+    )
+    # Tactile cluster: a movable sensor pad resting 0.5mm into a fixed table (static tree) with a movable box pressed
+    # through it (dynamic tree), so its probes hold candidates in both trees.
+    table = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.4, 0.4, 0.1),
+            pos=(*TACTILE_POS, -0.05),
+            fixed=True,
+            batch_fixed_verts=False,
+        )
+    )
+    pad = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.04, 0.04, 0.006),
+            pos=(*TACTILE_POS, PAD_POS_Z),
+        )
+    )
+    tactile_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.04, 0.04, 0.04),
+            pos=(*TACTILE_POS, TACTILE_BOX_BOTTOM_Z + 0.02),
+        )
+    )
+    depth_probe = scene.add_sensor(
+        gs.sensors.ContactDepthProbe(
+            entity_idx=pad.idx,
+            probe_local_pos=((0.0, 0.0, PROBE_1_LOCAL_Z), PROBE_2_LOCAL),
+            probe_radius=PROBE_RADIUS,
+            contact_depth_query="raycast",
+        )
+    )
+    taxel = scene.add_sensor(
+        gs.sensors.KinematicTaxel(
+            entity_idx=pad.idx,
+            probe_local_pos=((0.0, 0.0, PROBE_1_LOCAL_Z), PROBE_2_LOCAL),
+            probe_radius=PROBE_RADIUS,
+            normal_stiffness=100.0,
+            normal_damping=0.0,
+            shear_scalar=0.0,
+            twist_scalar=0.0,
+            contact_depth_query="raycast",
+        )
+    )
+    sensor = scene.add_sensor(
+        gs.sensors.Raycaster(
+            pattern=gs.sensors.raycaster.GridPattern(resolution=1.0, size=(0.0, 0.0), direction=(0.0, 0.0, -1.0)),
+            entity_idx=mount.idx,
+            return_world_frame=False,
+            no_hit_value=NO_HIT,
+        )
+    )
+    distances_only_sensor = scene.add_sensor(
+        gs.sensors.Raycaster(
+            pattern=gs.sensors.raycaster.GridPattern(resolution=1.0, size=(0.0, 0.0), direction=(0.0, 0.0, -1.0)),
+            entity_idx=mount.idx,
+            return_world_frame=False,
+            return_points=False,
+            no_hit_value=NO_HIT,
+        )
+    )
+    scene.build(n_envs=n_envs)
+
+    def assert_distances(expected, tol=gs.EPS):
+        assert_allclose(sensor.read().distances, expected, tol=tol)
+        assert_allclose(distances_only_sensor.read().distances, expected, tol=tol)
+
+    # The solver mixes static (fixed-link) and dynamic (movable-link) collision faces, so its collision mesh is split
+    # into one compacted BVH per group; the visual box contributes a third, visual entry.
+    collision_entries = [entry for entry in sensor._shared_context.bvh_contexts if entry.raycast_mask is None]
+    assert len(collision_entries) == 2
+    static_entry = next(entry for entry in collision_entries if entry.maybe_static)
+    dynamic_entry = next(entry for entry in collision_entries if not entry.maybe_static)
+    assert static_entry.faces_idx is not None and dynamic_entry.faces_idx is not None
+    # The static box declines batched fixed verts, so the static tree's build inputs are env-independent and the
+    # shared read across envs holds by construction, sparing the per-rebuild AABB comparison.
+    assert static_entry.is_env_uniform
+    assert not dynamic_entry.is_env_uniform
+
+    # Count the static tree rebuilds from here on: the point of the split is that only genuine motion of the fixed
+    # geometry triggers one.
+    static_builds = []
+
+    def spying_build(build=static_entry.bvh.build):
+        static_builds.append(None)
+        build()
+
+    monkeypatch.setattr(static_entry.bvh, "build", spying_build)
+
+    # Dynamic box parked far away: the ray hits the static box top through the static BVH; the closer static hit
+    # must survive the dynamic (miss) and visual (farther hit) merge passes.
+    scene.step()
+    assert_distances(MOUNT_Z - STATIC_TOP_Z)
+
+    # Tactile probes fold both trees by the globally nearest triangle. The step above populated the candidate
+    # contact pairs (pad-table, pad-box); the contact response displaced the interpenetrating movable pair, so their
+    # poses are restored before sampling the sensors alone. Probe 1 is nearer to the table face (0.5mm outside,
+    # static tree) than to the box bottom (1.5mm inside): a fold selecting by deepest penetration instead of
+    # smallest signed-distance magnitude would report the box's larger depth. Probe 2 is nearest to the box's x side
+    # face (2mm inside, dynamic tree).
+    pad.set_pos((*TACTILE_POS, PAD_POS_Z))
+    tactile_box.set_pos((*TACTILE_POS, TACTILE_BOX_BOTTOM_Z + 0.02))
+    scene.sim._sensor_manager.step()
+    probe_1_world_z = PAD_POS_Z + PROBE_1_LOCAL_Z
+    assert_allclose(
+        depth_probe.read_ground_truth(),
+        (PROBE_RADIUS - probe_1_world_z, PROBE_RADIUS + 0.002),
+        tol=1e-6,
+    )
+    # The taxel's contact normal must come from the same nearest triangle: the table's upward face at probe 1 (the
+    # box's deeper answer would push along its bottom face's downward normal instead).
+    assert (taxel.read_ground_truth().force[..., 0, 2] > gs.EPS).all()
+    # Park the tactile pair apart: left interpenetrating, the contact response keeps ejecting them across the scene.
+    pad.set_pos((*TACTILE_POS, 1.0))
+    tactile_box.set_pos((10.0, 3.0, 1.0))
+
+    # Dynamic box under the ray, above the static box: the closer dynamic hit wins the merge. Its set_pos cannot
+    # move the fixed links, so the link-filtered subscription must never even flag the static tree.
+    dynamic_box.set_pos((0.0, 0.0, DYNAMIC_TOP_Z - 0.2))
+    assert not static_entry.rebuild_subscriber.pending
+    scene.step()
+    assert_distances(MOUNT_Z - DYNAMIC_TOP_Z)
+    assert not static_builds
+
+    # Dynamic box parked again: back to the static hit (the dynamic BVH tracked the motion).
+    dynamic_box.set_pos(FAR_POS)
+    scene.step()
+    assert_distances(MOUNT_Z - STATIC_TOP_Z)
+
+    # Teleporting the static box is an explicit set_pos on otherwise-static geometry: it must flag the skipped static
+    # BVH for rebuild, after which the ray falls through to the visual box - a first-pass miss followed by a last-pass
+    # hit, the ordering that would report NO_HIT if a miss stamped it before the merge completed. Both collision
+    # trees rebuild in that update, so the solver's world-space vertices must refresh exactly once: the fused kernel
+    # serves the first entry and the AABBs-only kernel the second.
+    from genesis.engine.sensors import raycaster as raycaster_module
+
+    subset_kernel_calls = []
+
+    def spying_kernel(name, kernel):
+        def spy(*args, **kwargs):
+            subset_kernel_calls.append(name)
+            kernel(*args, **kwargs)
+
+        return spy
+
+    monkeypatch.setattr(
+        raycaster_module,
+        "kernel_update_verts_and_subset_aabbs",
+        spying_kernel("kernel_update_verts_and_subset_aabbs", raycaster_module.kernel_update_verts_and_subset_aabbs),
+    )
+    monkeypatch.setattr(
+        raycaster_module,
+        "kernel_update_subset_aabbs",
+        spying_kernel("kernel_update_subset_aabbs", raycaster_module.kernel_update_subset_aabbs),
+    )
+    static_box.set_pos((5.0, -5.0, 0.5))
+    assert static_entry.rebuild_subscriber.pending
+    scene.step()
+    assert_distances(MOUNT_Z - VISUAL_TOP_Z)
+    assert len(static_builds) == 1
+    assert subset_kernel_calls == ["kernel_update_verts_and_subset_aabbs", "kernel_update_subset_aabbs"]
+
+    # Same ordering with the hit coming from the middle (dynamic) pass instead of the last (visual) one.
+    dynamic_box.set_pos((0.0, 0.0, DYNAMIC_TOP_Z - 0.2))
+    scene.step()
+    assert_distances(MOUNT_Z - DYNAMIC_TOP_Z)
+
+    # Move everything out of the ray's path: only a miss on every pass settles to no_hit_value.
+    visual_box.set_pos((5.0, 0.0, 0.25))
+    dynamic_box.set_pos(FAR_POS)
+    scene.step()
+    assert_distances(NO_HIT)
+
+    # Physics-driven motion: a constant downward velocity moves the dynamic box without any GEOMETRY event, so the
+    # static BVH keeps skipping its rebuild (nothing pending, nothing flagged) while the dynamic BVH tracks the fall.
+    dynamic_box.set_pos((0.0, 0.0, DYNAMIC_TOP_Z - 0.2))
+    dynamic_box.set_dofs_velocity((0.0, 0.0, -1.0), dofs_idx_local=slice(0, 3))
+    scene.step()
+    assert_distances(MOUNT_Z - DYNAMIC_TOP_Z + DT, tol=tol)
+    assert static_entry.maybe_static
+    assert not static_entry.needs_rebuild
+    assert not static_entry.rebuild_subscriber.pending
+    scene.step()
+    assert_distances(MOUNT_Z - DYNAMIC_TOP_Z + 2 * DT, tol=tol)
+
+    # A reset restores the initial poses, possibly of fixed links (here the teleported static box), so it must
+    # rebuild the static tree; static entries resume skipping on subsequent steps.
+    scene.reset()
+    scene.step()
+    assert_distances(MOUNT_Z - STATIC_TOP_Z)
+    assert len(static_builds) == 2
+
+    if n_envs > 0:
+        # Identical fixed geometry in every env: the static tree is read once for all envs; the dynamic tree is
+        # per-env by construction.
+        assert static_entry.shared_across_envs
+        assert not dynamic_entry.shared_across_envs


### PR DESCRIPTION
## Description

Supersedes #2878 by @Kashu7100: the static/dynamic split idea, the leaf-slot remap, and the max_range-sentinel merge scheme originate there (the "multi-depth" decomposition from RPL, arXiv:2602.03002).

Follow-up to #2867: its static-rebuild skip only engages when every link in the solver is fixed, so the common RL case - one moving robot on a large static terrain - rebuilds the combined collision BVH over every face each step. This PR partitions the collision faces by owning-link fixedness into two compacted BVHs: static (built once, then skipped and shared across envs) and dynamic (rebuilds scaling with the robot's face count). They are cast separately and merged in place, giving results identical to a single tree.

## Implementation

- After each subset build, a tiny kernel rewrites the sorted leaf payloads to global face indices, so every traversal (sensor cast, viewer pick, tactile probe) is subset-agnostic and the cast kernels keep their pre-split signatures and codegen.
- Staticness is judged per face (its owning link), so a movable link without collision geoms no longer disables the static-rebuild skip.
- GEOMETRY notifications carry the links a setter can reach (`@mutates(..., links=...)`: the links-index argument for base-pose setters - which CAN name fixed links - `MutatedLinks.ARTICULATED` for configuration-space setters (a fixed link has no degree of freedom), and unbounded otherwise), and `Subscriber` gains a `links_filter` dropping disjoint notifications. A named-links reach closes over the kinematic subtrees (forward kinematics carries a base pose to every descendant, fixed children included). A static collision entry subscribes filtered on the fixed links owning its faces, so per-step teleports and configuration resets of movable state never flag a rebuild, at zero per-step cost.
- When several collision entries of one solver rebuild in the same update (e.g. after a reset), the world-space vertices refresh once: fused verts+AABBs kernel for the first entry, AABBs-only for the rest.
- A static tree whose faces all read unbatched fixed vertices (`batch_fixed_verts=False` links, whose env-specific poses are rejected by construction) in a non-heterogeneous solver is bit-identical across envs by construction: `shared_across_envs` holds permanently and the per-rebuild AABB comparison is spared.
- Tactile raycast-mode probes fold both trees per query by smallest signed-distance magnitude - each tree answers for its own nearest triangle, and penetration alone cannot decide between them (a farther inside triangle out-penetrates a nearer outside one) - reproducing the single-tree result exactly, link/normal included; the fold compiles out for single-tree solvers.
- The `no_hit_value >= max_range` guard is removed: an intermediate miss seeds a `max_range` sentinel that any real hit beats, and `no_hit_value` is stamped only by the final pass.

## Motivation and Context

Checkout-interleaved A/B/A/B against main (default Terrain, 41.7k static faces + Franka, 2.3k rays/env, distances-only):

- CUDA, 1024 envs: 72.4 -> 9.5 ms/step (7.7x); CPU, single env: 7.9 -> 2.6 ms/step (3.1x)
- Per-step configuration teleport of the robot (a GEOMETRY event every step, dropped by the link-filtered subscription): CUDA 82.0 ms/step on main -> 15.4 (5.3x; the remaining delta over the teleport-free arm is `set_qpos` itself, which costs 9.7 ms/step on main); CPU 2.44 ms/step, indistinguishable from the teleport-free arm

## How Has This Been Tested?

- One new packed test, `test_static_dynamic_bvh_split_merge` (n_envs in {0, 2}): split structure and by-construction env sharing, three-pass merge (static + dynamic + visual) with `no_hit_value=-1 < max_range`, rebuild on explicit `set_pos` with static-build counts (zero across dynamic-only teleports and physics motion - the filtered subscription never even flags - exactly one per genuine static move or reset), the single vertex refresh on a both-trees rebuild, a distances-only sensor sharing the chain, and a tactile cluster with probe candidates in both trees pinning the nearest-triangle fold (depth values analytic to 1e-6, taxel normal source included).
- `test_solver_state_change_subscribers` extended with `links_filter` coverage: disjoint base-pose and configuration-space setters stay silent; watched-fixed-link setters (explicit, implicit all-base-links selection, and through a fixed child link of a teleported base - the reach closes over kinematic subtrees) and whole-state restores wake the subscriber. The sdf-vs-raycast parity test runs over the split as well.
- `test_shared_context` expects the two-entry split; `test_heterogeneous_object` extended with a movable box (per-env variant gating through the static subset).

## Checklist

- [x] I read the CONTRIBUTING document.
- [x] I tagged the title correctly ([MISC]).
- [x] I added tests (`test_static_dynamic_bvh_split_merge`; extended `test_heterogeneous_object`, `test_shared_context`, `test_solver_state_change_subscribers`).
- [x] All existing tests pass (CI).
