### PR TITLE
[MISC] Fix reverse-mode autodiff on Apple Metal.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -754,7 +754,7 @@ def _kernel_solve_graph(
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    while qd.graph_do_while(graph_counter):
+    while qd.graph.do_while(graph_counter):
         # Fused: mv + jv + snorm + quad_gauss + eq_sum
         _func_decomp_linesearch_p0(dyn_state, constraint_state, dyn_info, rigid_info, rigid_config)
         # Fused: refinement + apply alpha
@@ -841,7 +841,7 @@ def _kernel_solve_graph(
 )
 def func_solve_decomposed(dyn_state, constraint_state, dyn_info, rigid_info, rigid_config, _n_iterations):
     """
-    GPU graph accelerated solver loop with parallel grid-search linesearch and GPU-side iteration via graph_do_while.
+    GPU graph accelerated solver loop with parallel grid-search linesearch and GPU-side iteration via graph.do_while.
 
     On CUDA SM 9.0+ (Hopper), the entire iteration loop runs on the GPU with no host involvement. On older CUDA GPUs,
     falls back to a host-side do-while loop that still benefits from CUDA graph kernel launch batching. On other GPUs,

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -522,7 +522,7 @@ class ConstraintState:
     use_full_hessian: qd.Tensor
     # Solver loop iteration counter (0-indexed, increments each iteration in the graph loop)
     solver_iter_counter: qd.Tensor
-    # Always ndarray (not field): graph_do_while requires the same physical ndarray on every call.
+    # Always ndarray (not field): graph.do_while requires the same physical ndarray on every call.
     graph_counter: qd.types.ndarray()
     early_exit_flag: qd.Tensor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==1.1.3",
+    "quadrants==1.2.0",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,6 @@ SKIP_NO_MADRONA = _skip_reason("BatchRenderer is not supported because 'gs_madro
 SKIP_NO_LUISA = _skip_reason("RayTracer is not supported because 'LuisaRenderPy' is not available.")
 SKIP_NO_VIEWER = _skip_reason("Interactive viewer not supported on this platform.")
 SKIP_NO_OMNIVERSE_KIT = _skip_reason("omniverse-kit support not available")
-SKIP_METAL_GRAD = _skip_reason("Apple Metal GPU computes wrong reverse-mode gradients (Quadrants backward bug).")
 
 
 def is_mem_monitoring_supported():

--- a/tests/grad/test_rigid_dynamics.py
+++ b/tests/grad/test_rigid_dynamics.py
@@ -1,25 +1,15 @@
 import math
-import sys
 
 import numpy as np
 import pytest
 
 import genesis as gs
 
-from ..conftest import SKIP_METAL_GRAD
 from .utils import assert_grad_matches_fd, make_diff_scene_pair
 
 
 @pytest.mark.required
-@pytest.mark.parametrize(
-    "backend",
-    [
-        gs.cpu,
-        # FIXME: Quadrants' released native-Metal reverse-mode autodiff collapses per-env adjoints (fixed upstream,
-        # see Quadrants issue #805). Re-enable once the fix ships in a Quadrants release.
-        pytest.param(gs.gpu, marks=pytest.mark.skipif(sys.platform == "darwin", reason=SKIP_METAL_GRAD)),
-    ],
-)
+@pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 @pytest.mark.parametrize(
     "model_name",
     [

--- a/tests/grad/test_rigid_optim.py
+++ b/tests/grad/test_rigid_optim.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import pytest
 import torch
@@ -7,19 +5,12 @@ import torch
 import genesis as gs
 from genesis.utils.misc import tensor_to_array
 
-from ..conftest import SKIP_METAL_GRAD
 from ..utils import assert_allclose
 from .utils import make_diff_scene_pair
 
 
 @pytest.mark.required
-@pytest.mark.parametrize(
-    "backend",
-    [
-        gs.cpu,
-        pytest.param(gs.gpu, marks=pytest.mark.skipif(sys.platform == "darwin", reason=SKIP_METAL_GRAD)),
-    ],
-)
+@pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 @pytest.mark.parametrize("control_target", ["init_vel", "control_force"])
 @pytest.mark.debug(False)
 def test_reference_trajectory_recovery_converges(control_target, grad_cartpole, show_viewer):


### PR DESCRIPTION
## Description

Move the Quadrants pin to 1.2.0 and stop skipping the rigid autodiff tests on Apple Silicon GPU. Quadrants 1.2.0 fixes the SPIR-V lowering of the reverse-mode adstack heap addressing, which collapsed the per-env slot address to a SIMD-group-uniform value on Metal, so every env ended up reading env 0's stashed value. Also switch the constraint solver's graph loop to the canonical `qd.graph.do_while` spelling, since 1.2.0 deprecates the flat `qd.graph_do_while` form.

## Motivation and Context

Reverse-mode gradients were silently wrong on Metal - all envs of a batch returned env 0's gradient rather than their own - so gradient-based workflows were unusable on Apple Silicon GPU and their tests were skipped there. With 1.2.0 the Metal backend gives correct per-env adjoints, so differentiable simulation now works on macOS GPU and the tests run on the same backends as everywhere else.

## How Has This Been / Can This Be Tested?

The tests that were previously skipped on macOS GPU are the check:

```
pytest tests/grad/test_rigid_dynamics.py tests/grad/test_rigid_optim.py -k gpu
```

On Apple Silicon this covers the 8 single-step FK joint gradients against finite differences and the two trajectory-recovery optimizations. `pytest tests/rigid/test_collision.py -k decomposed` exercises the renamed graph loop.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
