### PR TITLE
[FEATURE] Add method for querying terrain height.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -160,6 +160,9 @@ class KinematicEntity(Entity):
 
         self.terrain_hf: np.ndarray | None = None
         self.terrain_scale: np.ndarray | None = None
+        self._terrain_height_field: torch.Tensor | None = None
+        self._terrain_row_boundaries: torch.Tensor | None = None
+        self._terrain_col_boundaries: torch.Tensor | None = None
 
         self._load_model()
 
@@ -589,8 +592,7 @@ class KinematicEntity(Entity):
         self._terrain_height_field = torch.as_tensor(
             self.terrain_hf * self.terrain_scale[1], dtype=gs.tc_float, device=gs.device
         )
-        self._terrain_horizontal_scale = float(morph.horizontal_scale)
-        # Bucketize boundaries produce native 64-bit integer cell indices without a runtime dtype cast.
+        # Bucketization produces native 64-bit integer cell indices for advanced indexing
         self._terrain_row_boundaries = torch.arange(
             1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
         )
@@ -1972,16 +1974,16 @@ class KinematicEntity(Entity):
 
         Heights match the piecewise-planar surface on which rigid bodies rest. Terrain translation, yaw, and
         environment-specific poses are applied to the query. Positions up to one grid cell outside the terrain are
-        clamped to its edge. Non-finite positions, positions farther outside, and terrains with roll or pitch produce
-        not-a-number (NaN) heights.
+        clamped to its edge. The query returns not-a-number (NaN) heights for positions containing NaN or infinity,
+        positions farther outside, and terrains with roll or pitch.
 
         Parameters
         ----------
         positions : array_like
-            World-frame x-y positions in meters, with shape (2,), (n_points, 2), or (n_envs, n_points, 2). A
-            two-dimensional array is shared across the selected environments; use a three-dimensional array for
-            environment-specific positions. A leading dimension of 1 in the three-dimensional form is also treated as
-            shared.
+            World-frame x-y positions in meters, with shape (2,), (n_points, 2), or
+            (n_selected_envs, n_points, 2). A two-dimensional array is shared across the selected environments; use a
+            three-dimensional array for environment-specific positions. A leading dimension of 1 in the
+            three-dimensional form is also treated as shared.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
 
@@ -1994,20 +1996,12 @@ class KinematicEntity(Entity):
         Raises
         ------
         GenesisException
-            If this entity is not a terrain or `positions` is malformed.
+            If the entity type or the shape of `positions` is unsupported.
         """
-        if self.terrain_hf is None or self.terrain_scale is None:
+        if self.terrain_hf is None:
             gs.raise_exception("`get_terrain_height()` is only supported for terrain entities.")
 
-        return self._solver.get_terrain_height(
-            positions,
-            self.base_link_idx,
-            self._terrain_height_field,
-            self._terrain_horizontal_scale,
-            self._terrain_row_boundaries,
-            self._terrain_col_boundaries,
-            envs_idx,
-        )
+        return self._solver.get_terrain_height(positions, self.base_link_idx, envs_idx)
 
     @gs.assert_built
     def get_links_vel(self, links_idx_local=None, envs_idx=None):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -585,11 +585,12 @@ class KinematicEntity(Entity):
         return g_infos
 
     def _load_terrain(self, morph, surface):
-        vmesh, mesh, self.terrain_hf = tu.parse_terrain(morph, surface)
+        vmesh, mesh, terrain_hf = tu.parse_terrain(morph, surface)
         self.terrain_scale = np.array((morph.horizontal_scale, morph.vertical_scale), dtype=gs.np_float)
-        self._terrain_height_field = torch.as_tensor(
-            self.terrain_hf * self.terrain_scale[1], dtype=gs.tc_float, device=gs.device
-        )
+        self.terrain_hf = terrain_hf * self.terrain_scale[1]
+        # Collider storage covers only the first collision terrain; height queries support every terrain entity,
+        # including kinematic ones.
+        self._terrain_height_field = torch.as_tensor(self.terrain_hf, dtype=gs.tc_float, device=gs.device)
 
         g_infos = []
         if morph.visualization:
@@ -1965,8 +1966,9 @@ class KinematicEntity(Entity):
 
         Heights match the piecewise-planar surface on which rigid bodies rest. Terrain translation, yaw, and
         environment-specific poses are applied to the query. Positions up to one grid cell outside the terrain are
-        clamped to its edge. The query returns not-a-number (NaN) heights for positions containing NaN or infinity,
-        positions farther outside, and terrains with roll or pitch.
+        clamped to its edge. Terrain tilt up to 0.001 radians from world vertical is treated as numerical noise. The
+        query returns not-a-number (NaN) heights for positions containing NaN or infinity, positions farther outside,
+        and terrains with greater tilt.
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -158,6 +158,9 @@ class KinematicEntity(Entity):
         self._variant_offset_pos: list[np.ndarray] | None = None
         self._variant_offset_quat: list[np.ndarray] | None = None
 
+        self.terrain_hf: np.ndarray | None = None
+        self.terrain_scale: np.ndarray | None = None
+
         self._load_model()
 
         # Initialize target variables and checkpoint
@@ -2504,6 +2507,10 @@ class RigidEntity(KinematicEntity):
         self._visualize_contact: bool = visualize_contact
 
         self._batch_fixed_verts: bool = morph.batch_fixed_verts
+        self._terrain_height_field: torch.Tensor | None = None
+        self._terrain_horizontal_scale: torch.Tensor | None = None
+        self._terrain_row_boundaries: torch.Tensor | None = None
+        self._terrain_col_boundaries: torch.Tensor | None = None
 
         super().__init__(
             scene,
@@ -3614,6 +3621,60 @@ class RigidEntity(KinematicEntity):
 
     def get_aabb(self):
         raise DeprecationError("This method has been removed. Please use 'get_AABB()' instead.")
+
+    @gs.assert_built
+    def get_height(self, positions, envs_idx=None):
+        """
+        Return terrain surface heights in meters at world-frame XY positions.
+
+        Heights match the piecewise-planar surface on which rigid bodies rest. Terrain translation, yaw, and
+        environment-specific poses are applied to the query.
+
+        Parameters
+        ----------
+        positions : array_like
+            World-frame XY positions in meters, with shape (2,), (n_points, 2), or (n_envs, n_points, 2). A 2D array
+            is shared across the selected environments; use a 3D array for environment-specific positions. A leading
+            dimension of 1 in the 3D form is also treated as shared.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        heights : torch.Tensor
+            World-frame surface heights in meters. The point dimensions match `positions`, with an environment
+            dimension prepended in a parallelized scene.
+
+        Raises
+        ------
+        GenesisException
+            If this entity is not a terrain, the positions are malformed, non-finite, or outside the terrain, or the
+            terrain has roll or pitch.
+        """
+        if self.terrain_hf is None or self.terrain_scale is None:
+            gs.raise_exception("`get_height()` is only supported for terrain entities.")
+        if self._terrain_height_field is None or self._terrain_horizontal_scale is None:
+            height_field = self.terrain_hf * self.terrain_scale[1]
+            self._terrain_height_field = torch.as_tensor(height_field, dtype=gs.tc_float, device=gs.device).contiguous()
+            self._terrain_horizontal_scale = torch.as_tensor(
+                self.terrain_scale[:1], dtype=gs.tc_float, device=gs.device
+            ).contiguous()
+            self._terrain_row_boundaries = torch.arange(
+                1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
+            )
+            self._terrain_col_boundaries = torch.arange(
+                1, self.terrain_hf.shape[1] - 1, dtype=gs.tc_float, device=gs.device
+            )
+
+        return self._solver.get_terrain_height(
+            positions,
+            self.base_link_idx,
+            self._terrain_height_field,
+            self._terrain_horizontal_scale,
+            self._terrain_row_boundaries,
+            self._terrain_col_boundaries,
+            envs_idx,
+        )
 
     @gs.assert_built
     def get_links_pos(

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -160,6 +160,10 @@ class KinematicEntity(Entity):
 
         self.terrain_hf: np.ndarray | None = None
         self.terrain_scale: np.ndarray | None = None
+        self._terrain_height_field: torch.Tensor | None = None
+        self._terrain_horizontal_scale: torch.Tensor | None = None
+        self._terrain_row_boundaries: torch.Tensor | None = None
+        self._terrain_col_boundaries: torch.Tensor | None = None
 
         self._load_model()
 
@@ -1955,6 +1959,60 @@ class KinematicEntity(Entity):
         return torch.stack((aabbs[..., 0, :].min(dim=-2).values, aabbs[..., 1, :].max(dim=-2).values), dim=-2)
 
     @gs.assert_built
+    def get_height(self, positions, envs_idx=None):
+        """
+        Return terrain surface heights in meters at world-frame XY positions.
+
+        Heights match the piecewise-planar surface on which rigid bodies rest. Terrain translation, yaw, and
+        environment-specific poses are applied to the query.
+
+        Parameters
+        ----------
+        positions : array_like
+            World-frame XY positions in meters, with shape (2,), (n_points, 2), or (n_envs, n_points, 2). A 2D array
+            is shared across the selected environments; use a 3D array for environment-specific positions. A leading
+            dimension of 1 in the 3D form is also treated as shared.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        heights : torch.Tensor
+            World-frame surface heights in meters. The point dimensions match `positions`, with an environment
+            dimension prepended in a parallelized scene.
+
+        Raises
+        ------
+        GenesisException
+            If this entity is not a terrain, the positions are malformed, non-finite, or outside the terrain, or the
+            terrain has roll or pitch.
+        """
+        if self.terrain_hf is None or self.terrain_scale is None:
+            gs.raise_exception("`get_height()` is only supported for terrain entities.")
+        if self._terrain_height_field is None or self._terrain_horizontal_scale is None:
+            height_field = self.terrain_hf * self.terrain_scale[1]
+            self._terrain_height_field = torch.as_tensor(height_field, dtype=gs.tc_float, device=gs.device).contiguous()
+            self._terrain_horizontal_scale = torch.as_tensor(
+                self.terrain_scale[:1], dtype=gs.tc_float, device=gs.device
+            ).contiguous()
+            self._terrain_row_boundaries = torch.arange(
+                1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
+            )
+            self._terrain_col_boundaries = torch.arange(
+                1, self.terrain_hf.shape[1] - 1, dtype=gs.tc_float, device=gs.device
+            )
+
+        return self._solver.get_terrain_height(
+            positions,
+            self.base_link_idx,
+            self._terrain_height_field,
+            self._terrain_horizontal_scale,
+            self._terrain_row_boundaries,
+            self._terrain_col_boundaries,
+            envs_idx,
+        )
+
+    @gs.assert_built
     def get_links_vel(self, links_idx_local=None, envs_idx=None):
         """
         Returns linear velocity of all the entity's links expressed at a given reference position in world coordinates.
@@ -2507,10 +2565,6 @@ class RigidEntity(KinematicEntity):
         self._visualize_contact: bool = visualize_contact
 
         self._batch_fixed_verts: bool = morph.batch_fixed_verts
-        self._terrain_height_field: torch.Tensor | None = None
-        self._terrain_horizontal_scale: torch.Tensor | None = None
-        self._terrain_row_boundaries: torch.Tensor | None = None
-        self._terrain_col_boundaries: torch.Tensor | None = None
 
         super().__init__(
             scene,
@@ -3621,60 +3675,6 @@ class RigidEntity(KinematicEntity):
 
     def get_aabb(self):
         raise DeprecationError("This method has been removed. Please use 'get_AABB()' instead.")
-
-    @gs.assert_built
-    def get_height(self, positions, envs_idx=None):
-        """
-        Return terrain surface heights in meters at world-frame XY positions.
-
-        Heights match the piecewise-planar surface on which rigid bodies rest. Terrain translation, yaw, and
-        environment-specific poses are applied to the query.
-
-        Parameters
-        ----------
-        positions : array_like
-            World-frame XY positions in meters, with shape (2,), (n_points, 2), or (n_envs, n_points, 2). A 2D array
-            is shared across the selected environments; use a 3D array for environment-specific positions. A leading
-            dimension of 1 in the 3D form is also treated as shared.
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments will be considered. Defaults to None.
-
-        Returns
-        -------
-        heights : torch.Tensor
-            World-frame surface heights in meters. The point dimensions match `positions`, with an environment
-            dimension prepended in a parallelized scene.
-
-        Raises
-        ------
-        GenesisException
-            If this entity is not a terrain, the positions are malformed, non-finite, or outside the terrain, or the
-            terrain has roll or pitch.
-        """
-        if self.terrain_hf is None or self.terrain_scale is None:
-            gs.raise_exception("`get_height()` is only supported for terrain entities.")
-        if self._terrain_height_field is None or self._terrain_horizontal_scale is None:
-            height_field = self.terrain_hf * self.terrain_scale[1]
-            self._terrain_height_field = torch.as_tensor(height_field, dtype=gs.tc_float, device=gs.device).contiguous()
-            self._terrain_horizontal_scale = torch.as_tensor(
-                self.terrain_scale[:1], dtype=gs.tc_float, device=gs.device
-            ).contiguous()
-            self._terrain_row_boundaries = torch.arange(
-                1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
-            )
-            self._terrain_col_boundaries = torch.arange(
-                1, self.terrain_hf.shape[1] - 1, dtype=gs.tc_float, device=gs.device
-            )
-
-        return self._solver.get_terrain_height(
-            positions,
-            self.base_link_idx,
-            self._terrain_height_field,
-            self._terrain_horizontal_scale,
-            self._terrain_row_boundaries,
-            self._terrain_col_boundaries,
-            envs_idx,
-        )
 
     @gs.assert_built
     def get_links_pos(

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -161,8 +161,6 @@ class KinematicEntity(Entity):
         self.terrain_hf: np.ndarray | None = None
         self.terrain_scale: np.ndarray | None = None
         self._terrain_height_field: torch.Tensor | None = None
-        self._terrain_row_boundaries: torch.Tensor | None = None
-        self._terrain_col_boundaries: torch.Tensor | None = None
 
         self._load_model()
 
@@ -591,13 +589,6 @@ class KinematicEntity(Entity):
         self.terrain_scale = np.array((morph.horizontal_scale, morph.vertical_scale), dtype=gs.np_float)
         self._terrain_height_field = torch.as_tensor(
             self.terrain_hf * self.terrain_scale[1], dtype=gs.tc_float, device=gs.device
-        )
-        # Bucketization produces native 64-bit integer cell indices for advanced indexing
-        self._terrain_row_boundaries = torch.arange(
-            1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
-        )
-        self._terrain_col_boundaries = torch.arange(
-            1, self.terrain_hf.shape[1] - 1, dtype=gs.tc_float, device=gs.device
         )
 
         g_infos = []

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -160,10 +160,6 @@ class KinematicEntity(Entity):
 
         self.terrain_hf: np.ndarray | None = None
         self.terrain_scale: np.ndarray | None = None
-        self._terrain_height_field: torch.Tensor | None = None
-        self._terrain_horizontal_scale: torch.Tensor | None = None
-        self._terrain_row_boundaries: torch.Tensor | None = None
-        self._terrain_col_boundaries: torch.Tensor | None = None
 
         self._load_model()
 
@@ -590,6 +586,17 @@ class KinematicEntity(Entity):
     def _load_terrain(self, morph, surface):
         vmesh, mesh, self.terrain_hf = tu.parse_terrain(morph, surface)
         self.terrain_scale = np.array((morph.horizontal_scale, morph.vertical_scale), dtype=gs.np_float)
+        self._terrain_height_field = torch.as_tensor(
+            self.terrain_hf * self.terrain_scale[1], dtype=gs.tc_float, device=gs.device
+        )
+        self._terrain_horizontal_scale = float(morph.horizontal_scale)
+        # Bucketize boundaries produce native 64-bit integer cell indices without a runtime dtype cast.
+        self._terrain_row_boundaries = torch.arange(
+            1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
+        )
+        self._terrain_col_boundaries = torch.arange(
+            1, self.terrain_hf.shape[1] - 1, dtype=gs.tc_float, device=gs.device
+        )
 
         g_infos = []
         if morph.visualization:
@@ -1959,48 +1966,38 @@ class KinematicEntity(Entity):
         return torch.stack((aabbs[..., 0, :].min(dim=-2).values, aabbs[..., 1, :].max(dim=-2).values), dim=-2)
 
     @gs.assert_built
-    def get_height(self, positions, envs_idx=None):
+    def get_terrain_height(self, positions, envs_idx=None):
         """
-        Return terrain surface heights in meters at world-frame XY positions.
+        Return terrain surface heights in meters at world-frame x-y positions.
 
         Heights match the piecewise-planar surface on which rigid bodies rest. Terrain translation, yaw, and
-        environment-specific poses are applied to the query.
+        environment-specific poses are applied to the query. Positions up to one grid cell outside the terrain are
+        clamped to its edge. Non-finite positions, positions farther outside, and terrains with roll or pitch produce
+        not-a-number (NaN) heights.
 
         Parameters
         ----------
         positions : array_like
-            World-frame XY positions in meters, with shape (2,), (n_points, 2), or (n_envs, n_points, 2). A 2D array
-            is shared across the selected environments; use a 3D array for environment-specific positions. A leading
-            dimension of 1 in the 3D form is also treated as shared.
+            World-frame x-y positions in meters, with shape (2,), (n_points, 2), or (n_envs, n_points, 2). A
+            two-dimensional array is shared across the selected environments; use a three-dimensional array for
+            environment-specific positions. A leading dimension of 1 in the three-dimensional form is also treated as
+            shared.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
 
         Returns
         -------
         heights : torch.Tensor
-            World-frame surface heights in meters. The point dimensions match `positions`, with an environment
-            dimension prepended in a parallelized scene.
+            World-frame surface heights in meters. The point dimension is preserved except for an explicit `(2,)`
+            input, and an environment dimension is prepended in a parallelized scene.
 
         Raises
         ------
         GenesisException
-            If this entity is not a terrain, the positions are malformed, non-finite, or outside the terrain, or the
-            terrain has roll or pitch.
+            If this entity is not a terrain or `positions` is malformed.
         """
         if self.terrain_hf is None or self.terrain_scale is None:
-            gs.raise_exception("`get_height()` is only supported for terrain entities.")
-        if self._terrain_height_field is None or self._terrain_horizontal_scale is None:
-            height_field = self.terrain_hf * self.terrain_scale[1]
-            self._terrain_height_field = torch.as_tensor(height_field, dtype=gs.tc_float, device=gs.device).contiguous()
-            self._terrain_horizontal_scale = torch.as_tensor(
-                self.terrain_scale[:1], dtype=gs.tc_float, device=gs.device
-            ).contiguous()
-            self._terrain_row_boundaries = torch.arange(
-                1, self.terrain_hf.shape[0] - 1, dtype=gs.tc_float, device=gs.device
-            )
-            self._terrain_col_boundaries = torch.arange(
-                1, self.terrain_hf.shape[1] - 1, dtype=gs.tc_float, device=gs.device
-            )
+            gs.raise_exception("`get_terrain_height()` is only supported for terrain entities.")
 
         return self._solver.get_terrain_height(
             positions,

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -100,7 +100,7 @@ def _offset_world_shift(offset_pos, offset_quat, world_quat):
 def _tc_get_terrain_height(
     positions: torch.Tensor,
     height_field: torch.Tensor,
-    horizontal_scale: torch.Tensor,
+    horizontal_scale: float,
     row_boundaries: torch.Tensor,
     col_boundaries: torch.Tensor,
     link_pos: torch.Tensor,
@@ -122,22 +122,25 @@ def _tc_get_terrain_height(
         delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
         + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
     ) / quat_norm
-    row = local_x / horizontal_scale[0]
-    col = local_y / horizontal_scale[0]
+    row = local_x / horizontal_scale
+    col = local_y / horizontal_scale
     row_max = height_field.shape[0] - 1
     col_max = height_field.shape[1] - 1
-    has_invalid_query = (
-        (link_quat[..., 1:3].abs() > eps).any()
-        | (~torch.isfinite(row)).any()
-        | (~torch.isfinite(col)).any()
-        | (row < -eps).any()
-        | (row > row_max + eps).any()
-        | (col < -eps).any()
-        | (col > col_max + eps).any()
+    is_row_finite = torch.isfinite(row)
+    is_col_finite = torch.isfinite(col)
+    is_valid = (
+        (link_quat[..., 1].abs() <= eps)
+        & (link_quat[..., 2].abs() <= eps)
+        & is_row_finite
+        & is_col_finite
+        & (row >= -1.0)
+        & (row <= float(row_max + 1))
+        & (col >= -1.0)
+        & (col <= float(col_max + 1))
     )
 
-    row = row.clamp(0.0, float(row_max))
-    col = col.clamp(0.0, float(col_max))
+    row = torch.where(is_row_finite, row, torch.zeros_like(row)).clamp(0.0, float(row_max))
+    col = torch.where(is_col_finite, col, torch.zeros_like(col)).clamp(0.0, float(col_max))
     i_row = torch.bucketize(row, row_boundaries, right=True)
     i_col = torch.bucketize(col, col_boundaries, right=True)
     frac_row = row - i_row
@@ -150,7 +153,7 @@ def _tc_get_terrain_height(
     first = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
     second = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
     heights = torch.where(frac_row + frac_col <= 1.0, first, second) + link_pos[..., 2]
-    return heights, has_invalid_query
+    return heights.masked_fill(~is_valid, float("nan"))
 
 
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
@@ -1116,14 +1119,7 @@ class KinematicSolver(Solver):
         self._is_forward_vel_updated = True
 
     def get_terrain_height(
-        self,
-        positions,
-        link_idx,
-        height_field,
-        horizontal_scale,
-        row_boundaries,
-        col_boundaries,
-        envs_idx=None,
+        self, positions, link_idx, height_field, horizontal_scale, row_boundaries, col_boundaries, envs_idx=None
     ):
         positions = torch.as_tensor(positions, dtype=gs.tc_float, device=gs.device)
         if positions.ndim == 0 or positions.shape[-1] != 2:
@@ -1155,7 +1151,7 @@ class KinematicSolver(Solver):
         if gs.use_zerocopy:
             link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
             link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
-            heights, has_invalid_query = _tc_get_terrain_height(
+            heights = _tc_get_terrain_height(
                 positions,
                 height_field,
                 horizontal_scale,
@@ -1165,37 +1161,25 @@ class KinematicSolver(Solver):
                 link_quat,
                 gs.EPS,
             )
-            if has_invalid_query:
-                gs.raise_exception(
-                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
-                    "pitch."
-                )
 
         else:
             heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
-            invalid = torch.zeros(1, dtype=gs.tc_int, device=gs.device)
             kernel_get_terrain_height(
                 envs_idx,
                 link_idx,
+                horizontal_scale,
                 positions,
                 height_field,
-                horizontal_scale,
                 heights,
-                invalid,
                 self.dyn_state,
                 self.rigid_info,
                 self.rigid_config,
                 is_per_env,
             )
-            if invalid[0]:
-                gs.raise_exception(
-                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
-                    "pitch."
-                )
 
         if self.n_envs == 0:
             heights = heights[0]
-        if is_single_position or (is_per_env and n_points == 1):
+        if is_single_position:
             heights = heights[..., 0]
         return heights
 

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1107,10 +1107,6 @@ class KinematicSolver(Solver):
 
     def get_terrain_height(self, positions, link_idx, envs_idx=None):
         terrain = self._links[link_idx].entity
-        height_field = terrain._terrain_height_field
-        horizontal_scale = terrain._morph.horizontal_scale
-        row_boundaries = terrain._terrain_row_boundaries
-        col_boundaries = terrain._terrain_col_boundaries
 
         positions = torch.as_tensor(positions, dtype=gs.tc_float, device=gs.device)
         if positions.ndim == 0 or positions.ndim > 3 or positions.shape[-1] != 2:
@@ -1127,13 +1123,20 @@ class KinematicSolver(Solver):
         n_position_envs = n_envs if is_per_env else 1
         positions = broadcast_tensor(
             positions, gs.tc_float, (n_position_envs, n_points, 2), ("envs_idx", "positions", "")
-        ).contiguous()
+        )
 
         if gs.use_zerocopy:
-            link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
-            link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
+            link_pos = qd_to_torch(self.dyn_state.links.pos, envs_idx, link_idx, transpose=True)
+            link_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, link_idx, transpose=True)
             heights = _tc_get_terrain_height(
-                positions, height_field, horizontal_scale, row_boundaries, col_boundaries, link_pos, link_quat, gs.EPS
+                positions,
+                terrain._terrain_height_field,
+                terrain._morph.horizontal_scale,
+                terrain._terrain_row_boundaries,
+                terrain._terrain_col_boundaries,
+                link_pos,
+                link_quat,
+                gs.EPS,
             )
 
         else:
@@ -1141,9 +1144,9 @@ class KinematicSolver(Solver):
             kernel_get_terrain_height(
                 envs_idx,
                 link_idx,
-                horizontal_scale,
-                positions,
-                height_field,
+                terrain._morph.horizontal_scale,
+                positions.contiguous(),
+                terrain._terrain_height_field,
                 heights,
                 self.dyn_state,
                 self.rigid_info,

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1120,9 +1120,8 @@ class KinematicSolver(Solver):
             gs.raise_exception("`positions` must contain at least one position.")
 
         is_per_env = positions.ndim == 3 and positions.shape[0] != 1
-        n_position_envs = n_envs if is_per_env else 1
         positions = broadcast_tensor(
-            positions, gs.tc_float, (n_position_envs, n_points, 2), ("envs_idx", "positions", "")
+            positions, gs.tc_float, (n_envs if is_per_env else 1, n_points, 2), ("envs_idx", "positions", "")
         )
 
         if gs.use_zerocopy:

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -23,6 +23,7 @@ from .rigid.abd.accessor import (
     kernel_get_kinematic_state,
     kernel_get_links_vel,
     kernel_get_state_grad,
+    kernel_get_terrain_height,
     kernel_set_dofs_force_grad,
     kernel_set_dofs_position,
     kernel_set_dofs_velocity,
@@ -93,6 +94,25 @@ def _offset_world_shift(offset_pos, offset_quat, world_quat):
     """
     user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), world_quat)
     return gu.transform_by_quat(offset_pos, user_quat)
+
+
+def _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries):
+    row_max = height_field.shape[0] - 1
+    col_max = height_field.shape[1] - 1
+    row = row.clamp(0.0, float(row_max))
+    col = col.clamp(0.0, float(col_max))
+    i_row = torch.bucketize(row, row_boundaries, right=True)
+    i_col = torch.bucketize(col, col_boundaries, right=True)
+    frac_row = row - i_row
+    frac_col = col - i_col
+
+    h00 = height_field[i_row, i_col]
+    h10 = height_field[i_row + 1, i_col]
+    h01 = height_field[i_row, i_col + 1]
+    h11 = height_field[i_row + 1, i_col + 1]
+    first = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
+    second = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
+    return torch.where(frac_row + frac_col <= 1.0, first, second)
 
 
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
@@ -1056,6 +1076,113 @@ class KinematicSolver(Solver):
         kernel_forward_kinematics(envs_idx, self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config)
         self._is_forward_pos_updated = True
         self._is_forward_vel_updated = True
+
+    def get_terrain_height(
+        self,
+        positions,
+        link_idx,
+        height_field,
+        horizontal_scale,
+        row_boundaries,
+        col_boundaries,
+        envs_idx=None,
+    ):
+        positions = torch.as_tensor(positions, dtype=gs.tc_float, device=gs.device)
+        if positions.ndim == 0 or positions.shape[-1] != 2:
+            gs.raise_exception(f"`positions` must have shape (..., 2), got {tuple(positions.shape)}.")
+
+        envs_idx = self._scene._sanitize_envs_idx(envs_idx)
+        n_envs = len(envs_idx)
+        is_single_position = positions.ndim == 1
+        is_per_env = False
+
+        if positions.ndim == 1:
+            positions = positions[None, None]
+        elif positions.ndim == 2:
+            positions = positions[None]
+        elif positions.ndim == 3:
+            if positions.shape[0] not in (1, n_envs):
+                gs.raise_exception(
+                    f"The leading dimension of `positions` must be 1 or {n_envs}, got {positions.shape[0]}."
+                )
+            is_per_env = positions.shape[0] == n_envs
+        else:
+            gs.raise_exception("`positions` must have shape (2,), (n_points, 2), or (n_envs, n_points, 2).")
+
+        if positions.shape[-2] == 0:
+            gs.raise_exception("`positions` must contain at least one position.")
+
+        positions = positions.contiguous()
+        n_points = positions.shape[-2]
+        if gs.backend == gs.metal:
+            # Quadrants launch and error-flag synchronization overhead dominates this gather-heavy query on Metal.
+            link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
+            link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
+            delta_x = positions[..., 0] - link_pos[..., 0]
+            delta_y = positions[..., 1] - link_pos[..., 1]
+            quat_w = link_quat[..., 0]
+            quat_x = link_quat[..., 1]
+            quat_y = link_quat[..., 2]
+            quat_z = link_quat[..., 3]
+            quat_norm = quat_w.square() + quat_x.square() + quat_y.square() + quat_z.square()
+            local_x = (
+                delta_x * (quat_x.square() + quat_w.square() - quat_y.square() - quat_z.square())
+                + delta_y * (2.0 * quat_x * quat_y + 2.0 * quat_w * quat_z)
+            ) / quat_norm
+            local_y = (
+                delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
+                + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
+            ) / quat_norm
+            row = local_x / horizontal_scale[0]
+            col = local_y / horizontal_scale[0]
+            row_max = height_field.shape[0] - 1
+            col_max = height_field.shape[1] - 1
+
+            has_invalid_query = (
+                (link_quat[..., 1:3].abs() > gs.EPS).any()
+                | (~torch.isfinite(row)).any()
+                | (~torch.isfinite(col)).any()
+                | (row < -gs.EPS).any()
+                | (row > row_max + gs.EPS).any()
+                | (col < -gs.EPS).any()
+                | (col > col_max + gs.EPS).any()
+            )
+            if has_invalid_query:
+                gs.raise_exception(
+                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
+                    "pitch."
+                )
+
+            heights = (
+                _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries) + link_pos[..., 2]
+            )
+        else:
+            heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
+            invalid = torch.zeros(1, dtype=gs.tc_int, device=gs.device)
+            kernel_get_terrain_height(
+                envs_idx,
+                link_idx,
+                positions,
+                height_field,
+                horizontal_scale,
+                heights,
+                invalid,
+                self.dyn_state,
+                self.rigid_info,
+                self.rigid_config,
+                is_per_env,
+            )
+            if invalid[0]:
+                gs.raise_exception(
+                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
+                    "pitch."
+                )
+
+        if self.n_envs == 0:
+            heights = heights[0]
+        if is_single_position or (is_per_env and n_points == 1):
+            heights = heights[..., 0]
+        return heights
 
     def get_links_pos(self, links_idx=None, envs_idx=None, *, relative=False):
         if not gs.use_zerocopy:

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -96,9 +96,46 @@ def _offset_world_shift(offset_pos, offset_quat, world_quat):
     return gu.transform_by_quat(offset_pos, user_quat)
 
 
-def _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries):
+@torch.jit.script
+def _tc_get_terrain_height(
+    positions: torch.Tensor,
+    height_field: torch.Tensor,
+    horizontal_scale: torch.Tensor,
+    row_boundaries: torch.Tensor,
+    col_boundaries: torch.Tensor,
+    link_pos: torch.Tensor,
+    link_quat: torch.Tensor,
+    eps: float,
+):
+    delta_x = positions[..., 0] - link_pos[..., 0]
+    delta_y = positions[..., 1] - link_pos[..., 1]
+    quat_w = link_quat[..., 0]
+    quat_x = link_quat[..., 1]
+    quat_y = link_quat[..., 2]
+    quat_z = link_quat[..., 3]
+    quat_norm = quat_w.square() + quat_x.square() + quat_y.square() + quat_z.square()
+    local_x = (
+        delta_x * (quat_x.square() + quat_w.square() - quat_y.square() - quat_z.square())
+        + delta_y * (2.0 * quat_x * quat_y + 2.0 * quat_w * quat_z)
+    ) / quat_norm
+    local_y = (
+        delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
+        + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
+    ) / quat_norm
+    row = local_x / horizontal_scale[0]
+    col = local_y / horizontal_scale[0]
     row_max = height_field.shape[0] - 1
     col_max = height_field.shape[1] - 1
+    has_invalid_query = (
+        (link_quat[..., 1:3].abs() > eps).any()
+        | (~torch.isfinite(row)).any()
+        | (~torch.isfinite(col)).any()
+        | (row < -eps).any()
+        | (row > row_max + eps).any()
+        | (col < -eps).any()
+        | (col > col_max + eps).any()
+    )
+
     row = row.clamp(0.0, float(row_max))
     col = col.clamp(0.0, float(col_max))
     i_row = torch.bucketize(row, row_boundaries, right=True)
@@ -112,7 +149,8 @@ def _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boun
     h11 = height_field[i_row + 1, i_col + 1]
     first = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
     second = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
-    return torch.where(frac_row + frac_col <= 1.0, first, second)
+    heights = torch.where(frac_row + frac_col <= 1.0, first, second) + link_pos[..., 2]
+    return heights, has_invalid_query
 
 
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
@@ -1114,38 +1152,18 @@ class KinematicSolver(Solver):
 
         positions = positions.contiguous()
         n_points = positions.shape[-2]
-        if gs.backend == gs.metal:
-            # Quadrants launch and error-flag synchronization overhead dominates this gather-heavy query on Metal.
+        if gs.use_zerocopy:
             link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
             link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
-            delta_x = positions[..., 0] - link_pos[..., 0]
-            delta_y = positions[..., 1] - link_pos[..., 1]
-            quat_w = link_quat[..., 0]
-            quat_x = link_quat[..., 1]
-            quat_y = link_quat[..., 2]
-            quat_z = link_quat[..., 3]
-            quat_norm = quat_w.square() + quat_x.square() + quat_y.square() + quat_z.square()
-            local_x = (
-                delta_x * (quat_x.square() + quat_w.square() - quat_y.square() - quat_z.square())
-                + delta_y * (2.0 * quat_x * quat_y + 2.0 * quat_w * quat_z)
-            ) / quat_norm
-            local_y = (
-                delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
-                + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
-            ) / quat_norm
-            row = local_x / horizontal_scale[0]
-            col = local_y / horizontal_scale[0]
-            row_max = height_field.shape[0] - 1
-            col_max = height_field.shape[1] - 1
-
-            has_invalid_query = (
-                (link_quat[..., 1:3].abs() > gs.EPS).any()
-                | (~torch.isfinite(row)).any()
-                | (~torch.isfinite(col)).any()
-                | (row < -gs.EPS).any()
-                | (row > row_max + gs.EPS).any()
-                | (col < -gs.EPS).any()
-                | (col > col_max + gs.EPS).any()
+            heights, has_invalid_query = _tc_get_terrain_height(
+                positions,
+                height_field,
+                horizontal_scale,
+                row_boundaries,
+                col_boundaries,
+                link_pos,
+                link_quat,
+                gs.EPS,
             )
             if has_invalid_query:
                 gs.raise_exception(
@@ -1153,9 +1171,6 @@ class KinematicSolver(Solver):
                     "pitch."
                 )
 
-            heights = (
-                _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries) + link_pos[..., 2]
-            )
         else:
             heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
             invalid = torch.zeros(1, dtype=gs.tc_int, device=gs.device)

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -57,7 +57,6 @@ from .rigid.abd.misc import (
 )
 
 if TYPE_CHECKING:
-    from genesis.engine.entities import KinematicEntity
     from genesis.engine.scene import Scene
     from genesis.engine.simulator import Simulator
 
@@ -107,23 +106,11 @@ def _tc_get_terrain_height(
     link_quat: torch.Tensor,
     eps: float,
 ):
-    delta_x = positions[..., 0] - link_pos[..., 0]
-    delta_y = positions[..., 1] - link_pos[..., 1]
-    quat_w = link_quat[..., 0]
-    quat_x = link_quat[..., 1]
-    quat_y = link_quat[..., 2]
-    quat_z = link_quat[..., 3]
-    quat_norm = quat_w.square() + quat_x.square() + quat_y.square() + quat_z.square()
-    local_x = (
-        delta_x * (quat_x.square() + quat_w.square() - quat_y.square() - quat_z.square())
-        + delta_y * (2.0 * quat_x * quat_y + 2.0 * quat_w * quat_z)
-    ) / quat_norm
-    local_y = (
-        delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
-        + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
-    ) / quat_norm
-    row = local_x / horizontal_scale
-    col = local_y / horizontal_scale
+    query_pos = torch.nn.functional.pad(positions, (0, 1))
+    query_origin = torch.nn.functional.pad(link_pos[..., :2], (0, 1))
+    local_pos = gu._tc_inv_transform_by_trans_quat(query_pos, query_origin, link_quat)
+    row = local_pos[..., 0] / horizontal_scale
+    col = local_pos[..., 1] / horizontal_scale
     row_max = height_field.shape[0] - 1
     col_max = height_field.shape[1] - 1
     is_row_finite = torch.isfinite(row)
@@ -1118,48 +1105,35 @@ class KinematicSolver(Solver):
         self._is_forward_pos_updated = True
         self._is_forward_vel_updated = True
 
-    def get_terrain_height(
-        self, positions, link_idx, height_field, horizontal_scale, row_boundaries, col_boundaries, envs_idx=None
-    ):
+    def get_terrain_height(self, positions, link_idx, envs_idx=None):
+        terrain = self._links[link_idx].entity
+        height_field = terrain._terrain_height_field
+        horizontal_scale = terrain._morph.horizontal_scale
+        row_boundaries = terrain._terrain_row_boundaries
+        col_boundaries = terrain._terrain_col_boundaries
+
         positions = torch.as_tensor(positions, dtype=gs.tc_float, device=gs.device)
-        if positions.ndim == 0 or positions.shape[-1] != 2:
-            gs.raise_exception(f"`positions` must have shape (..., 2), got {tuple(positions.shape)}.")
+        if positions.ndim == 0 or positions.ndim > 3 or positions.shape[-1] != 2:
+            gs.raise_exception("`positions` must have shape (2,), (n_points, 2), or (n_envs, n_points, 2).")
 
         envs_idx = self._scene._sanitize_envs_idx(envs_idx)
         n_envs = len(envs_idx)
         is_single_position = positions.ndim == 1
-        is_per_env = False
-
-        if positions.ndim == 1:
-            positions = positions[None, None]
-        elif positions.ndim == 2:
-            positions = positions[None]
-        elif positions.ndim == 3:
-            if positions.shape[0] not in (1, n_envs):
-                gs.raise_exception(
-                    f"The leading dimension of `positions` must be 1 or {n_envs}, got {positions.shape[0]}."
-                )
-            is_per_env = positions.shape[0] == n_envs
-        else:
-            gs.raise_exception("`positions` must have shape (2,), (n_points, 2), or (n_envs, n_points, 2).")
-
-        if positions.shape[-2] == 0:
+        n_points = 1 if is_single_position else positions.shape[-2]
+        if n_points == 0:
             gs.raise_exception("`positions` must contain at least one position.")
 
-        positions = positions.contiguous()
-        n_points = positions.shape[-2]
+        is_per_env = positions.ndim == 3 and positions.shape[0] != 1
+        n_position_envs = n_envs if is_per_env else 1
+        positions = broadcast_tensor(
+            positions, gs.tc_float, (n_position_envs, n_points, 2), ("envs_idx", "positions", "")
+        ).contiguous()
+
         if gs.use_zerocopy:
             link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
             link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
             heights = _tc_get_terrain_height(
-                positions,
-                height_field,
-                horizontal_scale,
-                row_boundaries,
-                col_boundaries,
-                link_pos,
-                link_quat,
-                gs.EPS,
+                positions, height_field, horizontal_scale, row_boundaries, col_boundaries, link_pos, link_quat, gs.EPS
             )
 
         else:

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -100,8 +100,6 @@ def _tc_get_terrain_height(
     positions: torch.Tensor,
     height_field: torch.Tensor,
     horizontal_scale: float,
-    row_boundaries: torch.Tensor,
-    col_boundaries: torch.Tensor,
     link_pos: torch.Tensor,
     link_quat: torch.Tensor,
     eps: float,
@@ -128,8 +126,8 @@ def _tc_get_terrain_height(
 
     row = torch.where(is_row_finite, row, torch.zeros_like(row)).clamp(0.0, float(row_max))
     col = torch.where(is_col_finite, col, torch.zeros_like(col)).clamp(0.0, float(col_max))
-    i_row = torch.bucketize(row, row_boundaries, right=True)
-    i_col = torch.bucketize(col, col_boundaries, right=True)
+    i_row = torch.bucketize(row, torch.arange(1, row_max, device=row.device), right=True)
+    i_col = torch.bucketize(col, torch.arange(1, col_max, device=col.device), right=True)
     frac_row = row - i_row
     frac_col = col - i_col
 
@@ -1128,14 +1126,7 @@ class KinematicSolver(Solver):
             link_pos = qd_to_torch(self.dyn_state.links.pos, envs_idx, link_idx, transpose=True)
             link_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, link_idx, transpose=True)
             heights = _tc_get_terrain_height(
-                positions,
-                terrain._terrain_height_field,
-                terrain._morph.horizontal_scale,
-                terrain._terrain_row_boundaries,
-                terrain._terrain_col_boundaries,
-                link_pos,
-                link_quat,
-                gs.EPS,
+                positions, terrain._terrain_height_field, terrain._morph.horizontal_scale, link_pos, link_quat, gs.EPS
             )
 
         else:

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -95,52 +95,6 @@ def _offset_world_shift(offset_pos, offset_quat, world_quat):
     return gu.transform_by_quat(offset_pos, user_quat)
 
 
-@torch.jit.script
-def _tc_get_terrain_height(
-    positions: torch.Tensor,
-    height_field: torch.Tensor,
-    horizontal_scale: float,
-    link_pos: torch.Tensor,
-    link_quat: torch.Tensor,
-    eps: float,
-):
-    query_pos = torch.nn.functional.pad(positions, (0, 1))
-    query_origin = torch.nn.functional.pad(link_pos[..., :2], (0, 1))
-    local_pos = gu._tc_inv_transform_by_trans_quat(query_pos, query_origin, link_quat)
-    row = local_pos[..., 0] / horizontal_scale
-    col = local_pos[..., 1] / horizontal_scale
-    row_max = height_field.shape[0] - 1
-    col_max = height_field.shape[1] - 1
-    is_row_finite = torch.isfinite(row)
-    is_col_finite = torch.isfinite(col)
-    is_valid = (
-        (link_quat[..., 1].abs() <= eps)
-        & (link_quat[..., 2].abs() <= eps)
-        & is_row_finite
-        & is_col_finite
-        & (row >= -1.0)
-        & (row <= float(row_max + 1))
-        & (col >= -1.0)
-        & (col <= float(col_max + 1))
-    )
-
-    row = torch.where(is_row_finite, row, torch.zeros_like(row)).clamp(0.0, float(row_max))
-    col = torch.where(is_col_finite, col, torch.zeros_like(col)).clamp(0.0, float(col_max))
-    i_row = torch.bucketize(row, torch.arange(1, row_max, device=row.device), right=True)
-    i_col = torch.bucketize(col, torch.arange(1, col_max, device=col.device), right=True)
-    frac_row = row - i_row
-    frac_col = col - i_col
-
-    h00 = height_field[i_row, i_col]
-    h10 = height_field[i_row + 1, i_col]
-    h01 = height_field[i_row, i_col + 1]
-    h11 = height_field[i_row + 1, i_col + 1]
-    first = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
-    second = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
-    heights = torch.where(frac_row + frac_col <= 1.0, first, second) + link_pos[..., 2]
-    return heights.masked_fill(~is_valid, float("nan"))
-
-
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
     """Fill the per-geom forward offset for an entity's collision or visual geoms.
 
@@ -1122,27 +1076,19 @@ class KinematicSolver(Solver):
             positions, gs.tc_float, (n_envs if is_per_env else 1, n_points, 2), ("envs_idx", "positions", "")
         )
 
-        if gs.use_zerocopy:
-            link_pos = qd_to_torch(self.dyn_state.links.pos, envs_idx, link_idx, transpose=True)
-            link_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, link_idx, transpose=True)
-            heights = _tc_get_terrain_height(
-                positions, terrain._terrain_height_field, terrain._morph.horizontal_scale, link_pos, link_quat, gs.EPS
-            )
-
-        else:
-            heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
-            kernel_get_terrain_height(
-                envs_idx,
-                link_idx,
-                terrain._morph.horizontal_scale,
-                positions.contiguous(),
-                terrain._terrain_height_field,
-                heights,
-                self.dyn_state,
-                self.rigid_info,
-                self.rigid_config,
-                is_per_env,
-            )
+        heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
+        kernel_get_terrain_height(
+            envs_idx,
+            link_idx,
+            terrain._morph.horizontal_scale,
+            positions.contiguous(),
+            terrain._terrain_height_field,
+            heights,
+            self.dyn_state,
+            self.rigid_info,
+            self.rigid_config,
+            is_per_env,
+        )
 
         if self.n_envs == 0:
             heights = heights[0]

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -61,6 +61,9 @@ if TYPE_CHECKING:
     from genesis.engine.simulator import Simulator
 
 
+TERRAIN_HEIGHT_QUERY_TILT_TOLERANCE = 1e-3
+
+
 def _balanced_variant_mapping(n_variants, B):
     """Map N variants to B environments using balanced block assignment."""
     if B >= n_variants:
@@ -1085,9 +1088,9 @@ class KinematicSolver(Solver):
             terrain._terrain_height_field,
             heights,
             self.dyn_state,
-            self.rigid_info,
             self.rigid_config,
-            is_per_env,
+            tilt_tolerance=TERRAIN_HEIGHT_QUERY_TILT_TOLERANCE,
+            is_per_env=is_per_env,
         )
 
         if self.n_envs == 0:

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1049,11 +1049,13 @@ def kernel_get_terrain_height(
     height_field: qd.types.ndarray(),
     heights: qd.types.ndarray(),
     dyn_state: array_class.DynState,
-    rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
+    tilt_tolerance: float,
     is_per_env: qd.template(),
 ):
-    EPS = rigid_info.EPS[None]
+    # For a normalized quaternion, qx^2 + qy^2 equals sin(tilt / 2)^2, independent of yaw
+    tilt_sin_half = qd.sin(0.5 * tilt_tolerance)
+    tilt_sin_half_sq = tilt_sin_half * tilt_sin_half
     qd.loop_config(serialize=qd.static(rigid_config.para_level == gs.PARA_LEVEL.NEVER))
     for i_b_, i_p in qd.ndrange(heights.shape[0], heights.shape[1]):
         i_b = envs_idx[i_b_]
@@ -1068,8 +1070,7 @@ def kernel_get_terrain_height(
         col_max = height_field.shape[1] - 1
 
         is_valid = (
-            qd.abs(link_quat[1]) <= EPS
-            and qd.abs(link_quat[2]) <= EPS
+            link_quat[1] * link_quat[1] + link_quat[2] * link_quat[2] <= tilt_sin_half_sq
             and row >= -1.0
             and row <= row_max + 1
             and col >= -1.0
@@ -1186,17 +1187,17 @@ def kernel_update_drone_propeller_vgeoms(
 
 
 @qd.kernel(fastcache=True)
-def kernel_set_geom_friction(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction: qd.f32):
+def kernel_set_geom_friction(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction: float):
     dyn_info.geoms.friction[geoms_idx] = friction
 
 
 @qd.kernel(fastcache=True)
-def kernel_set_geom_friction_torsional(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_torsional: qd.f32):
+def kernel_set_geom_friction_torsional(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_torsional: float):
     dyn_info.geoms.friction_torsional[geoms_idx] = friction_torsional
 
 
 @qd.kernel(fastcache=True)
-def kernel_set_geom_friction_rolling(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_rolling: qd.f32):
+def kernel_set_geom_friction_rolling(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_rolling: float):
     dyn_info.geoms.friction_rolling[geoms_idx] = friction_rolling
 
 

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1044,11 +1044,10 @@ def kernel_get_links_acc(
 def kernel_get_terrain_height(
     envs_idx: qd.types.ndarray(),
     link_idx: qd.i32,
+    horizontal_scale: float,
     positions: qd.types.ndarray(),
     height_field: qd.types.ndarray(),
-    horizontal_scale: qd.types.ndarray(),
     heights: qd.types.ndarray(),
-    invalid: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
@@ -1063,21 +1062,19 @@ def kernel_get_terrain_height(
         link_quat = dyn_state.links.quat[link_idx, i_b]
         query_pos = qd.Vector([positions[i_b_pos, i_p, 0], positions[i_b_pos, i_p, 1], link_pos[2]], dt=gs.qd_float)
         local_pos = gu.qd_inv_transform_by_trans_quat(query_pos, link_pos, link_quat)
-        row = local_pos[0] / horizontal_scale[0]
-        col = local_pos[1] / horizontal_scale[0]
+        row = local_pos[0] / horizontal_scale
+        col = local_pos[1] / horizontal_scale
         row_max = height_field.shape[0] - 1
         col_max = height_field.shape[1] - 1
 
         is_valid = (
             qd.abs(link_quat[1]) <= EPS
             and qd.abs(link_quat[2]) <= EPS
-            and row >= -EPS
-            and row <= row_max + EPS
-            and col >= -EPS
-            and col <= col_max + EPS
+            and row >= -1.0
+            and row <= row_max + 1
+            and col >= -1.0
+            and col <= col_max + 1
         )
-        if not is_valid:
-            qd.atomic_or(invalid[0], 1)
         if is_valid:
             row = qd.min(qd.max(row, 0.0), qd.cast(row_max, gs.qd_float))
             col = qd.min(qd.max(col, 0.0), qd.cast(col_max, gs.qd_float))
@@ -1090,14 +1087,12 @@ def kernel_get_terrain_height(
             h10 = height_field[i_row + 1, i_col]
             h01 = height_field[i_row, i_col + 1]
             h11 = height_field[i_row + 1, i_col + 1]
-            height = gs.qd_float(0.0)
             if frac_row + frac_col <= 1.0:
-                height = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
+                heights[i_b_, i_p] = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00) + link_pos[2]
             else:
-                height = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
-            heights[i_b_, i_p] = height + link_pos[2]
+                heights[i_b_, i_p] = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11) + link_pos[2]
         else:
-            heights[i_b_, i_p] = 0.0
+            heights[i_b_, i_p] = qd.math.nan
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1054,7 +1054,7 @@ def kernel_get_terrain_height(
     is_per_env: qd.template(),
 ):
     EPS = rigid_info.EPS[None]
-    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    qd.loop_config(serialize=qd.static(rigid_config.para_level == gs.PARA_LEVEL.NEVER))
     for i_b_, i_p in qd.ndrange(heights.shape[0], heights.shape[1]):
         i_b = envs_idx[i_b_]
         i_b_pos = i_b_ if qd.static(is_per_env) else 0

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1041,6 +1041,66 @@ def kernel_get_links_acc(
 
 
 @qd.kernel(fastcache=True)
+def kernel_get_terrain_height(
+    envs_idx: qd.types.ndarray(),
+    link_idx: qd.i32,
+    positions: qd.types.ndarray(),
+    height_field: qd.types.ndarray(),
+    horizontal_scale: qd.types.ndarray(),
+    heights: qd.types.ndarray(),
+    invalid: qd.types.ndarray(),
+    dyn_state: array_class.DynState,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+    is_per_env: qd.template(),
+):
+    EPS = rigid_info.EPS[None]
+    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_b_, i_p in qd.ndrange(heights.shape[0], heights.shape[1]):
+        i_b = envs_idx[i_b_]
+        i_b_pos = i_b_ if qd.static(is_per_env) else 0
+        link_pos = dyn_state.links.pos[link_idx, i_b]
+        link_quat = dyn_state.links.quat[link_idx, i_b]
+        query_pos = qd.Vector([positions[i_b_pos, i_p, 0], positions[i_b_pos, i_p, 1], link_pos[2]], dt=gs.qd_float)
+        local_pos = gu.qd_inv_transform_by_trans_quat(query_pos, link_pos, link_quat)
+        row = local_pos[0] / horizontal_scale[0]
+        col = local_pos[1] / horizontal_scale[0]
+        row_max = height_field.shape[0] - 1
+        col_max = height_field.shape[1] - 1
+
+        is_valid = (
+            qd.abs(link_quat[1]) <= EPS
+            and qd.abs(link_quat[2]) <= EPS
+            and row >= -EPS
+            and row <= row_max + EPS
+            and col >= -EPS
+            and col <= col_max + EPS
+        )
+        if not is_valid:
+            qd.atomic_or(invalid[0], 1)
+        if is_valid:
+            row = qd.min(qd.max(row, 0.0), qd.cast(row_max, gs.qd_float))
+            col = qd.min(qd.max(col, 0.0), qd.cast(col_max, gs.qd_float))
+            i_row = qd.min(qd.cast(qd.floor(row), gs.qd_int), row_max - 1)
+            i_col = qd.min(qd.cast(qd.floor(col), gs.qd_int), col_max - 1)
+            frac_row = row - i_row
+            frac_col = col - i_col
+
+            h00 = height_field[i_row, i_col]
+            h10 = height_field[i_row + 1, i_col]
+            h01 = height_field[i_row, i_col + 1]
+            h11 = height_field[i_row + 1, i_col + 1]
+            height = gs.qd_float(0.0)
+            if frac_row + frac_col <= 1.0:
+                height = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
+            else:
+                height = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
+            heights[i_b_, i_p] = height + link_pos[2]
+        else:
+            heights[i_b_, i_p] = 0.0
+
+
+@qd.kernel(fastcache=True)
 def kernel_get_dofs_control_force(
     dofs_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -725,7 +725,7 @@ class Collider:
 
             scale = entity.terrain_scale.astype(gs.np_float)
             rc = np.array(entity.terrain_hf.shape, dtype=gs.np_int)
-            hf = entity.terrain_hf.astype(gs.np_float) * scale[1]
+            hf = entity.terrain_hf * scale[1]
             xyz_maxmin = np.array(
                 [rc[0] * scale[0], rc[1] * scale[0], hf.max(), 0, 0, hf.min() - 1.0], dtype=gs.np_float
             )

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -723,16 +723,22 @@ class Collider:
                 entity_idx = entity_idx[0]
             entity = solver._entities[entity_idx]
 
-            scale = entity.terrain_scale.astype(gs.np_float)
             rc = np.array(entity.terrain_hf.shape, dtype=gs.np_int)
-            hf = entity.terrain_hf * scale[1]
             xyz_maxmin = np.array(
-                [rc[0] * scale[0], rc[1] * scale[0], hf.max(), 0, 0, hf.min() - 1.0], dtype=gs.np_float
+                [
+                    rc[0] * entity.terrain_scale[0],
+                    rc[1] * entity.terrain_scale[0],
+                    entity.terrain_hf.max(),
+                    0,
+                    0,
+                    entity.terrain_hf.min() - 1.0,
+                ],
+                dtype=gs.np_float,
             )
 
-            self._collider_info.terrain_hf.from_numpy(hf)
+            self._collider_info.terrain_hf.from_numpy(entity.terrain_hf)
             self._collider_info.terrain_rc.from_numpy(rc)
-            self._collider_info.terrain_scale.from_numpy(scale)
+            self._collider_info.terrain_scale.from_numpy(entity.terrain_scale)
             self._collider_info.terrain_xyz_maxmin.from_numpy(xyz_maxmin)
 
     def activate_sdf(self) -> None:

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -166,6 +166,7 @@ from .abd.accessor import (
     kernel_control_dofs_position_velocity,
     kernel_get_links_vel,
     kernel_get_links_acc,
+    kernel_get_terrain_height,
     kernel_get_dofs_control_force,
     kernel_set_drone_rpm,
     kernel_update_drone_propeller_vgeoms,
@@ -211,6 +212,25 @@ IMP_MAX = 0.9999
 
 # Minimum ratio between simulation timestep `_substep_dt` and time constant of constraints
 TIME_CONSTANT_SAFETY_FACTOR = 2.0
+
+
+def _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries):
+    row_max = height_field.shape[0] - 1
+    col_max = height_field.shape[1] - 1
+    row = row.clamp(0.0, float(row_max))
+    col = col.clamp(0.0, float(col_max))
+    i_row = torch.bucketize(row, row_boundaries, right=True)
+    i_col = torch.bucketize(col, col_boundaries, right=True)
+    frac_row = row - i_row
+    frac_col = col - i_col
+
+    h00 = height_field[i_row, i_col]
+    h10 = height_field[i_row + 1, i_col]
+    h01 = height_field[i_row, i_col + 1]
+    h11 = height_field[i_row + 1, i_col + 1]
+    first = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
+    second = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
+    return torch.where(frac_row + frac_col <= 1.0, first, second)
 
 
 def _sanitize_sol_params(sol_params, min_timeconst: float, default_timeconst: float | None = None):
@@ -2820,6 +2840,113 @@ class RigidSolver(KinematicSolver):
     def get_links_acc_ang(self, links_idx=None, envs_idx=None):
         tensor = qd_to_torch(self.dyn_state.links.cacc_ang, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_terrain_height(
+        self,
+        positions,
+        link_idx,
+        height_field,
+        horizontal_scale,
+        row_boundaries,
+        col_boundaries,
+        envs_idx=None,
+    ):
+        positions = torch.as_tensor(positions, dtype=gs.tc_float, device=gs.device)
+        if positions.ndim == 0 or positions.shape[-1] != 2:
+            gs.raise_exception(f"`positions` must have shape (..., 2), got {tuple(positions.shape)}.")
+
+        envs_idx = self._scene._sanitize_envs_idx(envs_idx)
+        n_envs = len(envs_idx)
+        is_single_position = positions.ndim == 1
+        is_per_env = False
+
+        if positions.ndim == 1:
+            positions = positions[None, None]
+        elif positions.ndim == 2:
+            positions = positions[None]
+        elif positions.ndim == 3:
+            if positions.shape[0] not in (1, n_envs):
+                gs.raise_exception(
+                    f"The leading dimension of `positions` must be 1 or {n_envs}, got {positions.shape[0]}."
+                )
+            is_per_env = positions.shape[0] == n_envs
+        else:
+            gs.raise_exception("`positions` must have shape (2,), (n_points, 2), or (n_envs, n_points, 2).")
+
+        if positions.shape[-2] == 0:
+            gs.raise_exception("`positions` must contain at least one position.")
+
+        positions = positions.contiguous()
+        n_points = positions.shape[-2]
+        if gs.backend == gs.metal:
+            # Quadrants launch and error-flag synchronization overhead dominates this gather-heavy query on Metal.
+            link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
+            link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
+            delta_x = positions[..., 0] - link_pos[..., 0]
+            delta_y = positions[..., 1] - link_pos[..., 1]
+            quat_w = link_quat[..., 0]
+            quat_x = link_quat[..., 1]
+            quat_y = link_quat[..., 2]
+            quat_z = link_quat[..., 3]
+            quat_norm = quat_w.square() + quat_x.square() + quat_y.square() + quat_z.square()
+            local_x = (
+                delta_x * (quat_x.square() + quat_w.square() - quat_y.square() - quat_z.square())
+                + delta_y * (2.0 * quat_x * quat_y + 2.0 * quat_w * quat_z)
+            ) / quat_norm
+            local_y = (
+                delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
+                + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
+            ) / quat_norm
+            row = local_x / horizontal_scale[0]
+            col = local_y / horizontal_scale[0]
+            row_max = height_field.shape[0] - 1
+            col_max = height_field.shape[1] - 1
+
+            has_invalid_query = (
+                (link_quat[..., 1:3].abs() > gs.EPS).any()
+                | (~torch.isfinite(row)).any()
+                | (~torch.isfinite(col)).any()
+                | (row < -gs.EPS).any()
+                | (row > row_max + gs.EPS).any()
+                | (col < -gs.EPS).any()
+                | (col > col_max + gs.EPS).any()
+            )
+            if has_invalid_query:
+                gs.raise_exception(
+                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
+                    "pitch."
+                )
+
+            heights = (
+                _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries) + link_pos[..., 2]
+            )
+        else:
+            heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
+            invalid = torch.zeros(1, dtype=gs.tc_int, device=gs.device)
+            kernel_get_terrain_height(
+                envs_idx,
+                link_idx,
+                positions,
+                height_field,
+                horizontal_scale,
+                heights,
+                invalid,
+                self.dyn_state,
+                self.rigid_info,
+                self.rigid_config,
+                is_per_env,
+            )
+            if invalid[0]:
+                gs.raise_exception(
+                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
+                    "pitch."
+                )
+
+        if self.n_envs == 0:
+            heights = heights[0]
+        if is_single_position or (is_per_env and n_points == 1):
+            heights = heights[..., 0]
+        return heights
 
     def get_links_root_COM(self, links_idx=None, envs_idx=None):
         """

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1224,7 +1224,7 @@ class RigidSolver(KinematicSolver):
 
             scale = np.asarray(entity.terrain_scale, dtype=gs.np_float)
             rc = np.array(entity.terrain_hf.shape, dtype=gs.np_int)
-            hf = entity.terrain_hf.astype(gs.np_float, copy=False) * scale[1]
+            hf = entity.terrain_hf * scale[1]
             xyz_maxmin = np.array(
                 [rc[0] * scale[0], rc[1] * scale[0], hf.max(), 0, 0, hf.min() - 1.0], dtype=gs.np_float
             )

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -166,7 +166,6 @@ from .abd.accessor import (
     kernel_control_dofs_position_velocity,
     kernel_get_links_vel,
     kernel_get_links_acc,
-    kernel_get_terrain_height,
     kernel_get_dofs_control_force,
     kernel_set_drone_rpm,
     kernel_update_drone_propeller_vgeoms,
@@ -212,25 +211,6 @@ IMP_MAX = 0.9999
 
 # Minimum ratio between simulation timestep `_substep_dt` and time constant of constraints
 TIME_CONSTANT_SAFETY_FACTOR = 2.0
-
-
-def _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries):
-    row_max = height_field.shape[0] - 1
-    col_max = height_field.shape[1] - 1
-    row = row.clamp(0.0, float(row_max))
-    col = col.clamp(0.0, float(col_max))
-    i_row = torch.bucketize(row, row_boundaries, right=True)
-    i_col = torch.bucketize(col, col_boundaries, right=True)
-    frac_row = row - i_row
-    frac_col = col - i_col
-
-    h00 = height_field[i_row, i_col]
-    h10 = height_field[i_row + 1, i_col]
-    h01 = height_field[i_row, i_col + 1]
-    h11 = height_field[i_row + 1, i_col + 1]
-    first = h00 + frac_row * (h10 - h00) + frac_col * (h01 - h00)
-    second = h11 + (1.0 - frac_col) * (h10 - h11) + (1.0 - frac_row) * (h01 - h11)
-    return torch.where(frac_row + frac_col <= 1.0, first, second)
 
 
 def _sanitize_sol_params(sol_params, min_timeconst: float, default_timeconst: float | None = None):
@@ -2840,113 +2820,6 @@ class RigidSolver(KinematicSolver):
     def get_links_acc_ang(self, links_idx=None, envs_idx=None):
         tensor = qd_to_torch(self.dyn_state.links.cacc_ang, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
-
-    def get_terrain_height(
-        self,
-        positions,
-        link_idx,
-        height_field,
-        horizontal_scale,
-        row_boundaries,
-        col_boundaries,
-        envs_idx=None,
-    ):
-        positions = torch.as_tensor(positions, dtype=gs.tc_float, device=gs.device)
-        if positions.ndim == 0 or positions.shape[-1] != 2:
-            gs.raise_exception(f"`positions` must have shape (..., 2), got {tuple(positions.shape)}.")
-
-        envs_idx = self._scene._sanitize_envs_idx(envs_idx)
-        n_envs = len(envs_idx)
-        is_single_position = positions.ndim == 1
-        is_per_env = False
-
-        if positions.ndim == 1:
-            positions = positions[None, None]
-        elif positions.ndim == 2:
-            positions = positions[None]
-        elif positions.ndim == 3:
-            if positions.shape[0] not in (1, n_envs):
-                gs.raise_exception(
-                    f"The leading dimension of `positions` must be 1 or {n_envs}, got {positions.shape[0]}."
-                )
-            is_per_env = positions.shape[0] == n_envs
-        else:
-            gs.raise_exception("`positions` must have shape (2,), (n_points, 2), or (n_envs, n_points, 2).")
-
-        if positions.shape[-2] == 0:
-            gs.raise_exception("`positions` must contain at least one position.")
-
-        positions = positions.contiguous()
-        n_points = positions.shape[-2]
-        if gs.backend == gs.metal:
-            # Quadrants launch and error-flag synchronization overhead dominates this gather-heavy query on Metal.
-            link_pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)[envs_idx, link_idx : link_idx + 1]
-            link_quat = qd_to_torch(self.dyn_state.links.quat, transpose=True)[envs_idx, link_idx : link_idx + 1]
-            delta_x = positions[..., 0] - link_pos[..., 0]
-            delta_y = positions[..., 1] - link_pos[..., 1]
-            quat_w = link_quat[..., 0]
-            quat_x = link_quat[..., 1]
-            quat_y = link_quat[..., 2]
-            quat_z = link_quat[..., 3]
-            quat_norm = quat_w.square() + quat_x.square() + quat_y.square() + quat_z.square()
-            local_x = (
-                delta_x * (quat_x.square() + quat_w.square() - quat_y.square() - quat_z.square())
-                + delta_y * (2.0 * quat_x * quat_y + 2.0 * quat_w * quat_z)
-            ) / quat_norm
-            local_y = (
-                delta_x * (2.0 * quat_x * quat_y - 2.0 * quat_w * quat_z)
-                + delta_y * (quat_w.square() - quat_x.square() + quat_y.square() - quat_z.square())
-            ) / quat_norm
-            row = local_x / horizontal_scale[0]
-            col = local_y / horizontal_scale[0]
-            row_max = height_field.shape[0] - 1
-            col_max = height_field.shape[1] - 1
-
-            has_invalid_query = (
-                (link_quat[..., 1:3].abs() > gs.EPS).any()
-                | (~torch.isfinite(row)).any()
-                | (~torch.isfinite(col)).any()
-                | (row < -gs.EPS).any()
-                | (row > row_max + gs.EPS).any()
-                | (col < -gs.EPS).any()
-                | (col > col_max + gs.EPS).any()
-            )
-            if has_invalid_query:
-                gs.raise_exception(
-                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
-                    "pitch."
-                )
-
-            heights = (
-                _interpolate_terrain_height(height_field, row, col, row_boundaries, col_boundaries) + link_pos[..., 2]
-            )
-        else:
-            heights = torch.empty((n_envs, n_points), dtype=gs.tc_float, device=gs.device)
-            invalid = torch.zeros(1, dtype=gs.tc_int, device=gs.device)
-            kernel_get_terrain_height(
-                envs_idx,
-                link_idx,
-                positions,
-                height_field,
-                horizontal_scale,
-                heights,
-                invalid,
-                self.dyn_state,
-                self.rigid_info,
-                self.rigid_config,
-                is_per_env,
-            )
-            if invalid[0]:
-                gs.raise_exception(
-                    "`positions` must be finite and inside the terrain bounds, and the terrain must not have roll or "
-                    "pitch."
-                )
-
-        if self.n_envs == 0:
-            heights = heights[0]
-        if is_single_position or (is_per_env and n_points == 1):
-            heights = heights[..., 0]
-        return heights
 
     def get_links_root_COM(self, links_idx=None, envs_idx=None):
         """

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1222,21 +1222,27 @@ class RigidSolver(KinematicSolver):
                 entity_idx = entity_idx[0]
             entity = self._entities[entity_idx]
 
-            scale = np.asarray(entity.terrain_scale, dtype=gs.np_float)
             rc = np.array(entity.terrain_hf.shape, dtype=gs.np_int)
-            hf = entity.terrain_hf * scale[1]
             xyz_maxmin = np.array(
-                [rc[0] * scale[0], rc[1] * scale[0], hf.max(), 0, 0, hf.min() - 1.0], dtype=gs.np_float
+                [
+                    rc[0] * entity.terrain_scale[0],
+                    rc[1] * entity.terrain_scale[0],
+                    entity.terrain_hf.max(),
+                    0,
+                    0,
+                    entity.terrain_hf.min() - 1.0,
+                ],
+                dtype=gs.np_float,
             )
 
-            self.terrain_hf = qd.field(dtype=gs.qd_float, shape=hf.shape)
+            self.terrain_hf = qd.field(dtype=gs.qd_float, shape=entity.terrain_hf.shape)
             self.terrain_rc = qd.field(dtype=gs.qd_int, shape=(2,))
             self.terrain_scale = qd.field(dtype=gs.qd_float, shape=(2,))
             self.terrain_xyz_maxmin = qd.field(dtype=gs.qd_float, shape=(6,))
 
-            self.terrain_hf.from_numpy(hf)
+            self.terrain_hf.from_numpy(entity.terrain_hf)
             self.terrain_rc.from_numpy(rc)
-            self.terrain_scale.from_numpy(scale)
+            self.terrain_scale.from_numpy(entity.terrain_scale)
             self.terrain_xyz_maxmin.from_numpy(xyz_maxmin)
 
     def _init_constraint_solver(self):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1212,39 +1212,6 @@ class RigidSolver(KinematicSolver):
     def _init_collider(self):
         self.collider = Collider(self)
 
-        if self.collider._collider_static_config.has_terrain:
-            link_idx_ = next(
-                i for i, _type in enumerate(qd_to_numpy(self.dyn_info.geoms.type)) if _type == gs.GEOM_TYPE.TERRAIN
-            )
-            link_idx = qd_to_numpy(self.dyn_info.geoms.link_idx, link_idx_, keepdim=False)
-            entity_idx = qd_to_numpy(self.dyn_info.links.entity_idx, link_idx, keepdim=False)
-            if self._options.batch_links_info:
-                entity_idx = entity_idx[0]
-            entity = self._entities[entity_idx]
-
-            rc = np.array(entity.terrain_hf.shape, dtype=gs.np_int)
-            xyz_maxmin = np.array(
-                [
-                    rc[0] * entity.terrain_scale[0],
-                    rc[1] * entity.terrain_scale[0],
-                    entity.terrain_hf.max(),
-                    0,
-                    0,
-                    entity.terrain_hf.min() - 1.0,
-                ],
-                dtype=gs.np_float,
-            )
-
-            self.terrain_hf = qd.field(dtype=gs.qd_float, shape=entity.terrain_hf.shape)
-            self.terrain_rc = qd.field(dtype=gs.qd_int, shape=(2,))
-            self.terrain_scale = qd.field(dtype=gs.qd_float, shape=(2,))
-            self.terrain_xyz_maxmin = qd.field(dtype=gs.qd_float, shape=(6,))
-
-            self.terrain_hf.from_numpy(entity.terrain_hf)
-            self.terrain_rc.from_numpy(rc)
-            self.terrain_scale.from_numpy(entity.terrain_scale)
-            self.terrain_xyz_maxmin.from_numpy(xyz_maxmin)
-
     def _init_constraint_solver(self):
         # Islands are a per-island Newton solve inside ConstraintSolver.resolve, gated on use_contact_island.
         self.constraint_solver = ConstraintSolver(self)

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -1314,6 +1314,13 @@ def _tc_transform_by_quat(v, quat, out: torch.Tensor | None = None):
     return out
 
 
+@torch.jit.script
+def _tc_inv_transform_by_trans_quat(pos: torch.Tensor, trans: torch.Tensor, quat: torch.Tensor) -> torch.Tensor:
+    quat_inv = quat.clone()
+    quat_inv[..., 1:].neg_()
+    return _tc_transform_by_quat(pos - trans, quat_inv)
+
+
 def transform_by_quat(v, quat):
     """
     This method transforms quat_v by quat_u.
@@ -1360,6 +1367,8 @@ def inv_transform_by_quat(pos, quat):
 
 
 def inv_transform_by_trans_quat(pos, trans, quat):
+    if all(isinstance(e, torch.Tensor) for e in (pos, trans, quat)):
+        return _tc_inv_transform_by_trans_quat(pos, trans, quat)
     return inv_transform_by_quat(pos - trans, quat)
 
 

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -1331,13 +1331,6 @@ def _tc_transform_by_quat(v, quat, out: torch.Tensor | None = None):
     return out
 
 
-@torch.jit.script
-def _tc_inv_transform_by_trans_quat(pos: torch.Tensor, trans: torch.Tensor, quat: torch.Tensor) -> torch.Tensor:
-    quat_inv = quat.clone()
-    quat_inv[..., 1:].neg_()
-    return _tc_transform_by_quat(pos - trans, quat_inv)
-
-
 def transform_by_quat(v, quat):
     """
     This method transforms quat_v by quat_u.
@@ -1384,9 +1377,6 @@ def inv_transform_by_quat(pos, quat):
 
 
 def inv_transform_by_trans_quat(pos, trans, quat):
-    # FIXME: Compile chains of public geometry helpers without dedicated backend-specific wrappers
-    if all(isinstance(e, torch.Tensor) for e in (pos, trans, quat)):
-        return _tc_inv_transform_by_trans_quat(pos, trans, quat)
     return inv_transform_by_quat(pos - trans, quat)
 
 

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -1367,6 +1367,7 @@ def inv_transform_by_quat(pos, quat):
 
 
 def inv_transform_by_trans_quat(pos, trans, quat):
+    # FIXME: Compile chains of public geometry helpers without dedicated backend-specific wrappers
     if all(isinstance(e, torch.Tensor) for e in (pos, trans, quat)):
         return _tc_inv_transform_by_trans_quat(pos, trans, quat)
     return inv_transform_by_quat(pos - trans, quat)

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -166,6 +166,7 @@ def parse_terrain(morph: Terrain, surface):
             with open(gnd_file_path, "wb") as file:
                 pkl.dump(heightfield, file)
 
+    heightfield = np.asarray(heightfield, dtype=gs.np_float)
     need_uvs = getattr(surface, "diffuse_texture", None) is not None
     tmesh, sdf_tmesh = convert_heightfield_to_watertight_trimesh(
         heightfield,

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -164,6 +164,7 @@ def test_get_height(n_envs, tol):
             vertical_scale=0.01,
             collision=False,
         ),
+        material=gs.materials.Kinematic(),
     )
     box = scene.add_entity(
         morph=gs.morphs.Box(

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -134,7 +134,7 @@ def test_discrete_obstacles():
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
-def test_get_height(n_envs, tol):
+def test_get_terrain_height(n_envs, tol):
     height_field = np.array(
         [
             [0.0, 4.0, 9.0, 15.0],
@@ -159,8 +159,9 @@ def test_get_height(n_envs, tol):
     visual_terrain = scene.add_entity(
         morph=gs.morphs.Terrain(
             pos=(30.0, 40.0, 3.0),
-            height_field=np.array(((100.0, 200.0), (300.0, 400.0)), dtype=gs.np_float),
-            horizontal_scale=1.0,
+            quat=gu.xyz_to_quat(np.array((0.0, 0.0, 37.0)), degrees=True),
+            height_field=np.add.outer(np.arange(145), 2 * np.arange(145)).astype(gs.np_float),
+            horizontal_scale=0.25,
             vertical_scale=0.01,
             collision=False,
         ),
@@ -173,31 +174,20 @@ def test_get_height(n_envs, tol):
     )
     scene.build(n_envs=n_envs)
 
-    initial_height = terrain.get_height((2.0, -0.5))
+    initial_height = terrain.get_terrain_height((2.0, -0.5))
     assert_allclose(initial_height, 1.3, tol=tol)
 
-    visual_height = visual_terrain.get_height((30.0, 40.0))
-    assert_allclose(visual_height, 4.0, tol=tol)
-    visual_height_max = visual_terrain.get_height((31.0, 41.0))
-    assert_allclose(visual_height_max, 7.0, tol=tol)
+    visual_pose = gu.trans_quat_to_T(np.array(visual_terrain.morph.pos), np.array(visual_terrain.morph.quat))
+    visual_far_corner = visual_pose @ np.array((36.0, 36.0, 0.0, 1.0))
+    visual_height = visual_terrain.get_terrain_height(visual_far_corner[:2])
+    assert_allclose(visual_height, 7.32, tol=tol)
 
     if n_envs:
-        shared_positions = terrain.get_height(((2.0, -1.0), (2.0, -0.5)))
+        shared_positions = terrain.get_terrain_height(((2.0, -1.0), (2.0, -0.5)))
         assert_allclose(shared_positions, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
-        shared_positions_explicit = terrain.get_height((((2.0, -1.0), (2.0, -0.5)),))
-        assert_allclose(shared_positions_explicit, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
 
-        terrain.set_pos(
-            (
-                (10.0, 20.0, 1.0),
-                (-3.0, 4.0, -2.0),
-            ),
-            relative=False,
-        )
-        terrain.set_quat(
-            np.stack((gu.identity_quat(), quat_yaw)),
-            relative=False,
-        )
+        terrain.set_pos(((10.0, 20.0, 1.0), (-3.0, 4.0, -2.0)), relative=False)
+        terrain.set_quat(np.stack((gu.identity_quat(), quat_yaw)), relative=False)
     else:
         terrain.set_pos((10.0, 20.0, 1.0), relative=False)
         terrain.set_quat((1.0, 0.0, 0.0, 0.0), relative=False)
@@ -210,35 +200,45 @@ def test_get_height(n_envs, tol):
         (10.375, 20.25),
         (11.0, 21.5),
     )
-    expected = (1.0, 2.0, 1.4, 1.45, 2.1, 10.9)
+    terrain_mesh = terrain.geoms[0].get_trimesh().copy()
+    terrain_mesh.apply_transform(gu.trans_quat_to_T(np.array((10.0, 20.0, 1.0)), gu.identity_quat()))
+    ray_origins = np.column_stack((positions, np.full(len(positions), terrain_mesh.bounds[1, 2] + 1.0)))
+    ray_directions = np.tile((0.0, 0.0, -1.0), (len(positions), 1))
+    locations, ray_ids, _ = terrain_mesh.ray.intersects_location(
+        ray_origins=ray_origins, ray_directions=ray_directions, multiple_hits=False
+    )
+    expected = locations[np.argsort(ray_ids), 2]
     if n_envs:
-        heights = terrain.get_height(positions, envs_idx=[0])
+        heights = terrain.get_terrain_height(positions, envs_idx=[0])
 
         positions_per_env = ((positions[3], positions[4]), ((-3.25, 4.125), (-3.25, 4.375)))
-        heights_per_env = terrain.get_height(positions_per_env)
+        heights_per_env = terrain.get_terrain_height(positions_per_env)
         assert_allclose(heights_per_env, ((1.45, 2.1), (-1.55, -0.9)), tol=tol)
 
-        one_position_per_env = terrain.get_height(((positions_per_env[0][0],), (positions_per_env[1][0],)))
-        assert_allclose(one_position_per_env, (1.45, -1.55), tol=tol)
+        one_position_per_env = terrain.get_terrain_height(((positions_per_env[0][0],), (positions_per_env[1][0],)))
+        assert one_position_per_env.shape == (2, 1)
+        assert_allclose(one_position_per_env, ((1.45,), (-1.55,)), tol=tol)
 
-        heights_env_1 = terrain.get_height(positions_per_env[1], envs_idx=1)
+        heights_env_1 = terrain.get_terrain_height(positions_per_env[1], envs_idx=1)
         assert_allclose(heights_env_1, (-1.55, -0.9), tol=tol)
     else:
-        heights = terrain.get_height(positions)
+        heights = terrain.get_terrain_height(positions)
 
-    assert_allclose(heights, expected, tol=tol)
+    assert_allclose(heights, expected, atol=1e-6, rtol=1e-6)
 
     envs_idx = [0] if n_envs else None
+    boundary_heights = terrain.get_terrain_height(((9.5, 20.0), (9.499, 20.0), (np.nan, 20.0)), envs_idx=envs_idx)
+    assert_allclose(boundary_heights[..., 0], 1.0, tol=tol)
+    assert torch.isnan(boundary_heights[..., 1:]).all()
+
     with pytest.raises(gs.GenesisException):
-        terrain.get_height((11.001, 20.0), envs_idx=envs_idx)
+        terrain.get_terrain_height((10.0, 20.0, 1.0), envs_idx=envs_idx)
     with pytest.raises(gs.GenesisException):
-        terrain.get_height((10.0, 20.0, 1.0), envs_idx=envs_idx)
-    with pytest.raises(gs.GenesisException):
-        box.get_height((0.0, 0.0), envs_idx=envs_idx)
+        box.get_terrain_height((0.0, 0.0), envs_idx=envs_idx)
 
     terrain.set_quat(gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), degrees=True), envs_idx=envs_idx, relative=False)
-    with pytest.raises(gs.GenesisException):
-        terrain.get_height((10.5, 20.0), envs_idx=envs_idx)
+    height = terrain.get_terrain_height((10.5, 20.0), envs_idx=envs_idx)
+    assert torch.isnan(height).all()
 
 
 @pytest.mark.required

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -159,7 +159,7 @@ def test_get_height(n_envs, tol):
     visual_terrain = scene.add_entity(
         morph=gs.morphs.Terrain(
             pos=(30.0, 40.0, 3.0),
-            height_field=np.full((2, 2), 100.0, dtype=gs.np_float),
+            height_field=np.array(((100.0, 200.0), (300.0, 400.0)), dtype=gs.np_float),
             horizontal_scale=1.0,
             vertical_scale=0.01,
             collision=False,
@@ -175,20 +175,17 @@ def test_get_height(n_envs, tol):
 
     initial_height = terrain.get_height((2.0, -0.5))
     assert_allclose(initial_height, 1.3, tol=tol)
-    assert initial_height.shape == ((2,) if n_envs else ())
 
     visual_height = visual_terrain.get_height((30.0, 40.0))
-    assert_allclose(visual_height, (4.0, 4.0) if n_envs else 4.0, tol=tol)
+    assert_allclose(visual_height, 4.0, tol=tol)
     visual_height_max = visual_terrain.get_height((31.0, 41.0))
-    assert_allclose(visual_height_max, (4.0, 4.0) if n_envs else 4.0, tol=tol)
+    assert_allclose(visual_height_max, 7.0, tol=tol)
 
     if n_envs:
         shared_positions = terrain.get_height(((2.0, -1.0), (2.0, -0.5)))
         assert_allclose(shared_positions, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
-        assert shared_positions.shape == (2, 2)
         shared_positions_explicit = terrain.get_height((((2.0, -1.0), (2.0, -0.5)),))
         assert_allclose(shared_positions_explicit, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
-        assert shared_positions_explicit.shape == (2, 2)
 
         terrain.set_pos(
             (
@@ -216,61 +213,32 @@ def test_get_height(n_envs, tol):
     expected = (1.0, 2.0, 1.4, 1.45, 2.1, 10.9)
     if n_envs:
         heights = terrain.get_height(positions, envs_idx=[0])
-        assert heights.shape == (1, len(positions))
 
-        positions_per_env = (
-            (
-                positions[3],
-                positions[4],
-            ),
-            (
-                (-3.25, 4.125),
-                (-3.25, 4.375),
-            ),
-        )
+        positions_per_env = ((positions[3], positions[4]), ((-3.25, 4.125), (-3.25, 4.375)))
         heights_per_env = terrain.get_height(positions_per_env)
         assert_allclose(heights_per_env, ((1.45, 2.1), (-1.55, -0.9)), tol=tol)
-        assert heights_per_env.shape == (2, 2)
 
         one_position_per_env = terrain.get_height(((positions_per_env[0][0],), (positions_per_env[1][0],)))
         assert_allclose(one_position_per_env, (1.45, -1.55), tol=tol)
-        assert one_position_per_env.shape == (2,)
 
         heights_env_1 = terrain.get_height(positions_per_env[1], envs_idx=1)
-        assert_allclose(heights_env_1, ((-1.55, -0.9),), tol=tol)
+        assert_allclose(heights_env_1, (-1.55, -0.9), tol=tol)
     else:
         heights = terrain.get_height(positions)
-        assert heights.shape == (len(positions),)
 
-    assert_allclose(heights, (expected,) if n_envs else expected, tol=tol)
-    assert heights.dtype == gs.tc_float
-    assert heights.device.type == gs.device.type
+    assert_allclose(heights, expected, tol=tol)
 
     envs_idx = [0] if n_envs else None
-    with pytest.raises(gs.GenesisException):
-        terrain.get_height((9.999, 20.0), envs_idx=envs_idx)
     with pytest.raises(gs.GenesisException):
         terrain.get_height((11.001, 20.0), envs_idx=envs_idx)
     with pytest.raises(gs.GenesisException):
         terrain.get_height((10.0, 20.0, 1.0), envs_idx=envs_idx)
     with pytest.raises(gs.GenesisException):
-        terrain.get_height(np.empty((0, 2)), envs_idx=envs_idx)
-    with pytest.raises(gs.GenesisException):
-        terrain.get_height(np.empty((3, 1, 2)), envs_idx=envs_idx)
-    with pytest.raises(gs.GenesisException):
-        terrain.get_height((np.nan, 20.0), envs_idx=envs_idx)
-    with pytest.raises(gs.GenesisException):
-        terrain.get_height((np.inf, 20.0), envs_idx=envs_idx)
-    with pytest.raises(gs.GenesisException):
         box.get_height((0.0, 0.0), envs_idx=envs_idx)
 
-    terrain.set_quat(
-        gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), degrees=True),
-        envs_idx=envs_idx,
-        relative=False,
-    )
+    terrain.set_quat(gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), degrees=True), envs_idx=envs_idx, relative=False)
     with pytest.raises(gs.GenesisException):
-        terrain.get_height((10.0, 20.0), envs_idx=envs_idx)
+        terrain.get_height((10.5, 20.0), envs_idx=envs_idx)
 
 
 @pytest.mark.required

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -182,7 +182,7 @@ def test_get_terrain_height(n_envs, tol):
     assert_allclose(visual_height, 3.04, tol=tol)
 
     if n_envs:
-        shared_positions = terrain.get_terrain_height(((2.0, -1.0), (2.0, -0.5)))
+        shared_positions = terrain.get_terrain_height((((2.0, -1.0), (2.0, -0.5)),))
         assert_allclose(shared_positions, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
 
         terrain.set_pos(((10.0, 20.0, 1.0), (-3.0, 4.0, -2.0)), relative=False)
@@ -215,7 +215,6 @@ def test_get_terrain_height(n_envs, tol):
         assert_allclose(heights_per_env, ((1.45, 2.1), (-1.55, -0.9)), tol=tol)
 
         one_position_per_env = terrain.get_terrain_height(((positions_per_env[0][0],), (positions_per_env[1][0],)))
-        assert one_position_per_env.shape == (2, 1)
         assert_allclose(one_position_per_env, ((1.45,), (-1.55,)), tol=tol)
 
         heights_env_1 = terrain.get_terrain_height(positions_per_env[1], envs_idx=1)
@@ -223,7 +222,7 @@ def test_get_terrain_height(n_envs, tol):
     else:
         heights = terrain.get_terrain_height(positions)
 
-    assert_allclose(heights, expected, atol=1e-6, rtol=1e-6)
+    assert_allclose(heights, expected, tol=1e-6)
 
     envs_idx = [0] if n_envs else None
     boundary_heights = terrain.get_terrain_height(((9.5, 20.0), (9.499, 20.0), (np.nan, 20.0)), envs_idx=envs_idx)

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -141,7 +141,6 @@ def test_get_terrain_height(n_envs, tol):
             [10.0, 20.0, 33.0, 49.0],
             [30.0, 50.0, 73.0, 99.0],
         ],
-        dtype=gs.np_float,
     )
     quat_yaw = gu.xyz_to_quat(np.array((0.0, 0.0, 90.0)), degrees=True)
 
@@ -150,20 +149,20 @@ def test_get_terrain_height(n_envs, tol):
         morph=gs.morphs.Terrain(
             pos=(2.0, -1.0, 0.3),
             quat=quat_yaw,
-            height_field=height_field,
+            batch_fixed_verts=True,
             horizontal_scale=0.5,
             vertical_scale=0.1,
-            batch_fixed_verts=True,
+            height_field=height_field,
         ),
     )
     visual_terrain = scene.add_entity(
         morph=gs.morphs.Terrain(
             pos=(30.0, 40.0, 3.0),
             quat=gu.xyz_to_quat(np.array((0.0, 0.0, 37.0)), degrees=True),
-            height_field=np.add.outer(np.arange(145), 2 * np.arange(145)).astype(gs.np_float),
+            collision=False,
             horizontal_scale=0.25,
             vertical_scale=0.01,
-            collision=False,
+            height_field=np.add.outer(np.arange(3), 2 * np.arange(3)),
         ),
         material=gs.materials.Kinematic(),
     )
@@ -178,9 +177,9 @@ def test_get_terrain_height(n_envs, tol):
     assert_allclose(initial_height, 1.3, tol=tol)
 
     visual_pose = gu.trans_quat_to_T(np.array(visual_terrain.morph.pos), np.array(visual_terrain.morph.quat))
-    visual_far_corner = visual_pose @ np.array((36.0, 36.0, 0.0, 1.0))
-    visual_height = visual_terrain.get_terrain_height(visual_far_corner[:2])
-    assert_allclose(visual_height, 7.32, tol=tol)
+    visual_position = visual_pose @ np.array((0.5, 0.25, 0.0, 1.0))
+    visual_height = visual_terrain.get_terrain_height(visual_position[:2])
+    assert_allclose(visual_height, 3.04, tol=tol)
 
     if n_envs:
         shared_positions = terrain.get_terrain_height(((2.0, -1.0), (2.0, -0.5)))

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -234,8 +234,12 @@ def test_get_terrain_height(n_envs, tol):
     with pytest.raises(gs.GenesisException):
         box.get_terrain_height((0.0, 0.0), envs_idx=envs_idx)
 
-    terrain.set_quat(gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), degrees=True), envs_idx=envs_idx, relative=False)
-    height = terrain.get_terrain_height((10.5, 20.0), envs_idx=envs_idx)
+    terrain.set_quat(gu.xyz_to_quat(np.array((5e-4, 0.0, 0.0))), envs_idx=envs_idx, relative=False)
+    height = terrain.get_terrain_height((10.0, 20.0), envs_idx=envs_idx)
+    assert_allclose(height, 1.0, tol=tol)
+
+    terrain.set_quat(gu.xyz_to_quat(np.array((2e-3, 0.0, 0.0))), envs_idx=envs_idx, relative=False)
+    height = terrain.get_terrain_height((10.0, 20.0), envs_idx=envs_idx)
     assert torch.isnan(height).all()
 
 

--- a/tests/rigid/test_terrain.py
+++ b/tests/rigid/test_terrain.py
@@ -11,9 +11,7 @@ import genesis.utils.geom as gu
 import genesis.utils.terrain as tu
 from genesis.utils.misc import get_assets_dir, tensor_to_array
 
-from ..utils import (
-    assert_allclose,
-)
+from ..utils import assert_allclose
 
 
 @pytest.mark.parametrize(
@@ -132,6 +130,146 @@ def test_discrete_obstacles():
     assert height_field.max() == 2.0
     assert height_field.min() == -2.0
     assert (platform < gs.EPS).all()
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_get_height(n_envs, tol):
+    height_field = np.array(
+        [
+            [0.0, 4.0, 9.0, 15.0],
+            [10.0, 20.0, 33.0, 49.0],
+            [30.0, 50.0, 73.0, 99.0],
+        ],
+        dtype=gs.np_float,
+    )
+    quat_yaw = gu.xyz_to_quat(np.array((0.0, 0.0, 90.0)), degrees=True)
+
+    scene = gs.Scene(show_viewer=False)
+    terrain = scene.add_entity(
+        morph=gs.morphs.Terrain(
+            pos=(2.0, -1.0, 0.3),
+            quat=quat_yaw,
+            height_field=height_field,
+            horizontal_scale=0.5,
+            vertical_scale=0.1,
+            batch_fixed_verts=True,
+        ),
+    )
+    visual_terrain = scene.add_entity(
+        morph=gs.morphs.Terrain(
+            pos=(30.0, 40.0, 3.0),
+            height_field=np.full((2, 2), 100.0, dtype=gs.np_float),
+            horizontal_scale=1.0,
+            vertical_scale=0.01,
+            collision=False,
+        ),
+    )
+    box = scene.add_entity(
+        morph=gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+        ),
+    )
+    scene.build(n_envs=n_envs)
+
+    initial_height = terrain.get_height((2.0, -0.5))
+    assert_allclose(initial_height, 1.3, tol=tol)
+    assert initial_height.shape == ((2,) if n_envs else ())
+
+    visual_height = visual_terrain.get_height((30.0, 40.0))
+    assert_allclose(visual_height, (4.0, 4.0) if n_envs else 4.0, tol=tol)
+    visual_height_max = visual_terrain.get_height((31.0, 41.0))
+    assert_allclose(visual_height_max, (4.0, 4.0) if n_envs else 4.0, tol=tol)
+
+    if n_envs:
+        shared_positions = terrain.get_height(((2.0, -1.0), (2.0, -0.5)))
+        assert_allclose(shared_positions, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
+        assert shared_positions.shape == (2, 2)
+        shared_positions_explicit = terrain.get_height((((2.0, -1.0), (2.0, -0.5)),))
+        assert_allclose(shared_positions_explicit, ((0.3, 1.3), (0.3, 1.3)), tol=tol)
+        assert shared_positions_explicit.shape == (2, 2)
+
+        terrain.set_pos(
+            (
+                (10.0, 20.0, 1.0),
+                (-3.0, 4.0, -2.0),
+            ),
+            relative=False,
+        )
+        terrain.set_quat(
+            np.stack((gu.identity_quat(), quat_yaw)),
+            relative=False,
+        )
+    else:
+        terrain.set_pos((10.0, 20.0, 1.0), relative=False)
+        terrain.set_quat((1.0, 0.0, 0.0, 0.0), relative=False)
+
+    positions = (
+        (10.0, 20.0),
+        (10.5, 20.0),
+        (10.0, 20.5),
+        (10.125, 20.25),
+        (10.375, 20.25),
+        (11.0, 21.5),
+    )
+    expected = (1.0, 2.0, 1.4, 1.45, 2.1, 10.9)
+    if n_envs:
+        heights = terrain.get_height(positions, envs_idx=[0])
+        assert heights.shape == (1, len(positions))
+
+        positions_per_env = (
+            (
+                positions[3],
+                positions[4],
+            ),
+            (
+                (-3.25, 4.125),
+                (-3.25, 4.375),
+            ),
+        )
+        heights_per_env = terrain.get_height(positions_per_env)
+        assert_allclose(heights_per_env, ((1.45, 2.1), (-1.55, -0.9)), tol=tol)
+        assert heights_per_env.shape == (2, 2)
+
+        one_position_per_env = terrain.get_height(((positions_per_env[0][0],), (positions_per_env[1][0],)))
+        assert_allclose(one_position_per_env, (1.45, -1.55), tol=tol)
+        assert one_position_per_env.shape == (2,)
+
+        heights_env_1 = terrain.get_height(positions_per_env[1], envs_idx=1)
+        assert_allclose(heights_env_1, ((-1.55, -0.9),), tol=tol)
+    else:
+        heights = terrain.get_height(positions)
+        assert heights.shape == (len(positions),)
+
+    assert_allclose(heights, (expected,) if n_envs else expected, tol=tol)
+    assert heights.dtype == gs.tc_float
+    assert heights.device.type == gs.device.type
+
+    envs_idx = [0] if n_envs else None
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height((9.999, 20.0), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height((11.001, 20.0), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height((10.0, 20.0, 1.0), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height(np.empty((0, 2)), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height(np.empty((3, 1, 2)), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height((np.nan, 20.0), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height((np.inf, 20.0), envs_idx=envs_idx)
+    with pytest.raises(gs.GenesisException):
+        box.get_height((0.0, 0.0), envs_idx=envs_idx)
+
+    terrain.set_quat(
+        gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), degrees=True),
+        envs_idx=envs_idx,
+        relative=False,
+    )
+    with pytest.raises(gs.GenesisException):
+        terrain.get_height((10.0, 20.0), envs_idx=envs_idx)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

This adds `get_terrain_height(positions, envs_idx=None)` for querying terrain surface heights at world-frame x-y positions.

The query follows the terrain's piecewise-planar mesh and supports terrain translation, yaw, per-environment poses, shared point sets, explicit per-environment point sets, and visual-only kinematic terrains. The point dimension is preserved unless the input is the scalar form `(2,)`.

Queries up to one grid cell outside the terrain clamp to the nearest edge. Queries farther outside, non-finite positions, and terrains with roll or pitch return `NaN` per point. Malformed positions and calls on other entity types raise `GenesisException`.

The zero-copy path uses TorchScript and the non-zero-copy path uses a Quadrants kernel. Both paths remain on device. Terrain height data is cached when the terrain is loaded.

## Related Issue

Resolves #2094

Supersedes #2691, which was closed without merging. This implementation matches the simulated triangle surface, uses consistent height-field axes, and honors the current terrain pose.

## Motivation and Context

Locomotion tasks need the ground height below robot feet for observations, rewards, and swing-height control. Reading only height-field vertices does not provide the surface height between vertices.

This implementation evaluates the same two triangles used to construct each terrain cell, so the returned height matches the terrain mesh used by the simulator.

## How Has This Been / Can This Be Tested?

The focused test compares queried heights with ray intersections against the generated terrain mesh. It also covers a non-square height field, scaling, translation, yaw, per-environment poses, point layouts, environment selection, visual-only terrain, edge clamping, and `NaN` results.

```bash
python -m pytest tests/rigid/test_terrain.py::test_get_terrain_height -n 0 --backend cpu -q
GS_ENABLE_ZEROCOPY=0 python -m pytest tests/rigid/test_terrain.py::test_get_terrain_height -n 0 --backend cpu -q
python -m pytest tests/rigid/test_terrain.py::test_get_terrain_height -n 0 --backend gpu -q
GS_ENABLE_ZEROCOPY=0 python -m pytest tests/rigid/test_terrain.py::test_get_terrain_height -n 0 --backend gpu -q
python -m pre_commit run --files \
  genesis/engine/entities/rigid_entity/rigid_entity.py \
  genesis/engine/solvers/kinematic_solver.py \
  genesis/engine/solvers/rigid/abd/accessor.py \
  genesis/engine/solvers/rigid/collider/collider.py \
  genesis/engine/solvers/rigid/rigid_solver.py \
  genesis/utils/geom.py \
  genesis/utils/terrain.py \
  tests/rigid/test_terrain.py
```

Results on macOS with an Apple M4:

- Focused test: 2 passed in each of the four backend and zero-copy combinations.
- Ruff check and formatting: passed.
- Python bytecode compilation for all changed Python files: passed.

Warm timings through the public getter using 8 environments and a 65 by 65 terrain. Values are the minimum of five synchronized runs after warm-up:

| Backend | Path | 128 points per environment | 16,384 points per environment |
| --- | --- | ---: | ---: |
| CPU | Scripted Torch | 132 us | 2,329 us |
| CPU | Quadrants | 76 us | 738 us |
| Metal | Scripted Torch | 265 us | 986 us |
| Metal | Quadrants | 1,566 us | 1,769 us |

Dispatch follows `gs.use_zerocopy`. CUDA was not measured.

## Screenshots (if appropriate):

Not applicable.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
