### PR TITLE
[FEATURE] Support raycasting against visual meshes in viewer plugins.

### DIFF
--- a/examples/viewer_plugin/mesh_point_selector.py
+++ b/examples/viewer_plugin/mesh_point_selector.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import os
 from typing import TYPE_CHECKING, NamedTuple
@@ -40,6 +41,8 @@ class MeshPointSelectorPlugin(RaycasterViewerPlugin):
     """
     Interactive viewer plugin that enables using mouse clicks to select points on rigid meshes.
     Selected points are stored in local coordinates relative to their link's frame.
+
+    See RaycasterViewerPlugin for `use_visual_geom`.
     """
 
     def __init__(
@@ -49,8 +52,9 @@ class MeshPointSelectorPlugin(RaycasterViewerPlugin):
         hover_color: tuple = (0.3, 0.5, 1.0, 1.0),
         grid_snap: tuple[float, float, float] = (-1.0, -1.0, -1.0),
         output_file: str = "selected_points.csv",
+        use_visual_geom: bool = False,
     ) -> None:
-        super().__init__()
+        super().__init__(use_visual_geom)
         self.sphere_radius = sphere_radius
         self.sphere_color = sphere_color
         self.hover_color = hover_color
@@ -226,6 +230,12 @@ class MeshPointSelectorPlugin(RaycasterViewerPlugin):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Mesh point selector viewer plugin example.")
+    parser.add_argument(
+        "--use_visual_geom", action="store_true", help="Select points on the visual mesh instead of the collision one"
+    )
+    args = parser.parse_args()
+
     gs.init(backend=gs.gpu)
 
     scene = gs.Scene(
@@ -246,6 +256,12 @@ if __name__ == "__main__":
         show_viewer=True,
     )
 
+    # Only entities opting into visual raycasting can be selected with --use_visual_geom.
+    raycastable = gs.materials.Rigid(
+        use_visual_raycasting=True,
+    )
+    vis_mode = "visual" if args.use_visual_geom else "collision"
+
     hand = scene.add_entity(
         morph=gs.morphs.URDF(
             file="urdf/shadow_hand/shadow_hand.urdf",
@@ -255,6 +271,18 @@ if __name__ == "__main__":
             fixed=True,
             merge_fixed_links=False,
         ),
+        material=raycastable,
+        vis_mode=vis_mode,
+    )
+    duck = scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file="meshes/duck/duck.obj",
+            pos=(0.0, 0.3, 0.0),
+            scale=0.001,
+            fixed=True,
+        ),
+        material=raycastable,
+        vis_mode=vis_mode,
     )
 
     scene.viewer.add_plugin(
@@ -262,6 +290,7 @@ if __name__ == "__main__":
             sphere_radius=0.004,
             grid_snap=(-1.0, 0.01, 0.01),
             output_file="selected_points.csv",
+            use_visual_geom=args.use_visual_geom,
         )
     )
 

--- a/examples/viewer_plugin/mesh_point_selector.py
+++ b/examples/viewer_plugin/mesh_point_selector.py
@@ -112,7 +112,7 @@ class MeshPointSelectorPlugin(RaycasterViewerPlugin):
             ray = self._screen_position_to_ray(x, y)
             ray_hit = self._raycaster.cast(*ray)
 
-            if ray_hit is not None and ray_hit.geom:
+            if ray_hit is not None and ray_hit.geom is not None:
                 link = ray_hit.geom.link
                 world_pos = ray_hit.position
                 world_normal = ray_hit.normal

--- a/examples/viewer_plugin/mouse_interaction.py
+++ b/examples/viewer_plugin/mouse_interaction.py
@@ -10,6 +10,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--use_force", "-f", action="store_true", help="Apply spring forces instead of setting position"
     )
+    parser.add_argument(
+        "--use_visual_geom",
+        action="store_true",
+        help="Grab entities by their visual mesh instead of their collision one",
+    )
     parser.add_argument("--num_envs", "-b", type=int, default=1, help="Number of environments to create")
     args = parser.parse_args()
 
@@ -29,11 +34,28 @@ if __name__ == "__main__":
 
     scene.add_entity(gs.morphs.Plane())
 
+    # Only entities opting into visual raycasting can be grabbed with --use_visual_geom.
+    raycastable = gs.materials.Rigid(
+        use_visual_raycasting=True,
+    )
+    vis_mode = "visual" if args.use_visual_geom else "collision"
+
     sphere = scene.add_entity(
         morph=gs.morphs.Sphere(
             pos=(-0.3, -0.3, 0),
             radius=0.1,
         ),
+        material=raycastable,
+        vis_mode=vis_mode,
+    )
+    duck = scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file="meshes/duck/duck.obj",
+            pos=(0.0, 0.0, 0.5),
+            scale=0.001,
+        ),
+        material=raycastable,
+        vis_mode=vis_mode,
     )
     for i in range(6):
         angle = i * (2 * math.pi / 6)
@@ -43,12 +65,15 @@ if __name__ == "__main__":
                 pos=(radius * math.cos(angle), radius * math.sin(angle), 0.1 + i * 0.1),
                 size=(0.2, 0.2, 0.2),
             ),
+            material=raycastable,
+            vis_mode=vis_mode,
         )
 
     scene.viewer.add_plugin(
         gs.vis.viewer_plugins.MouseInteractionPlugin(
             use_force=args.use_force,
             color=(0.1, 0.6, 0.8, 0.6),
+            use_visual_geom=args.use_visual_geom,
         )
     )
 

--- a/genesis/engine/materials/kinematic.py
+++ b/genesis/engine/materials/kinematic.py
@@ -6,6 +6,13 @@ class Kinematic(Material[EntityT]):
     Visualization-only material for ghost/reference entities.
 
     Kinematic entities are rendered but do not participate in physics simulation, collision detection, or constraint
-    solving. They are ignored by raycaster sensors by default; set use_visual_raycasting=True to include their visual
-    mesh in the raycaster BVH.
+    solving.
+
+    Parameters
+    ----------
+    use_visual_raycasting : bool, optional
+        Expose this entity's visual mesh to every consumer that casts against visual geometry: raycaster sensors, and
+        viewer plugins built on RaycasterViewerPlugin with use_visual_geom set. Each such consumer then spans the
+        entity's visual triangles in its BVH, rebuilt as the entity moves, so reserve it for the entities that are
+        meant to be sensed or picked. Default is False.
     """

--- a/genesis/engine/materials/kinematic.py
+++ b/genesis/engine/materials/kinematic.py
@@ -12,7 +12,7 @@ class Kinematic(Material[EntityT]):
     ----------
     use_visual_raycasting : bool, optional
         Expose this entity's visual mesh to every consumer that casts against visual geometry: raycaster sensors, and
-        viewer plugins built on RaycasterViewerPlugin with use_visual_geom set. Each such consumer then spans the
-        entity's visual triangles in its BVH, rebuilt as the entity moves, so reserve it for the entities that are
-        meant to be sensed or picked. Default is False.
+        viewer plugins built on RaycasterViewerPlugin with use_visual_geom set. Each such consumer then re-scans the
+        entity's visual triangles as it moves, so reserve it for the entities meant to be sensed or picked.
+        Default is False.
     """

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -24,6 +24,8 @@ class Rigid(Kinematic["RigidEntity"]):
 
     Parameters
     ----------
+    use_visual_raycasting : bool, optional
+        See Kinematic. Default is False.
     rho : float or None, optional
         The density of the material used to estimate mass if necessary. When None, the default depends on context:
         1000 kg/m^3 if MuJoCo compatibility is enabled (``RigidOptions.enable_mujoco_compatibility``),

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -12,7 +12,7 @@ from genesis.engine.solvers.rigid.rigid_solver import RigidSolver, kernel_update
 from genesis.options.sensors import Raycaster as RaycasterOptions
 from genesis.options.sensors import RaycastPattern
 from genesis.utils.geom import normalize, transform_by_quat, transform_by_trans_quat
-from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_numpy, qd_to_torch, tensor_to_array
+from genesis.utils.misc import concat_with_tensor, make_tensor_field, qd_to_numpy, qd_to_torch
 from genesis.utils.raycast_qd import (
     kernel_cast_rays,
     kernel_cast_rays_visual,
@@ -175,66 +175,48 @@ class RaycastContext(SharedSensorContext):
         if entry.raycast_mask is None:
             links_mask = free_verts_mask = None
             if entry.faces_idx is not None:
-                faces_geom_idx = qd_to_numpy(solver.dyn_info.faces.geom_idx)
-                subset_faces_idx = tensor_to_array(entry.faces_idx)
-                links_mask_np = np.zeros(solver.n_links, dtype=np.bool_)
-                links_mask_np[qd_to_numpy(solver.dyn_info.geoms.link_idx)[faces_geom_idx[subset_faces_idx]]] = True
-                links_mask = torch.as_tensor(links_mask_np, device=gs.device)
-                verts_is_fixed = qd_to_numpy(solver.dyn_info.verts.is_fixed)
-                subset_verts_idx = np.unique(qd_to_numpy(solver.dyn_info.faces.verts_idx)[subset_faces_idx])
-                subset_verts_idx = subset_verts_idx[~verts_is_fixed[subset_verts_idx]]
-                free_verts_mask_np = np.zeros(solver.n_free_verts, dtype=np.bool_)
-                free_verts_mask_np[qd_to_numpy(solver.dyn_info.verts.verts_state_idx)[subset_verts_idx]] = True
-                free_verts_mask = torch.as_tensor(free_verts_mask_np, device=gs.device)
+                subset_geoms_idx = qd_to_torch(solver.dyn_info.faces.geom_idx, entry.faces_idx)
+                links_mask = torch.zeros(solver.n_links, dtype=torch.bool, device=gs.device)
+                links_mask[qd_to_torch(solver.dyn_info.geoms.link_idx, subset_geoms_idx)] = True
+                subset_verts_idx = torch.unique(qd_to_torch(solver.dyn_info.faces.verts_idx, entry.faces_idx))
+                subset_verts_idx = subset_verts_idx[qd_to_torch(solver.dyn_info.verts.is_fixed, subset_verts_idx) == 0]
+                free_verts_mask = torch.zeros(solver.n_free_verts, dtype=torch.bool, device=gs.device)
+                free_verts_mask[qd_to_torch(solver.dyn_info.verts.verts_state_idx, subset_verts_idx)] = True
             if solver._options.batch_links_info:
                 # (B, n_links) active-geom range per env
-                geom_start = qd_to_torch(solver.dyn_info.links.geom_start, transpose=True)
-                geom_end = qd_to_torch(solver.dyn_info.links.geom_end, transpose=True)
-                if links_mask is not None:
-                    geom_start = geom_start[:, links_mask]
-                    geom_end = geom_end[:, links_mask]
+                geom_start = qd_to_torch(solver.dyn_info.links.geom_start, None, links_mask, transpose=True)
+                geom_end = qd_to_torch(solver.dyn_info.links.geom_end, None, links_mask, transpose=True)
                 parts += [geom_start, geom_end]
             if solver.n_free_verts > 0:
                 # (B, n_free_verts, 3) per-env vertex positions
-                free_verts_pos = qd_to_torch(solver.dyn_state.free_verts.pos, transpose=True)
-                if free_verts_mask is not None:
-                    free_verts_pos = free_verts_pos[:, free_verts_mask]
-                parts.append(free_verts_pos)
+                parts.append(qd_to_torch(solver.dyn_state.free_verts.pos, None, free_verts_mask, transpose=True))
         else:
-            vgeoms_mask_np = np.zeros(solver.n_vgeoms, dtype=np.bool_)
-            raycast_mask_np = tensor_to_array(entry.raycast_mask)
-            vgeoms_mask_np[qd_to_numpy(solver.dyn_info.vfaces.vgeom_idx)[raycast_mask_np != 0]] = True
-            vgeoms_mask = None
-            if not vgeoms_mask_np.all():
-                vgeoms_mask = torch.as_tensor(vgeoms_mask_np, device=gs.device)
+            vgeoms_mask = torch.zeros(solver.n_vgeoms, dtype=torch.bool, device=gs.device)
+            vgeoms_mask[qd_to_torch(solver.dyn_info.vfaces.vgeom_idx, entry.raycast_mask != 0)] = True
+            # An all-opted-in mask would force advanced indexing to reproduce the whole field, so drop the selection.
+            vgeoms_col_mask = None if vgeoms_mask.all() else vgeoms_mask
             # (B, n_vgeoms, 3/4) per-env visual geom poses
-            vgeoms_pos = qd_to_torch(solver.dyn_state.vgeoms.pos, transpose=True)
-            vgeoms_quat = qd_to_torch(solver.dyn_state.vgeoms.quat, transpose=True)
-            if vgeoms_mask is not None:
-                vgeoms_pos = vgeoms_pos[:, vgeoms_mask]
-                vgeoms_quat = vgeoms_quat[:, vgeoms_mask]
+            vgeoms_pos = qd_to_torch(solver.dyn_state.vgeoms.pos, None, vgeoms_col_mask, transpose=True)
+            vgeoms_quat = qd_to_torch(solver.dyn_state.vgeoms.quat, None, vgeoms_col_mask, transpose=True)
             parts += [vgeoms_pos, vgeoms_quat]
             if solver._options.batch_links_info:
                 # (B, n_links) active-vgeom range per env: variants of one link hold identical vgeom poses, so the
                 # range alone separates them, and the fit keeps only that of the env backing a tree.
-                links_mask_np = np.zeros(solver.n_links, dtype=np.bool_)
-                links_mask_np[qd_to_numpy(solver.dyn_info.vgeoms.link_idx)[vgeoms_mask_np]] = True
-                links_mask = torch.as_tensor(links_mask_np, device=gs.device)
-                parts += [
-                    qd_to_torch(solver.dyn_info.links.vgeom_start, transpose=True)[:, links_mask],
-                    qd_to_torch(solver.dyn_info.links.vgeom_end, transpose=True)[:, links_mask],
-                ]
+                links_mask = torch.zeros(solver.n_links, dtype=torch.bool, device=gs.device)
+                links_mask[qd_to_torch(solver.dyn_info.vgeoms.link_idx, vgeoms_mask)] = True
+                vgeom_start = qd_to_torch(solver.dyn_info.links.vgeom_start, None, links_mask, transpose=True)
+                vgeom_end = qd_to_torch(solver.dyn_info.links.vgeom_end, None, links_mask, transpose=True)
+                parts += [vgeom_start, vgeom_end]
             if solver.dyn_state.vverts.pos.shape[0] > 0:
                 # (B, n_vvert_slots, 3) per-env custom vvert positions (set_vverts overrides), restricted to the
-                # opted-in vgeoms' slots.
-                vverts_state_idx = qd_to_numpy(solver.dyn_info.vverts.vverts_state_idx)
-                slots_sel = (vverts_state_idx >= 0) & vgeoms_mask_np[qd_to_numpy(solver.dyn_info.vverts.vgeom_idx)]
-                vverts_mask_np = np.zeros(solver.dyn_state.vverts.pos.shape[0], dtype=np.bool_)
-                vverts_mask_np[vverts_state_idx[slots_sel]] = True
-                vverts_pos = qd_to_torch(solver.dyn_state.vverts.pos, transpose=True)
-                if not vverts_mask_np.all():
-                    vverts_pos = vverts_pos[:, torch.as_tensor(vverts_mask_np, device=gs.device)]
-                parts.append(vverts_pos)
+                # opted-in vgeoms' slots. The slot selection is derived from vverts_state_idx itself, so that one
+                # field is read whole.
+                vverts_state_idx = qd_to_torch(solver.dyn_info.vverts.vverts_state_idx)
+                slots_mask = (vverts_state_idx >= 0) & vgeoms_mask[qd_to_torch(solver.dyn_info.vverts.vgeom_idx)]
+                vverts_mask = torch.zeros(solver.dyn_state.vverts.pos.shape[0], dtype=torch.bool, device=gs.device)
+                vverts_mask[vverts_state_idx[slots_mask]] = True
+                vverts_col_mask = None if vverts_mask.all() else vverts_mask
+                parts.append(qd_to_torch(solver.dyn_state.vverts.pos, None, vverts_col_mask, transpose=True))
         return cls._group_envs_by_parts(solver._B, parts)
 
     @staticmethod
@@ -348,7 +330,7 @@ class RaycastContext(SharedSensorContext):
                             faces_idx=faces_idx,
                         )
                     self._bvh_contexts.append(entry)
-            mask = solver.get_vfaces_raycast_mask()
+            mask = solver.vfaces_raycast_mask
             if mask.any():
                 if maybe_static:
                     # A static visual entry watches every GEOMETRY change: an explicit set_vverts can reshape any

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -52,9 +52,9 @@ class BVHContext:
     # per distinct per-env geometry); allocated per env up front for movable entries.
     bvh: LBVH | None = None
     aabb: AABB | None = None
-    # None for a collision BVH (faces_info / verts_info, no per-face mask), else an int8 (n_vfaces,) array selecting
+    # None for a collision BVH (faces_info / verts_info, no per-face mask), else an int8 (n_vfaces,) tensor selecting
     # which visual faces contribute.
-    raycast_mask: np.ndarray | None = None
+    raycast_mask: torch.Tensor | None = None
 
     # True when the physics cannot move any of the geometry this BVH covers (every covered collision face sits on a
     # fixed link; for a visual BVH, all links in the solver are fixed), so that geometry only ever changes through an
@@ -202,7 +202,8 @@ class RaycastContext(SharedSensorContext):
                 parts.append(free_verts_pos)
         else:
             vgeoms_mask_np = np.zeros(solver.n_vgeoms, dtype=np.bool_)
-            vgeoms_mask_np[qd_to_numpy(solver.dyn_info.vfaces.vgeom_idx)[entry.raycast_mask != 0]] = True
+            raycast_mask_np = tensor_to_array(entry.raycast_mask)
+            vgeoms_mask_np[qd_to_numpy(solver.dyn_info.vfaces.vgeom_idx)[raycast_mask_np != 0]] = True
             vgeoms_mask = None
             if not vgeoms_mask_np.all():
                 vgeoms_mask = torch.as_tensor(vgeoms_mask_np, device=gs.device)

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -121,24 +121,6 @@ class RaycastContext(SharedSensorContext):
         return [entry for entry in self.bvh_contexts if entry.raycast_mask is None]
 
     @staticmethod
-    def _compute_visual_raycast_mask(solver: "KinematicSolver") -> np.ndarray:
-        """Build a per-vface mask (int8, shape (n_vfaces,)) selecting vfaces opted into visual raycasting.
-
-        A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
-        """
-        n_vfaces = solver.dyn_info.vfaces.vgeom_idx.shape[0]
-        if n_vfaces == 0:
-            return np.zeros(0, dtype=np.int8)
-        vgeom_enabled = np.zeros(solver.n_vgeoms, dtype=np.bool_)
-        for entity in solver.entities:
-            if not entity.material.use_visual_raycasting:
-                continue
-            for vgeom in entity.vgeoms:
-                vgeom_enabled[vgeom.idx] = True
-        vface_vgeom_idx = qd_to_numpy(solver.dyn_info.vfaces.vgeom_idx)
-        return vgeom_enabled[vface_vgeom_idx].astype(np.int8)
-
-    @staticmethod
     def _group_envs_by_parts(B: int, parts: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Group envs by exact equality of the (B, ...) signature parts.
 
@@ -231,6 +213,16 @@ class RaycastContext(SharedSensorContext):
                 vgeoms_pos = vgeoms_pos[:, vgeoms_mask]
                 vgeoms_quat = vgeoms_quat[:, vgeoms_mask]
             parts += [vgeoms_pos, vgeoms_quat]
+            if solver._options.batch_links_info:
+                # (B, n_links) active-vgeom range per env: variants of one link hold identical vgeom poses, so the
+                # range alone separates them, and the fit keeps only that of the env backing a tree.
+                links_mask_np = np.zeros(solver.n_links, dtype=np.bool_)
+                links_mask_np[qd_to_numpy(solver.dyn_info.vgeoms.link_idx)[vgeoms_mask_np]] = True
+                links_mask = torch.as_tensor(links_mask_np, device=gs.device)
+                parts += [
+                    qd_to_torch(solver.dyn_info.links.vgeom_start, transpose=True)[:, links_mask],
+                    qd_to_torch(solver.dyn_info.links.vgeom_end, transpose=True)[:, links_mask],
+                ]
             if solver.dyn_state.vverts.pos.shape[0] > 0:
                 # (B, n_vvert_slots, 3) per-env custom vvert positions (set_vverts overrides), restricted to the
                 # opted-in vgeoms' slots.
@@ -355,26 +347,23 @@ class RaycastContext(SharedSensorContext):
                             faces_idx=faces_idx,
                         )
                     self._bvh_contexts.append(entry)
-            n_vfaces = solver.dyn_info.vfaces.vgeom_idx.shape[0]
-            if n_vfaces > 0:
-                mask = self._compute_visual_raycast_mask(solver)
-                if mask.any():
-                    if maybe_static:
-                        # A static visual entry watches every GEOMETRY change: an explicit set_vverts can reshape
-                        # any opted-in vgeom, so its subscription carries no links filter. It is sized at first
-                        # update to one tree per distinct per-env visual geometry, like a static collision subset.
-                        rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
-                        solver.subscribe(rebuild_subscriber)
-                        entry = BVHContext(
-                            solver, raycast_mask=mask, maybe_static=True, rebuild_subscriber=rebuild_subscriber
-                        )
-                    else:
-                        # A movable visual mesh rebuilds every step and may diverge per env: one tree per env.
-                        aabb = AABB(n_batches=n_envs, n_aabbs=n_vfaces)
-                        bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
-                        env_tree_identity = torch.arange(n_envs, dtype=gs.tc_int, device=gs.device)
-                        entry = BVHContext(solver, bvh, aabb, mask, env_bvh_idx=env_tree_identity)
-                    self._bvh_contexts.append(entry)
+            mask = solver.get_vfaces_raycast_mask()
+            if mask.any():
+                if maybe_static:
+                    # A static visual entry watches every GEOMETRY change: an explicit set_vverts can reshape any
+                    # opted-in vgeom, so its subscription carries no links filter.
+                    rebuild_subscriber = Subscriber(to=frozenset({StateChange.GEOMETRY}))
+                    solver.subscribe(rebuild_subscriber)
+                    entry = BVHContext(
+                        solver, raycast_mask=mask, maybe_static=True, rebuild_subscriber=rebuild_subscriber
+                    )
+                else:
+                    # A movable visual mesh rebuilds every step and may diverge per env: one tree per env.
+                    aabb = AABB(n_batches=n_envs, n_aabbs=mask.shape[0])
+                    bvh = LBVH(aabb, max_n_query_result_per_aabb=0, n_radix_sort_groups=64)
+                    env_tree_identity = torch.arange(n_envs, dtype=gs.tc_int, device=gs.device)
+                    entry = BVHContext(solver, bvh, aabb, mask, env_bvh_idx=env_tree_identity)
+                self._bvh_contexts.append(entry)
 
         self.update()
 
@@ -465,10 +454,17 @@ class RaycastContext(SharedSensorContext):
                     self._sized_grouped_trees(entry, batch_repr_env.shape[0], solver.dyn_info.vfaces.vgeom_idx.shape[0])
                     entry.env_bvh_idx = env_bvh_idx
                     kernel_update_grouped_visual_aabbs(
-                        batch_repr_env, entry.raycast_mask, solver.dyn_state, entry.aabb, solver.dyn_info
+                        batch_repr_env,
+                        entry.raycast_mask,
+                        solver.dyn_state,
+                        entry.aabb,
+                        solver.dyn_info,
+                        solver.rigid_config,
                     )
                 else:
-                    kernel_update_visual_aabbs(entry.raycast_mask, solver.dyn_state, entry.aabb, solver.dyn_info)
+                    kernel_update_visual_aabbs(
+                        entry.raycast_mask, solver.dyn_state, entry.aabb, solver.dyn_info, solver.rigid_config
+                    )
                 entry.bvh.build()
             entry.needs_rebuild = False
 

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -8,12 +8,11 @@ import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 from genesis.engine.entities.rigid_entity import KinematicEntity
 from genesis.engine.states.solvers import KinematicSolverState
-from genesis.options.solvers import RigidOptions, KinematicOptions
+from genesis.options.solvers import KinematicOptions, RigidOptions
 from genesis.utils.misc import (
     assign_indexed_tensor,
     broadcast_tensor,
     indices_to_mask,
-    qd_to_numpy,
     qd_to_torch,
     qd_zero_grad,
     sanitize_indexed_tensor,
@@ -1076,21 +1075,22 @@ class KinematicSolver(Solver):
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_vfaces_raycast_mask(self) -> np.ndarray:
+    def get_vfaces_raycast_mask(self) -> torch.Tensor:
         """Per-vface mask (int8, shape (n_vfaces,)) selecting the vfaces opted into visual raycasting.
 
         A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
         Consumed by every visual raycast BVH (raycaster sensors, viewer plugins) to gate which vfaces contribute.
+        The int8 dtype is what the AABB-update kernels take for the mask.
         """
         if self.dyn_info.vfaces.vgeom_idx.shape[0] == 0:
-            return np.zeros(0, dtype=np.int8)
-        vgeom_enabled = np.zeros(self.n_vgeoms, dtype=np.bool_)
+            return torch.zeros(0, dtype=torch.int8, device=gs.device)
+        vgeom_enabled = torch.zeros(self.n_vgeoms, dtype=torch.int8, device=gs.device)
         for entity in self.entities:
             if not entity.material.use_visual_raycasting:
                 continue
             for vgeom in entity.vgeoms:
-                vgeom_enabled[vgeom.idx] = True
-        return vgeom_enabled[qd_to_numpy(self.dyn_info.vfaces.vgeom_idx)].astype(np.int8)
+                vgeom_enabled[vgeom.idx] = 1
+        return vgeom_enabled[qd_to_torch(self.dyn_info.vfaces.vgeom_idx)]
 
     def get_links_vel(self, links_idx=None, envs_idx=None):
         if gs.use_zerocopy:

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -10,24 +10,32 @@ from genesis.engine.entities.rigid_entity import KinematicEntity
 from genesis.engine.states.solvers import KinematicSolverState
 from genesis.options.solvers import RigidOptions, KinematicOptions
 from genesis.utils.misc import (
+    assign_indexed_tensor,
+    broadcast_tensor,
+    indices_to_mask,
+    qd_to_numpy,
     qd_to_torch,
     qd_zero_grad,
     sanitize_indexed_tensor,
-    indices_to_mask,
-    broadcast_tensor,
-    assign_indexed_tensor,
 )
 
 from .base_solver import MutatedLinks, Solver, StateChange, mutates
-from .rigid.abd.misc import (
-    kernel_init_dof_fields,
-    kernel_init_link_fields,
-    kernel_init_joint_fields,
-    kernel_init_vvert_fields,
-    kernel_init_vgeom_fields,
-    kernel_init_entity_fields,
-    kernel_update_heterogeneous_links_vgeom,
-    kernel_update_vgeoms_render_T,
+from .rigid.abd.accessor import (
+    kernel_get_kinematic_state,
+    kernel_get_links_vel,
+    kernel_get_state_grad,
+    kernel_set_dofs_force_grad,
+    kernel_set_dofs_position,
+    kernel_set_dofs_velocity,
+    kernel_set_dofs_velocity_grad,
+    kernel_set_dofs_zero_velocity,
+    kernel_set_kinematic_state,
+    kernel_set_links_pos,
+    kernel_set_links_pos_grad,
+    kernel_set_links_quat,
+    kernel_set_links_quat_grad,
+    kernel_set_qpos,
+    kernel_set_vverts,
 )
 from .rigid.abd.forward_kinematics import (
     kernel_forward_kinematics,
@@ -37,22 +45,15 @@ from .rigid.abd.forward_kinematics import (
     kernel_update_vgeoms,
     kernel_update_vverts_for_vgeoms,
 )
-from .rigid.abd.accessor import (
-    kernel_get_kinematic_state,
-    kernel_get_state_grad,
-    kernel_set_kinematic_state,
-    kernel_set_links_pos_grad,
-    kernel_set_links_quat_grad,
-    kernel_set_dofs_position,
-    kernel_set_dofs_velocity,
-    kernel_set_dofs_velocity_grad,
-    kernel_set_dofs_force_grad,
-    kernel_set_dofs_zero_velocity,
-    kernel_set_links_pos,
-    kernel_set_links_quat,
-    kernel_set_qpos,
-    kernel_set_vverts,
-    kernel_get_links_vel,
+from .rigid.abd.misc import (
+    kernel_init_dof_fields,
+    kernel_init_entity_fields,
+    kernel_init_joint_fields,
+    kernel_init_link_fields,
+    kernel_init_vgeom_fields,
+    kernel_init_vvert_fields,
+    kernel_update_heterogeneous_links_vgeom,
+    kernel_update_vgeoms_render_T,
 )
 
 if TYPE_CHECKING:
@@ -1074,6 +1075,22 @@ class KinematicSolver(Solver):
             offset_quat = self._vgeoms_offset_quat if vgeoms_idx is None else self._vgeoms_offset_quat[vgeoms_idx]
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_vfaces_raycast_mask(self) -> np.ndarray:
+        """Per-vface mask (int8, shape (n_vfaces,)) selecting the vfaces opted into visual raycasting.
+
+        A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
+        Consumed by every visual raycast BVH (raycaster sensors, viewer plugins) to gate which vfaces contribute.
+        """
+        if self.dyn_info.vfaces.vgeom_idx.shape[0] == 0:
+            return np.zeros(0, dtype=np.int8)
+        vgeom_enabled = np.zeros(self.n_vgeoms, dtype=np.bool_)
+        for entity in self.entities:
+            if not entity.material.use_visual_raycasting:
+                continue
+            for vgeom in entity.vgeoms:
+                vgeom_enabled[vgeom.idx] = True
+        return vgeom_enabled[qd_to_numpy(self.dyn_info.vfaces.vgeom_idx)].astype(np.int8)
 
     def get_links_vel(self, links_idx=None, envs_idx=None):
         if gs.use_zerocopy:

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -167,6 +167,8 @@ class KinematicSolver(Solver):
         self._is_forward_pos_updated: bool = False
         self._is_forward_vel_updated: bool = False
 
+        self._vfaces_raycast_mask: torch.Tensor | None = None
+
     # ------------------------------------------------------------------------------------
     # ----------------------------------- add_entity -------------------------------------
     # ------------------------------------------------------------------------------------
@@ -324,6 +326,7 @@ class KinematicSolver(Solver):
         self._init_vgeom_fields()
         self._init_link_fields()
         self._init_entity_fields()
+        self._init_vfaces_raycast_mask()
 
         self._init_envs_offset()
         self._init_vverts_state()
@@ -551,6 +554,20 @@ class KinematicSolver(Solver):
                 self.dyn_info,
                 self.rigid_config,
             )
+
+    def _init_vfaces_raycast_mask(self):
+        """Fit the static per-vface visual-raycasting opt-in mask; see the vfaces_raycast_mask property.
+
+        Sized over the padded vgeom count so the gather also covers a solver holding no vgeom at all, whose vface
+        fields still carry one padding slot: nothing opts in there, so every entry stays 0.
+        """
+        vgeom_enabled = torch.zeros(self.n_vgeoms_, dtype=gs.tc_bool, device=gs.device)
+        for entity in self.entities:
+            if not entity.material.use_visual_raycasting:
+                continue
+            for vgeom in entity.vgeoms:
+                vgeom_enabled[vgeom.idx] = 1
+        self._vfaces_raycast_mask = vgeom_enabled[qd_to_torch(self.dyn_info.vfaces.vgeom_idx)]
 
     def _init_entity_fields(self):
         if self._entities:
@@ -1075,23 +1092,6 @@ class KinematicSolver(Solver):
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_vfaces_raycast_mask(self) -> torch.Tensor:
-        """Per-vface mask (int8, shape (n_vfaces,)) selecting the vfaces opted into visual raycasting.
-
-        A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
-        Consumed by every visual raycast BVH (raycaster sensors, viewer plugins) to gate which vfaces contribute.
-        The int8 dtype is what the AABB-update kernels take for the mask.
-        """
-        if self.dyn_info.vfaces.vgeom_idx.shape[0] == 0:
-            return torch.zeros(0, dtype=torch.int8, device=gs.device)
-        vgeom_enabled = torch.zeros(self.n_vgeoms, dtype=torch.int8, device=gs.device)
-        for entity in self.entities:
-            if not entity.material.use_visual_raycasting:
-                continue
-            for vgeom in entity.vgeoms:
-                vgeom_enabled[vgeom.idx] = 1
-        return vgeom_enabled[qd_to_torch(self.dyn_info.vfaces.vgeom_idx)]
-
     def get_links_vel(self, links_idx=None, envs_idx=None):
         if gs.use_zerocopy:
             mask = (0, *indices_to_mask(links_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, links_idx)
@@ -1236,6 +1236,17 @@ class KinematicSolver(Solver):
         if self.is_built:
             return self._vgeoms
         return gs.List(vgeom for entity in self._entities for vgeom in entity.vgeoms)
+
+    @property
+    def vfaces_raycast_mask(self) -> torch.Tensor:
+        """Per-vface mask, shape (n_vfaces,), selecting the vfaces opted into visual raycasting.
+
+        A vface is opted in iff its owning vgeom belongs to an entity whose material has use_visual_raycasting=True.
+        Both the entity materials and the vface-to-vgeom mapping are fixed once the scene is built, so the mask is
+        fitted at build time and shared by every visual raycast BVH (raycaster sensors, viewer plugins) to gate which
+        vfaces contribute.
+        """
+        return self._vfaces_raycast_mask
 
     @property
     def n_links(self):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1219,6 +1219,20 @@ class RigidSolver(KinematicSolver):
         # Islands are a per-island Newton solve inside ConstraintSolver.resolve, gated on use_contact_island.
         self.constraint_solver = ConstraintSolver(self)
 
+    def update_forward_pos(self):
+        """Run forward kinematics over links and geoms if they are not already up to date for the current pose.
+
+        Geoms are refreshed alongside links, unlike the geom-less base solver: the flag this sets also authorizes the
+        next step to skip its own Cartesian-space update, which covers geoms too. Refreshing links alone would leave
+        collision - and any raycast deriving its vertices from geom poses - reading a one-step-stale pose.
+        """
+        if self._is_forward_pos_updated:
+            return
+        kernel_forward_kinematics_links_geoms(
+            self.scene._envs_idx, self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config
+        )
+        self._is_forward_pos_updated = True
+
     def substep(self, f):
         # from genesis.utils.tools import create_timer
         from genesis.engine.couplers import SAPCoupler

--- a/genesis/utils/raycast.py
+++ b/genesis/utils/raycast.py
@@ -5,7 +5,7 @@ import numpy as np
 import genesis as gs
 
 if TYPE_CHECKING:
-    from genesis.engine.entities.rigid_entity.rigid_geom import RigidGeom
+    from genesis.engine.entities.rigid_entity.rigid_geom import RigidGeom, RigidVisGeom
 
 
 class Ray(NamedTuple):
@@ -17,7 +17,7 @@ class RayHit(NamedTuple):
     distance: float
     position: np.ndarray  # (3,)
     normal: np.ndarray  # (3,)
-    geom: "RigidGeom | None"
+    geom: "RigidGeom | RigidVisGeom | None"
 
 
 def plane_raycast(normal: np.ndarray, distance: float, ray: Ray) -> RayHit | None:

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -535,7 +535,7 @@ def update_visual_face_aabb(
     treat as a definitive miss: either face_mask holds 0, meaning its entity did not opt into raycasting, or its vgeom
     falls outside env i_b's active vgeom range (links_info.vgeom_start / vgeom_end). For a homogeneous solver every
     vgeom is always in range. For a heterogeneous solver, where all envs share one visual mesh but activate different
-    per-env vgeom ranges, this makes each env cast against only its own variant instead of the union of every variant.
+    per-env vgeom ranges, this keeps each env casting against its own variant alone.
     """
     aabb_state.aabbs[i_t, i_f].min.fill(qd.math.inf)
     aabb_state.aabbs[i_t, i_f].max.fill(-qd.math.inf)
@@ -604,7 +604,7 @@ def kernel_cast_ray(
     that env is written to result[i_b]; envs not in envs_idx are left as no-hit (geom_idx == -1, distance == +inf).
     Aggregation across envs is intentionally out of scope, because cross-env reduction has no use beyond the viewer.
 
-    ``is_visual`` selects the mesh the BVH covers: the visual mesh (vfaces, result.geom_idx holds the hit vgeom) or
+    `is_visual` selects the mesh the BVH covers: the visual mesh (vfaces, result.geom_idx holds the hit vgeom) or
     the collision mesh (faces, result.geom_idx holds the hit geom).
     """
     ray_start_world = qd.math.vec3(ray_start[0], ray_start[1], ray_start[2])

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -527,20 +527,28 @@ def update_visual_face_aabb(
     dyn_state: array_class.DynState,
     aabb_state: qd.template(),
     dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
 ):
     """Fit the AABB of vface i_f in tree slot i_t from env i_b's visual mesh (i_t == i_b for a per-env BVH).
 
-    face_mask gates inclusion: 0 keeps the AABB inverted (unhittable) so vfaces from entities not opted into
-    raycasting are skipped by ray queries.
+    A vface that does not contribute to env i_b is left with an inverted AABB (min=+inf, max=-inf), which ray queries
+    treat as a definitive miss: either face_mask holds 0, meaning its entity did not opt into raycasting, or its vgeom
+    falls outside env i_b's active vgeom range (links_info.vgeom_start / vgeom_end). For a homogeneous solver every
+    vgeom is always in range. For a heterogeneous solver, where all envs share one visual mesh but activate different
+    per-env vgeom ranges, this makes each env cast against only its own variant instead of the union of every variant.
     """
     aabb_state.aabbs[i_t, i_f].min.fill(qd.math.inf)
     aabb_state.aabbs[i_t, i_f].max.fill(-qd.math.inf)
     if face_mask[i_f] != 0:
-        for i in qd.static(range(3)):
-            i_vv = dyn_info.vfaces.vverts_idx[i_f][i]
-            pos_v = get_visual_vvert_pos(i_vv, i_b, dyn_state, dyn_info)
-            aabb_state.aabbs[i_t, i_f].min = qd.min(aabb_state.aabbs[i_t, i_f].min, pos_v)
-            aabb_state.aabbs[i_t, i_f].max = qd.max(aabb_state.aabbs[i_t, i_f].max, pos_v)
+        i_vg = dyn_info.vfaces.vgeom_idx[i_f]
+        i_l = dyn_info.vgeoms.link_idx[i_vg]
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.vgeom_start[I_l] <= i_vg and i_vg < dyn_info.links.vgeom_end[I_l]:
+            for i in qd.static(range(3)):
+                i_vv = dyn_info.vfaces.vverts_idx[i_f][i]
+                pos_v = get_visual_vvert_pos(i_vv, i_b, dyn_state, dyn_info)
+                aabb_state.aabbs[i_t, i_f].min = qd.min(aabb_state.aabbs[i_t, i_f].min, pos_v)
+                aabb_state.aabbs[i_t, i_f].max = qd.max(aabb_state.aabbs[i_t, i_f].max, pos_v)
 
 
 @qd.kernel
@@ -549,12 +557,13 @@ def kernel_update_visual_aabbs(
     dyn_state: array_class.DynState,
     aabb_state: qd.template(),
     dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
 ):
     """Update the per-vface AABBs of a per-env visual BVH (one tree slot per env). See update_visual_face_aabb."""
     _B = dyn_state.vgeoms.pos.shape[1]
     n_vfaces = dyn_info.vfaces.vverts_idx.shape[0]
     for i_b, i_f in qd.ndrange(_B, n_vfaces):
-        update_visual_face_aabb(i_b, i_f, i_b, face_mask, dyn_state, aabb_state, dyn_info)
+        update_visual_face_aabb(i_b, i_f, i_b, face_mask, dyn_state, aabb_state, dyn_info, rigid_config)
 
 
 @qd.kernel
@@ -564,11 +573,12 @@ def kernel_update_grouped_visual_aabbs(
     dyn_state: array_class.DynState,
     aabb_state: qd.template(),
     dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
 ):
     """Build the per-vface AABBs of a grouped static visual BVH: one tree slot per distinct per-env visual geometry,
     each built from its representative env (see RaycastContext update)."""
     for i_t, i_f in qd.ndrange(aabb_state.aabbs.shape[0], dyn_info.vfaces.vverts_idx.shape[0]):
-        update_visual_face_aabb(i_t, i_f, batch_repr_env[i_t], face_mask, dyn_state, aabb_state, dyn_info)
+        update_visual_face_aabb(i_t, i_f, batch_repr_env[i_t], face_mask, dyn_state, aabb_state, dyn_info, rigid_config)
 
 
 # FIXME: Fastcache is not supported because of 'bvh_nodes', 'bvh_morton_codes'.
@@ -585,6 +595,7 @@ def kernel_cast_ray(
     rigid_info: array_class.RigidInfo,
     max_range: float,
     eps: float,
+    is_visual: qd.template(),
 ):
     """
     Cast a single ray against each env's BVH in parallel.
@@ -592,6 +603,9 @@ def kernel_cast_ray(
     Per-env: the ray is shifted by -envs_offset[i_b] (each BVH is in env-local coordinates) and the closest hit on
     that env is written to result[i_b]; envs not in envs_idx are left as no-hit (geom_idx == -1, distance == +inf).
     Aggregation across envs is intentionally out of scope, because cross-env reduction has no use beyond the viewer.
+
+    ``is_visual`` selects the mesh the BVH covers: the visual mesh (vfaces, result.geom_idx holds the hit vgeom) or
+    the collision mesh (faces, result.geom_idx holds the hit geom).
     """
     ray_start_world = qd.math.vec3(ray_start[0], ray_start[1], ray_start[2])
     ray_direction_world = qd.math.vec3(ray_direction[0], ray_direction[1], ray_direction[2])
@@ -605,21 +619,42 @@ def kernel_cast_ray(
     for i_b_ in range(envs_idx.shape[0]):
         i_b = envs_idx[i_b_]
         env_offset = rigid_info.envs_offset[i_b]
-        cur_hit_face, cur_distance, cur_hit_normal = bvh_ray_cast(
-            i_b,
-            i_b,
-            ray_start_world - env_offset,
-            ray_direction_world,
-            max_range,
-            bvh_nodes,
-            bvh_morton_codes,
-            dyn_state,
-            dyn_info,
-            eps,
-        )
+        # Declared before the compile-time branch, whose body is a nested scope in quadrants.
+        cur_hit_face = -1
+        cur_distance = gs.qd_float(max_range)
+        cur_hit_normal = qd.math.vec3(0.0, 0.0, 0.0)
+        if qd.static(is_visual):
+            cur_hit_face, cur_distance, cur_hit_normal = bvh_ray_cast_visual(
+                i_b,
+                i_b,
+                ray_start_world - env_offset,
+                ray_direction_world,
+                max_range,
+                bvh_nodes,
+                bvh_morton_codes,
+                dyn_state,
+                dyn_info,
+                eps,
+            )
+        else:
+            cur_hit_face, cur_distance, cur_hit_normal = bvh_ray_cast(
+                i_b,
+                i_b,
+                ray_start_world - env_offset,
+                ray_direction_world,
+                max_range,
+                bvh_nodes,
+                bvh_morton_codes,
+                dyn_state,
+                dyn_info,
+                eps,
+            )
         if cur_hit_face >= 0:
             result.distance[i_b] = cur_distance
-            result.geom_idx[i_b] = dyn_info.faces.geom_idx[cur_hit_face]
+            if qd.static(is_visual):
+                result.geom_idx[i_b] = dyn_info.vfaces.vgeom_idx[cur_hit_face]
+            else:
+                result.geom_idx[i_b] = dyn_info.faces.geom_idx[cur_hit_face]
             result.normal[i_b] = cur_hit_normal
             result.hit_point[i_b] = ray_start_world + cur_distance * ray_direction_world
 

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -252,7 +252,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             self._debug_interact_nodes.clear()
 
             # Hover arrow: only show for pickable (non-fixed, sufficient mass) entities
-            closest_hit: RayHit = self._raycaster.cast(mouse_ray[0], mouse_ray[1])
+            closest_hit: RayHit | None = self._raycaster.cast(mouse_ray[0], mouse_ray[1])
             link = closest_hit.geom.link if closest_hit is not None and closest_hit.geom is not None else None
             is_pickable = (
                 self._sim_running

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -6,6 +6,7 @@ from typing_extensions import override
 
 import genesis as gs
 import genesis.utils.geom as gu
+from genesis.engine.entities.rigid_entity import RigidLink
 from genesis.utils.mesh import create_cylinder, create_plane
 from genesis.utils.misc import tensor_to_array, with_lock
 from genesis.utils.raycast import Ray, RayHit, plane_raycast
@@ -15,7 +16,6 @@ from ..base import EVENT_HANDLE_STATE, EVENT_HANDLED
 from ..raycast import RaycasterViewerPlugin
 
 if TYPE_CHECKING:
-    from genesis.engine.entities.rigid_entity import RigidLink
     from genesis.engine.scene import Scene
     from genesis.ext.pyrender.node import Node
 
@@ -26,6 +26,8 @@ MIN_PICKABLE_MASS = 1e-3  # kg - links below this threshold are skipped to avoid
 class MouseInteractionPlugin(RaycasterViewerPlugin):
     """
     Basic interactive viewer plugin that enables using mouse to apply spring force on rigid entities.
+
+    See RaycasterViewerPlugin for `use_visual_geom`.
     """
 
     def __init__(
@@ -33,8 +35,9 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         use_force: bool = True,
         spring_const: float = 1000.0,
         color: tuple[float, float, float, float] = (0.2, 0.8, 0.8, 0.6),
+        use_visual_geom: bool = False,
     ) -> None:
-        super().__init__()
+        super().__init__(use_visual_geom)
         self.use_force = bool(use_force)
         self.spring_const = float(spring_const)
         self.color = tuple(color)
@@ -102,7 +105,9 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             if ray_hit is None:
                 return
 
-            if ray_hit.geom and ray_hit.geom.link is not None and not ray_hit.geom.link.is_fixed:
+            # Dragging applies forces, so only a movable rigid link qualifies: a visual cast also reaches the
+            # kinematic solver, whose links carry no mass.
+            if ray_hit.geom is not None and isinstance(ray_hit.geom.link, RigidLink) and not ray_hit.geom.link.is_fixed:
                 link = ray_hit.geom.link
                 hit_env_idx = self._get_last_raycast_env_idx()
                 mass = float(link.get_mass())
@@ -251,7 +256,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             link = closest_hit.geom.link if closest_hit is not None and closest_hit.geom is not None else None
             is_pickable = (
                 self._sim_running
-                and link is not None
+                and isinstance(link, RigidLink)
                 and not link.is_fixed
                 and float(link.get_mass()) >= MIN_PICKABLE_MASS
             )

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -43,7 +43,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         self.color = tuple(color)
 
         self._lock: Lock = Lock()
-        self._held_link: "RigidLink | None" = None
+        self._held_link: RigidLink | None = None
         # The plugin is active only while the simulation advances (scene.t increases). _last_step_t is the step
         # counter seen at the previous sim-step callback; _sim_running caches whether it advanced so on_draw and the
         # mouse handlers, which run off the step loop, share the same paused/running verdict.

--- a/genesis/vis/viewer_plugins/raycast.py
+++ b/genesis/vis/viewer_plugins/raycast.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from typing_extensions import override
@@ -11,8 +11,22 @@ from genesis.ext.pyrender.camera import OrthographicCamera
 from .base import ViewerPlugin
 
 if TYPE_CHECKING:
+    from genesis.engine.bvh import AABB, LBVH
     from genesis.engine.scene import Scene
+    from genesis.engine.solvers.kinematic_solver import KinematicSolver
     from genesis.ext.pyrender.node import Node
+    from genesis.utils.array_class import RaycastResult
+
+
+class RaycastTarget(NamedTuple):
+    """One BVH the viewer casts against, over a single solver's collision faces or visual vfaces."""
+
+    solver: "KinematicSolver"
+    aabb: "AABB"
+    bvh: "LBVH"
+    result: "RaycastResult"
+    # (n_vfaces,) int8 opt-in mask for a visual BVH; None for a collision BVH, which covers every face.
+    vfaces_mask: np.ndarray | None
 
 
 class Raycaster:
@@ -23,35 +37,58 @@ class Raycaster:
     reduces across envs in torch to pick the closest hit. Cross-env reduction is intentionally a viewer-side concern,
     not part of the kernel, because parallel envs are otherwise meant to be isolated.
 
+    `use_visual_geom` casts against the visual meshes instead of the collision meshes, so `RayHit.geom` is a
+    `RigidVisGeom`. The visual meshes of both the rigid and the kinematic solver are covered, restricted to the
+    entities opting in through `material.use_visual_raycasting` - the same opt-in the raycaster sensors use, so the
+    two describe the same pickable geometry.
+
     After each `cast()`, `last_hit_env_idx` exposes the env that produced the returned `RayHit` (None when no hit).
     """
 
-    def __init__(self, scene: "Scene"):
+    def __init__(self, scene: "Scene", use_visual_geom: bool = False):
         # NOTE: delayed imports to avoid pulling in rigid_solver / array_class before gs is fully initialized.
         import genesis.utils.array_class as array_class
         from genesis.engine.bvh import AABB, LBVH
 
         self.scene = scene
-        self.solver = scene.sim.rigid_solver
         self.envs_idx = scene._envs_idx
+        self.use_visual_geom = use_visual_geom
         self.last_hit_env_idx: int | None = None
-
-        n_faces = self.solver.dyn_info.faces.geom_idx.shape[0]
-        if n_faces == 0:
-            gs.logger.warning("No faces found in scene, viewer raycasting will not work.")
-            self.aabb = None
-            self.bvh = None
-            self.result = None
-            return
+        self.targets: list[RaycastTarget] = []
 
         n_envs_max = len(self.envs_idx)
-        self.aabb = AABB(n_batches=n_envs_max, n_aabbs=n_faces)
-        self.bvh = LBVH(
-            self.aabb,
-            max_n_query_result_per_aabb=0,  # Not used for ray queries
-            n_radix_sort_groups=min(64, n_faces),
-        )
-        self.result = array_class.get_raycast_result(n_envs_max)
+        # Visual meshes exist on both solvers, while collision geometry is the rigid solver's alone.
+        solvers = (scene.sim.rigid_solver, scene.sim.kinematic_solver) if use_visual_geom else (scene.sim.rigid_solver,)
+        for solver in solvers:
+            if not solver.is_active:
+                continue
+            vfaces_mask = None
+            if use_visual_geom:
+                vfaces_mask = solver.get_vfaces_raycast_mask()
+                if not vfaces_mask.any():
+                    continue
+                # The tree spans every vface, masked-out ones staying unhittable, so a leaf payload is the vface
+                # index itself (see kernel_update_visual_aabbs).
+                n_slots = vfaces_mask.shape[0]
+            else:
+                n_slots = solver.dyn_info.faces.geom_idx.shape[0]
+                if n_slots == 0:
+                    continue
+            aabb = AABB(n_batches=n_envs_max, n_aabbs=n_slots)
+            bvh = LBVH(
+                aabb,
+                max_n_query_result_per_aabb=0,  # Not used for ray queries
+                n_radix_sort_groups=min(64, n_slots),
+            )
+            result = array_class.get_raycast_result(n_envs_max)
+            self.targets.append(RaycastTarget(solver, aabb, bvh, result, vfaces_mask))
+
+        if not self.targets:
+            if use_visual_geom:
+                gs.logger.warning("No entity has material.use_visual_raycasting=True, viewer raycasting will not work.")
+            else:
+                gs.logger.warning("No collision faces found in scene, viewer raycasting will not work.")
+            return
 
         self.update()
 
@@ -59,19 +96,28 @@ class Raycaster:
         self.cast(ray_origin=np.zeros(3, dtype=gs.np_float), ray_direction=np.zeros(3, dtype=gs.np_float))
 
     def update(self) -> None:
-        """Refresh per-env vertex positions, AABBs and rebuild the BVH."""
-        if self.bvh is None:
-            return
-        from genesis.utils.raycast_qd import kernel_update_verts_and_aabbs
+        """Refresh per-env vertex positions, AABBs and rebuild every BVH."""
+        from genesis.utils.raycast_qd import kernel_update_verts_and_aabbs, kernel_update_visual_aabbs
 
-        kernel_update_verts_and_aabbs(self.solver.dyn_state, self.aabb, self.solver.dyn_info, self.solver.rigid_config)
-        self.bvh.build()
+        for target in self.targets:
+            solver = target.solver
+            if self.use_visual_geom:
+                # Visual vertices are derived from the vgeom poses on the fly, so refreshing those poses is enough;
+                # the custom vverts buffer the sensor path relies on stays untouched.
+                solver.update_forward_pos()
+                solver.update_vgeoms()
+                kernel_update_visual_aabbs(
+                    target.vfaces_mask, solver.dyn_state, target.aabb, solver.dyn_info, solver.rigid_config
+                )
+            else:
+                kernel_update_verts_and_aabbs(solver.dyn_state, target.aabb, solver.dyn_info, solver.rigid_config)
+            target.bvh.build()
 
     def cast(
         self, ray_origin: np.ndarray, ray_direction: np.ndarray, max_range: float = 1000.0, envs_idx=None
     ) -> RayHit | None:
         """
-        Cast a single ray against the BVH of each env in parallel and return the closest hit across envs.
+        Cast a single ray against the BVH of each env in parallel and return the closest hit across envs and solvers.
 
         Parameters
         ----------
@@ -86,52 +132,70 @@ class Raycaster:
         """
         from genesis.utils.raycast_qd import kernel_cast_ray
 
-        kernel_cast_ray(
-            np.ascontiguousarray(ray_origin, dtype=gs.np_float),
-            envs_idx if envs_idx is not None else self.envs_idx,
-            self.bvh.nodes,
-            self.bvh.morton_codes,
-            np.ascontiguousarray(ray_direction, dtype=gs.np_float),
-            self.solver.dyn_state,
-            self.result,
-            self.solver.dyn_info,
-            self.solver.rigid_info,
-            max_range,
-            gs.EPS,
-        )
+        ray_origin = np.ascontiguousarray(ray_origin, dtype=gs.np_float)
+        ray_direction = np.ascontiguousarray(ray_direction, dtype=gs.np_float)
+        closest_hit: RayHit | None = None
+        self.last_hit_env_idx = None
+        for target in self.targets:
+            solver = target.solver
+            # Each pass caps its traversal at the best distance so far, so any hit it reports is closer by
+            # construction and the closest hit across targets needs no further comparison.
+            kernel_cast_ray(
+                ray_origin,
+                envs_idx if envs_idx is not None else self.envs_idx,
+                target.bvh.nodes,
+                target.bvh.morton_codes,
+                ray_direction,
+                solver.dyn_state,
+                target.result,
+                solver.dyn_info,
+                solver.rigid_info,
+                max_range if closest_hit is None else closest_hit.distance,
+                eps=gs.EPS,
+                is_visual=self.use_visual_geom,
+            )
 
-        # Reduce per-env hits to the closest one. Distance is +inf for envs that didn't hit, so argmin alone
-        # picks the closest hitting env; geom_idx then confirms the winner actually hit (argmin on all-inf
-        # would otherwise return env 0).
-        distances = qd_to_torch(self.result.distance, copy=None)
-        winner = int(distances.argmin())
-        geom_idx = int(qd_to_numpy(self.result.geom_idx, row_mask=winner, keepdim=False))
-        if geom_idx < 0:
-            self.last_hit_env_idx = None
-            return None
+            # A no-hit env holds +inf, so argmin lands on the closest hitting env; geom_idx then rejects the
+            # all-inf case, which would otherwise report env 0 as a hit.
+            distances = qd_to_torch(target.result.distance, copy=None)
+            winner = int(distances.argmin())
+            geom_idx = int(qd_to_numpy(target.result.geom_idx, row_mask=winner, keepdim=False))
+            if geom_idx < 0:
+                continue
 
-        distance = float(distances[winner])
-        position = qd_to_numpy(self.result.hit_point, row_mask=winner, keepdim=False, transpose=True)
-        normal = qd_to_numpy(self.result.normal, row_mask=winner, keepdim=False, transpose=True)
-        geom = self.solver.geoms[geom_idx] if 0 <= geom_idx < len(self.solver.geoms) else None
+            distance = float(distances[winner])
+            position = qd_to_numpy(target.result.hit_point, row_mask=winner, keepdim=False, transpose=True)
+            normal = qd_to_numpy(target.result.normal, row_mask=winner, keepdim=False, transpose=True)
+            geoms = solver.vgeoms if self.use_visual_geom else solver.geoms
+            geom = geoms[geom_idx] if 0 <= geom_idx < len(geoms) else None
 
-        self.last_hit_env_idx = winner if self.scene.n_envs > 0 else None
-        return RayHit(distance, position, normal, geom)
+            closest_hit = RayHit(distance, position, normal, geom)
+            self.last_hit_env_idx = winner if self.scene.n_envs > 0 else None
+        return closest_hit
 
 
 class RaycasterViewerPlugin(ViewerPlugin):
     """
     Base viewer plugins using mouse raycast
+
+    Parameters
+    ----------
+    use_visual_geom : bool
+        Cast against the visual meshes rather than the collision meshes. Picking then matches what is on screen, which
+        the collision meshes cannot do when they are coarser, larger or entirely absent, and it reaches entities with no
+        collision geometry at all. It costs casting against the finer visual triangles, it reports geometry the physics
+        ignores, and it only sees entities whose material sets use_visual_raycasting=True.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, use_visual_geom: bool = False) -> None:
         super().__init__()
+        self.use_visual_geom = bool(use_visual_geom)
         self._raycaster: "Raycaster | None" = None
 
     def build(self, viewer, camera: "Node", scene: "Scene"):
         super().build(viewer, camera, scene)
 
-        self._raycaster = Raycaster(self.scene)
+        self._raycaster = Raycaster(self.scene, self.use_visual_geom)
 
     @override
     def update_on_sim_step(self) -> None:

--- a/genesis/vis/viewer_plugins/raycast.py
+++ b/genesis/vis/viewer_plugins/raycast.py
@@ -5,9 +5,9 @@ import torch
 from typing_extensions import override
 
 import genesis as gs
+from genesis.ext.pyrender.camera import OrthographicCamera
 from genesis.utils.misc import qd_to_numpy, qd_to_torch
 from genesis.utils.raycast import Ray, RayHit
-from genesis.ext.pyrender.camera import OrthographicCamera
 
 from .base import ViewerPlugin
 
@@ -20,20 +20,19 @@ if TYPE_CHECKING:
 
 
 class RaycastTarget(NamedTuple):
-    """One BVH the viewer casts against, over a single solver's collision faces or visual vfaces."""
+    """One bounding volume hierarchy (BVH) the viewer casts against, over one solver's collision or visual mesh."""
 
     solver: "KinematicSolver"
     aabb: "AABB"
     bvh: "LBVH"
     result: "RaycastResult"
-    # (n_vfaces,) int8 opt-in mask for a visual BVH; None for a collision BVH, which covers every face. This is what
-    # tells the two kinds of target apart, in `update` and in `cast` alike.
+    # (n_vfaces,) opt-in mask for a visual BVH; None for a collision BVH, which covers every face.
     vfaces_mask: torch.Tensor | None
 
 
 class Raycaster:
     """
-    BVH-accelerated single-ray cast for the viewer.
+    Bounding volume hierarchy (BVH) accelerated single-ray cast for the viewer.
 
     The per-env raycast (`kernel_cast_ray`) writes one hit per env into a batched `RaycastResult`; this class then
     reduces across envs in torch to pick the closest hit. Cross-env reduction is intentionally a viewer-side concern,
@@ -45,11 +44,11 @@ class Raycaster:
     ----------
     scene : Scene
         Scene whose geometry the rays are cast against.
-    use_visual_geom : bool
+    use_visual_geom : bool, optional
         Cast against the visual meshes of both the rigid and the kinematic solver, restricted to the entities opting
         in through `material.use_visual_raycasting` - the same opt-in the raycaster sensors use, so the two describe
         the same pickable geometry. `RayHit.geom` is then a `RigidVisGeom`. See `RaycasterViewerPlugin` for the
-        tradeoff this carries for the user.
+        tradeoff this carries for the user. Default is False.
     """
 
     def __init__(self, scene: "Scene", use_visual_geom: bool = False):
@@ -59,7 +58,6 @@ class Raycaster:
 
         self.scene = scene
         self.envs_idx = scene._envs_idx
-        self.use_visual_geom = use_visual_geom
         self.last_hit_env_idx: int | None = None
         self.targets: list[RaycastTarget] = []
 
@@ -71,7 +69,7 @@ class Raycaster:
                 continue
             vfaces_mask = None
             if use_visual_geom:
-                vfaces_mask = solver.get_vfaces_raycast_mask()
+                vfaces_mask = solver.vfaces_raycast_mask
                 if not vfaces_mask.any():
                     continue
                 # The tree spans every vface, masked-out ones staying unhittable, so a leaf payload is the vface
@@ -109,8 +107,9 @@ class Raycaster:
         for target in self.targets:
             solver = target.solver
             if target.vfaces_mask is not None:
-                # Visual vertices are derived from the vgeom poses on the fly, so refreshing those poses is enough;
-                # the custom vverts buffer the sensor path relies on stays untouched.
+                # A visual vertex follows its vgeom pose, except on an entity opting into custom vverts, where it
+                # follows the vverts buffer instead (see get_visual_vvert_pos). Refreshing the poses therefore covers
+                # every vertex this pass owns, the buffer moving only when the user calls set_vverts.
                 solver.update_forward_pos()
                 solver.update_vgeoms()
                 kernel_update_visual_aabbs(
@@ -188,17 +187,17 @@ class RaycasterViewerPlugin(ViewerPlugin):
 
     Parameters
     ----------
-    use_visual_geom : bool
+    use_visual_geom : bool, optional
         Cast against the visual meshes rather than the collision meshes, so picking follows what is drawn on screen and
-        reaches entities carrying visual geometry alone. The cost is a per-step rebuild of a BVH spanning every visual
-        triangle, several times the price of the collision-mesh rebuild on detailed meshes, and the reported geometry is
-        the visual one, which the physics ignores. Only entities whose material sets use_visual_raycasting=True are
-        visible to the cast.
+        reaches entities carrying visual geometry alone. The cost is re-scanning every visual triangle on each step,
+        several times the price of the collision meshes on detailed geometry, and the geometry reported back is the
+        visual one, which the physics ignores. Only entities whose material sets use_visual_raycasting=True are visible
+        to the cast. Default is False.
     """
 
     def __init__(self, use_visual_geom: bool = False) -> None:
         super().__init__()
-        self.use_visual_geom = bool(use_visual_geom)
+        self.use_visual_geom = use_visual_geom
         self._raycaster: "Raycaster | None" = None
 
     def build(self, viewer, camera: "Node", scene: "Scene"):

--- a/genesis/vis/viewer_plugins/raycast.py
+++ b/genesis/vis/viewer_plugins/raycast.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
+import torch
 from typing_extensions import override
 
 import genesis as gs
@@ -25,8 +26,9 @@ class RaycastTarget(NamedTuple):
     aabb: "AABB"
     bvh: "LBVH"
     result: "RaycastResult"
-    # (n_vfaces,) int8 opt-in mask for a visual BVH; None for a collision BVH, which covers every face.
-    vfaces_mask: np.ndarray | None
+    # (n_vfaces,) int8 opt-in mask for a visual BVH; None for a collision BVH, which covers every face. This is what
+    # tells the two kinds of target apart, in `update` and in `cast` alike.
+    vfaces_mask: torch.Tensor | None
 
 
 class Raycaster:
@@ -37,12 +39,17 @@ class Raycaster:
     reduces across envs in torch to pick the closest hit. Cross-env reduction is intentionally a viewer-side concern,
     not part of the kernel, because parallel envs are otherwise meant to be isolated.
 
-    `use_visual_geom` casts against the visual meshes instead of the collision meshes, so `RayHit.geom` is a
-    `RigidVisGeom`. The visual meshes of both the rigid and the kinematic solver are covered, restricted to the
-    entities opting in through `material.use_visual_raycasting` - the same opt-in the raycaster sensors use, so the
-    two describe the same pickable geometry.
-
     After each `cast()`, `last_hit_env_idx` exposes the env that produced the returned `RayHit` (None when no hit).
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene whose geometry the rays are cast against.
+    use_visual_geom : bool
+        Cast against the visual meshes of both the rigid and the kinematic solver, restricted to the entities opting
+        in through `material.use_visual_raycasting` - the same opt-in the raycaster sensors use, so the two describe
+        the same pickable geometry. `RayHit.geom` is then a `RigidVisGeom`. See `RaycasterViewerPlugin` for the
+        tradeoff this carries for the user.
     """
 
     def __init__(self, scene: "Scene", use_visual_geom: bool = False):
@@ -84,10 +91,10 @@ class Raycaster:
             self.targets.append(RaycastTarget(solver, aabb, bvh, result, vfaces_mask))
 
         if not self.targets:
-            if use_visual_geom:
-                gs.logger.warning("No entity has material.use_visual_raycasting=True, viewer raycasting will not work.")
-            else:
-                gs.logger.warning("No collision faces found in scene, viewer raycasting will not work.")
+            what = (
+                "visual mesh opting in through material.use_visual_raycasting" if use_visual_geom else "collision face"
+            )
+            gs.logger.warning(f"Scene holds no {what}, viewer raycasting will not work.")
             return
 
         self.update()
@@ -101,7 +108,7 @@ class Raycaster:
 
         for target in self.targets:
             solver = target.solver
-            if self.use_visual_geom:
+            if target.vfaces_mask is not None:
                 # Visual vertices are derived from the vgeom poses on the fly, so refreshing those poses is enough;
                 # the custom vverts buffer the sensor path relies on stays untouched.
                 solver.update_forward_pos()
@@ -138,6 +145,7 @@ class Raycaster:
         self.last_hit_env_idx = None
         for target in self.targets:
             solver = target.solver
+            is_visual = target.vfaces_mask is not None
             # Each pass caps its traversal at the best distance so far, so any hit it reports is closer by
             # construction and the closest hit across targets needs no further comparison.
             kernel_cast_ray(
@@ -152,7 +160,7 @@ class Raycaster:
                 solver.rigid_info,
                 max_range if closest_hit is None else closest_hit.distance,
                 eps=gs.EPS,
-                is_visual=self.use_visual_geom,
+                is_visual=is_visual,
             )
 
             # A no-hit env holds +inf, so argmin lands on the closest hitting env; geom_idx then rejects the
@@ -166,7 +174,7 @@ class Raycaster:
             distance = float(distances[winner])
             position = qd_to_numpy(target.result.hit_point, row_mask=winner, keepdim=False, transpose=True)
             normal = qd_to_numpy(target.result.normal, row_mask=winner, keepdim=False, transpose=True)
-            geoms = solver.vgeoms if self.use_visual_geom else solver.geoms
+            geoms = solver.vgeoms if is_visual else solver.geoms
             geom = geoms[geom_idx] if 0 <= geom_idx < len(geoms) else None
 
             closest_hit = RayHit(distance, position, normal, geom)
@@ -181,10 +189,11 @@ class RaycasterViewerPlugin(ViewerPlugin):
     Parameters
     ----------
     use_visual_geom : bool
-        Cast against the visual meshes rather than the collision meshes. Picking then matches what is on screen, which
-        the collision meshes cannot do when they are coarser, larger or entirely absent, and it reaches entities with no
-        collision geometry at all. It costs casting against the finer visual triangles, it reports geometry the physics
-        ignores, and it only sees entities whose material sets use_visual_raycasting=True.
+        Cast against the visual meshes rather than the collision meshes, so picking follows what is drawn on screen and
+        reaches entities carrying visual geometry alone. The cost is a per-step rebuild of a BVH spanning every visual
+        triangle, several times the price of the collision-mesh rebuild on detailed meshes, and the reported geometry is
+        the visual one, which the physics ignores. Only entities whose material sets use_visual_raycasting=True are
+        visible to the cast.
     """
 
     def __init__(self, use_visual_geom: bool = False) -> None:

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -10,6 +10,7 @@ import genesis as gs
 from genesis.options.sensors import RasterizerCameraOptions
 from genesis.utils.misc import tensor_to_array
 from genesis.vis.keybindings import Key, KeyAction, Keybind, KeyMod, MouseButton
+from genesis.vis.viewer_plugins.raycast import Raycaster
 
 from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE, SKIP_NO_VIEWER
 from ..utils import assert_allclose
@@ -325,6 +326,15 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
             rho=MASS / (BOX_LENGTH**3),
         ),
     )
+    kinematic = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 2.0, BOX_LENGTH / 2),
+            size=(BOX_LENGTH,) * 3,
+        ),
+        material=gs.materials.Kinematic(
+            use_visual_raycasting=True,
+        ),
+    )
     scene.viewer.add_plugin(
         gs.vis.viewer_plugins.MouseInteractionPlugin(
             use_force=True,
@@ -460,6 +470,114 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
         rtol=0.5,
         err_msg="Final z velocity does not match expected value based on spring dynamics.",
     )
+
+    # A visual-mesh cast also reaches the kinematic solver, so hovering and pressing on a movable kinematic link must
+    # leave the plugin idle instead of raising inside the viewer callbacks.
+    visual_plugin = scene.viewer.add_plugin(
+        gs.vis.viewer_plugins.MouseInteractionPlugin(
+            use_force=True,
+            spring_const=SPRING_CONST,
+            use_visual_geom=True,
+        )
+    )
+    kinematic.set_pos((target_offset[0], target_offset[1], target_offset[2] + BOX_LENGTH))
+    scene.step()
+    x, y = viewport_size[0] // 2, viewport_size[1] // 2
+    pyrender_viewer.dispatch_event("on_mouse_motion", x, y, 0, 0)
+    pyrender_viewer.dispatch_event("on_mouse_press", x, y, MouseButton.LEFT, 0)
+    wait_for_viewer_events(pyrender_viewer, check_event_count())
+    scene.step()
+
+    assert pyrender_viewer.is_active
+    assert visual_plugin._held_link is None
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_raycast_visual_geom(n_envs, show_viewer):
+    DECOY_SIZE = 0.4
+    DECOY_Z = 0.5
+    TARGET_SIZE = 0.2
+    TARGET_Z = 1.5
+    KINEMATIC_SIZE = 0.3
+    KINEMATIC_Z = 1.0
+    LANE_X = 1.0
+    RAY_Z = -1.0
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, 0.0),
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            res=CAM_RES,
+            camera_pos=(2.0, -1.5, 1.0),
+            camera_lookat=(0.25, 0.0, 1.0),
+            camera_fov=60,
+        ),
+        show_viewer=show_viewer,
+    )
+    decoy = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 0.0, DECOY_Z),
+            size=(DECOY_SIZE,) * 3,
+            fixed=True,
+            visualization=False,
+        ),
+    )
+    target = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 0.0, TARGET_Z),
+            size=(TARGET_SIZE,) * 3,
+            fixed=True,
+            collision=False,
+        ),
+        material=gs.materials.Rigid(
+            use_visual_raycasting=True,
+        ),
+    )
+    # A kinematic entity carries visual meshes only, in a separate solver from the rigid entities above.
+    kinematic = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(-LANE_X, 0.0, KINEMATIC_Z),
+            size=(KINEMATIC_SIZE,) * 3,
+            fixed=True,
+        ),
+        material=gs.materials.Kinematic(
+            use_visual_raycasting=True,
+        ),
+    )
+    # Without the opt-in material, an entity stays unpickable.
+    scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(LANE_X, 0.0, TARGET_Z),
+            size=(TARGET_SIZE,) * 3,
+            fixed=True,
+            collision=False,
+        ),
+    )
+    scene.build(n_envs=n_envs)
+    scene.step()
+
+    ray_direction = np.array((0.0, 0.0, 1.0), dtype=gs.np_float)
+    collision_raycaster = Raycaster(scene)
+    visual_raycaster = Raycaster(scene, use_visual_geom=True)
+
+    ray_origin = np.array((0.0, 0.0, RAY_Z), dtype=gs.np_float)
+    collision_hit = collision_raycaster.cast(ray_origin, ray_direction)
+    assert collision_hit.geom.entity is decoy
+    assert_allclose(collision_hit.distance, DECOY_Z - 0.5 * DECOY_SIZE - RAY_Z, tol=1e-6)
+    assert_allclose(collision_hit.normal, (0.0, 0.0, -1.0), tol=gs.EPS)
+
+    visual_hit = visual_raycaster.cast(ray_origin, ray_direction)
+    assert visual_hit.geom.entity is target
+    assert_allclose(visual_hit.distance, TARGET_Z - 0.5 * TARGET_SIZE - RAY_Z, tol=1e-6)
+    assert_allclose(visual_hit.normal, (0.0, 0.0, -1.0), tol=gs.EPS)
+
+    kinematic_hit = visual_raycaster.cast(np.array((-LANE_X, 0.0, RAY_Z), dtype=gs.np_float), ray_direction)
+    assert kinematic_hit.geom.entity is kinematic
+    assert_allclose(kinematic_hit.distance, KINEMATIC_Z - 0.5 * KINEMATIC_SIZE - RAY_Z, tol=1e-6)
+
+    assert visual_raycaster.cast(np.array((LANE_X, 0.0, RAY_Z), dtype=gs.np_float), ray_direction) is None
 
 
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason=SKIP_NO_VIEWER)

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -10,7 +10,6 @@ import genesis as gs
 from genesis.options.sensors import RasterizerCameraOptions
 from genesis.utils.misc import tensor_to_array
 from genesis.vis.keybindings import Key, KeyAction, Keybind, KeyMod, MouseButton
-from genesis.vis.viewer_plugins.raycast import Raycaster
 
 from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE, SKIP_NO_VIEWER
 from ..utils import assert_allclose
@@ -279,15 +278,16 @@ def test_key_press(renderer_type, tmp_path, monkeypatch, renderer, png_snapshot)
 @pytest.mark.required
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason=SKIP_NO_VIEWER)
 @pytest.mark.parametrize(
-    "n_envs, env_spacing, n_envs_per_row, target_env_idx, target_offset",
+    "n_envs, env_spacing, n_envs_per_row, target_env_idx, target_offset, use_visual_geom",
     [
-        (0, (0.0, 0.0), None, None, (0.0, 0.0, 0.0)),
+        (0, (0.0, 0.0), None, None, (0.0, 0.0, 0.0), False),
         # Two envs spaced along x so envs_offset is non-zero. Camera is positioned over env 1, so a viewport-center
         # click must pick env 1 (exercising kernel_cast_ray's per-env offset transform) and leave env 0 untouched.
-        (2, (0.5, 0.0), 1, 1, (0.25, 0.0, 0.0)),
+        (2, (0.5, 0.0), 1, 1, (0.25, 0.0, 0.0), False),
+        (2, (0.5, 0.0), 1, 1, (0.25, 0.0, 0.0), True),
     ],
 )
-def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_env_idx, target_offset):
+def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_env_idx, target_offset, use_visual_geom):
     DT = 0.01
     MASS = 100.0
     BOX_LENGTH = 0.2
@@ -295,6 +295,15 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     DRAG_DY = 8
     SPRING_CONST = 1000.0
     CAM_FOV = 30
+    # Probe lanes parked along y, clear of the drag: envs are spaced along x only, so a lane is one env's alone.
+    DECOY_SIZE = 0.4
+    DECOY_Z = 0.5
+    TARGET_SIZE = 0.2
+    TARGET_Z = 1.5
+    STACK_LANE_Y = 1.5
+    KINEMATIC_LANE_Y = 2.0
+    OPTOUT_LANE_Y = 2.5
+    PROBE_Z = 3.0
     target_offset = np.asarray(target_offset, dtype=gs.np_float)
     CAM_POS = (target_offset[0], 0.6, 1.2)
 
@@ -324,21 +333,53 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
         ),
         material=gs.materials.Rigid(
             rho=MASS / (BOX_LENGTH**3),
+            use_visual_raycasting=True,
         ),
     )
+    # One lane stacks a collision-only box under a visual-only one, so the two cast modes land on different entities.
+    decoy = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, STACK_LANE_Y, DECOY_Z),
+            size=(DECOY_SIZE,) * 3,
+            fixed=True,
+            visualization=False,
+        ),
+    )
+    target = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, STACK_LANE_Y, TARGET_Z),
+            size=(TARGET_SIZE,) * 3,
+            fixed=True,
+            collision=False,
+        ),
+        material=gs.materials.Rigid(
+            use_visual_raycasting=True,
+        ),
+    )
+    # A kinematic entity carries visual meshes only, in a separate solver from the rigid entities above.
     kinematic = scene.add_entity(
         morph=gs.morphs.Box(
-            pos=(0.0, 2.0, BOX_LENGTH / 2),
+            pos=(0.0, KINEMATIC_LANE_Y, BOX_LENGTH / 2),
             size=(BOX_LENGTH,) * 3,
         ),
         material=gs.materials.Kinematic(
             use_visual_raycasting=True,
         ),
     )
+    # Without the opt-in material, an entity stays unpickable.
+    scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, OPTOUT_LANE_Y, TARGET_Z),
+            size=(TARGET_SIZE,) * 3,
+            fixed=True,
+            collision=False,
+        ),
+    )
     scene.viewer.add_plugin(
         gs.vis.viewer_plugins.MouseInteractionPlugin(
             use_force=True,
             spring_const=SPRING_CONST,
+            use_visual_geom=use_visual_geom,
         )
     )
     scene.build(
@@ -387,6 +428,7 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
 
     viewport_size = pyrender_viewer._viewport_size
     x, y = viewport_size[0] // 2, viewport_size[1] // 2
+    plugin = next(p for p in scene.viewer.plugins if isinstance(p, gs.vis.viewer_plugins.MouseInteractionPlugin))
 
     # Press mouse to grab the box
     pyrender_viewer.dispatch_event("on_mouse_press", x, y, MouseButton.LEFT, 0)
@@ -395,7 +437,6 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
 
     # Confirm the raycaster picked the expected env
     if target_env_idx is not None:
-        plugin = next(p for p in scene.viewer.plugins if isinstance(p, gs.vis.viewer_plugins.MouseInteractionPlugin))
         assert plugin._interact_env_idx == target_env_idx, (
             f"Expected mouse to pick env {target_env_idx}, got env {plugin._interact_env_idx}"
         )
@@ -471,113 +512,45 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
         err_msg="Final z velocity does not match expected value based on spring dynamics.",
     )
 
-    # A visual-mesh cast also reaches the kinematic solver, so hovering and pressing on a movable kinematic link must
-    # leave the plugin idle instead of raising inside the viewer callbacks.
-    visual_plugin = scene.viewer.add_plugin(
-        gs.vis.viewer_plugins.MouseInteractionPlugin(
-            use_force=True,
-            spring_const=SPRING_CONST,
-            use_visual_geom=True,
-        )
+    # Each mode follows the geometry it is meant to: the collision cast stops on the hull it can see, the visual cast
+    # reaches through it to the rendered mesh, spans the kinematic solver too, and skips entities without the opt-in.
+    probe_dir = np.array((0.0, 0.0, -1.0), dtype=gs.np_float)
+    stack_hit = plugin._raycaster.cast(
+        np.array((target_offset[0], STACK_LANE_Y, PROBE_Z), dtype=gs.np_float), probe_dir
     )
-    kinematic.set_pos((target_offset[0], target_offset[1], target_offset[2] + BOX_LENGTH))
+    if not use_visual_geom:
+        assert stack_hit.geom.entity is decoy
+        assert_allclose(stack_hit.distance, PROBE_Z - (DECOY_Z + 0.5 * DECOY_SIZE), tol=1e-6)
+        return
+
+    assert stack_hit.geom.entity is target
+    assert_allclose(stack_hit.distance, PROBE_Z - (TARGET_Z + 0.5 * TARGET_SIZE), tol=1e-6)
+    kinematic_origin = np.array((target_offset[0], KINEMATIC_LANE_Y, PROBE_Z), dtype=gs.np_float)
+    kinematic_hit = plugin._raycaster.cast(kinematic_origin, probe_dir)
+    assert kinematic_hit.geom.entity is kinematic
+    assert_allclose(kinematic_hit.distance, PROBE_Z - BOX_LENGTH, tol=1e-6)
+    optout_origin = np.array((target_offset[0], OPTOUT_LANE_Y, PROBE_Z), dtype=gs.np_float)
+    assert plugin._raycaster.cast(optout_origin, probe_dir) is None
+
+    # A kinematic entity carries no mass or inertia, so dragging it is forbidden: hovering, pressing and dragging on
+    # one must leave it exactly where it stands and the plugin holding nothing, instead of raising inside the viewer
+    # callbacks. Park it on the camera ray at a fraction RAY_T of the way from the camera to what it looks at, ahead
+    # of anything the box can reach, so the cursor lands on it rather than on the box.
+    RAY_T = 0.35
+    parked_pos = (0.0, CAM_POS[1] * (1.0 - RAY_T), CAM_POS[2] - RAY_T * (CAM_POS[2] - BOX_LENGTH))
+    kinematic.set_pos(parked_pos)
     scene.step()
     x, y = viewport_size[0] // 2, viewport_size[1] // 2
     pyrender_viewer.dispatch_event("on_mouse_motion", x, y, 0, 0)
     pyrender_viewer.dispatch_event("on_mouse_press", x, y, MouseButton.LEFT, 0)
     wait_for_viewer_events(pyrender_viewer, check_event_count())
+    pyrender_viewer.dispatch_event("on_mouse_drag", x, y + DRAG_DY, 0, DRAG_DY, MouseButton.LEFT, 0)
+    wait_for_viewer_events(pyrender_viewer, check_event_count())
     scene.step()
 
     assert pyrender_viewer.is_active
-    assert visual_plugin._held_link is None
-
-
-@pytest.mark.required
-@pytest.mark.parametrize("n_envs", [0, 2])
-def test_raycast_visual_geom(n_envs, show_viewer):
-    DECOY_SIZE = 0.4
-    DECOY_Z = 0.5
-    TARGET_SIZE = 0.2
-    TARGET_Z = 1.5
-    KINEMATIC_SIZE = 0.3
-    KINEMATIC_Z = 1.0
-    LANE_X = 1.0
-    RAY_Z = -1.0
-
-    scene = gs.Scene(
-        sim_options=gs.options.SimOptions(
-            gravity=(0.0, 0.0, 0.0),
-        ),
-        viewer_options=gs.options.ViewerOptions(
-            res=CAM_RES,
-            camera_pos=(2.0, -1.5, 1.0),
-            camera_lookat=(0.25, 0.0, 1.0),
-            camera_fov=60,
-        ),
-        show_viewer=show_viewer,
-    )
-    decoy = scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(0.0, 0.0, DECOY_Z),
-            size=(DECOY_SIZE,) * 3,
-            fixed=True,
-            visualization=False,
-        ),
-    )
-    target = scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(0.0, 0.0, TARGET_Z),
-            size=(TARGET_SIZE,) * 3,
-            fixed=True,
-            collision=False,
-        ),
-        material=gs.materials.Rigid(
-            use_visual_raycasting=True,
-        ),
-    )
-    # A kinematic entity carries visual meshes only, in a separate solver from the rigid entities above.
-    kinematic = scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(-LANE_X, 0.0, KINEMATIC_Z),
-            size=(KINEMATIC_SIZE,) * 3,
-            fixed=True,
-        ),
-        material=gs.materials.Kinematic(
-            use_visual_raycasting=True,
-        ),
-    )
-    # Without the opt-in material, an entity stays unpickable.
-    scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(LANE_X, 0.0, TARGET_Z),
-            size=(TARGET_SIZE,) * 3,
-            fixed=True,
-            collision=False,
-        ),
-    )
-    scene.build(n_envs=n_envs)
-    scene.step()
-
-    ray_direction = np.array((0.0, 0.0, 1.0), dtype=gs.np_float)
-    collision_raycaster = Raycaster(scene)
-    visual_raycaster = Raycaster(scene, use_visual_geom=True)
-
-    ray_origin = np.array((0.0, 0.0, RAY_Z), dtype=gs.np_float)
-    collision_hit = collision_raycaster.cast(ray_origin, ray_direction)
-    assert collision_hit.geom.entity is decoy
-    assert_allclose(collision_hit.distance, DECOY_Z - 0.5 * DECOY_SIZE - RAY_Z, tol=1e-6)
-    assert_allclose(collision_hit.normal, (0.0, 0.0, -1.0), tol=gs.EPS)
-
-    visual_hit = visual_raycaster.cast(ray_origin, ray_direction)
-    assert visual_hit.geom.entity is target
-    assert_allclose(visual_hit.distance, TARGET_Z - 0.5 * TARGET_SIZE - RAY_Z, tol=1e-6)
-    assert_allclose(visual_hit.normal, (0.0, 0.0, -1.0), tol=gs.EPS)
-
-    kinematic_hit = visual_raycaster.cast(np.array((-LANE_X, 0.0, RAY_Z), dtype=gs.np_float), ray_direction)
-    assert kinematic_hit.geom.entity is kinematic
-    assert_allclose(kinematic_hit.distance, KINEMATIC_Z - 0.5 * KINEMATIC_SIZE - RAY_Z, tol=1e-6)
-
-    assert visual_raycaster.cast(np.array((LANE_X, 0.0, RAY_Z), dtype=gs.np_float), ray_direction) is None
+    assert plugin._held_link is None
+    assert_allclose(kinematic.get_pos(), parked_pos, tol=gs.EPS)
 
 
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason=SKIP_NO_VIEWER)

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -304,6 +304,7 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     KINEMATIC_LANE_Y = 2.0
     OPTOUT_LANE_Y = 2.5
     PROBE_Z = 3.0
+    RAY_T = 0.35
     target_offset = np.asarray(target_offset, dtype=gs.np_float)
     CAM_POS = (target_offset[0], 0.6, 1.2)
 
@@ -512,12 +513,8 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
         err_msg="Final z velocity does not match expected value based on spring dynamics.",
     )
 
-    # Each mode follows the geometry it is meant to: the collision cast stops on the hull it can see, the visual cast
-    # reaches through it to the rendered mesh, spans the kinematic solver too, and skips entities without the opt-in.
-    probe_dir = np.array((0.0, 0.0, -1.0), dtype=gs.np_float)
-    stack_hit = plugin._raycaster.cast(
-        np.array((target_offset[0], STACK_LANE_Y, PROBE_Z), dtype=gs.np_float), probe_dir
-    )
+    probe_dir = (0.0, 0.0, -1.0)
+    stack_hit = plugin._raycaster.cast((target_offset[0], STACK_LANE_Y, PROBE_Z), probe_dir)
     if not use_visual_geom:
         assert stack_hit.geom.entity is decoy
         assert_allclose(stack_hit.distance, PROBE_Z - (DECOY_Z + 0.5 * DECOY_SIZE), tol=1e-6)
@@ -525,18 +522,13 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
 
     assert stack_hit.geom.entity is target
     assert_allclose(stack_hit.distance, PROBE_Z - (TARGET_Z + 0.5 * TARGET_SIZE), tol=1e-6)
-    kinematic_origin = np.array((target_offset[0], KINEMATIC_LANE_Y, PROBE_Z), dtype=gs.np_float)
-    kinematic_hit = plugin._raycaster.cast(kinematic_origin, probe_dir)
+    kinematic_hit = plugin._raycaster.cast((target_offset[0], KINEMATIC_LANE_Y, PROBE_Z), probe_dir)
     assert kinematic_hit.geom.entity is kinematic
     assert_allclose(kinematic_hit.distance, PROBE_Z - BOX_LENGTH, tol=1e-6)
-    optout_origin = np.array((target_offset[0], OPTOUT_LANE_Y, PROBE_Z), dtype=gs.np_float)
-    assert plugin._raycaster.cast(optout_origin, probe_dir) is None
+    assert plugin._raycaster.cast((target_offset[0], OPTOUT_LANE_Y, PROBE_Z), probe_dir) is None
 
-    # A kinematic entity carries no mass or inertia, so dragging it is forbidden: hovering, pressing and dragging on
-    # one must leave it exactly where it stands and the plugin holding nothing, instead of raising inside the viewer
-    # callbacks. Park it on the camera ray at a fraction RAY_T of the way from the camera to what it looks at, ahead
-    # of anything the box can reach, so the cursor lands on it rather than on the box.
-    RAY_T = 0.35
+    # A kinematic entity carries no mass or inertia, so dragging it is forbidden. RAY_T places it that fraction of the
+    # way from the camera to what it looks at, which puts it on the centre ray ahead of anything the box can reach.
     parked_pos = (0.0, CAM_POS[1] * (1.0 - RAY_T), CAM_POS[2] - RAY_T * (CAM_POS[2] - BOX_LENGTH))
     kinematic.set_pos(parked_pos)
     scene.step()

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -619,8 +619,10 @@ def test_heterogeneous_object(show_viewer, tol):
             use_visual_raycasting=True,
         ),
     )
-    # Every link of the kinematic solver is fixed, so its visual BVH is static and groups envs by geometry. The
-    # variants share one link, hence identical vgeom poses, and are told apart only by their active vgeom range.
+    # Every link of the kinematic solver is fixed, so its visual BVH is static and groups envs by geometry. A box
+    # primitive puts its vgeom at the link origin, so these same-pos variants hold identical vgeom poses and differ
+    # only in rest-pose vverts, which are shared across envs: the active vgeom range is the sole discriminator the
+    # grouping signature can read.
     het_visual = scene.add_entity(
         morph=(
             gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(4.0, 0.0, 0.5), fixed=True),
@@ -685,8 +687,6 @@ def test_heterogeneous_object(show_viewer, tol):
     # static tree per distinct variant, so each env still reads its own.
     het_obstacle.set_pos((10.0, 0.0, 0.5))
     scene.step()
-    visual_bvh = next(entry for entry in lidar._shared_context.bvh_contexts if entry.solver is het_visual.solver)
-    assert visual_bvh.aabb.n_batches == 3
     assert_allclose(lidar.read().distances[:, 0, 0], (3.9, 3.9, 3.8, 3.8, 3.7, 3.7), tol=5e-3)
 
 

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -615,6 +615,21 @@ def test_heterogeneous_object(show_viewer, tol):
             gs.morphs.Sphere(radius=0.2, pos=(1.0, 0.0, 0.5), fixed=True),
             gs.morphs.Box(size=(0.6, 0.6, 0.6), pos=(1.0, 0.0, 0.5), fixed=True),
         ),
+        material=gs.materials.Rigid(
+            use_visual_raycasting=True,
+        ),
+    )
+    # Every link of the kinematic solver is fixed, so its visual BVH is static and groups envs by geometry. The
+    # variants share one link, hence identical vgeom poses, and are told apart only by their active vgeom range.
+    het_visual = scene.add_entity(
+        morph=(
+            gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(4.0, 0.0, 0.5), fixed=True),
+            gs.morphs.Box(size=(0.4, 0.4, 0.4), pos=(4.0, 0.0, 0.5), fixed=True),
+            gs.morphs.Box(size=(0.6, 0.6, 0.6), pos=(4.0, 0.0, 0.5), fixed=True),
+        ),
+        material=gs.materials.Kinematic(
+            use_visual_raycasting=True,
+        ),
     )
     # A movable entity parked off the ray's path: it makes the solver mixed, so the heterogeneous variants are served
     # through the static subset of the split collision BVH.
@@ -665,6 +680,14 @@ def test_heterogeneous_object(show_viewer, tol):
     movable_box.set_pos((3.0, 2.0, 0.5))
     scene.step()
     assert_allclose(lidar.read().distances[:, 0, 0], (0.9, 0.9, 0.8, 0.8, 0.7, 0.7), tol=5e-3)
+
+    # Sending the rigid variants out of range leaves the kinematic ones as the nearest hit, cast through one grouped
+    # static tree per distinct variant, so each env still reads its own.
+    het_obstacle.set_pos((10.0, 0.0, 0.5))
+    scene.step()
+    visual_bvh = next(entry for entry in lidar._shared_context.bvh_contexts if entry.solver is het_visual.solver)
+    assert visual_bvh.aabb.n_batches == 3
+    assert_allclose(lidar.read().distances[:, 0, 0], (3.9, 3.9, 3.8, 3.8, 3.7, 3.7), tol=5e-3)
 
 
 @pytest.mark.required

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -623,7 +623,7 @@ def test_heterogeneous_object(show_viewer, tol):
     # primitive puts its vgeom at the link origin, so these same-pos variants hold identical vgeom poses and differ
     # only in rest-pose vverts, which are shared across envs: the active vgeom range is the sole discriminator the
     # grouping signature can read.
-    het_visual = scene.add_entity(
+    scene.add_entity(
         morph=(
             gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(4.0, 0.0, 0.5), fixed=True),
             gs.morphs.Box(size=(0.4, 0.4, 0.4), pos=(4.0, 0.0, 0.5), fixed=True),

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -11,8 +11,11 @@ from ..utils import assert_allclose, assert_equal
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("n_envs", [0, 2])
-def test_hits(show_viewer, n_envs):
+# A raycast consumer refreshes the solver's forward kinematics before casting; under MuJoCo compatibility the
+# solver relies on redoing that itself, geoms included, so the arm below pins that a raycaster leaves the physics
+# alone - obstacle_1 falls onto the ground plane and the grid rays must still find its top face where it rests.
+@pytest.mark.parametrize("n_envs, enable_mujoco_compatibility", [(0, False), (2, True)])
+def test_hits(show_viewer, n_envs, enable_mujoco_compatibility):
     NUM_RAYS_XY = (3, 5)
     SPHERE_POS = (2.5, 0.5, 1.0)
     BOX_SIZE = 0.05
@@ -21,6 +24,9 @@ def test_hits(show_viewer, n_envs):
     RAYCAST_HEIGHT = 1.0
 
     scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            enable_mujoco_compatibility=enable_mujoco_compatibility,
+        ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(-3.0, RAYCAST_GRID_SIZE_X * (NUM_RAYS_XY[1] / NUM_RAYS_XY[0]), 2 * RAYCAST_HEIGHT),
             camera_lookat=(1.5, RAYCAST_GRID_SIZE_X * (NUM_RAYS_XY[1] / NUM_RAYS_XY[0]), RAYCAST_HEIGHT),
@@ -106,6 +112,9 @@ def test_hits(show_viewer, n_envs):
         gs.morphs.Box(
             size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
             pos=(grid_res, grid_res, 0.5 * BOX_SIZE),
+        ),
+        material=gs.materials.Rigid(
+            use_visual_raycasting=True,
         ),
     )
     obstacle_2 = scene.add_entity(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,7 +21,7 @@ ALLOW_PATTERNS = {
     "sensors/**/*.py",
     "tutorials/**/*.py",
     "usd/**/*.py",
-    "viewer_plugins/**/*.py",
+    "viewer_plugin/**/*.py",
     "gui/**/*.py",
 }
 IGNORE_SCRIPT_NAMES = {


### PR DESCRIPTION
## Description

`RaycasterViewerPlugin` takes a new `use_visual_geom` option, inherited by `MouseInteractionPlugin` and by any downstream plugin (e.g. the `examples/viewer_plugin/mesh_point_selector.py` selector). When set, the viewer raycaster casts against visual meshes and `RayHit.geom` is the hit `RigidVisGeom`, whose `.link` / `.entity` keep existing plugin code working unchanged.

- Support both Rigid and Kinematic solver, so visual-only entities are pickable. `Raycaster` holds one BVH per solver and keeps the closest hit across them, capping each pass at the best distance so far.
- Restricted to entities that set `material.use_visual_raycasting=True` - the same opt-in the raycaster sensors use, so both describe the same pickable geometry. An entity without the flag is not pickable, and casting with nothing opted in logs a warning naming the option.
- That opt-in mask now has a single definition, the `KinematicSolver.vfaces_raycast_mask` property, fitted once at build time and read by both the sensor context and the viewer.
- The single-ray kernel selects the mesh through a compile-time `is_visual` flag, reusing the visual traversal that already backs the sensors rather than adding a second copy.
- Drive-by fix: casting in a scene with no geometry to cast against now returns no hit instead of raising (`cast()` dereferenced a `None` BVH left behind by `__init__`).
- A heterogeneous entity now casts against its own variant alone: a visual face is skipped when its vgeom falls outside the environment's active `links.vgeom_start` / `vgeom_end` range, and the static-BVH environment grouping keys on that range so environments holding different variants no longer share a tree. This corrects the raycaster sensors too, which previously saw the union of every variant.
- Bug fix, pre-existing on `main` and reachable from the raycaster sensors alone: a raycast consumer calls `update_forward_pos`, and the flag it sets also authorizes the next step to skip its Cartesian-space update, which covers geoms as well as links. `RigidSolver` now refreshes geoms alongside links, so a raycast consumer no longer leaves collision reading a one-step-stale geom pose. With `enable_mujoco_compatibility=True` this silently dropped contacts - a box resting on the ground sank through it - and `tests/sensors/test_raycaster.py::test_hits` now pins it.

## Motivation and Context

Better user experience with viewer

## How Has This Been / Can This Be Tested?

Unit tests:

```bash
pytest tests/sensors/test_raycaster.py tests/rendering/test_interactive_viewer.py
```

Interactively, running each example with and without the new option:

```bash
python examples/viewer_plugin/mouse_interaction.py
python examples/viewer_plugin/mouse_interaction.py --use_visual_geom
python examples/viewer_plugin/mesh_point_selector.py
python examples/viewer_plugin/mesh_point_selector.py --use_visual_geom
```

## Screenshots (if appropriate):

The `mouse_interaction.py` example, picking the same scene both ways:

<table>
<tr>
<th width="50%">Collision meshes (<code>use_visual_geom=False</code>)</th>
<th width="50%">Visual meshes (<code>use_visual_geom=True</code>)</th>
</tr>
<tr>
<td><video src="https://github.com/user-attachments/assets/98846629-6424-4750-90a9-ee40a8a66e3d"></video></td>
<td><video src="https://github.com/user-attachments/assets/34d6f0a3-e1d6-4668-b5bb-bb3cd5d275f0"></video></td>
</tr>
</table>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.

Resolves SIM-293

