### PR TITLE
[MISC] Fix memory usage report in perf regression benchmarks.

### DIFF
--- a/tests/gpu_info.py
+++ b/tests/gpu_info.py
@@ -86,7 +86,10 @@ class NvidiaBackend(GpuBackend):
         usage: dict[int, int] = {}
         for handle in self._handles:
             # Genesis test workers use the GPU both for compute (Quadrants) and for rendering (EGL/OpenGL), which
-            # the driver reports as separate process lists.
+            # the driver reports as two separate process lists. usedGpuMemory is the process' total memory on the
+            # device in either list, so a process doing both appears in both with the same footprint: take it once
+            # per device (max), then sum across devices for genuine multi-GPU use.
+            per_device: dict[int, int] = {}
             for get_processes in (
                 self._pynvml.nvmlDeviceGetComputeRunningProcesses,
                 self._pynvml.nvmlDeviceGetGraphicsRunningProcesses,
@@ -94,7 +97,9 @@ class NvidiaBackend(GpuBackend):
                 for proc in get_processes(handle):
                     # usedGpuMemory is None when the driver cannot attribute memory to the process.
                     if proc.usedGpuMemory is not None:
-                        usage[proc.pid] = usage.get(proc.pid, 0) + (proc.usedGpuMemory >> 20)
+                        per_device[proc.pid] = max(per_device.get(proc.pid, 0), proc.usedGpuMemory >> 20)
+            for pid, mem in per_device.items():
+                usage[pid] = usage.get(pid, 0) + mem
         return usage
 
 


### PR DESCRIPTION
## Description
The benchmark memory profiler double-counts VRAM for any process that both computes and renders on the GPU. `NvidiaBackend.get_per_process_vram_mib` sums `usedGpuMemory` over NVML's compute-running and graphics-running process lists. NVML reports the process' *total* device memory in each list, so a process present in both (every Genesis test worker uses Quadrants for compute and EGL/OpenGL for rendering) is added twice.

The fix takes each PID's footprint once per device (the max over the two lists, since both report the same value), then sums across devices so genuine multi-GPU usage is still aggregated.

## Motivation and Context
The "Benchmark Comparison" job flags every scene as a ~+100% memory regression, exactly double the baseline, uniformly across CPU/GPU backends, `field`/`ndarray`, and all scene sizes - which is a measurement artifact, not a real regression. The baseline was captured with the previous `nvidia-smi`-parsing profiler, whose single Processes table listed each PID once. The only unchanged row (`duck_in_box_hard` batch 0, CPU, 8 MiB) is a process that renders nothing and thus appears in a single list, confirming the double-counting mechanism.

## How Has This Been / Can This Be Tested?
The profiler runs only on the CI benchmark host with real GPUs. Once merged, the "Benchmark Comparison" job memory column returns to baseline (roughly halved from the current numbers) instead of reporting uniform +100% regressions.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
