### PR TITLE
[MISC] Fix Nyx CI pipeline.

### DIFF
--- a/.github/workflows/nyx_plugin.yml
+++ b/.github/workflows/nyx_plugin.yml
@@ -111,10 +111,11 @@ jobs:
           # test, leaving the tests exercising something else entirely. Overriding that single requirement with the
           # checkout keeps every other dependency of the plugin resolved from its own metadata. The plugin pins the
           # renderer to an internal index that this repository has no credentials for, so that source alone is
-          # ignored in favour of the public one.
+          # ignored in favour of the public one. The override has to carry the extra providing the test runner, since
+          # it replaces the requirement it overrides in full, extras included.
           uv pip install --system \
               --no-sources-package gs-nyx \
-              --overrides <(printf 'genesis-world @ file://%s\n' "$GITHUB_WORKSPACE") \
+              --overrides <(printf 'genesis-world[dev] @ file://%s\n' "$GITHUB_WORKSPACE") \
               ".[dev]" ./nyx_plugin
       - name: Run Nyx plugin unit tests
         # Running from the plugin root keeps its own pytest configuration in charge, and makes the paths the tests


### PR DESCRIPTION
## Description

Carries the `dev` extra in the override pinning `genesis-world` to the revision under test, so that the test runner gets installed.

## Motivation and Context

The job reached the tests for the first time and died on `pytest: command not found`. An override replaces the requirement it overrides in full, extras included, so overriding `genesis-world` silently dropped the `dev` extra that provides `pytest`, `pytest-xdist` and `scipy`.

## How Has This Been / Can This Be Tested?

Reproduced on a pair of throwaway packages: overriding a dependency requested with an extra installs it without the extra's own dependencies, and adding the extra to the override restores them.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
