### PR TITLE
[MISC] Fix fragile rendering unit test.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -976,20 +976,23 @@ def png_snapshot(request, snapshot):
     snapshot_dir = Path(PixelMatchSnapshotExtension.dirname(test_location=snapshot_obj.test_location))
     snapshot_name = PixelMatchSnapshotExtension.get_snapshot_name(test_location=snapshot_obj.test_location)
 
+    # The brackets a parametrized test carries in its name are a character class to any glob, so they must be escaped
+    # for the pattern to match the files that name belongs to
+    snapshot_pattern = "".join(f"[{char}]" if char in ("[", "]") else char for char in snapshot_name) + "*"
+
     must_update_snapshot = request.config.getoption("--snapshot-update")
     if must_update_snapshot:
-        for path in (Path(snapshot_dir.parent) / snapshot_dir.name).glob(f"{snapshot_name}*"):
+        for path in (Path(snapshot_dir.parent) / snapshot_dir.name).glob(snapshot_pattern):
             assert path.is_file()
             path.unlink()
     else:
         from .utils import get_hf_dataset
 
-        snapshot_name_ = "".join(f"[{char}]" if char in ("[", "]") else char for char in snapshot_name)
         # The snapshots repository mirrors the tests tree ('rendering/__snapshots__/test_offscreen/...'), so the
         # snapshot directory path relative to the tests root is also its path in the repository.
         tests_dir = Path(__file__).parent
         get_hf_dataset(
-            pattern=f"{snapshot_dir.relative_to(tests_dir).as_posix()}/{snapshot_name_}*",
+            pattern=f"{snapshot_dir.relative_to(tests_dir).as_posix()}/{snapshot_pattern}",
             repo_name="snapshots",
             local_dir=tests_dir,
         )

--- a/tests/rendering/test_offscreen.py
+++ b/tests/rendering/test_offscreen.py
@@ -1328,8 +1328,10 @@ def test_rasterizer_env_separate(renderer, png_snapshot, show_viewer, force_show
     CAM_RES = (256, 256)
     RENDERED_ENVS = (1, 2)
 
-    # FIXME: Small discrepancies between different hardware due to contact visualization with onscreen viewer
-    STD_ERR_THR_MARKERS_OFF, STD_ERR_THR_MARKERS_ON = 1.0, 3.5 if force_show_viewer else 1.05
+    # One threshold for every frame. Marker lines land on slightly different pixels from one rasterizer to the next,
+    # which the offscreen frames absorb through a blur; the viewer frame holds up without one.
+    STD_ERR_THR = 1.5
+    BLUR_OFFSCREEN = 3
 
     scene = gs.Scene(
         vis_options=gs.options.VisOptions(
@@ -1341,7 +1343,8 @@ def test_rasterizer_env_separate(renderer, png_snapshot, show_viewer, force_show
             shadow=False,
         ),
         viewer_options=gs.options.ViewerOptions(
-            camera_pos=(2.0, 0.2, 1.5),
+            # Far enough back for the whole ground to fit in frame, as every camera below requires
+            camera_pos=(3.0, 0.3, 2.0),
             camera_lookat=(0.0, 0.0, 0.4),
             res=CAM_RES,
             run_in_thread=False,
@@ -1352,12 +1355,16 @@ def test_rasterizer_env_separate(renderer, png_snapshot, show_viewer, force_show
         show_viewer=force_show_viewer,
         show_FPS=False,
     )
-    scene.add_entity(gs.morphs.Plane())
+    scene.add_entity(
+        gs.morphs.Plane(
+            # Software rendering backends misrasterize geometry reaching outside the frustum, so every vertex of the
+            # ground stays in frame from each camera below. Collision keeps its own infinite plane.
+            plane_size=(1.4, 1.4),
+        )
+    )
     franka = scene.add_entity(
         gs.morphs.MJCF(
             file="xml/franka_emika_panda/panda.xml",
-            # Add small negative offset to force contact with the ground
-            pos=(0.0, 0.0, -0.01),
         ),
         visualize_contact=True,
     )
@@ -1379,14 +1386,14 @@ def test_rasterizer_env_separate(renderer, png_snapshot, show_viewer, force_show
     )
     scene.build(n_envs=4, env_spacing=(0.3, 0.3))
 
-    # Hardcoded joint positions from a converged 200-step simulation with randomized initial states.
-    # Each env has a distinct pose so per-env renders differ visually.
+    # Hardcoded joint positions from a converged 200-step simulation with randomized initial states, each arm resting
+    # against the ground so the contact markers have contacts to draw, in a pose distinct from the other envs.
     franka.set_dofs_position(
         [
-            [0.199, 1.763, -0.148, -0.224, -0.790, 0.822, 0.051, 0.002, 0.002],
-            [0.372, 1.763, 0.172, -0.369, 1.498, -0.018, -0.040, 0.000, 0.000],
-            [-0.114, -1.763, -2.885, -0.234, -1.195, 0.159, 0.316, 0.000, 0.000],
-            [-0.254, -1.763, 2.193, -0.217, 1.109, 0.501, 0.727, 0.001, 0.001],
+            [1.728, -1.763, -2.157, -2.275, -0.327, 2.201, 1.833, 0.018, 0.018],
+            [-2.717, -1.763, -2.217, -2.566, 0.226, 2.933, 1.307, 0.017, 0.017],
+            [-1.411, 1.763, 0.657, -2.817, 1.597, 3.567, 2.872, 0.000, 0.000],
+            [-2.098, 1.763, -1.004, -2.421, -0.227, 2.850, -0.136, 0.020, 0.020],
         ]
     )
     scene.step()
@@ -1399,13 +1406,8 @@ def test_rasterizer_env_separate(renderer, png_snapshot, show_viewer, force_show
         pyrender_viewer.on_draw()
         viewer_rgb = pyrender_viewer._renderer.jit.read_color_buf(*pyrender_viewer._viewport_size, rgba=False)
 
-        try:
-            png_snapshot.extension._std_err_threshold = STD_ERR_THR_MARKERS_ON
-            assert rgb_array_to_png_bytes(viewer_rgb) == png_snapshot
-        except AssertionError:
-            if sys.platform == "darwin" and scene.visualizer.is_software:
-                pytest.xfail("Flaky on MacOS with Apple Software Renderer.")
-            raise
+        png_snapshot.extension._std_err_threshold = STD_ERR_THR
+        assert rgb_array_to_png_bytes(viewer_rgb) == png_snapshot
 
     # Render both cameras
     rgb, *_ = cam.render(rgb=True)
@@ -1440,17 +1442,12 @@ def test_rasterizer_env_separate(renderer, png_snapshot, show_viewer, force_show
     assert rgb is not None
 
     # Non-debug camera should NOT show markers — snapshot per env validates only robots are visible
-    png_snapshot.extension._std_err_threshold = STD_ERR_THR_MARKERS_OFF
+    png_snapshot.extension._std_err_threshold = STD_ERR_THR
+    png_snapshot.extension._blurred_kernel_size = BLUR_OFFSCREEN
     for rgb_i in rgb:
-        try:
-            assert rgb_array_to_png_bytes(rgb_i) == png_snapshot
-        except AssertionError:
-            if sys.platform == "darwin" and scene.visualizer.is_software:
-                pytest.xfail("Flaky on MacOS with Apple Software Renderer.")
-            raise
+        assert rgb_array_to_png_bytes(rgb_i) == png_snapshot
 
     # Debug camera SHOULD show markers (frames, contact arrows) — snapshot per env validates markers
-    png_snapshot.extension._std_err_threshold = STD_ERR_THR_MARKERS_ON
     for rgb_debug_i in rgb_debug:
         assert rgb_array_to_png_bytes(rgb_debug_i) == png_snapshot
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,7 @@ REPOSITY_URL = "Genesis-Embodied-AI/Genesis"
 DEFAULT_BRANCH_NAME = "main"
 
 HUGGINGFACE_ASSETS_REVISION = "990a727788f11e34ad006c69bf769303b20cb11c"
-HUGGINGFACE_SNAPSHOT_REVISION = "dab1f3556b879f7fa7be4c1158be85885fbc7658"
+HUGGINGFACE_SNAPSHOT_REVISION = "afeaad9ab5f8d221b2cd96977feafb340c5b67af"
 
 MESH_EXTENSIONS = (".mtl", *MESH_FORMATS, *GLTF_FORMATS, *USD_FORMATS)
 IMAGE_EXTENSIONS = (".png", ".jpg")
@@ -330,18 +330,18 @@ def assert_pixel_match(
         if blurred_kernel_size == 1:
             blurred.append(img_arr)
             continue
-        kernel = np.ones((blurred_kernel_size, blurred_kernel_size), dtype=np.float32) / (blurred_kernel_size**2)
         pad_size = blurred_kernel_size // 2
         h, w = img_arr.shape[:2]
         padded = np.pad(img_arr, ((pad_size, pad_size), (pad_size, pad_size), (0, 0)), mode="edge")
-        blurred_arr = np.zeros_like(img_arr, dtype=np.float32)
-        for c in range(img_arr.shape[-1]):
-            for i in range(h):
-                for j in range(w):
-                    blurred_arr[i, j, c] = np.sum(
-                        padded[i : i + blurred_kernel_size, j : j + blurred_kernel_size, c] * kernel
-                    )
-        blurred.append(blurred_arr)
+        # A box kernel is separable, so the window sum accumulates one row shift at a time, then one column shift at a
+        # time over that, which costs a handful of whole-array additions instead of a pass per pixel.
+        rows = np.zeros((h, padded.shape[1], img_arr.shape[-1]), dtype=np.float32)
+        for i in range(blurred_kernel_size):
+            rows += padded[i : i + h]
+        window_sum = np.zeros_like(img_arr, dtype=np.float32)
+        for j in range(blurred_kernel_size):
+            window_sum += rows[:, j : j + w]
+        blurred.append(window_sum / blurred_kernel_size**2)
 
     img_err = np.minimum(np.abs(blurred[1] - blurred[0]), 255).astype(np.uint8)
     std_err = float(np.max(np.std(img_err.reshape((-1, img_err.shape[-1])), axis=0)))


### PR DESCRIPTION
## Description

The franka was spawned 1 cm below the ground to "force contact with the ground", but its base is a fixed link and both-fixed geom pairs never collide: the offset produced no contact and buried the base in every reference image. It now stands flush, with joint positions re-derived so the arm comes to rest against the ground.

The ground is sized to stay inside every frustum the test renders through, instead of spanning the default kilometre, since geometry reaching outside is misrasterized by software rendering backends. Deviation between hardware OpenGL and the Apple Software Renderer drops from 9.4-13.2 to 0.5-1.2, so every frame now shares one threshold, the offscreen ones through a blur.

Regenerating a snapshot also never deleted the stale files: the fixture globs the snapshot name, and a parametrized name carries brackets, which a glob reads as a character class.

## Motivation and Context

A reference image showing a robot sunk into the ground pins the defect instead of the behaviour.

## How Has This Been / Can This Be Tested?

```bash
pytest tests/rendering/test_offscreen.py::test_rasterizer_env_separate -n 0
```

Passes on hardware OpenGL and on the Apple Software Renderer alike. Every environment rests on the ground with 4 to 6 contacts at 17 to 40 N, where the sunk pose reached 681 N. The nine references are regenerated.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
