### PR TITLE
[BUG FIX] Fix handling of negative index for rigid accessor filter 'envs_idx'.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1606,7 +1606,7 @@ class Scene(RBC):
         if isinstance(envs_idx, (slice, range)):
             return self._envs_idx[envs_idx]
         if isinstance(envs_idx, (int, np.integer)):
-            return self._envs_idx[envs_idx : envs_idx + 1]
+            return self._envs_idx[envs_idx][None]
 
         return sanitize_index(envs_idx, -1, self.n_envs, 0, "envs_idx")
 

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1610,7 +1610,7 @@ class Scene(RBC):
             if not -n_envs <= envs_idx < n_envs:
                 gs.raise_exception(f"`envs_idx` out of range: {envs_idx} not in [{-n_envs}, {n_envs}).")
             if envs_idx < 0:
-                envs_idx += n_envs
+                envs_idx = envs_idx + n_envs
             return self._envs_idx[envs_idx : envs_idx + 1]
 
         return sanitize_index(envs_idx, -1, self.n_envs, 0, "envs_idx")

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1606,7 +1606,12 @@ class Scene(RBC):
         if isinstance(envs_idx, (slice, range)):
             return self._envs_idx[envs_idx]
         if isinstance(envs_idx, (int, np.integer)):
-            return self._envs_idx[envs_idx][None]
+            n_envs = self.n_envs
+            if not -n_envs <= envs_idx < n_envs:
+                gs.raise_exception(f"`envs_idx` out of range: {envs_idx} not in [{-n_envs}, {n_envs}).")
+            if envs_idx < 0:
+                envs_idx += n_envs
+            return self._envs_idx[envs_idx : envs_idx + 1]
 
         return sanitize_index(envs_idx, -1, self.n_envs, 0, "envs_idx")
 

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -26,7 +26,11 @@ def test_gravity(show_viewer, tol):
 
     scene.sim.set_gravity(torch.tensor([0.0, 0.0, 0.0]))
     scene.sim.set_gravity(torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]), envs_idx=[0, 1])
+    scene.sim.set_gravity(torch.tensor([1.0, 0.0, 0.0]), envs_idx=np.int64(-3))
     scene.sim.set_gravity(torch.tensor([0.0, 0.0, 3.0]), envs_idx=-1)
+    for envs_idx in (-4, 3, np.int64(-4), np.int64(3)):
+        with pytest.raises(gs.GenesisException, match="`envs_idx` out of range"):
+            scene.sim.set_gravity(torch.tensor([0.0, 0.0, 0.0]), envs_idx=envs_idx)
     with np.testing.assert_raises(RuntimeError):
         scene.sim.set_gravity(torch.tensor([0.0, -10.0]))
     with np.testing.assert_raises(RuntimeError):

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -26,7 +26,7 @@ def test_gravity(show_viewer, tol):
 
     scene.sim.set_gravity(torch.tensor([0.0, 0.0, 0.0]))
     scene.sim.set_gravity(torch.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]), envs_idx=[0, 1])
-    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 3.0]), envs_idx=2)
+    scene.sim.set_gravity(torch.tensor([0.0, 0.0, 3.0]), envs_idx=-1)
     with np.testing.assert_raises(RuntimeError):
         scene.sim.set_gravity(torch.tensor([0.0, -10.0]))
     with np.testing.assert_raises(RuntimeError):


### PR DESCRIPTION
 ## Description

  `Scene._sanitize_envs_idx()` used a slice to preserve the dimension of scalar environment indices. For `envs_idx=-1`,
  this produced the empty slice `[-1:0]`, so the operation silently affected no environment.

  This changes the scalar branch to index the requested environment and then restore the one-element dimension. Valid
  negative scalar indices now follow normal Python indexing, and out-of-range scalar indices raise instead of being
  silently ignored.

  The change is limited to scalar integer indices. The `slice`, `range`, and collection paths are unchanged.

  ## Related Issue

  Resolves #3116

  ## Motivation and Context

  Using `envs_idx=-1` should select the last environment, but it previously produced no warning and made no change.
  Since `_sanitize_envs_idx()` is shared by several per-environment APIs, the same silent behavior could affect scene,
  sensor, camera, and rigid-body operations.

  ## How Has This Been / Can This Be Tested?

  The existing gravity test now uses `envs_idx=-1` to update the last of three environments. Its existing assertion
  verifies that only the last environment receives the new gravity.

  The regression test failed before the fix because the last environment remained unchanged, and passed after the fix.

  Tested on macOS 15.7.3 with an Apple M4, Python 3.11.14, and the CPU backend:

  ```bash
  pytest tests/rigid/test_dynamics.py::test_gravity -n 0 -v
  pytest 'tests/rigid/test_api.py::test_data_accessor[3-False-cpu]' -v
  pre-commit run --files genesis/engine/scene.py tests/rigid/test_dynamics.py
  ```

  Results:

  ```text
  test_gravity: 1 passed
  test_data_accessor[3-False-cpu]: 1 passed
  ruff check: Passed
  ruff format: Passed
  ```

  ## Screenshots (if appropriate):

  Not applicable.

  ## Checklist:

  - [x] I read the **CONTRIBUTING** document.
  - [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
  - [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
  - [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is
  needed.
  - [x] I tested my changes and added instructions on how to test it for reviewers.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.