### PR TITLE
[MISC] Run Nyx CI without waiting for production CI.

### DIFF
--- a/.github/workflows/nyx_plugin.yml
+++ b/.github/workflows/nyx_plugin.yml
@@ -6,7 +6,7 @@ name: Nyx Plugin
 # outcome has to be published as a check on the commit under test to show up on it at all.
 on:
   workflow_run:
-    workflows: ["Production"]
+    workflows: ["Precommit Checks (Lint and Format)"]
     types: [completed]
 
 concurrency:
@@ -60,6 +60,12 @@ jobs:
         id: plugin
         shell: bash
         run: |
+          # The pin has to come from the revision under test, so a revision branched before it was introduced is
+          # rejected rather than tested against something it never chose.
+          if [[ ! -f .github/nyx_plugin_commit ]] ; then
+            echo "::error::'.github/nyx_plugin_commit' is missing. Rebase onto the default branch."
+            exit 1
+          fi
           COMMIT=$(tr -d '[:space:]' < .github/nyx_plugin_commit)
           if [[ ! "${COMMIT}" =~ ^[0-9a-f]{40}$ ]] ; then
             echo "::error::'.github/nyx_plugin_commit' must hold a full 40-character commit hash."


### PR DESCRIPTION
## Description

Hangs the job off the quickest workflow running on every pull request, rather than off the one sharing the self-hosted runner. It needs nothing from what it follows, so there is no reason for its verdict to arrive hours later.

Rejects a revision under test carrying no plugin pin with an explicit message asking for a rebase. It used to fail on the missing file, which said nothing useful.

## Motivation and Context

The pin has to come from the revision under test, since that is what lets a pull request choose its plugin revision, so a revision branched before the pin existed is rejected rather than tested against something it never chose.

## How Has This Been / Can This Be Tested?

`workflow_run` only triggers from the default branch, so this cannot run before it lands. The workflow parses and no line exceeds the width limit.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
