### PR TITLE
[BUG FIX] Fix recording a black video when frames cannot be encoded.

### DIFF
--- a/genesis/recorders/file_writers.py
+++ b/genesis/recorders/file_writers.py
@@ -80,9 +80,9 @@ class VideoFileWriter(BaseFileWriter):
         )
 
     def process(self, data, cur_time):
-        # 'astype' copies unconditionally, which is what lets the frame be encoded asynchronously while the caller is
-        # free to reuse its own buffer.
-        self.encoder.write(data.astype(np.uint8))
+        # The copy is unconditional, which is what lets the frame be encoded asynchronously while the caller is free to
+        # reuse its own buffer.
+        self.encoder.write(data.copy())
 
     def cleanup(self):
         try:

--- a/genesis/utils/video_encoder.py
+++ b/genesis/utils/video_encoder.py
@@ -158,8 +158,6 @@ class VideoEncoder:
 
     def _open(self, frame):
         is_color = frame.ndim == 3 and frame.shape[-1] == 3
-        if frame.ndim != 2 + is_color or not np.issubdtype(frame.dtype, np.integer):
-            gs.raise_exception("Frames must be either grayscale [H, W] or color [H, W, RGB] of integer type.")
         height, width, *_ = frame.shape
         # 4:2:0 chroma subsampling halves both axes, so encoders reject an odd width or height. The frame is padded to
         # the next even size rather than cropped, keeping every pixel the camera rendered.
@@ -219,6 +217,13 @@ class VideoEncoder:
         on the thread owning the rendering context rather than on the encoding thread. When threaded, the frame must
         not be mutated after this call, since it is encoded asynchronously.
         """
+        # Every frame is validated, not just the first one: the reusable frame storage is 8-bit, so anything else
+        # would be truncated on assignment instead of raising. Validating here rather than at encoding time also
+        # reports the error on the calling thread, where it can propagate, rather than on the encoding thread.
+        is_color = frame.ndim == 3 and frame.shape[-1] == 3
+        if frame.ndim != 2 + is_color or not np.issubdtype(frame.dtype, np.integer):
+            gs.raise_exception("Frames must be either grayscale [H, W] or color [H, W, RGB] of integer type.")
+
         if self._is_threaded:
             if self._thread is None:
                 self._is_encoding_over = False

--- a/tests/core/test_recorders.py
+++ b/tests/core/test_recorders.py
@@ -252,6 +252,14 @@ def test_video_writer(tmp_path):
         lookat=(0.0, 0.0, 0.2),
         GUI=False,
     )
+    # Registered first, so that rejecting its very last frame aborts the step before the others have sampled it
+    video_dtype_path = tmp_path / "test_dtype.mp4"
+    scene.start_recording(
+        data_func=lambda: np.zeros((64, 64, 3), dtype=np.uint8) if scene.t <= STEPS else np.full((64, 64, 3), 0.5),
+        rec_options=gs.recorders.VideoFile(
+            filename=video_dtype_path,
+        ),
+    )
     video_rgb_path = tmp_path / "test_rgb.mp4"
     scene.start_recording(
         data_func=lambda: camera.render(rgb=True, depth=False, segmentation=False, normal=False)[0],
@@ -272,11 +280,16 @@ def test_video_writer(tmp_path):
     for _ in range(STEPS):
         scene.step()
 
+    # A normalized floating-point frame cannot be represented and must be reported, whichever frame it is, rather than
+    # truncated to a black one
+    with pytest.raises(gs.GenesisException, match="integer type"):
+        scene.step()
+
     scene.stop_recording()
 
     # Every sampled step must survive into the file: frames buffered by the encoder but never flushed, or dropped
     # because it fell behind, would leave a shorter video that a size check cannot distinguish from a complete one
-    for video_path in (video_rgb_path, video_depth_path):
+    for video_path in (video_dtype_path, video_rgb_path, video_depth_path):
         assert video_path.exists(), "Recorded video file should exist"
         with av.open(video_path) as container:
             assert sum(1 for _ in container.decode(video=0)) == STEPS


### PR DESCRIPTION
## Description

`VideoFileWriter.process` converted every frame to 8-bit before handing it over, so the type check of the encoder could never see what the user actually passed. The frame is now copied without altering its type, and the encoder checks every frame rather than only the first one, which also covers a type changing mid-recording.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3111

## Motivation and Context

`VideoFile` documents its input as 8-bit integer frames, but normalized floating-point frames were truncated to zero instead of being rejected, so recording appeared to succeed and silently produced a black video.

## How Has This Been / Can This Be Tested?

`pytest ./tests/core/test_recorders.py::test_video_writer`, extended with a recording whose very last frame is normalized floating-point, expecting the error while the frames recorded before it still reach the file. It does not raise either without the type conversion removed or without the per-frame check.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
