### PR TITLE
[BUG FIX] Fix wrong mechanical energy and speed up computations.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -4282,14 +4282,9 @@ class RigidEntity(KinematicEntity):
     def get_kinetic_energy(self, envs_idx=None) -> torch.Tensor:
         """Get the total kinetic energy of the entity in Joules [J] (translational + rotational).
 
-        Computed using the joint-space mass matrix: ``KE = 0.5 * dq^T * M(q) * dq``.
-        The mass matrix is recomputed to include motor armature on the diagonal.
-
-        Note
-        ----
-        When the ``approximate_implicitfast`` integrator is used, this method forces recomputation of the
-        mass matrix to exclude implicit damping terms added during integration. Other integrators do not
-        require this recomputation.
+        Summed over the entity's links, each contributing ``0.5 * V^T * I * V`` for its spatial velocity ``V`` and
+        spatial inertia ``I`` about the center of mass (COM) of its kinematic tree, plus the motor armature
+        contribution ``0.5 * sum_d(armature_d * dq_d^2)`` of its DOFs.
 
         Parameters
         ----------
@@ -4300,27 +4295,18 @@ class RigidEntity(KinematicEntity):
         -------
         kinetic_energy : torch.Tensor, shape () or (n_envs,)
         """
-        if self._solver.rigid_config.integrator == gs.integrator.approximate_implicitfast:
-            from genesis.engine.solvers.rigid.abd.forward_dynamics import kernel_compute_mass_matrix
-
-            kernel_compute_mass_matrix(
-                self._solver.dyn_state,
-                self._solver.dyn_info,
-                self._solver.rigid_info,
-                self._solver.rigid_config,
-                decompose=False,
-            )
-        mass_mat = self.get_mass_mat(envs_idx=envs_idx)
-        dofs_vel = self.get_dofs_velocity(envs_idx=envs_idx)
-        Mv = torch.matmul(mass_mat, dofs_vel.unsqueeze(-1)).squeeze(-1)
-        return 0.5 * torch.sum(dofs_vel * Mv, dim=-1)
+        links_idx = self._get_global_idx(None, self.n_links, self._link_start, unsafe=True)
+        dofs_idx = self._get_global_idx(None, self.n_dofs, self._dof_start, unsafe=True)
+        return self._solver.get_kinetic_energy(links_idx, dofs_idx, envs_idx)
 
     @gs.assert_built
     def get_potential_energy(self, envs_idx=None) -> torch.Tensor:
-        """Get the total gravitational potential energy of the entity in Joules [J].
+        """Get the total potential energy of the entity in Joules [J] (gravitational + joint springs).
 
-        Computed as the sum over all links: ``PE = sum_i(m_i * g^T * p_i)``, where ``p_i`` is the
-        center-of-mass position of link *i* and ``g`` is the gravity vector obtained from the solver.
+        Gravity contributes ``-sum_i(m_i * g^T * p_i)`` over the entity's links, where ``p_i`` is the center-of-mass
+        position of link *i* and ``g`` is the gravity vector obtained from the solver. Its joint springs contribute
+        ``0.5 * sum_d(stiffness_d * (q_d - q0_d)^2)``, the elastic energy stored by holding each DOF away from its
+        neutral position.
 
         Parameters
         ----------
@@ -4331,15 +4317,9 @@ class RigidEntity(KinematicEntity):
         -------
         potential_energy : torch.Tensor, shape () or (n_envs,)
         """
-        gravity = self._solver.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
-        links_pos = self.get_links_pos(envs_idx=envs_idx, ref="link_com")  # (..., n_links, 3)
-        # See `RigidSolver.get_links_inertial_mass` about only passing `envs_idx` when links info is batched.
-        links_mass = self.get_links_inertial_mass(envs_idx=envs_idx if self._solver._options.batch_links_info else None)
-
-        # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
-        # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)
-        g_dot_p = torch.sum(gravity.unsqueeze(-2) * links_pos, dim=-1)  # (..., n_links)
-        return -torch.sum(links_mass * g_dot_p, dim=-1)
+        links_idx = self._get_global_idx(None, self.n_links, self._link_start, unsafe=True)
+        dofs_idx = self._get_global_idx(None, self.n_dofs, self._dof_start, unsafe=True)
+        return self._solver.get_potential_energy(links_idx, dofs_idx, envs_idx)
 
     @gs.assert_built
     def get_total_energy(self, envs_idx=None) -> torch.Tensor:

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2986,13 +2986,96 @@ class RigidSolver(KinematicSolver):
 
         return tensor
 
+    def get_kinetic_energy(self, links_idx=None, dofs_idx=None, envs_idx=None):
+        """Get the kinetic energy of the specified links and DOFs in Joules [J] (translational + rotational).
+
+        Summed over the links, each contributing ``0.5 * V^T * I * V`` for its spatial velocity ``V`` and spatial
+        inertia ``I`` about the center of mass (COM) of its kinematic tree, plus the motor armature contribution
+        ``0.5 * sum_d(armature_d * dq_d^2)`` of the DOFs. This equals the joint-space form ``0.5 * dq^T * M(q) * dq``
+        while reading the link velocities and inertias that forward kinematics already maintains, so it needs no mass
+        matrix and stays consistent with the current configuration whatever the integrator.
+
+        A link and the DOFs driving it contribute independently, so selecting one without the other is meaningful only
+        to isolate that one term.
+
+        Parameters
+        ----------
+        links_idx : None | array_like, optional
+            The indices of the links. If None, all links will be considered. Defaults to None.
+        dofs_idx : None | array_like, optional
+            The indices of the degrees of freedom. If None, all of them will be considered. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        kinetic_energy : torch.Tensor, shape () or (n_envs,)
+        """
+        # Spatial velocity and inertia are both referenced to the tree COM, so the quadratic form expands as
+        # 0.5 * m * |v|^2 + v . (w x (m * c)) + 0.5 * w . (I * w), with `cinr_pos` holding the first moment m * c.
+        cd_ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
+        cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, envs_idx, links_idx, transpose=True)
+        cinr_inertial = qd_to_torch(self.dyn_state.links.cinr_inertial, envs_idx, links_idx, transpose=True)
+        cinr_pos = qd_to_torch(self.dyn_state.links.cinr_pos, envs_idx, links_idx, transpose=True)
+        cinr_mass = qd_to_torch(self.dyn_state.links.cinr_mass, envs_idx, links_idx, transpose=True)
+        translational = cinr_mass * torch.sum(cd_vel * cd_vel, dim=-1)
+        coupling = torch.sum(cd_vel * torch.cross(cd_ang, cinr_pos, dim=-1), dim=-1)
+        rotational = torch.sum(cd_ang * torch.matmul(cinr_inertial, cd_ang.unsqueeze(-1)).squeeze(-1), dim=-1)
+        kinetic_energy = torch.sum(0.5 * (translational + rotational) + coupling, dim=-1)
+
+        dofs_vel = qd_to_torch(self.dyn_state.dofs.vel, envs_idx, dofs_idx, transpose=True)
+        armature = self.get_dofs_armature(dofs_idx, envs_idx if self._options.batch_dofs_info else None)
+        kinetic_energy += 0.5 * torch.sum(armature * dofs_vel * dofs_vel, dim=-1)
+
+        return kinetic_energy[0] if self.n_envs == 0 else kinetic_energy
+
+    def get_potential_energy(self, links_idx=None, dofs_idx=None, envs_idx=None):
+        """Get the potential energy of the specified links and DOFs in Joules [J] (gravitational + joint springs).
+
+        Gravity contributes ``-sum_i(m_i * g^T * p_i)`` over the links, where ``p_i`` is the center of mass (COM)
+        position of link *i*. Joint springs contribute ``0.5 * sum_d(stiffness_d * (q_d - q0_d)^2)``, the elastic
+        energy stored by holding each DOF away from its neutral position. Both are state functions, so their sum with
+        the kinetic energy is conserved by a passive, frictionless, contact-free model.
+
+        Contacts contribute nothing: they are resolved by the constraint solver, which stabilizes a penetration
+        rather than storing it as an elastic potential.
+
+        Parameters
+        ----------
+        links_idx : None | array_like, optional
+            The indices of the links. If None, all links will be considered. Defaults to None.
+        dofs_idx : None | array_like, optional
+            The indices of the degrees of freedom. If None, all of them will be considered. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        potential_energy : torch.Tensor, shape () or (n_envs,)
+        """
+        gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
+        links_pos = self.get_links_pos(links_idx, envs_idx, ref="link_com")  # (..., n_links, 3)
+        # `get_links_inertial_mass` only accepts `envs_idx` when links info is batched, since all the environments
+        # share the very same link masses otherwise.
+        links_mass = self.get_links_inertial_mass(links_idx, envs_idx if self._options.batch_links_info else None)
+
+        # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
+        # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)
+        g_dot_p = torch.sum(gravity.unsqueeze(-2) * links_pos, dim=-1)  # (..., n_links)
+        potential_energy = -torch.sum(links_mass * g_dot_p, dim=-1)
+
+        # `dofs.pos` holds the deflection `qpos - qpos0` that the spring force is proportional to, so the elastic
+        # energy integrates directly against it whatever the neutral configuration.
+        dofs_pos = qd_to_torch(self.dyn_state.dofs.pos, envs_idx, dofs_idx, transpose=True)
+        stiffness = self.get_dofs_stiffness(dofs_idx, envs_idx if self._options.batch_dofs_info else None)
+        spring_energy = 0.5 * torch.sum(stiffness * dofs_pos * dofs_pos, dim=-1)
+        if self.n_envs == 0:
+            spring_energy = spring_energy[0]
+
+        return potential_energy + spring_energy
+
     def get_total_energy(self, envs_idx=None):
         """Get the total mechanical energy of all entities in Joules [J] (kinetic + potential).
-
-        Kinetic energy is computed using the joint-space mass matrix: ``KE = 0.5 * dq^T * M(q) * dq``. When the
-        ``approximate_implicitfast`` integrator is used, the mass matrix is recomputed once to exclude implicit
-        damping terms added during integration. Potential energy is the sum over all links:
-        ``PE = -sum_i(m_i * g^T * p_i)``, where ``p_i`` is the center-of-mass position of link *i*.
 
         Parameters
         ----------
@@ -3003,27 +3086,7 @@ class RigidSolver(KinematicSolver):
         -------
         total_energy : torch.Tensor, shape () or (n_envs,)
         """
-        if self.rigid_config.integrator == gs.integrator.approximate_implicitfast:
-            kernel_compute_mass_matrix(
-                self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config, decompose=False
-            )
-        mass_mat = self.get_mass_mat(envs_idx=envs_idx)
-        dofs_vel = self.get_dofs_velocity(envs_idx=envs_idx)
-        Mv = torch.matmul(mass_mat, dofs_vel.unsqueeze(-1)).squeeze(-1)
-        kinetic_energy = 0.5 * torch.sum(dofs_vel * Mv, dim=-1)
-
-        gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
-        links_pos = self.get_links_pos(envs_idx=envs_idx, ref="link_com")  # (..., n_links, 3)
-        # `get_links_inertial_mass` only accepts `envs_idx` when links info is batched, since all the environments
-        # share the very same link masses otherwise.
-        links_mass = self.get_links_inertial_mass(envs_idx=envs_idx if self._options.batch_links_info else None)
-
-        # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
-        # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)
-        g_dot_p = torch.sum(gravity.unsqueeze(-2) * links_pos, dim=-1)  # (..., n_links)
-        potential_energy = -torch.sum(links_mass * g_dot_p, dim=-1)
-
-        return kinetic_energy + potential_energy
+        return self.get_kinetic_energy(envs_idx=envs_idx) + self.get_potential_energy(envs_idx=envs_idx)
 
     def get_geoms_friction(self, geoms_idx=None):
         return qd_to_torch(self.dyn_info.geoms.friction, geoms_idx, copy=True)

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -848,3 +848,20 @@ def merged_overlapping_models():
     # Long box reaching back from the tip over the (non-adjacent) a2 link.
     ET.SubElement(palm, "geom", type="box", size="0.15 0.03 0.03", pos="-0.1 0 0", mass="0.2")
     return ET.tostring(arm, encoding="unicode"), ET.tostring(hand, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
+def spring_double_pendulum():
+    """Generate an MJCF model for an undamped two-link arm whose hinges are held by stiff springs.
+
+    Its mass matrix depends on the elbow angle, so the arm only conserves energy if the kinetic term is evaluated at
+    the current configuration, and the springs store a share of the energy large enough to dominate rounding.
+    """
+    mjcf = ET.Element("mujoco")
+    upper = ET.SubElement(ET.SubElement(mjcf, "worldbody"), "body", name="arm_upper", pos="0.25 0.5 0.8")
+    ET.SubElement(upper, "joint", name="shoulder", type="hinge", axis="0 1 0", stiffness="20.0", damping="0")
+    ET.SubElement(upper, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.02", density="1000")
+    lower = ET.SubElement(upper, "body", name="arm_lower", pos="0.2 0 0")
+    ET.SubElement(lower, "joint", name="elbow", type="hinge", axis="0 1 0", stiffness="20.0", damping="0")
+    ET.SubElement(lower, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.02", density="1000")
+    return ET.tostring(mjcf, encoding="unicode")

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -1,5 +1,4 @@
 import math
-import xml.etree.ElementTree as ET
 
 import numpy as np
 import pytest
@@ -262,14 +261,13 @@ def test_apply_external_forces(xml_path, show_viewer):
 
 @pytest.mark.required
 @pytest.mark.parametrize("integrator", [gs.integrator.Euler, gs.integrator.approximate_implicitfast])
-def test_energy_analytical_and_conservation(show_viewer, tol, integrator):
+def test_energy_analytical_and_conservation(spring_double_pendulum, show_viewer, tol, integrator):
     g = 9.81
     dt = 0.001
     h0 = 0.5
     radius = 0.1
     n_steps = 400
     undamped_sol_params = [10.0, 0.001, 0.9, 0.95, 0.001, 0.5, 2.0]
-    stiffness = 20.0
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -298,20 +296,9 @@ def test_energy_analytical_and_conservation(show_viewer, tol, integrator):
             pos=(0.5, 0, h0),
         ),
     )
-    # Undamped two-link arm on stiff springs, swinging clear of the ground and the spheres. Its mass matrix is
-    # configuration-dependent, so its energy only balances if the kinetic term tracks the current configuration and
-    # the potential term accounts for the springs holding the joints off their neutral pose.
-    mjcf = ET.Element("mujoco")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    upper = ET.SubElement(worldbody, "body", name="arm_upper", pos="0.25 0.5 0.8")
-    ET.SubElement(upper, "joint", name="shoulder", type="hinge", axis="0 1 0", stiffness=str(stiffness), damping="0")
-    ET.SubElement(upper, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.02", density="1000")
-    lower = ET.SubElement(upper, "body", name="arm_lower", pos="0.2 0 0")
-    ET.SubElement(lower, "joint", name="elbow", type="hinge", axis="0 1 0", stiffness=str(stiffness), damping="0")
-    ET.SubElement(lower, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.02", density="1000")
     arm = scene.add_entity(
         gs.morphs.MJCF(
-            file=ET.tostring(mjcf, encoding="unicode"),
+            file=spring_double_pendulum,
         ),
     )
     scene.build()

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -1,4 +1,5 @@
 import math
+import xml.etree.ElementTree as ET
 
 import numpy as np
 import pytest
@@ -268,6 +269,7 @@ def test_energy_analytical_and_conservation(show_viewer, tol, integrator):
     radius = 0.1
     n_steps = 400
     undamped_sol_params = [10.0, 0.001, 0.9, 0.95, 0.001, 0.5, 2.0]
+    stiffness = 20.0
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -296,7 +298,25 @@ def test_energy_analytical_and_conservation(show_viewer, tol, integrator):
             pos=(0.5, 0, h0),
         ),
     )
+    # Undamped two-link arm on stiff springs, swinging clear of the ground and the spheres. Its mass matrix is
+    # configuration-dependent, so its energy only balances if the kinetic term tracks the current configuration and
+    # the potential term accounts for the springs holding the joints off their neutral pose.
+    mjcf = ET.Element("mujoco")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    upper = ET.SubElement(worldbody, "body", name="arm_upper", pos="0.25 0.5 0.8")
+    ET.SubElement(upper, "joint", name="shoulder", type="hinge", axis="0 1 0", stiffness=str(stiffness), damping="0")
+    ET.SubElement(upper, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.02", density="1000")
+    lower = ET.SubElement(upper, "body", name="arm_lower", pos="0.2 0 0")
+    ET.SubElement(lower, "joint", name="elbow", type="hinge", axis="0 1 0", stiffness=str(stiffness), damping="0")
+    ET.SubElement(lower, "geom", type="capsule", fromto="0 0 0 0.2 0 0", size="0.02", density="1000")
+    arm = scene.add_entity(
+        gs.morphs.MJCF(
+            file=ET.tostring(mjcf, encoding="unicode"),
+        ),
+    )
     scene.build()
+
+    arm.set_dofs_position([0.5, -0.8])
 
     # Nearly undamped contact for sphere_a: small dampratio gives very stiff elastic spring with minimal damping.
     # Contact sol_params are averaged: 0.5*(geom_a + geom_b), so both geoms must share the same params.
@@ -306,10 +326,11 @@ def test_energy_analytical_and_conservation(show_viewer, tol, integrator):
     mass = sphere_a.get_links_inertial_mass()
     te_initial = sphere_a.get_total_energy()
 
-    ke_a, pe_a, ke_b, pe_b = [], [], [], []
+    ke_a, pe_a, ke_b, pe_b, te_arm = [], [], [], [], []
     impact_step = -1
     for i in range(n_steps):
         scene.step()
+        te_arm.append(arm.get_total_energy())
         ke_a.append(sphere_a.get_kinetic_energy())
         pe_a.append(sphere_a.get_potential_energy())
         ke_b.append(sphere_b.get_kinetic_energy())
@@ -336,6 +357,13 @@ def test_energy_analytical_and_conservation(show_viewer, tol, integrator):
     # Damped sphere_b: energy strictly decreased
     te_b_final = ke_b[-1] + pe_b[-1]
     assert te_b_final < te_initial
+
+    # Spring-driven arm: nothing dissipates, so its energy holds throughout the swing to integration error
+    te_arm = torch.stack(te_arm)
+    assert_allclose(te_arm, te_arm[0], tol=0.01)
+    # The springs must carry a real share of that energy, otherwise the check above would hold with no spring term
+    spring_energy = 0.5 * torch.sum(arm.get_dofs_stiffness() * arm.get_dofs_position() ** 2)
+    assert spring_energy > 0.1 * te_arm[-1]
 
 
 @pytest.mark.slow  # ~250s


### PR DESCRIPTION
## Description

The kinetic energy was read off the stored mass matrix, which is only reassembled during forward dynamics, so any configuration change since then left it stale and the reported value wrong after every step - except with `approximate_implicitfast`, which hid the issue by reassembling the whole matrix on every call. It is now summed over the links from the spatial velocities and inertias that forward kinematics already maintains, which is equivalent, always consistent with the current configuration, and needs no mass matrix. The potential energy was also missing the elastic energy of the joint springs, so it was not conserved by any model using joint stiffness. Contacts stay excluded: the constraint solver stabilizes a penetration instead of storing it, so a penetrating pair still gains energy as it is pushed apart.

## Motivation and Context

Energy is used as a diagnostic, so a silently wrong value is worse than none. Dropping the mass matrix also makes the read linear in the number of links rather than quadratic in the DOFs: on 16 Frankas over 128 environments, 3.32 ms -> 0.77 ms for the solver getter and 0.94 ms -> 0.09 ms per entity.

## How Has This Been / Can This Be Tested?

`pytest tests/rigid/test_dynamics.py::test_energy_analytical_and_conservation`, strengthened with an undamped two-link arm on joint springs whose mass matrix is configuration-dependent, so its energy only balances if both fixes are in: it drifts by 2.1 relative without them against 4.7e-3 with them, for a 0.01 tolerance. The kinetic energy was also checked against `0.5 * dq^T * M(q) * dq` reassembled at the current configuration, matching to 6e-14 in double precision across a franka, a go2 and a mixed scene, 0 and 3 environments, the three integrators, and batched and non-batched info.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.