### PR TITLE
[BUG FIX] Fix camera sensor not being refreshed after scene reset.

### DIFF
--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -263,6 +263,12 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         # `uses_ring_pipeline = False`, so the manager passes both timeline rings as ``None`` here.
         pass
 
+    @classmethod
+    def reset(cls, shared_metadata: SharedSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
+        super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
+        # Reset can restore a different state at the last rendered timestep, so force the next read to rerender.
+        shared_metadata.last_render_timestep = -1
+
     def _draw_debug(self, context: "RasterizerContext"):
         """No debug drawing for cameras."""
         pass

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -267,6 +267,8 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
     def reset(cls, shared_metadata: SharedSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
         super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
         # Reset can restore a different state at the last rendered timestep, so force the next read to rerender.
+        # FIXME: the frame cache keys on a single timestep for the whole batch, so a partial-env reset invalidates
+        # every environment. Extend the caching mechanism to be env-aware so envs_idx only refreshes the reset envs.
         shared_metadata.last_render_timestep = -1
 
     def _draw_debug(self, context: "RasterizerContext"):

--- a/tests/sensors/test_camera.py
+++ b/tests/sensors/test_camera.py
@@ -39,8 +39,13 @@ def test_rasterizer_non_batched(n_envs, show_viewer):
         show_viewer=show_viewer,
     )
 
+    # Finite plane sized and placed to sit fully inside raster_cam0's frustum: the Apple Software Renderer misrasterizes
+    # any geometry with vertices outside the view, which would break the exact post-reset frame comparison below.
     scene.add_entity(
-        morph=gs.morphs.Plane(),
+        morph=gs.morphs.Plane(
+            pos=(-1.75, 0.0, 0.0),
+            plane_size=(6.5, 6.0),
+        ),
         surface=gs.surfaces.Rough(
             color=(0.4, 0.4, 0.4),
         ),
@@ -82,7 +87,7 @@ def test_rasterizer_non_batched(n_envs, show_viewer):
     raster_cam0 = scene.add_sensor(
         gs.sensors.RasterizerCameraOptions(
             res=(512, 512),
-            pos=(3.0, 0.0, 2.0),
+            pos=(6.0, 0.0, 4.0),
             lookat=(0.0, 0.0, 1.0),
             up=(0.0, 0.0, 1.0),
             fov=60.0,
@@ -192,14 +197,23 @@ def test_rasterizer_non_batched(n_envs, show_viewer):
     assert cam_move_dist_offset_T > 1e-2
     assert_allclose(cam_move_dist_offset_T, cam_move_dist, atol=1e-2)
 
-    sphere.set_pos(pos=(0.0, 1.0, 2.0))
-    reset_state = scene.get_state()
+    # A reset restores state but rewinds the timestep, which the frame cache keys on; the cached frame must follow the
+    # restored state, not the timestep. Render two visibly-distinct states, each fresh after a reset, then confirm that
+    # resetting back to either one reproduces its frame exactly rather than returning the other cached frame. Both
+    # resets pass an explicit state because reset with a state argument also overwrites the registered initial state.
     scene.reset()
-    initial_frame = raster_cam0.read().rgb.clone()
-    scene.reset(state=reset_state)
-    reset_frame = raster_cam0.read().rgb
+    default_state = scene.get_state()
+    default_frame = raster_cam0.read().rgb.clone()
+    sphere.set_pos(pos=(0.0, 1.0, 2.0))
+    shifted_state = scene.get_state()
+    scene.reset(state=shifted_state)
+    shifted_frame = raster_cam0.read().rgb.clone()
+    assert (shifted_frame != default_frame).any()
 
-    assert (reset_frame != initial_frame).any()
+    scene.reset(state=default_state)
+    assert_equal(raster_cam0.read().rgb, default_frame)
+    scene.reset(state=shifted_state)
+    assert_equal(raster_cam0.read().rgb, shifted_frame)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/sensors/test_camera.py
+++ b/tests/sensors/test_camera.py
@@ -192,6 +192,15 @@ def test_rasterizer_non_batched(n_envs, show_viewer):
     assert cam_move_dist_offset_T > 1e-2
     assert_allclose(cam_move_dist_offset_T, cam_move_dist, atol=1e-2)
 
+    sphere.set_pos(pos=(0.0, 1.0, 2.0))
+    reset_state = scene.get_state()
+    scene.reset()
+    initial_frame = raster_cam0.read().rgb.clone()
+    scene.reset(state=reset_state)
+    reset_frame = raster_cam0.read().rgb
+
+    assert (reset_frame != initial_frame).any()
+
 
 @pytest.mark.slow  # ~200s
 @pytest.mark.required


### PR DESCRIPTION
## Description

This PR invalidates cached camera sensor frames when the scene is reset. The next `camera.read()` therefore renders the reset simulation state. Rendering remains lazy: resetting the scene does not render immediately, and no public API is changed.

## Related Issue
Resolves Genesis-Embodied-AI/genesis-world#3099

## Motivation and Context
Camera frames are cached using the simulation timestep and an internal refresh flag. `scene.reset()` can restore a different state while returning to the same timestep. Because camera reset previously did not invalidate the cached frame, the next `camera.read()` could return the frame captured before the reset.

## How Has This Been / Can This Be Tested?

```bash
python -m pytest -q -n 0 tests/sensors/test_camera.py::test_rasterizer_non_batched --backend gpu
```

Result:

```text
2 passed
```

The test covers both `n_envs=0` and `n_envs=1`. The added assertion fails in both cases on the unmodified base commit and passes with this change.

## Screenshots (if appropriate):
The left panel shows the frame before reset. With the previous implementation, the post-reset read incorrectly returns the same frame (middle). With this change, it renders the restored state correctly (right).
<img width="1440" height="398" alt="rasterizer-reset-before-after" src="https://github.com/user-attachments/assets/7603acc3-7b4b-48d7-9d50-0e269ded1d2c" />

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.