### PR TITLE
[BUG FIX] Correct environment indexing for link information.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -4333,9 +4333,9 @@ class RigidEntity(KinematicEntity):
         """
         gravity = self._solver.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
         links_pos = self.get_links_pos(envs_idx=envs_idx, ref="link_com")  # (..., n_links, 3)
-        # Link masses are static properties (not batched per environment),
-        # so always fetch without envs_idx to avoid indexing conflicts.
-        links_mass = self.get_links_inertial_mass()  # (n_links,)
+        links_mass = self.get_links_inertial_mass(
+            envs_idx=envs_idx if self._solver._options.batch_links_info else None
+        )  # (n_links,), or (n_envs, n_links) if batched
 
         # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
         # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2802,13 +2802,13 @@ class RigidSolver(KinematicSolver):
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_inertial_mass(self, links_idx=None, envs_idx=None):
-        if self._options.batch_links_info and envs_idx is not None:
+        if not self._options.batch_links_info and envs_idx is not None:
             gs.raise_exception("`envs_idx` cannot be specified for non-batched links info.")
         tensor = qd_to_torch(self.dyn_info.links.inertial_mass, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 and self._options.batch_links_info else tensor
 
     def get_links_invweight(self, links_idx=None, envs_idx=None):
-        if self._options.batch_links_info and envs_idx is not None:
+        if not self._options.batch_links_info and envs_idx is not None:
             gs.raise_exception("`envs_idx` cannot be specified for non-batched links info.")
         tensor = qd_to_torch(self.dyn_info.links.invweight, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 and self._options.batch_links_info else tensor
@@ -3014,7 +3014,9 @@ class RigidSolver(KinematicSolver):
 
         gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
         links_pos = self.get_links_pos(envs_idx=envs_idx, ref="link_com")  # (..., n_links, 3)
-        links_mass = self.get_links_inertial_mass(envs_idx=envs_idx)  # (n_links,), or (n_envs, n_links) if batched
+        links_mass = self.get_links_inertial_mass(
+            envs_idx=envs_idx if self._options.batch_links_info else None
+        )  # (n_links,), or (n_envs, n_links) if batched
 
         # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
         # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -456,6 +456,55 @@ def test_batched_info(batch_links_info, batch_joints_info, batch_dofs_info):
     assert act_gain.shape == (9, 2) if batch_dofs_info else (9,)
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("batch_links_info", [False, True])
+def test_link_info_environment_indexing(batch_links_info, tol):
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            batch_links_info=batch_links_info,
+        ),
+        show_viewer=False,
+    )
+    entities = (
+        scene.add_entity(gs.morphs.Box(size=(0.1, 0.1, 0.1), pos=(0.0, 0.0, 1.0))),
+        scene.add_entity(gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(0.0, 0.0, 2.0))),
+    )
+    scene.build(n_envs=3)
+
+    getters = (scene.rigid_solver.get_links_inertial_mass, scene.rigid_solver.get_links_invweight)
+    if not batch_links_info:
+        for getter in getters:
+            with pytest.raises(gs.GenesisException, match="envs_idx.*non-batched links info"):
+                getter(envs_idx=[1])
+    else:
+        entities[0].links[0].set_mass((1.0, 2.0, 3.0))
+        entities[1].links[0].set_mass((4.0, 5.0, 6.0))
+        assert_allclose(
+            scene.rigid_solver.get_links_inertial_mass(),
+            ((1.0, 4.0), (2.0, 5.0), (3.0, 6.0)),
+            tol=tol,
+        )
+        for getter in getters:
+            values = getter()
+            assert_allclose(getter(envs_idx=[1]), values[[1]], tol=tol)
+            assert_allclose(getter(links_idx=[1], envs_idx=[2, 0]), values[[2, 0]][:, [1]], tol=tol)
+        assert_allclose(
+            scene.rigid_solver.get_links_inertial_mass(links_idx=[1], envs_idx=[2, 0]),
+            ((6.0,), (4.0,)),
+            tol=tol,
+        )
+        for getter in (entities[0].get_links_inertial_mass, entities[0].get_links_invweight):
+            values = getter()
+            assert_allclose(getter(links_idx_local=[0], envs_idx=[2, 0]), values[[2, 0]][:, [0]], tol=tol)
+
+    total_energy = scene.rigid_solver.get_total_energy()
+    assert_allclose(scene.rigid_solver.get_total_energy(envs_idx=[1]), total_energy[[1]], tol=tol)
+    for entity in entities:
+        for getter in (entity.get_potential_energy, entity.get_total_energy):
+            values = getter()
+            assert_allclose(getter(envs_idx=[1]), values[[1]], tol=tol)
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_info_batching(tol):


### PR DESCRIPTION
## Description

I fixed environment indexing for batched link information.

The link mass and inverse-weight getters checked `batch_links_info` in reverse. This allowed `envs_idx` for shared link information and rejected it for batched link information. I corrected those checks.

I also updated the solver and entity energy calculations so they select per-environment masses only when link information is batched.

I added a regression test for shared and batched link information, combined link and environment selection, and solver and entity energy values.

## Related Issue

Resolves #3112

## Motivation and Context

The previous behavior could interpret an environment index as a link index in shared mode. It could also reject valid environment selection in batched mode or return energy values for the wrong set of environments.

## How Has This Been / Can This Be Tested?

I ran:

```bash
python -m pytest tests/rigid/test_api.py::test_link_info_environment_indexing -v
python -m pytest tests/rigid/test_api.py -m "required and not slow" -v
python -m pytest tests/rigid/test_dynamics.py::test_energy_analytical_and_conservation -v
uvx --from ruff==0.14.11 ruff check genesis/engine/entities/rigid_entity/rigid_entity.py genesis/engine/solvers/rigid/rigid_solver.py tests/rigid/test_api.py
uvx --from ruff==0.14.11 ruff format --check genesis/engine/entities/rigid_entity/rigid_entity.py genesis/engine/solvers/rigid/rigid_solver.py tests/rigid/test_api.py
uv build --wheel
```

Results:

- Link information regression test: 2 passed
- Required non-slow rigid API tests: 8 passed
- Analytical energy tests: 2 passed
- Ruff checks passed
- Wheel build passed

I also started the full required test suite. It reached 21% before I stopped it because of its runtime. Two unrelated macOS rendering and plotting tests failed during that run. The rigid API and batching tests reached during the run passed.

## Screenshots (if appropriate):

Not applicable.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
