### PR TITLE
[FEATURE] Add set_entity_variant for heterogeneous entities.

### DIFF
--- a/examples/rigid/heterogeneous_interactive.py
+++ b/examples/rigid/heterogeneous_interactive.py
@@ -1,0 +1,123 @@
+"""Interactive demo of runtime heterogeneous variant switching.
+
+A single entity is built from a list of morphs -- randomly sized boxes/spheres/cylinders, or (with --articulated)
+2-link pendulum chains -- and each environment shows one of them, switched live via `entity.set_entity_variant`;
+both the physics and the rendered geometry follow. Run with -v/--vis to open the viewer and press SPACE to
+randomize the arrangement interactively; without it the demo performs a single switch as a headless smoke check.
+"""
+
+import argparse
+
+import numpy as np
+
+import genesis as gs
+from genesis.utils.procedural import build_articulated_chain
+from genesis.vis.keybindings import Key, KeyAction, Keybind
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--vis", action="store_true", help="Open the interactive viewer to drive switching live")
+    parser.add_argument("-g", "--gpu", action="store_true", help="Run on GPU instead of CPU")
+    parser.add_argument("-b", "--num-envs", type=int, default=4, help="Number of parallel environments")
+    parser.add_argument("--n-variants", type=int, default=3, help="Number of morph variants to build")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument(
+        "--articulated", action="store_true", help="Use 2-link pendulum chains instead of primitive shapes"
+    )
+    args = parser.parse_args()
+
+    gs.init(backend=gs.gpu if args.gpu else gs.cpu)
+
+    rng = np.random.default_rng(args.seed)
+
+    # A box, sphere and cylinder in rotation (or 2-link chains under --articulated), each at a random size.
+    variants = []
+    for i in range(args.n_variants):
+        if args.articulated:
+            # Vary only the radius: the rebind does not move joint anchors, so a different length would misplace links.
+            variants.append(
+                gs.morphs.MJCF(
+                    file=build_articulated_chain(
+                        n_links=2,
+                        link_radius=rng.uniform(0.015, 0.07),
+                        link_length=0.25,
+                    ),
+                    pos=(0.0, 0.0, 0.8),
+                )
+            )
+        elif i % 3 == 0:
+            side = rng.uniform(0.12, 0.28)
+            variants.append(gs.morphs.Box(size=(side, side, side), pos=(0.0, 0.0, 0.3)))
+        elif i % 3 == 1:
+            variants.append(gs.morphs.Sphere(radius=rng.uniform(0.08, 0.16), pos=(0.0, 0.0, 0.3)))
+        else:
+            variants.append(
+                gs.morphs.Cylinder(radius=rng.uniform(0.07, 0.13), height=rng.uniform(0.15, 0.35), pos=(0.0, 0.0, 0.3))
+            )
+
+    scene = gs.Scene(
+        show_viewer=args.vis,
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(4.0, 4.0, 3.0),
+            camera_lookat=(0.0, 0.0, 0.4 if args.articulated else 0.1),
+        ),
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    het = scene.add_entity(
+        morph=variants,
+    )
+    if args.vis:
+        # Mouse-drag to sanity-check collision and mass; spring force works for free and anchored bodies alike.
+        scene.viewer.add_plugin(
+            gs.vis.viewer_plugins.MouseInteractionPlugin(
+                use_force=True,
+            )
+        )
+    scene.build(
+        n_envs=args.num_envs,
+        env_spacing=(1.0, 1.0),
+    )
+
+    n_variants = len(variants)
+    is_running = True
+    pending_randomize = True  # start from a random arrangement
+
+    def randomize():
+        nonlocal pending_randomize
+        pending_randomize = True
+
+    def stop():
+        nonlocal is_running
+        is_running = False
+
+    if args.vis:
+        scene.viewer.register_keybinds(
+            Keybind("randomize_variants", Key.SPACE, KeyAction.PRESS, callback=randomize),
+            Keybind("quit", Key.ESCAPE, KeyAction.RELEASE, callback=stop),
+        )
+        print("\nSPACE randomizes each environment's variant, drag objects with the mouse, ESC to quit.\n")
+
+    while is_running:
+        # Keybind callbacks fire on the viewer thread; mutate the scene here on the stepping thread.
+        if pending_randomize:
+            pending_randomize = False
+            het.set_entity_variant(rng.integers(0, n_variants, size=args.num_envs))
+            if args.articulated:
+                # Kick the hinges so the fresh chain swings.
+                het.set_dofs_velocity(rng.uniform(-5.0, 5.0, size=het.n_dofs))
+            else:
+                # Drop the fresh geometry so the switch reads clearly.
+                het.set_pos((0.0, 0.0, 0.3))
+                het.set_dofs_velocity(np.zeros(6))
+        scene.step()
+
+        # Without a viewer there is no interactive quit, so one switch suffices as a headless smoke check.
+        if not args.vis:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -45,6 +45,7 @@ from .rigid_link import (
 
 if TYPE_CHECKING:
     from genesis.engine.scene import Scene
+    from genesis.engine.sensors.base_sensor import Sensor
     from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
     from genesis.engine.solvers.kinematic_solver import KinematicSolver
 
@@ -157,6 +158,13 @@ class KinematicEntity(Entity):
         # Per-variant base-link offset for heterogeneous entities, primary first and aligned with '_variant_init_qpos'
         self._variant_offset_pos: list[np.ndarray] | None = None
         self._variant_offset_quat: list[np.ndarray] | None = None
+
+        # Per-env active variant index (heterogeneous only), shape (B,).
+        self._variant_idx_per_env: np.ndarray | None = None
+
+        # Sensors that sample this entity's geometry once at build (e.g. a point-cloud tactile sensor) and cannot
+        # follow a runtime variant switch; a non-empty list makes set_entity_variant raise. Populated from their build.
+        self._variant_switch_blockers: list["Sensor"] = []
 
         self.terrain_hf: np.ndarray | None = None
         self.terrain_scale: np.ndarray | None = None
@@ -2120,6 +2128,71 @@ class KinematicEntity(Entity):
         if zero_velocity:
             self.zero_all_dofs_velocity(envs_idx=envs_idx, skip_forward=True)
         self._solver.set_qpos(qpos, qs_idx, envs_idx, skip_forward=skip_forward)
+
+    @gs.assert_built
+    def set_entity_variant(self, variants_idx, envs_idx=None):
+        """
+        Switch which declared variant this heterogeneous entity shows per environment, at runtime.
+
+        Only valid for an entity built from a list of morphs (`scene.add_entity(morph=[m0, m1, ...])`). All
+        variants share the same kinematic tree; only their collision/visual geometry and inertial differ.
+
+        Parameters
+        ----------
+        variants_idx : int | array_like
+            Variant index/indices, like `envs_idx`: a single index (0 is the first/primary morph) switches every
+            selected environment to that variant, while an array of one index per selected environment switches
+            each independently.
+        envs_idx : None | array_like, optional
+            The environments to switch. If None, all environments are switched. Defaults to None.
+        """
+        if not self._enable_heterogeneous:
+            gs.raise_exception("`set_entity_variant` requires a heterogeneous entity built with a list of morphs.")
+        if self._scene.requires_grad:
+            gs.raise_exception(
+                "`set_entity_variant` is not supported in a differentiable simulation (`requires_grad=True`): the "
+                "variant change is not checkpointed, so backward replay would use the wrong dynamics."
+            )
+        if self._scene.visualizer.batch_renderer is not None or self._scene.visualizer.raytracer is not None:
+            gs.raise_exception(
+                "`set_entity_variant` is not supported with the batch renderer or ray tracer, whose per-variant "
+                "visibility is fixed at build time. Use the interactive viewer or a rasterizer camera for runtime "
+                "switching."
+            )
+        if self._variant_switch_blockers:
+            blocker = type(self._variant_switch_blockers[0]).__name__
+            gs.raise_exception(
+                f"`set_entity_variant` is not supported: a {blocker} samples this entity's geometry at build and "
+                "would read stale values after a switch."
+            )
+        if self._morph.enable_custom_vverts:
+            gs.raise_exception(
+                "`set_entity_variant` is not supported with `enable_custom_vverts=True`: the custom visual vertex "
+                "buffer is tied to the build-time variant and cannot follow a switch."
+            )
+        n_variants = len(self._morph_heterogeneous) + 1
+        variants_idx = np.atleast_1d(np.asarray(variants_idx, dtype=gs.np_int))
+        if ((variants_idx < 0) | (variants_idx >= n_variants)).any():
+            gs.raise_exception(f"`variants_idx` must be in range [0, {n_variants}), got {variants_idx.tolist()}.")
+        self._solver.set_entity_variant(self, variants_idx, envs_idx)
+
+    @gs.assert_built
+    def get_entity_variant(self, envs_idx=None):
+        """
+        Return the currently-active variant index for each selected environment, shape `(n_envs,)`.
+
+        Only valid for a heterogeneous entity built from a list of morphs.
+
+        Parameters
+        ----------
+        envs_idx : None | array_like, optional
+            The environments to query. If None, all environments are returned. Defaults to None.
+        """
+        if not self._enable_heterogeneous:
+            gs.raise_exception("`get_entity_variant` requires a heterogeneous entity built with a list of morphs.")
+        if envs_idx is None:
+            return self._variant_idx_per_env.copy()
+        return self._variant_idx_per_env[tensor_to_array(self._scene._sanitize_envs_idx(envs_idx))]
 
     @gs.assert_built
     @tracked

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -645,6 +645,20 @@ class RigidSensorMixin(_LinkAttachedSensorMixin, Generic[RigidSensorMetadataMixi
     def _register_link(self, entity, link_idx: int):
         self._shared_metadata.links_idx = concat_with_tensor(self._shared_metadata.links_idx, link_idx)
 
+    def _block_variant_switch_on_tracked_heterogeneous(self, track_link_idx) -> None:
+        """
+        Register this sensor as a variant-switch blocker on the heterogeneous entity owning any of `track_link_idx`.
+
+        A sensor that samples its tracked geometry once at build (a point cloud, a link-local triangle BVH) cannot
+        follow a runtime variant switch, so it makes the entity's set_entity_variant raise instead of returning
+        readings against the outgoing variant.
+        """
+        solver = self._shared_metadata.solver
+        for link_idx in track_link_idx:
+            entity = solver.links[link_idx].entity
+            if entity._enable_heterogeneous and self not in entity._variant_switch_blockers:
+                entity._variant_switch_blockers.append(self)
+
 
 class KinematicSensorMixin(_LinkAttachedSensorMixin, Generic[KinematicSensorMetadataMixinT]):
     """

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -633,6 +633,11 @@ class PointCloudTactileSensorMixin(ProbeSensorMixin[PointCloudTactileSensorMetad
         # row into the just-grown pc_pos_link.
         self._shared_metadata.pc_bvh.append_sensor(pc_start_row=pc_start_row, idx_cat=idx_cat, pos_cat=pos_cat)
 
+        # TODO: Add support for tactile sensors following a runtime variant switch (subscribe and rebuild the sampled
+        # point cloud). Until then, the point cloud above is sampled from the tracked geometry as it stands at build,
+        # so block a switch of any tracked heterogeneous entity rather than silently reading the outgoing variant.
+        self._block_variant_switch_on_tracked_heterogeneous(self._options.track_link_idx)
+
     def _draw_debug_probes(
         self, context: "RasterizerContext", color_groups_fn: Callable[[list[int] | None], list[tuple]] | None = None
     ) -> tuple[list[int] | None, int, np.ndarray | None]:
@@ -1999,6 +2004,9 @@ class ElastomerTaxelSensor(
         self._shared_metadata.elastomer_geom_active_envs_mask = concat_with_tensor(
             self._shared_metadata.elastomer_geom_active_envs_mask, elastomer_geom_active_envs_mask
         )
+        # The elastomer geom indices and masks above are snapshot from the attached link's build-time variant, so
+        # block a runtime switch of its entity too (the tracked-link block comes from the point-cloud mixin build).
+        self._block_variant_switch_on_tracked_heterogeneous((self._link.idx,))
         self._shared_metadata.sensor_elastomer_geom_start = concat_with_tensor(
             self._shared_metadata.sensor_elastomer_geom_start, elastomer_geom_start_row, expand=(1,)
         )

--- a/genesis/engine/sensors/surface_distance_probe.py
+++ b/genesis/engine/sensors/surface_distance_probe.py
@@ -374,6 +374,8 @@ class SurfaceDistanceProbeSensor(
         # Build the per-(sensor, tracked-link) triangle BVH in link-local frame. Rigid links don't deform,
         # so this is a one-shot scene-build cost; per-step queries traverse the static structure.
         self._shared_metadata.bvh.append_sensor(track_link_idx, self._shared_metadata.solver)
+        # That BVH is tied to the build-time variant, so block a runtime switch of any tracked heterogeneous entity.
+        self._block_variant_switch_on_tracked_heterogeneous(track_link_idx)
 
     @classmethod
     def reset(cls, shared_metadata: SurfaceDistanceProbeMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -26,12 +26,16 @@ class StateChange(enum.Enum):
 
     Solver-agnostic: it names what kind of state changed, never an index space (links, dofs, particles, ...), which
     differs from one solver to the next. GEOMETRY is the kinematic configuration that places or deforms the world
-    surface (link poses, qpos, vertices); DYNAMICS is the velocity state. Model parameters (mass, inertia, friction,
-    gains, limits) are not scene state and are never broadcast.
+    surface (link poses, qpos, vertices); DYNAMICS is the velocity state; TOPOLOGY is which surface each environment
+    carries, i.e. its active geom set, which a heterogeneous entity changes by switching variant. A mutation that
+    swaps the geom set also moves the surface, so it broadcasts GEOMETRY alongside TOPOLOGY: a consumer that only
+    tracks where the surface is needs no TOPOLOGY subscription. Model parameters (mass, inertia, friction, gains,
+    limits) are not scene state and are never broadcast.
     """
 
     GEOMETRY = enum.auto()
     DYNAMICS = enum.auto()
+    TOPOLOGY = enum.auto()
 
 
 class MutatedLinks(enum.Enum):

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -16,6 +16,7 @@ from genesis.utils.misc import (
     qd_to_torch,
     qd_zero_grad,
     sanitize_indexed_tensor,
+    tensor_to_array,
 )
 
 from .base_solver import MutatedLinks, Solver, StateChange, mutates
@@ -270,12 +271,12 @@ class KinematicSolver(Solver):
         vgeoms_offset_quat = np.tile(gu.identity_quat(), (self.n_vgeoms, 1))
         for entity in self._entities:
             if links_offset_per_env and entity._variant_offset_pos is not None:
-                variant_idx = _balanced_variant_mapping(len(entity._variant_offset_pos), self._B)
+                variants_idx = _balanced_variant_mapping(len(entity._variant_offset_pos), self._B)
                 links_offset_pos[np.arange(self._B), entity.base_link_idx] = np.stack(
-                    [entity._variant_offset_pos[v] for v in variant_idx]
+                    [entity._variant_offset_pos[v] for v in variants_idx]
                 )
                 links_offset_quat[np.arange(self._B), entity.base_link_idx] = np.stack(
-                    [entity._variant_offset_quat[v] for v in variant_idx]
+                    [entity._variant_offset_quat[v] for v in variants_idx]
                 )
                 vgeoms_ranges = entity.base_link._variant_vgeom_ranges
             else:
@@ -293,6 +294,20 @@ class KinematicSolver(Solver):
             np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0, atol=gs.EPS), axis=2
         ).all(axis=0)
         self._links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=2).all(axis=0)
+        # A heterogeneous entity can switch to any variant at runtime, so its base-link offset counts as identity only
+        # when every variant's offset is; the arrays above hold just the build-assigned subset (and none when the env
+        # count is below the variant count). set_entity_variant rebinds the values; this keeps the gate conservative.
+        for entity in self._entities:
+            if entity._variant_offset_pos is None:
+                continue
+            base_link_idx = entity.base_link_idx
+            self._links_offset_pos_is_identity[base_link_idx] &= all(
+                np.allclose(offset_pos, 0.0, atol=gs.EPS) for offset_pos in entity._variant_offset_pos
+            )
+            self._links_offset_quat_is_identity[base_link_idx] &= all(
+                np.allclose(gu.quat_to_xyz(offset_quat), 0.0, atol=gs.EPS)
+                for offset_quat in entity._variant_offset_quat
+            )
         self._links_offset_pos = self._links_offset_quat = None
         if not (self._links_offset_pos_is_identity.all() and self._links_offset_quat_is_identity.all()):
             self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
@@ -481,10 +496,10 @@ class KinematicSolver(Solver):
                 if entity._variant_init_qpos is None:
                     continue
                 n_variants = len(entity._variant_init_qpos)
-                variant_idx = _balanced_variant_mapping(n_variants, self._B)
+                variants_idx = _balanced_variant_mapping(n_variants, self._B)
                 q_s, q_e = entity.q_start, entity.q_start + entity.n_qs
                 for i_b in range(self._B):
-                    init_qpos[q_s:q_e, i_b] = entity._variant_init_qpos[variant_idx[i_b]]
+                    init_qpos[q_s:q_e, i_b] = entity._variant_init_qpos[variants_idx[i_b]]
 
             self.qpos0.from_numpy(init_qpos)
             is_init_qpos_out_of_bounds = False
@@ -502,23 +517,87 @@ class KinematicSolver(Solver):
         self._dispatch_heterogeneous_vgeoms()
 
     def _dispatch_heterogeneous_vgeoms(self):
-        """Override per-link vgeom ranges for heterogeneous variants. RigidSolver extends this."""
+        """Assign each env its build-time variant. RigidSolver extends the per-link bind with geoms + inertial."""
+        envs_idx = torch.arange(self._B, device=gs.device)
         for link in self.links:
             if link._variant_vgeom_ranges is None:
                 continue
+            variants_idx = _balanced_variant_mapping(len(link._variant_vgeom_ranges), self._B)
+            self._bind_heterogeneous_variant(link, variants_idx, envs_idx)
+            # All of an entity's links share one mapping; record it once for get_entity_variant.
+            link.entity._variant_idx_per_env = variants_idx
 
-            n_variants = len(link._variant_vgeom_ranges)
-            variant_idx = _balanced_variant_mapping(n_variants, self._B)
+    def _bind_heterogeneous_variant(self, link, variants_idx, envs_idx):
+        """
+        Bind link's per-env vgeom ranges to the variants in variants_idx (aligned with envs_idx).
 
-            vgeom_starts = np.array([link._variant_vgeom_ranges[v][0] for v in variant_idx], dtype=gs.np_int)
-            vgeom_ends = np.array([link._variant_vgeom_ranges[v][1] for v in variant_idx], dtype=gs.np_int)
+        Shared by build-time dispatch (all envs) and runtime `set_entity_variant` (a subset). RigidSolver extends
+        it with collision-geom ranges and per-variant inertial.
+        """
+        vgeom_starts = np.array([link._variant_vgeom_ranges[v][0] for v in variants_idx], dtype=gs.np_int)
+        vgeom_ends = np.array([link._variant_vgeom_ranges[v][1] for v in variants_idx], dtype=gs.np_int)
+        kernel_update_heterogeneous_links_vgeom(link.idx, envs_idx, vgeom_starts, vgeom_ends, self.dyn_info)
+        self._set_variant_active_envs(link.vgeoms, vgeom_starts, vgeom_ends, envs_idx)
 
-            kernel_update_heterogeneous_links_vgeom(link.idx, vgeom_starts, vgeom_ends, self.dyn_info)
+    def _set_variant_active_envs(self, geoms, starts, ends, envs_idx):
+        """
+        Refresh each (v)geom's per-env active mask/idx for the rebound envs; starts/ends are aligned with envs_idx.
 
-            for vgeom in link.vgeoms:
-                active_envs_mask = (vgeom_starts <= vgeom.idx) & (vgeom.idx < vgeom_ends)
-                vgeom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
-                (vgeom.active_envs_idx,) = np.where(active_envs_mask)
+        A (v)geom is active in a rebound env when its global index falls in that env's newly-bound range. Only the
+        rebound entries of the full-B mask are overwritten, so a subset rebind leaves the other envs untouched.
+        """
+        for geom in geoms:
+            active_envs = torch.as_tensor((starts <= geom.idx) & (geom.idx < ends), device=gs.device)
+            if geom.active_envs_mask is None:
+                geom.active_envs_mask = torch.zeros(self._B, dtype=torch.bool, device=gs.device)
+            geom.active_envs_mask[envs_idx] = active_envs
+            (geom.active_envs_idx,) = np.where(tensor_to_array(geom.active_envs_mask))
+
+    @mutates(StateChange.GEOMETRY, StateChange.TOPOLOGY, links=MutatedLinks.ALL)
+    def set_entity_variant(self, entity, variants_idx, envs_idx):
+        """
+        Rebind a heterogeneous entity's active morph variant for the given envs, at runtime.
+
+        `variants_idx` is a 1D array of variant indices: a single entry (applied to every selected env) or one per
+        selected env. Reuses the build-time per-link bind, then lets `_on_variant_rebound` refresh any solver
+        caches invalidated by the swapped geometry. Announces the change over all links (a fixed link's geometry can
+        swap too), so subscribers such as the raycaster's static BVH rebuild for the new variant.
+        """
+        envs_idx = self._scene._sanitize_envs_idx(envs_idx)
+        if len(variants_idx) == 1:
+            variants_idx = np.broadcast_to(variants_idx, (len(envs_idx),))
+        elif len(variants_idx) != len(envs_idx):
+            gs.raise_exception(
+                f"`variants_idx` has length {len(variants_idx)}; expected a single index or one per selected "
+                f"environment ({len(envs_idx)})."
+            )
+        for link in entity.links:
+            if link._variant_vgeom_ranges is None:
+                continue
+            self._bind_heterogeneous_variant(link, variants_idx, envs_idx)
+        entity._variant_idx_per_env[tensor_to_array(envs_idx)] = variants_idx
+        # Rebind the base link's per-env relative-pose offset to each newly-active variant: a variant with a
+        # different morph offset or inertial-alignment frame has a different user<-world frame, and relative
+        # get/set would otherwise keep the outgoing variant's. Only divergent-offset entities have per-env storage
+        # (self._B rows); an offset-invariant entity has no per-env row to update.
+        if (
+            self._links_offset_pos is not None
+            and self._links_offset_pos.shape[0] == self._B
+            and entity._variant_offset_pos is not None
+        ):
+            base_link_idx = entity.base_link_idx
+            offset_pos = np.stack([entity._variant_offset_pos[v] for v in variants_idx])
+            offset_quat = np.stack([entity._variant_offset_quat[v] for v in variants_idx])
+            self._links_offset_pos[envs_idx, base_link_idx] = torch.as_tensor(
+                offset_pos, dtype=gs.tc_float, device=gs.device
+            )
+            self._links_offset_quat[envs_idx, base_link_idx] = torch.as_tensor(
+                offset_quat, dtype=gs.tc_float, device=gs.device
+            )
+        self._on_variant_rebound(envs_idx)
+
+    def _on_variant_rebound(self, envs_idx):
+        """Refresh solver caches invalidated by a variant rebind. Base solver has none; RigidSolver overrides."""
 
     def _init_vvert_fields(self):
         if self.n_vverts == 0:

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -347,22 +347,26 @@ def kernel_init_link_fields(
 @qd.kernel(fastcache=True)
 def kernel_update_heterogeneous_links_vgeom(
     i_l: qd.i32,
+    envs_idx: qd.types.ndarray(),
     links_vgeom_start: qd.types.ndarray(),
     links_vgeom_end: qd.types.ndarray(),
     # Quadrants variables
     dyn_info: array_class.DynInfo,
 ):
-    """Update per-environment links vgeom for heterogeneous entities."""
-    _B = links_vgeom_start.shape[0]
+    """Bind link i_l's per-environment vgeom range to a heterogeneous variant, for the envs in envs_idx.
 
-    for i_b in range(_B):
-        dyn_info.links.vgeom_start[i_l, i_b] = links_vgeom_start[i_b]
-        dyn_info.links.vgeom_end[i_l, i_b] = links_vgeom_end[i_b]
+    The per-env arrays are aligned with envs_idx (position i_b_ selects env envs_idx[i_b_]), so the same kernel
+    serves both build-time dispatch (envs_idx = all envs) and runtime rebind (envs_idx = a subset)."""
+    for i_b_ in range(envs_idx.shape[0]):
+        i_b = envs_idx[i_b_]
+        dyn_info.links.vgeom_start[i_l, i_b] = links_vgeom_start[i_b_]
+        dyn_info.links.vgeom_end[i_l, i_b] = links_vgeom_end[i_b_]
 
 
 @qd.kernel(fastcache=True)
 def kernel_update_heterogeneous_link_info(
     i_l: qd.i32,
+    envs_idx: qd.types.ndarray(),
     links_geom_start: qd.types.ndarray(),
     links_geom_end: qd.types.ndarray(),
     links_vgeom_start: qd.types.ndarray(),
@@ -374,24 +378,26 @@ def kernel_update_heterogeneous_link_info(
     # Quadrants variables
     dyn_info: array_class.DynInfo,
 ):
-    """Update per-environment link info for heterogeneous entities."""
-    _B = links_geom_start.shape[0]
+    """Bind link i_l's per-environment geom/vgeom ranges and inertial to a variant, for the envs in envs_idx.
 
-    for i_b in range(_B):
-        dyn_info.links.geom_start[i_l, i_b] = links_geom_start[i_b]
-        dyn_info.links.geom_end[i_l, i_b] = links_geom_end[i_b]
-        dyn_info.links.vgeom_start[i_l, i_b] = links_vgeom_start[i_b]
-        dyn_info.links.vgeom_end[i_l, i_b] = links_vgeom_end[i_b]
-        dyn_info.links.inertial_mass[i_l, i_b] = links_inertial_mass[i_b]
+    The per-env arrays are aligned with envs_idx (position i_b_ selects env envs_idx[i_b_]), so the same kernel
+    serves both build-time dispatch (envs_idx = all envs) and runtime rebind (envs_idx = a subset)."""
+    for i_b_ in range(envs_idx.shape[0]):
+        i_b = envs_idx[i_b_]
+        dyn_info.links.geom_start[i_l, i_b] = links_geom_start[i_b_]
+        dyn_info.links.geom_end[i_l, i_b] = links_geom_end[i_b_]
+        dyn_info.links.vgeom_start[i_l, i_b] = links_vgeom_start[i_b_]
+        dyn_info.links.vgeom_end[i_l, i_b] = links_vgeom_end[i_b_]
+        dyn_info.links.inertial_mass[i_l, i_b] = links_inertial_mass[i_b_]
 
         for j in qd.static(range(3)):
-            dyn_info.links.inertial_pos[i_l, i_b][j] = links_inertial_pos[i_b, j]
+            dyn_info.links.inertial_pos[i_l, i_b][j] = links_inertial_pos[i_b_, j]
 
         for j in qd.static(range(4)):
-            dyn_info.links.inertial_quat[i_l, i_b][j] = links_inertial_quat[i_b, j]
+            dyn_info.links.inertial_quat[i_l, i_b][j] = links_inertial_quat[i_b_, j]
 
         for j1, j2 in qd.static(qd.ndrange(3, 3)):
-            dyn_info.links.inertial_i[i_l, i_b][j1, j2] = links_inertial_i[i_b, j1, j2]
+            dyn_info.links.inertial_i[i_l, i_b][j1, j2] = links_inertial_i[i_b_, j1, j2]
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -19,6 +19,7 @@ from genesis.utils.misc import (
     qd_to_torch,
     qd_to_numpy,
     qd_zero_grad,
+    tensor_to_array,
     indices_to_mask,
     broadcast_tensor,
     sanitize_indexed_tensor,
@@ -1003,61 +1004,66 @@ class RigidSolver(KinematicSolver):
 
         self.rigid_info.gravity.from_numpy(self.gravity)
 
-    def _dispatch_heterogeneous_vgeoms(self):
+    def _bind_heterogeneous_variant(self, link, variants_idx, envs_idx):
         """
-        Dispatch per-environment geom/vgeom ranges and inertial properties for heterogeneous links.
+        Extend the base vgeom bind with link's per-env collision-geom ranges and per-variant inertial.
 
-        Extends the base class (which handles vgeom-only dispatch) to also dispatch collision geom
-        ranges and per-variant inertial properties. Per-variant inertial is pre-computed during
-        link._build() from actual geom objects, using analytic formulas for primitives.
+        variants_idx is aligned with envs_idx (one target variant index per selected env). Per-variant inertial is
+        pre-computed during link._build() from the variant's geoms. A link with visual-only variants (no collision
+        geoms) falls back to the base vgeom-only bind.
         """
-        from genesis.engine.solvers.kinematic_solver import _balanced_variant_mapping
+        if link._variant_geom_ranges is None:
+            super()._bind_heterogeneous_variant(link, variants_idx, envs_idx)
+            return
 
-        for link in self.links:
-            if link._variant_vgeom_ranges is None:
-                continue
+        geom_starts = np.array([link._variant_geom_ranges[v][0] for v in variants_idx], dtype=gs.np_int)
+        geom_ends = np.array([link._variant_geom_ranges[v][1] for v in variants_idx], dtype=gs.np_int)
+        vgeom_starts = np.array([link._variant_vgeom_ranges[v][0] for v in variants_idx], dtype=gs.np_int)
+        vgeom_ends = np.array([link._variant_vgeom_ranges[v][1] for v in variants_idx], dtype=gs.np_int)
+        links_inertial_mass = np.array([link._variant_inertial[v][0] for v in variants_idx], dtype=gs.np_float)
+        links_inertial_pos = np.array([link._variant_inertial[v][1] for v in variants_idx], dtype=gs.np_float)
+        links_inertial_quat = np.array([link._variant_inertial[v][2] for v in variants_idx], dtype=gs.np_float)
+        links_inertial_i = np.array([link._variant_inertial[v][3] for v in variants_idx], dtype=gs.np_float)
 
-            n_variants = len(link._variant_vgeom_ranges)
-            variant_idx = _balanced_variant_mapping(n_variants, self._B)
+        kernel_update_heterogeneous_link_info(
+            link.idx,
+            envs_idx,
+            geom_starts,
+            geom_ends,
+            vgeom_starts,
+            vgeom_ends,
+            links_inertial_mass,
+            links_inertial_pos,
+            links_inertial_quat,
+            links_inertial_i,
+            self.dyn_info,
+        )
 
-            # Build per-env arrays from link's variant data
-            geom_starts = np.array([link._variant_geom_ranges[v][0] for v in variant_idx], dtype=gs.np_int)
-            geom_ends = np.array([link._variant_geom_ranges[v][1] for v in variant_idx], dtype=gs.np_int)
-            vgeom_starts = np.array([link._variant_vgeom_ranges[v][0] for v in variant_idx], dtype=gs.np_int)
-            vgeom_ends = np.array([link._variant_vgeom_ranges[v][1] for v in variant_idx], dtype=gs.np_int)
+        self._set_variant_active_envs(link.geoms, geom_starts, geom_ends, envs_idx)
+        self._set_variant_active_envs(link.vgeoms, vgeom_starts, vgeom_ends, envs_idx)
 
-            # Build per-env inertial arrays from pre-computed per-variant inertial
-            links_inertial_mass = np.array([link._variant_inertial[v][0] for v in variant_idx], dtype=gs.np_float)
-            links_inertial_pos = np.array([link._variant_inertial[v][1] for v in variant_idx], dtype=gs.np_float)
-            links_inertial_quat = np.array([link._variant_inertial[v][2] for v in variant_idx], dtype=gs.np_float)
-            links_inertial_i = np.array([link._variant_inertial[v][3] for v in variant_idx], dtype=gs.np_float)
+    def _on_variant_rebound(self, envs_idx):
+        """
+        Refresh the collider and inertia-dependent caches after a runtime variant rebind.
 
-            # Update links_info with per-environment values
-            # Note: when batch_links_info is True, the shape is (n_links, B)
-            kernel_update_heterogeneous_link_info(
-                link.idx,
-                geom_starts,
-                geom_ends,
-                vgeom_starts,
-                vgeom_ends,
-                links_inertial_mass,
-                links_inertial_pos,
-                links_inertial_quat,
-                links_inertial_i,
-                self.dyn_info,
-            )
-
-            # Set active_envs on geoms — indicates which environments each geom is active in
-            for geom in link.geoms:
-                active_envs_mask = (geom_starts <= geom.idx) & (geom.idx < geom_ends)
-                geom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
-                (geom.active_envs_idx,) = np.where(active_envs_mask)
-
-            # Set active_envs on vgeoms
-            for vgeom in link.vgeoms:
-                active_envs_mask = (vgeom_starts <= vgeom.idx) & (vgeom.idx < vgeom_ends)
-                vgeom.active_envs_mask = torch.tensor(active_envs_mask, device=gs.device)
-                (vgeom.active_envs_idx,) = np.where(active_envs_mask)
+        Recomputes the rest-state constraint caches (which depend on link mass/inertia a variant can change) for
+        the rebound envs, preserving the running qpos, then re-poses the newly-active geoms (including fixed ones)
+        and rebuilds the broadphase sort buffer, which the pose-only cache reset done by set_qpos leaves stale
+        after a geom-set change. Also refreshes the hibernation DOF lengths, whose rotational radius follows the
+        variant's body extent.
+        """
+        # The batched qpos/inertia caches and the collider reset sanitize their envs_idx, which rejects an explicit
+        # one on a non-parallelized scene; pass None there. `_func_update_geoms` feeds a kernel directly, so it keeps
+        # the concrete index tensor.
+        envs_idx_batched = envs_idx if self.n_envs > 0 else None
+        qs_idx = torch.arange(self.n_qs, dtype=gs.tc_int, device=gs.device)
+        qpos_cur = self.get_qpos(qs_idx=qs_idx, envs_idx=envs_idx_batched)
+        self._init_invweight_and_meaninertia(envs_idx=envs_idx_batched, force_update=True)
+        self.set_qpos(qpos_cur, qs_idx=qs_idx, envs_idx=envs_idx_batched)
+        self._func_update_geoms(envs_idx, force_update_fixed_geoms=True)
+        self.collider.reset(envs_idx_batched, cache_only=False)
+        # Reads the per-geom active-env masks the rebind just updated; a no-op unless hibernation is on.
+        self._init_dof_length()
 
     def _init_vert_fields(self):
         if self.n_verts > 0:

--- a/genesis/utils/procedural.py
+++ b/genesis/utils/procedural.py
@@ -1,0 +1,89 @@
+"""Procedurally generate simple articulated bodies as inline URDF or MJCF, for reuse in tests and examples."""
+
+import math
+import xml.etree.ElementTree as ET
+
+
+def build_articulated_chain(n_links, link_radius, link_length, *, format="mjcf", density=1000.0):
+    """Build an ``n_links`` pendulum chain of equal links joined by hinge joints, as an inline XML string.
+
+    The returned string is ready to pass to ``gs.morphs.MJCF(file=...)`` / ``gs.morphs.URDF(file=...)``. Each link
+    is ``link_length`` long and ``link_radius`` thick; consecutive links are connected by a revolute joint about
+    the y axis. Both forms use cylinder links at the given ``density`` with matching mass and inertia.
+
+    The MJCF form hinges its first link to the world, so it is a fixed-base ``n_links`` pendulum. The URDF form
+    keeps an explicit ``base`` root link whose fixing follows the morph: pass ``gs.morphs.URDF(file=..., fixed=True)``
+    for the same fixed-base pendulum, otherwise the base is free and the whole chain falls under gravity.
+
+    Parameters
+    ----------
+    n_links : int
+        Number of links in the chain (must be >= 1).
+    link_radius : float
+        Radius of each link.
+    link_length : float
+        Length of each link along its local axis.
+    format : str
+        Either "mjcf" or "urdf".
+    density : float
+        Solid density of each link.
+    """
+    if n_links < 1:
+        raise ValueError(f"`n_links` must be >= 1, got {n_links}.")
+
+    if format == "mjcf":
+        root = ET.Element("mujoco", model="chain")
+        worldbody = ET.SubElement(root, "worldbody")
+        parent = worldbody
+        for i in range(n_links):
+            body = ET.SubElement(parent, "body", name=f"link_{i}", pos=f"0 0 {0.0 if i == 0 else -link_length}")
+            ET.SubElement(body, "joint", name=f"joint_{i}", type="hinge", axis="0 1 0")
+            ET.SubElement(
+                body,
+                "geom",
+                type="cylinder",
+                fromto=f"0 0 0 0 0 {-link_length}",
+                size=f"{link_radius}",
+                density=f"{density}",
+            )
+            parent = body
+        return ET.tostring(root, encoding="unicode")
+
+    if format == "urdf":
+        root = ET.Element("robot", name="chain")
+        ET.SubElement(root, "link", name="base")
+        # Solid-cylinder inertial (URDF requires an explicit one).
+        mass = density * math.pi * link_radius**2 * link_length
+        i_transverse = mass * (3.0 * link_radius**2 + link_length**2) / 12.0
+        i_axial = mass * link_radius**2 / 2.0
+        parent_name = "base"
+        for i in range(n_links):
+            link_name = f"link_{i}"
+            joint = ET.SubElement(root, "joint", name=f"joint_{i}", type="continuous")
+            ET.SubElement(joint, "parent", link=parent_name)
+            ET.SubElement(joint, "child", link=link_name)
+            ET.SubElement(joint, "origin", xyz=f"0 0 {0.0 if i == 0 else -link_length}", rpy="0 0 0")
+            ET.SubElement(joint, "axis", xyz="0 1 0")
+            link = ET.SubElement(root, "link", name=link_name)
+            for tag in ("visual", "collision"):
+                node = ET.SubElement(link, tag)
+                ET.SubElement(node, "origin", xyz=f"0 0 {-0.5 * link_length}", rpy="0 0 0")
+                geometry = ET.SubElement(node, "geometry")
+                ET.SubElement(geometry, "cylinder", radius=f"{link_radius}", length=f"{link_length}")
+            inertial = ET.SubElement(link, "inertial")
+            ET.SubElement(inertial, "origin", xyz=f"0 0 {-0.5 * link_length}", rpy="0 0 0")
+            ET.SubElement(inertial, "mass", value=f"{mass}")
+            ET.SubElement(
+                inertial,
+                "inertia",
+                ixx=f"{i_transverse}",
+                ixy="0",
+                ixz="0",
+                iyy=f"{i_transverse}",
+                iyz="0",
+                izz=f"{i_axial}",
+            )
+            parent_name = link_name
+        return ET.tostring(root, encoding="unicode")
+
+    raise ValueError(f"`format` must be 'mjcf' or 'urdf', got {format!r}.")

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -6,6 +6,7 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 import genesis.utils.particle as pu
+from genesis.engine.solvers.base_solver import StateChange, Subscriber
 from genesis.ext import pyrender
 from genesis.ext.pyrender.jit_render import JITRenderer
 from genesis.utils.misc import tensor_to_array, qd_to_numpy
@@ -110,6 +111,9 @@ class RasterizerContext:
         self.external_nodes = dict()  # nodes added by external user
         self.seg_node_map = dict()
         self.seg_color_map = SegmentationColorMap()
+        # Wakes update_rigid when a heterogeneous entity switches variant, the one runtime change to which geom is
+        # active in which environment. Lazy, so a switch during a frame is picked up by the next render.
+        self._topology_subscriber = Subscriber(to=frozenset({StateChange.TOPOLOGY}))
 
         self.init_meshes()
 
@@ -158,6 +162,9 @@ class RasterizerContext:
             self.on_link_frame()
         if self.show_cameras:
             self.on_camera_frustum()
+
+        for solver in self._rigid_solvers():
+            solver.subscribe(self._topology_subscriber)
 
         self.on_tool()
         self.on_rigid()
@@ -422,7 +429,10 @@ class RasterizerContext:
                 for geom in geoms:
                     # For heterogeneous simulation, filter envs based on geom's assigned environments
                     geom_envs_idx = self._get_geom_active_envs_idx(geom, self.rendered_envs_idx)
-                    if len(geom_envs_idx) == 0:
+                    # A heterogeneous variant inactive in every rendered env at build still gets a node (masked to no
+                    # env, via the branch below) so a later set_entity_variant can reveal it. A non-heterogeneous
+                    # geom with no rendered env is genuinely absent and skipped.
+                    if len(geom_envs_idx) == 0 and (geom.active_envs_idx is None or len(self.rendered_envs_idx) == 0):
                         continue
 
                     if "sdf" in entity.surface.vis_mode:
@@ -472,6 +482,8 @@ class RasterizerContext:
                         self.set_reflection_mat(geom_T)
 
     def update_rigid(self):
+        is_topology_changed = StateChange.TOPOLOGY in self._topology_subscriber.pending
+        self._topology_subscriber.clear()
         for solver in self._rigid_solvers():
             for entity in solver.entities:
                 if entity.surface.vis_mode == "visual":
@@ -555,14 +567,24 @@ class RasterizerContext:
 
                     # For heterogeneous simulation, filter envs based on geom's assigned environments
                     geom_envs_idx = self._get_geom_active_envs_idx(geom, self.rendered_envs_idx)
-                    if len(geom_envs_idx) == 0:
-                        continue
 
-                    # Mirror on_rigid: full per-env poses for env-masked variants, compacted otherwise.
-                    if len(geom_envs_idx) < len(self.rendered_envs_idx):
+                    node = self.rigid_nodes[geom.uid]
+                    primitive = node.mesh.primitives[0]
+
+                    # A geom driven to zero active envs still takes the masked path here, to clear its stale mask.
+                    is_env_masked = len(geom_envs_idx) < len(self.rendered_envs_idx)
+                    if is_env_masked:
                         geom_T = geoms_T[geom.idx][self.rendered_envs_idx]
                     else:
                         geom_T = geoms_T[geom.idx][geom_envs_idx]
+
+                    # active_envs reaches the jit env_active buffer only through a meshes_updated rebuild, so flag one
+                    # whenever a variant switch may have moved which env each geom belongs to.
+                    if is_topology_changed:
+                        primitive.active_envs = (
+                            np.isin(self.rendered_envs_idx, geom_envs_idx) if is_env_masked else None
+                        )
+                        self._scene._meshes_updated = True
 
                     # Keep single-instance for z-axis normal planes (see on_rigid)
                     if isinstance(entity.main_morph, gs.morphs.Plane):
@@ -575,10 +597,11 @@ class RasterizerContext:
                         ):
                             geom_T = geom_T[:1]
 
-                    node = self.rigid_nodes[geom.uid]
                     node.mesh._bounds = None
-                    node.mesh.primitives[0].poses = geom_T
-                    self.jit.update_buffer(node, "model", geom_T.transpose((0, 2, 1)))
+                    primitive.poses = geom_T
+                    # A pending rebuild re-reads primitive.poses, so skip the now-redundant push.
+                    if not self._scene.meshes_updated:
+                        self.jit.update_buffer(node, "model", geom_T.transpose((0, 2, 1)))
                     if isinstance(entity._morph, gs.morphs.Plane):
                         self.set_reflection_mat(geom_T)
 

--- a/tests/rendering/test_offscreen.py
+++ b/tests/rendering/test_offscreen.py
@@ -773,6 +773,23 @@ def test_renders_heterogeneous_entities(n_envs, show_viewer, png_snapshot, rende
     for frame in frames:
         assert rgb_array_to_png_bytes(frame) == png_snapshot
 
+    if IS_BATCHRENDER:
+        # The batch renderers bake per-variant visibility at build time, so a runtime switch must be rejected outright
+        # rather than render the outgoing variant.
+        with pytest.raises(gs.GenesisException):
+            heterogeneous.set_entity_variant(1)
+    else:
+        # Switching every environment onto the duck variant must reveal it wherever the sphere was showing, including
+        # an environment whose build-time variant was the sphere in every rendered environment. Visual state refreshes
+        # once per simulation step, so the switch reaches the renderer on the next one.
+        yellow_before = int(duck_yellow(rgb).sum())
+        heterogeneous.set_entity_variant(1)
+        scene.step()
+        yellow_after = int(duck_yellow(tensor_to_array(camera.render(rgb=True)[0])).sum())
+        assert yellow_after > max(yellow_before, 3), (
+            f"switched-to variant must render; {yellow_before} -> {yellow_after}"
+        )
+
 
 @pytest.mark.parametrize(
     "renderer_type",

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -11,6 +11,7 @@ import genesis.utils.geom as gu
 from genesis.ext import urdfpy
 from genesis.utils import urdf as uu
 from genesis.utils.misc import get_assets_dir, qd_to_numpy, tensor_to_array
+from genesis.utils.procedural import build_articulated_chain
 
 from ..utils import (
     assert_allclose,
@@ -44,6 +45,44 @@ def test_depth_first_link_ordering(xml_path, model_name, show_viewer):
             subtree.append(link)
             stack.extend(children[link])
         assert sorted(subtree) == list(range(i, i + len(subtree))), f"subtree at link {i} is not contiguous"
+
+
+@pytest.mark.required
+def test_build_articulated_chain(show_viewer, tol):
+    L, R = 0.2, 0.04
+    xml_2link_mjcf = build_articulated_chain(n_links=2, link_radius=R, link_length=L, format="mjcf")
+    xml_2link_urdf = build_articulated_chain(n_links=2, link_radius=R, link_length=L, format="urdf")
+    xml_3link_mjcf = build_articulated_chain(n_links=3, link_radius=R, link_length=L, format="mjcf")
+
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, 2.0, 0.5),
+            camera_lookat=(1.0, 0.0, -0.3),
+        ),
+    )
+    arm_mjcf = scene.add_entity(gs.morphs.MJCF(file=xml_2link_mjcf))
+    # Genesis floats a URDF root and adds default joint armature; override both to match the fixed-base MJCF arm.
+    arm_urdf = scene.add_entity(
+        gs.morphs.URDF(file=xml_2link_urdf, pos=(1.0, 0.0, 0.0), fixed=True, default_armature=0.0)
+    )
+    arm_3link = scene.add_entity(gs.morphs.MJCF(file=xml_3link_mjcf, pos=(2.0, 0.0, 0.0)))
+    scene.build(n_envs=0)
+
+    # The URDF and MJCF forms load to the same links: one hinge DOF per link and equal total mass.
+    assert arm_mjcf.n_dofs == 2
+    assert arm_urdf.n_dofs == 2
+    assert_allclose(arm_urdf.get_mass(), arm_mjcf.get_mass(), tol=tol)
+    # A longer chain is heavier.
+    assert arm_3link.get_mass() > arm_mjcf.get_mass()
+
+    # Start the arm horizontal; under gravity it swings below -1.5*L, only reachable if the second link swings too.
+    arm_mjcf.set_dofs_position([np.pi / 2, 0.0], zero_velocity=True)
+    lowest_z = tensor_to_array(arm_mjcf.get_AABB())[0, 2]
+    for _ in range(60):
+        scene.step()
+        lowest_z = min(lowest_z, tensor_to_array(arm_mjcf.get_AABB())[0, 2])
+    assert lowest_z < -1.5 * L
 
 
 @pytest.mark.slow  # ~250s

--- a/tests/rigid/test_heterogeneous.py
+++ b/tests/rigid/test_heterogeneous.py
@@ -8,6 +8,7 @@ from genesis.utils.misc import tensor_to_array
 
 from ..utils import (
     assert_allclose,
+    assert_equal,
     get_hf_dataset,
 )
 
@@ -69,6 +70,25 @@ def test_physics_parity(show_viewer, tol):
         )
         assert_allclose(het_obj.get_quat(relative=relative), ref_quats, tol=tol)
 
+    # Switching every environment onto the first variant rebinds both the inertial and the user frame. Mass collapses
+    # onto the first reference's, and driving the user frame to identity must land every environment on that same
+    # reference's world orientation: a user frame left on the outgoing variant would carry its offset into the world.
+    variants_idx = list(range(len(VARIANTS)))
+    assert_equal(het_obj.get_entity_variant(), variants_idx)
+    world_pos, world_quat = het_obj.get_pos(relative=False), het_obj.get_quat(relative=False)
+    het_obj.set_entity_variant(0)
+    assert_equal(het_obj.get_entity_variant(), 0)
+    assert_allclose(het_obj.get_mass(), ref_objs[0].get_mass(), tol=tol)
+    het_obj.set_quat(gu.identity_quat(), relative=True)
+    assert_allclose(het_obj.get_quat(relative=False), ref_objs[0].get_quat(relative=False), tol=tol)
+
+    # Restoring the variants and the world pose the switch was measured from puts the dynamics below back at build.
+    het_obj.set_entity_variant(variants_idx)
+    het_obj.set_quat(world_quat, relative=False)
+    het_obj.set_pos(world_pos, relative=False)
+    assert_allclose(gu.quat_to_xyz(het_obj.get_quat(relative=True)), 0.0, tol=tol)
+    assert_allclose(het_obj.get_pos(), POSITIONS, tol=tol)
+
     for _ in range(N_STEPS):
         scene.step()
 
@@ -90,7 +110,7 @@ def test_fewer_envs_than_variants():
     scene = gs.Scene(
         show_viewer=False,
     )
-    scene.add_entity(gs.morphs.Plane())
+    plane = scene.add_entity(gs.morphs.Plane())
 
     # 4 variants with different positions but only 2 environments
     morphs_heterogeneous = [
@@ -100,6 +120,12 @@ def test_fewer_envs_than_variants():
         gs.morphs.Sphere(radius=0.02, pos=(0.3, 0.0, 0.25)),
     ]
     het_obj = scene.add_entity(morph=morphs_heterogeneous)
+    # A Kinematic-material entity carries visual geometry only, so its variant rebind goes through the base solver
+    # without any collision or inertia refresh: no rigid entity can reach that path.
+    het_kinematic = scene.add_entity(
+        morph=morphs_heterogeneous,
+        material=gs.materials.Kinematic(),
+    )
 
     # Building with only 2 environments should work - each env gets a unique variant
     scene.build(n_envs=2)
@@ -109,6 +135,34 @@ def test_fewer_envs_than_variants():
     assert mass.shape == (scene.n_envs,)
     # Different box sizes should have different masses
     assert mass[0] != mass[1]
+
+    # A variant no environment was built with is still reachable at runtime, and each environment switches on its own.
+    het_obj.set_entity_variant(3, envs_idx=[0])
+    assert_equal(het_obj.get_entity_variant(), [3, 1])
+    mass_sphere_variant = het_obj.get_mass()
+    assert mass_sphere_variant[1] == mass[1]
+    assert mass_sphere_variant[0] != mass[0]
+    geom_sphere = het_obj.links[0].geoms[3]
+    assert_equal(geom_sphere.active_envs_idx, [0])
+
+    # One index per environment switches them independently, in a single call.
+    het_obj.set_entity_variant([2, 0])
+    assert_equal(het_obj.get_entity_variant(), [2, 0])
+    assert len(geom_sphere.active_envs_idx) == 0
+    assert het_obj.get_mass()[1] == mass[0]
+
+    het_kinematic.set_entity_variant(3)
+    assert_equal(het_kinematic.get_entity_variant(), 3)
+    assert_equal(het_kinematic.links[0].vgeoms[3].active_envs_idx, [0, 1])
+    assert len(het_kinematic.links[0].vgeoms[0].active_envs_idx) == 0
+
+    # A homogeneous entity declares no variant, and an index past the declared ones is out of range.
+    with pytest.raises(gs.GenesisException):
+        plane.set_entity_variant(0)
+    with pytest.raises(gs.GenesisException):
+        plane.get_entity_variant()
+    with pytest.raises(gs.GenesisException):
+        het_obj.set_entity_variant(len(morphs_heterogeneous))
 
 
 @pytest.mark.slow  # ~200s
@@ -165,6 +219,14 @@ def test_aabb(tol):
     aabb_size_sphere = aabb[2, 1] - aabb[2, 0]
     vaabb_size_sphere = vaabb[2, 1] - vaabb[2, 0]
     assert_allclose(aabb_size_sphere, vaabb_size_sphere, tol=1e-3)  # Allow small tolerance for decimation
+
+    # Switching the box environments onto the sphere variant re-poses their geoms right away, without a step: their
+    # extent becomes the sphere's while the world placement they already hold stays put.
+    het_obj.set_entity_variant(1, envs_idx=[0, 1])
+    aabb_switched = het_obj.get_AABB()
+    assert_allclose(aabb_switched[[0, 1], 1] - aabb_switched[[0, 1], 0], aabb_size_sphere, tol=gs.EPS)
+    assert_allclose(aabb_switched[[0, 1]].mean(axis=1), aabb[[0, 1]].mean(axis=1), tol=gs.EPS)
+    assert_allclose(aabb_switched[2:], aabb[2:], tol=gs.EPS)
 
 
 # 30s


### PR DESCRIPTION

## Description

Adds `RigidEntity.set_entity_variant(variant, envs_idx=None)`, letting a heterogeneous entity
(`scene.add_entity(morph=[m0, m1, ...])`) switch which declared variant each environment shows **at
runtime**, not just at build time.

At this point, we still require same kinematic tree across variants. Only the collision/visual
geometry and inertial differ.

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/genesis-world/issues/2531

## Motivation and Context

Part 1 of a series of heterogeneous entity updates!

## How Has This Been / Can This Be Tested?

- `tests/rigid/test_heterogeneous.py::test_runtime_variant_rebind`

## Screenshots (if appropriate):

 `examples/rigid/heterogeneous_interactive.py`

[Screencast From 2026-07-24 10-07-10.webm](https://github.com/user-attachments/assets/efd615ad-5b8e-4dad-8fde-80dc989d289c)

[Screencast From 2026-07-24 11-25-02.webm](https://github.com/user-attachments/assets/d5af241a-02a8-402d-92c3-a24bddaea8f5)


## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Resolves SIM-271