### PR TITLE
[BUG FIX] Fix delete weld constraint when not last added dynamic equality.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1928,9 +1928,14 @@ def kernel_delete_weld_constraint(
                 and dyn_info.equalities.eq_obj2id[i_e, i_b] == link2_idx
             ):
                 if i_e < constraint_state.qd_n_equalities[i_b] - 1:
-                    dyn_info.equalities.eq_type[i_e, i_b] = dyn_info.equalities.eq_type[
-                        constraint_state.qd_n_equalities[i_b] - 1, i_b
-                    ]
+                    # Swap-remove must move the whole constraint record, not just its type,
+                    # otherwise the surviving slot keeps the deleted constraint's links/data.
+                    i_last = constraint_state.qd_n_equalities[i_b] - 1
+                    dyn_info.equalities.eq_type[i_e, i_b] = dyn_info.equalities.eq_type[i_last, i_b]
+                    dyn_info.equalities.eq_obj1id[i_e, i_b] = dyn_info.equalities.eq_obj1id[i_last, i_b]
+                    dyn_info.equalities.eq_obj2id[i_e, i_b] = dyn_info.equalities.eq_obj2id[i_last, i_b]
+                    dyn_info.equalities.eq_data[i_e, i_b] = dyn_info.equalities.eq_data[i_last, i_b]
+                    dyn_info.equalities.sol_params[i_e, i_b] = dyn_info.equalities.sol_params[i_last, i_b]
                 constraint_state.qd_n_equalities[i_b] = constraint_state.qd_n_equalities[i_b] - 1
 
 

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -176,6 +176,46 @@ def test_dynamic_weld_scene_reset():
 
 
 @pytest.mark.required
+def test_dynamic_weld_delete_keeps_other_welds(show_viewer, tol):
+    scene = gs.Scene(
+        show_viewer=show_viewer,
+        show_FPS=False,
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+    )
+    boxes = [
+        scene.add_entity(
+            gs.morphs.Box(
+                size=(0.05, 0.05, 0.05),
+                pos=(0.3 * i, 0.0, 0.5),
+            )
+        )
+        for i in range(4)
+    ]
+    scene.build()
+
+    solver = scene.sim.rigid_solver
+    link_a, link_b, link_c, link_d = (box.base_link.idx for box in boxes)
+    solver.add_weld_constraint(link_a, link_b)
+    solver.add_weld_constraint(link_c, link_d)
+
+    # Deleting a weld that is not the last dynamic equality must remove that weld and
+    # preserve the full record of the surviving one, not just its type.
+    solver.delete_weld_constraint(link_a, link_b)
+    weld_const_info = solver.get_weld_constraints(as_tensor=True, to_torch=True)
+    assert_allclose(weld_const_info["link_a"].flatten(), (link_c,), tol=0)
+    assert_allclose(weld_const_info["link_b"].flatten(), (link_d,), tol=0)
+
+    # The surviving weld must still act on its own links: c and d keep their relative
+    # pose while falling, which fails if the swap left behind the deleted weld's data.
+    rel_pos = boxes[3].get_pos() - boxes[2].get_pos()
+    for _ in range(100):
+        scene.step()
+    assert_allclose(boxes[3].get_pos() - boxes[2].get_pos(), rel_pos, tol=1e-3)
+
+
+@pytest.mark.required
 def test_urdf_mimic(show_viewer, tol):
     # create and build the scene
     scene = gs.Scene(

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -9,6 +9,7 @@ from genesis.utils.misc import tensor_to_array
 
 from ..utils import (
     assert_allclose,
+    assert_equal,
     simulate_and_check_mujoco_consistency,
 )
 
@@ -65,6 +66,7 @@ def test_equality_link(gs_sim, mj_sim, gs_solver, xml_path):
 @pytest.mark.required
 def test_dynamic_weld(show_viewer, tol):
     CUBE_POS = (0.65, 0.0, 0.02)
+    HANGING_BOX_POS = (0.0, 1.0, 0.4)
 
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
@@ -89,6 +91,19 @@ def test_dynamic_weld(show_viewer, tol):
     robot = scene.add_entity(
         gs.morphs.MJCF(
             file="xml/universal_robots_ur5e/ur5e.xml",
+        ),
+    )
+    fixed_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.04, 0.04, 0.04),
+            pos=(0.0, 1.0, 0.5),
+            fixed=True,
+        ),
+    )
+    hanging_box = scene.add_entity(
+        gs.morphs.Box(
+            size=(0.04, 0.04, 0.04),
+            pos=(0.0, 1.0, 0.02),
         ),
     )
     scene.build(n_envs=4, env_spacing=(3.0, 3.0))
@@ -119,8 +134,11 @@ def test_dynamic_weld(show_viewer, tol):
     for i in range(70):
         scene.step()
 
-    # add weld constraint and move back up
+    # add weld constraint and move back up. The hanging box is welded in the air afterwards, so that deleting the
+    # cube weld goes through the swap-remove path and must preserve the full record of the hanging box weld.
     scene.sim.rigid_solver.add_weld_constraint(cube.base_link.idx, end_effector.idx, envs_idx=(0, 1, 2))
+    hanging_box.set_pos(HANGING_BOX_POS)
+    scene.sim.rigid_solver.add_weld_constraint(hanging_box.base_link.idx, fixed_box.base_link.idx)
     robot.control_dofs_position(qpos_up)
     for _ in range(60):
         scene.step()
@@ -129,15 +147,23 @@ def test_dynamic_weld(show_viewer, tol):
     assert_allclose(torch.diff(cubes_pos[[0, 1, 2]], dim=0), 0.0, tol=tol)
     assert_allclose(cubes_pos[3], CUBE_POS, tol=1e-3)
     assert_allclose(cubes_pos[-1] - cubes_pos[0], ee_pos_down - ee_pos_up, tol=1e-2)
+    assert_allclose(hanging_box.get_pos(), HANGING_BOX_POS, tol=1e-3)
 
     # drop
     scene.sim.rigid_solver.delete_weld_constraint(cube.base_link.idx, end_effector.idx, envs_idx=(0, 1))
+    weld_const_info = scene.sim.rigid_solver.get_weld_constraints(as_tensor=True, to_torch=True)
+    links_ab = torch.stack((weld_const_info["link_a"], weld_const_info["link_b"]), dim=-1)
+    box_weld = (hanging_box.base_link.idx, fixed_box.base_link.idx)
+    cube_weld = (cube.base_link.idx, end_effector.idx)
+    no_weld = (-1, -1)
+    assert_equal(links_ab, [[box_weld, no_weld], [box_weld, no_weld], [cube_weld, box_weld], [box_weld, no_weld]])
     for _ in range(110):
         scene.step()
     cubes_pos, cubes_quat = cube.get_pos(), tensor_to_array(cube.get_quat())
     assert_allclose(gu.quat_to_rotvec(cubes_quat), 0.0, tol=1e-3)
     assert_allclose(torch.diff(cubes_pos[[0, 1, 3]], dim=0), 0.0, tol=1e-2)
     assert_allclose(cubes_pos[2] - cubes_pos[0], ee_pos_up - ee_pos_down, tol=1e-3)
+    assert_allclose(hanging_box.get_pos(), HANGING_BOX_POS, tol=1e-3)
 
 
 @pytest.mark.slow  # ~200s
@@ -173,46 +199,6 @@ def test_dynamic_weld_scene_reset():
     scene.reset(state=scene.get_state(), envs_idx=[0])
     assert solver.constraint_solver.constraint_state.qd_n_equalities[0] == n_eq_base
     assert solver.constraint_solver.constraint_state.qd_n_equalities[1] == n_eq_base + 1
-
-
-@pytest.mark.required
-def test_dynamic_weld_delete_keeps_other_welds(show_viewer, tol):
-    scene = gs.Scene(
-        show_viewer=show_viewer,
-        show_FPS=False,
-    )
-    scene.add_entity(
-        gs.morphs.Plane(),
-    )
-    boxes = [
-        scene.add_entity(
-            gs.morphs.Box(
-                size=(0.05, 0.05, 0.05),
-                pos=(0.3 * i, 0.0, 0.5),
-            )
-        )
-        for i in range(4)
-    ]
-    scene.build()
-
-    solver = scene.sim.rigid_solver
-    link_a, link_b, link_c, link_d = (box.base_link.idx for box in boxes)
-    solver.add_weld_constraint(link_a, link_b)
-    solver.add_weld_constraint(link_c, link_d)
-
-    # Deleting a weld that is not the last dynamic equality must remove that weld and
-    # preserve the full record of the surviving one, not just its type.
-    solver.delete_weld_constraint(link_a, link_b)
-    weld_const_info = solver.get_weld_constraints(as_tensor=True, to_torch=True)
-    assert_allclose(weld_const_info["link_a"].flatten(), (link_c,), tol=0)
-    assert_allclose(weld_const_info["link_b"].flatten(), (link_d,), tol=0)
-
-    # The surviving weld must still act on its own links: c and d keep their relative
-    # pose while falling, which fails if the swap left behind the deleted weld's data.
-    rel_pos = boxes[3].get_pos() - boxes[2].get_pos()
-    for _ in range(100):
-        scene.step()
-    assert_allclose(boxes[3].get_pos() - boxes[2].get_pos(), rel_pos, tol=1e-3)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description
`kernel_delete_weld_constraint` removes a weld via swap-remove, but only copied `eq_type` from the last equality slot into the deleted slot. The surviving slot therefore kept the deleted constraint's `eq_obj1id`, `eq_obj2id`, `eq_data`, and `sol_params`: deleting any weld that was not the last dynamically added equality effectively deleted the *last-added* weld instead, while the targeted weld stayed active.

This change copies the full constraint record (`eq_type`, `eq_obj1id`, `eq_obj2id`, `eq_data`, `sol_params`) during the swap.

## Related Issue
Resolves Genesis-Embodied-AI/Genesis#3122

## Motivation and Context
With two grippers each holding an object via a weld, releasing the first-grasped object silently detached the *other* arm's object (it falls) while the released object stayed welded — with no error raised. Any workflow that deletes a weld while other dynamic welds exist is affected.

## How Has This Been / Can This Be Tested?
Added `test_dynamic_weld_delete_keeps_other_welds` in `tests/rigid/test_constraints.py`: welds A-B and C-D, deletes A-B, and checks via `get_weld_constraints` that C-D survives and that C and D keep their relative pose while falling (which fails if the swap leaves the deleted weld's data behind). The test fails on `main` without this fix and passes with it (verified on Linux, CPU backend, and it is backend-independent kernel logic).

Minimal repro from the linked issue:

```python
import genesis as gs

gs.init(backend=gs.cpu, logging_level="warning")
scene = gs.Scene(show_viewer=False)
scene.add_entity(gs.morphs.Plane())
boxes = [
    scene.add_entity(gs.morphs.Box(size=(0.05, 0.05, 0.05), pos=(0.3 * i, 0.0, 0.5)))
    for i in range(4)
]
scene.build()

rs = scene.rigid_solver
a, b, c, d = (box.base_link.idx for box in boxes)
rs.add_weld_constraint(a, b)
rs.add_weld_constraint(c, d)
rs.delete_weld_constraint(a, b)
info = rs.get_weld_constraints(as_tensor=True, to_torch=True)
pairs = list(zip(info["link_a"].flatten().tolist(), info["link_b"].flatten().tolist()))
assert pairs == [(c, d)], f"expected [({c}, {d})], got {pairs}"  # fails on main
```

## Screenshots (if appropriate):
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
