### PR TITLE
[MISC] Fix unit test from timing out.

### DIFF
--- a/examples/usd/kitchen.py
+++ b/examples/usd/kitchen.py
@@ -34,7 +34,10 @@ FULL_ROOM_ASSETS = ("Lightwheel_Kitchen/KitchenRoom.usd", ["Lightwheel_Kitchen/*
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
-        "--asset", default="all", choices=[*SAMPLE_ASSETS, "all"], help="Which sample asset(s) to load."
+        "--asset",
+        default="bottle" if "PYTEST_VERSION" in os.environ else "all",
+        choices=[*SAMPLE_ASSETS, "all"],
+        help="Which sample asset(s) to load.",
     )
     parser.add_argument("--full", action="store_true", help="Load the entire kitchen scene instead of the samples.")
     parser.add_argument("-v", "--vis", action="store_true", default=False, help="Show the interactive viewer.")


### PR DESCRIPTION

## Description
Dishwasher asset processing takes too long so CI was timing out sometimes
https://github.com/Genesis-Embodied-AI/genesis-world/actions/runs/29885960263/job/88816440594#step:8:325

## Related Issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been / Can This Be Tested?

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.
<!--- Optionally -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
