### PR TITLE
[BUG FIX] Fix missing prerequisite for Nyx CI workflow.

### DIFF
--- a/.github/workflows/nyx_plugin.yml
+++ b/.github/workflows/nyx_plugin.yml
@@ -100,6 +100,11 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
+      # Remeshing goes through 'pymeshlab', which loads it from a plugin linked against GLU, and drops the filter
+      # without a word when that library is missing, leaving it to fail much later as a missing attribute.
+      - name: Install the GLU library
+        run: sudo apt-get install -y libglu1-mesa
+
       - name: Install Genesis and the Nyx plugin
         # Process substitution feeds the overrides without writing a file, so bash is required.
         shell: bash


### PR DESCRIPTION
## Description

Installs GLU on the runner of the Nyx plugin check.

## Motivation and Context

Three tests started failing on `'MeshSet' object has no attribute 'meshing_isotropic_explicit_remeshing'` once the runner stopped being given that library. `pymeshlab`, which Genesis remeshes with, serves that filter from a plugin linked against `libGLU.so.1`, and drops the plugin without a word when the library is missing, so the filter goes missing instead of the import failing. Genesis compounds it by importing `pymeshlab` with the standard error of the loader redirected away.

## How Has This Been / Can This Be Tested?

The Nyx plugin check itself, whose three failures on that attribute should be gone. `libGLU.so.1` is listed among the libraries the plugin serving the filter is linked against, in the wheel resolved for the runner.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
