### PR TITLE
[BUG FIX] Keep the Nyx plugin check working on pull requests that predate it.

### DIFF
--- a/.github/workflows/nyx_plugin.yml
+++ b/.github/workflows/nyx_plugin.yml
@@ -59,8 +59,17 @@ jobs:
       - name: Resolve the pinned Nyx plugin revision
         id: plugin
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          COMMIT=$(tr -d '[:space:]' < .github/nyx_plugin_commit)
+          # A revision branched before the pin was introduced carries none, so the default branch stands in for it.
+          if [[ -f .github/nyx_plugin_commit ]] ; then
+            COMMIT=$(tr -d '[:space:]' < .github/nyx_plugin_commit)
+          else
+            COMMIT=$(gh api "/repos/${GITHUB_REPOSITORY}/contents/.github/nyx_plugin_commit?ref=${DEFAULT_BRANCH}" \
+                         -H "Accept: application/vnd.github.raw" | tr -d '[:space:]')
+          fi
           if [[ ! "${COMMIT}" =~ ^[0-9a-f]{40}$ ]] ; then
             echo "::error::'.github/nyx_plugin_commit' must hold a full 40-character commit hash."
             exit 1


### PR DESCRIPTION
## Description

Falls back to the pin of the default branch when the revision under test carries none, instead of failing outright.

## Motivation and Context

Reading the pin from the revision under test is what lets a pull request choose its plugin revision, but a revision branched before the pin existed has no such file, and every open pull request predating it is in that situation. The job died on the very first use, before checking anything out.

## How Has This Been / Can This Be Tested?

The fallback query was run against the default branch and returns the pinned hash, which passes the same validation as an in-tree pin.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
