### PR TITLE
  [BUG FIX] Record one camera frame per simulation step.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1017,6 +1017,9 @@ class Scene(RBC):
         # TODO: Could be optimized to only clear cache associated the the environments being reset.
         if self._visualizer.is_built:
             self._visualizer.reset()
+            # Restart camera recording sequences because the scene clock was reset above
+            for camera in self._visualizer.cameras:
+                camera._recorded_t_prev = -1
 
         # TODO: sets _next_particle = 0; not sure this is env isolation safe
         for emitter in self._emitters:

--- a/genesis/vis/camera.py
+++ b/genesis/vis/camera.py
@@ -492,7 +492,7 @@ class Camera(RBC):
                 gs.raise_exception(
                     "Missing frames in recording. Please call 'camera.render()' after 'every scene.step()'."
                 )
-            self._recorded_t_prev == self._visualizer.scene._t
+            self._recorded_t_prev = self._visualizer.scene._t
             rgb_frame = tensor_to_array(rgb_arr)
             self._recorded_imgs.append(rgb_frame)
 
@@ -684,6 +684,9 @@ class Camera(RBC):
         Start recording on the camera. After recording is started, all the rgb images rendered by `camera.render()`
         will be stored, and saved to a video file when `camera.stop_recording()` is called.
         """
+        # Restart timestamp tracking when recording becomes active, excluding simulation steps elapsed while paused
+        if not self._in_recording:
+            self._recorded_t_prev = -1
         self._in_recording = True
 
     @gs.assert_built

--- a/tests/rendering/test_offscreen.py
+++ b/tests/rendering/test_offscreen.py
@@ -1532,3 +1532,60 @@ def test_rasterizer_sensor_env_spacing_invariance(renderer, context_mode):
     # Per-env sensor images must be invariant to env_spacing — the offset is purely for
     # visual separation in the interactive viewer and must be transparent to sensors.
     assert np.abs(img_ref.astype(np.float32) - img_test.astype(np.float32)).mean() < 1.0
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("renderer_type", [RENDERER_TYPE.RASTERIZER])
+def test_recording_stores_one_frame_per_timestamp(renderer, show_viewer):
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.5, 0.0, 1.5),
+            camera_lookat=(0.0, 0.0, 0.5),
+        ),
+        renderer=renderer,
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 0.5),
+            size=(0.2, 0.2, 0.2),
+        ),
+    )
+    cam = scene.add_camera(
+        res=(64, 64),
+        pos=(2.5, 0.0, 1.5),
+        lookat=(0.0, 0.0, 0.5),
+    )
+    scene.build()
+
+    cam.start_recording()
+
+    scene.step()
+    cam.render()
+    cam.render()
+    assert len(cam._recorded_imgs) == 1
+
+    # Starting an already active recording must preserve timestamp tracking
+    cam.start_recording()
+    cam.render()
+    assert len(cam._recorded_imgs) == 1
+
+    scene.step()
+    cam.render()
+    assert len(cam._recorded_imgs) == 2
+
+    # Resuming starts a new sequence, so the steps elapsed while paused are not missing frames
+    cam.pause_recording()
+    scene.step()
+    scene.step()
+    cam.start_recording()
+    cam.render()
+    assert len(cam._recorded_imgs) == 3
+
+    scene.step()
+    scene.step()
+    with pytest.raises(gs.GenesisException, match="Missing frames"):
+        cam.render()

--- a/tests/rendering/test_offscreen.py
+++ b/tests/rendering/test_offscreen.py
@@ -1589,3 +1589,18 @@ def test_recording_stores_one_frame_per_timestamp(renderer, show_viewer):
     scene.step()
     with pytest.raises(gs.GenesisException, match="Missing frames"):
         cam.render()
+
+    # Resetting rewinds the scene clock, so a recording spanning the reset starts a new sequence
+    scene.reset()
+    cam.render()
+    assert len(cam._recorded_imgs) == 4
+
+    # Visualizer refreshes at the same timestamp must preserve recording state
+    scene.visualizer.update()
+    cam.render()
+    assert len(cam._recorded_imgs) == 4
+
+    # A reset at timestamp zero still starts a new recording sequence
+    scene.reset()
+    cam.render()
+    assert len(cam._recorded_imgs) == 5


### PR DESCRIPTION
## Description

  `Camera.render()` did not update `_recorded_t_prev` after storing a video frame because it used `==`
  instead of `=`.

  This caused repeated calls to `render()` at the same simulation timestamp to store duplicate frames.
  It also kept the existing missing-frame check inactive because `_recorded_t_prev` remained at `-1`.

  This change updates the timestamp after storing a frame. It also resets timestamp tracking when
  recording transitions from inactive to active, so simulation steps elapsed while recording is paused
  are not treated as missing frames. Calling `start_recording()` while already recording preserves the
  current timestamp.

  ## Related Issue

  Resolves #3105

  ## Motivation and Context

  Camera recording is intended to store at most one frame per simulation timestamp and report skipped
  timestamps during continuous recording. Both behaviors were inactive because the previous timestamp
  was never updated.

  This restores the existing intended behavior without changing the public API.

  ## How Has This Been / Can This Be Tested?

  Tested on macOS 15.7.3 with an Apple M4, the CPU backend, and Python 3.13.11.

  A regression test was added for duplicate rendering, consecutive timestamps, repeated
  `start_recording()` calls, pause/resume, and skipped-frame detection.

  ```bash
  pytest tests/rendering/test_offscreen.py::test_recording_stores_one_frame_per_timestamp -v -n 0 --forked
  pytest tests/rendering/test_offscreen.py::test_render_api_advanced -v -n 0
  pytest tests/rendering/test_offscreen.py -v -m required -n 0 --forked
  pre-commit run --files genesis/vis/camera.py tests/rendering/test_offscreen.py
```

  The regression test fails on main because two calls to render() at the same timestamp store two
  frames. It passes with this change.

  All locally supported required offscreen-rendering cases passed, including 162 snapshots. Tests
  requiring CUDA, LuisaRender, or an interactive viewer were skipped because those backends are not
  available on my machine. Both pre-commit hooks passed.

  ## Screenshots (if appropriate):

  Not applicable.

  ## Checklist:

  - [x] I read the CONTRIBUTING document.
  - [x] I followed the Submitting Code Changes section of CONTRIBUTING document.
  - [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
  - [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
  - [x] I tested my changes and added instructions on how to test it for reviewers.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.