### PR TITLE
[MISC] Polish Nyx CI workflow.

### DIFF
--- a/.github/workflows/nyx_plugin.yml
+++ b/.github/workflows/nyx_plugin.yml
@@ -9,8 +9,12 @@ on:
     workflows: ["Precommit Checks (Lint and Format)"]
     types: [completed]
 
+# Pull requests come from forks, whose branch names collide across contributors, so the repository they live in is
+# part of what tells two runs apart.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}
+    ${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 env:
@@ -30,6 +34,9 @@ jobs:
     # reference images comparable.
     runs-on: gpu-t4-4-core
 
+    # Only a pull request is worth checking, the plugin being validated before a change lands rather than after.
+    if: github.event.workflow_run.event == 'pull_request'
+
     permissions:
       contents: read
       # To be able to resolve the log of this very job.
@@ -37,7 +44,8 @@ jobs:
       checks: write
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y git-lfs
+      - name: Install Git LFS
+        run: sudo apt-get update && sudo apt-get install -y git-lfs
 
       - name: Checkout the revision of Genesis under test
         uses: actions/checkout@v5
@@ -92,15 +100,6 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
-      - name: Install Mesa OpenGL driver
-        run: |
-          for retry in {1..10}; do
-            sudo add-apt-repository -y ppa:kisak/kisak-mesa && break || sleep 5;
-          done
-          sudo apt install -y \
-              libglu1-mesa \
-              libegl-mesa0 \
-              libgl1-mesa-dev
       - name: Install Genesis and the Nyx plugin
         # Process substitution feeds the overrides without writing a file, so bash is required.
         shell: bash


### PR DESCRIPTION
## Description

Tells two runs apart by the repository their branch lives in, not by its name alone, so that pushing to a pull request cancels the run it supersedes. Branch names collide across forks, and every pull request here comes from one, so unrelated pull requests were cancelling each other instead.

Restricts the job to pull requests, the plugin being worth validating before a change lands rather than after.

Stops upgrading the Mesa of the runner, which brought in a Vulkan driver owning no device here, reported on every single test. Nothing needed that upgrade: every runtime library it touched was already installed, and all it added on top were development packages. Git LFS stays, being genuinely absent from the runner and required to fetch the test assets of the plugin.

## How Has This Been / Can This Be Tested?

The Nyx plugin check itself, whose log should no longer carry those failures.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
