### PR TITLE
[BREAKING][MISC] Rename the 'impedance' contact resolution mode to 'convex'.

### DIFF
--- a/genesis/constants.py
+++ b/genesis/constants.py
@@ -84,27 +84,27 @@ class contact_resolution(IntEnum):
     """
     How a contact's normal force and friction force are resolved against each other.
 
-    'impedance' poses the whole contact as a single cost and lets the solver trade the normal residual against the
-    tangential one. Because the friction limit mu * f_n bounds the pair jointly, a contact sliding fast enough that
-    its friction rows demand more force than the cone allows can be answered by raising f_n instead: a body launched
-    horizontally then lifts off a flat floor, by more the faster it slides. In exchange the cost is smooth and the
-    solve is one convex program, which converges predictably on stiff articulated chains and high mass ratios.
+    'convex' poses the whole contact as a single smooth convex cost and lets the solver trade the normal residual
+    against the tangential one. Because the friction limit mu * f_n bounds the pair jointly, a contact sliding fast
+    enough that its friction rows demand more force than the cone allows can be answered by raising f_n instead: a body
+    launched horizontally then lifts off a flat floor, by more the faster it slides. In exchange the whole problem stays
+    one convex program, which converges predictably on stiff articulated chains and high mass ratios.
 
-    'signorini' bounds friction against the normal force the contact has actually developed, so the normal force is
-    set by penetration alone and sliding can never inflate it - a sliding body decelerates at mu * g and stays down at
-    any speed. Contacts are resolved by successive approximation, costing extra solver iterations and giving up the
-    single-convex-program guarantee. Prefer it whenever sliding contact matters; choose 'impedance' for parity with
-    engines built on that formulation, or if a stiff scene converges better under it.
+    'signorini' bounds friction against the normal force the contact has actually developed, so that force is set by the
+    contact's own normal state rather than by tangential demand, and sliding can never inflate it - a sliding body
+    decelerates at mu * g and stays down at any speed. Contacts are resolved by successive approximation, costing extra
+    solver iterations and giving up the single-convex-program guarantee. Prefer it whenever sliding contact matters;
+    choose 'convex' for parity with engines built on that formulation, or if a stiff scene converges better under it.
 
     'signorini' requires the elliptic friction cone, whose rows separate into a normal row and a friction disc - the
     pyramidal cone mixes the normal direction into every row and admits no such split - and the Newton constraint
     solver, the only one that reaches the fixed point of the resulting successive approximation. It implements the
-    Coulomb complementarity problem eq. (C.22) of Alexis Duburcq, "Learning and Optimization of the Locomotion with
-    an Exoskeleton for Paraplegic People", PhD thesis, Universite Paris Sciences et Lettres, 2022 (HAL tel-04166955),
+    Coulomb complementarity problem eq. (C.22) of Alexis Duburcq, "Learning and Optimization of the Locomotion with an
+    Exoskeleton for Paraplegic People", PhD thesis, Universite Paris Sciences et Lettres, 2022 (HAL tel-04166955),
     Appendix C, whose Signorini condition is what forbids the normal force from absorbing tangential demand.
     """
 
-    impedance = 0
+    convex = 0
     signorini = 1
 
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -5028,9 +5028,9 @@ def _tri_idx(i, j, dim):
 def _friction_blocks(rigid_config):
     """Row offset and width of each independently-bounded friction block of one elliptic contact, at trace time.
 
-    Sliding friction spans the two tangent axes, torsional friction the spin axis and rolling friction the two
-    tangent axes again, laid out as described in efc_frictionloss (see array_class.py). Only the 'signorini'
-    resolution bounds them separately; 'impedance' couples every axis into one ellipsoid.
+    Sliding friction spans the two tangent axes, torsional friction the spin axis and rolling friction the two tangent
+    axes again, laid out as described in efc_frictionloss (see array_class.py). Only the 'signorini' resolution bounds
+    them separately; 'convex' couples every axis into one ellipsoid.
     """
     blocks = [(1, 2)]
     if rigid_config.enable_torsional_friction:
@@ -5044,9 +5044,9 @@ def _friction_blocks(rigid_config):
 def _func_cone_zone(rows_jaref, rows_efc_D, con_mu, rows_friction, rigid_config: qd.template()):
     """Classify one elliptic contact from its per-row residuals rows_jaref, for the resolution in force.
 
-    Returns (zone, N, T). Under 'impedance' these are MuJoCo's three cone zones - 0 = top (dual-cone interior,
-    inactive), 1 = bottom (polar cone, plain quadratic), 2 = middle (cone boundary) - with N and T the rescaled
-    normal/tangential magnitudes the middle-zone force/cost/Hessian reuses.
+    Returns (zone, N, T). Under 'convex' these are MuJoCo's three cone zones - 0 = top (dual-cone interior, inactive),
+    1 = bottom (polar cone, plain quadratic), 2 = middle (cone boundary) - with N and T the rescaled normal/tangential
+    magnitudes the middle-zone force/cost/Hessian reuses.
 
     Under 'signorini' a contact only ever separates (zone 0) or carries force (zone 2), since friction is bounded
     against the normal force rather than traded against it: N carries that latched normal force, the radius scale of
@@ -5188,19 +5188,19 @@ def _func_disc_middle(rows_jaref, rows_efc_D, rows_friction, f_n, rigid_config: 
 
 @qd.func
 def _func_cone_middle(rows_jaref, rows_efc_D, con_mu, rows_friction, N, T, rigid_config: qd.template()):
-    """Middle-zone force, cost and packed symmetric local Hessian of one elliptic contact, for the resolution in
-    force: MuJoCo's coupled cone under 'impedance', the latched-radius friction discs under 'signorini'.
+    """Middle-zone force, cost and packed symmetric local Hessian of one elliptic contact, for the resolution in force:
+    MuJoCo's coupled cone under 'convex', the latched-radius friction discs under 'signorini'.
 
     Returns (rows_force, cost, cone_H), cone_H packed row-major upper-triangle (see _tri_idx). N and T carry what
     _func_cone_zone returned for this contact; only valid in the middle zone.
     """
     if qd.static(rigid_config.enable_signorini_contact):
         return _func_disc_middle(rows_jaref, rows_efc_D, rows_friction, N, rigid_config)
-    return _func_cone_middle_impedance(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
+    return _func_cone_middle_convex(rows_jaref, rows_efc_D[0], con_mu, rows_friction, N, T)
 
 
 @qd.func
-def _func_cone_middle_impedance(rows_jaref, D0, con_mu, rows_friction, N, T):
+def _func_cone_middle_convex(rows_jaref, D0, con_mu, rows_friction, N, T):
     """Middle-zone (cone-boundary) force, cost, and packed symmetric local Hessian for one elliptic contact.
 
     Returns (rows_force, cost, cone_H): the per-row forces, the coupled cost, and the row-major upper-triangle
@@ -5358,12 +5358,12 @@ def _func_disc_cost_along_alpha(rows_jaref, rows_jv, alpha, rows_efc_D, rows_fri
 def _func_cone_cost_along_alpha(
     rows_jaref, rows_jv, alpha, rows_efc_D, con_mu, rows_friction, rigid_config: qd.template()
 ):
-    """Exact elliptic-contact cost and its first/second derivatives in the linesearch step alpha, for the resolution
-    in force: MuJoCo's coupled cone under 'impedance', the latched-radius friction discs under 'signorini'.
+    """Exact elliptic-contact cost and its first/second derivatives in the linesearch step alpha, for the resolution in
+    force: MuJoCo's coupled cone under 'convex', the latched-radius friction discs under 'signorini'.
 
-    Evaluated at rows_jaref + alpha * rows_jv, returning (cost, dcost/dalpha, d2cost/dalpha2). Under 'impedance' the
-    zone is re-classified at this alpha, so the cost is exact along the whole search line (top: 0; bottom: plain
-    quadratic; middle: the cone potential 0.5*Dm*(N - con_mu*T)^2 differentiated through T = ||rows_friction[1:] *
+    Evaluated at rows_jaref + alpha * rows_jv, returning (cost, dcost/dalpha, d2cost/dalpha2). Under 'convex' the zone
+    is re-classified at this alpha, so the cost is exact along the whole search line (top: 0; bottom: plain quadratic;
+    middle: the cone potential 0.5*Dm*(N - con_mu*T)^2 differentiated through T = ||rows_friction[1:] *
     rows_jaref[1:]||).
     """
     if qd.static(rigid_config.enable_signorini_contact):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -294,7 +294,7 @@ class RigidSolver(KinematicSolver):
             gs.raise_exception("The elliptic friction cone is not supported yet when 'requires_grad' is True.")
 
         # Bounding friction against the developed normal force needs the contact to split into a normal row and a
-        # friction disc, which only the elliptic cone provides. MuJoCo compatibility keeps the joint cone regardless,
+        # friction disc, which only the elliptic cone provides. MuJoCo compatibility keeps the coupled cone regardless,
         # since letting sliding inflate the normal force is part of the behaviour being reproduced. The disc radius is
         # relatched every iteration, making the solve a successive approximation whose objective moves underneath the
         # solver; only Newton re-derives its curvature each iteration and lands on the fixed point, while conjugate
@@ -308,7 +308,7 @@ class RigidSolver(KinematicSolver):
             signorini_blocker = "it requires 'constraint_solver' to be 'gs.constraint_solver.Newton'"
         if options.contact_resolution is None:
             options.contact_resolution = (
-                gs.contact_resolution.impedance if signorini_blocker else gs.contact_resolution.signorini
+                gs.contact_resolution.convex if signorini_blocker else gs.contact_resolution.signorini
             )
         elif options.contact_resolution == gs.contact_resolution.signorini and signorini_blocker:
             gs.raise_exception(

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -467,14 +467,13 @@ class RigidOptions(Options):
         for the description of each model. Unsupported with the noslip solver or differentiable simulation.
     contact_resolution : gs.contact_resolution, optional
         How a contact's normal force and friction force are resolved against each other.
-        'gs.contact_resolution.signorini' bounds friction against the normal force the contact has developed, so
-        sliding never inflates it and a body launched horizontally decelerates at mu * g instead of lifting off, at
-        the cost of extra solver iterations. 'gs.contact_resolution.impedance' poses the contact as a single convex
-        program, which converges more predictably on stiff scenes but lets fast sliding buy normal force. See
-        'gs.contact_resolution' for the description of each model. Defaults to None, resolving to 'signorini' with
-        the elliptic cone and the Newton solver, and 'impedance' otherwise - the pyramidal cone's rows do not
-        separate, and the conjugate gradient solver does not reach the fixed point. Always 'impedance' when
-        'enable_mujoco_compatibility' is set.
+        'gs.contact_resolution.signorini' bounds friction against the normal force the contact has developed, so sliding
+        never inflates it and a body launched horizontally decelerates at mu * g instead of lifting off, at the cost of
+        extra solver iterations. 'gs.contact_resolution.convex' poses the contact as a single convex program, which
+        converges more predictably on stiff scenes but lets fast sliding buy normal force. See 'gs.contact_resolution'
+        for the description of each model. Defaults to None, resolving to 'signorini' with the elliptic cone and the
+        Newton solver, and 'convex' otherwise - the pyramidal cone's rows do not separate, and the conjugate gradient
+        solver does not reach the fixed point. Always 'convex' when 'enable_mujoco_compatibility' is set.
     enable_torsional_friction : bool, optional
         Whether contacts also resist relative spin about their normal, with strength set per geometry by the material
         option 'friction_torsional' (see 'gs.materials.Rigid'). Enable it when spin resistance matters - a grasped

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -521,7 +521,7 @@ def test_rolling_friction_deceleration_rate(friction_cone, n_envs, show_viewer):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("contact_resolution", [gs.contact_resolution.impedance, gs.contact_resolution.signorini])
+@pytest.mark.parametrize("contact_resolution", [gs.contact_resolution.convex, gs.contact_resolution.signorini])
 def test_elliptic_cone_push_isotropy(contact_resolution, show_viewer):
     N_ENVS = 8
     FRICTION = 0.5
@@ -529,13 +529,12 @@ def test_elliptic_cone_push_isotropy(contact_resolution, show_viewer):
     # Pusher path in the box's local frame; the shared +y offset gives the push a lever arm that spins the box.
     PUSH_START_LOCAL = (-0.15, 0.03, 0.05)
     PUSH_END_LOCAL = (0.02, 0.03, 0.05)
-    # FIXME(#3127): the box-cylinder manifold places its interior contact point at a yaw-dependent height, so the
-    # push carries an orientation-dependent lever arm that the friction model cannot undo. 'impedance' keeps
-    # bouncing the box off the plane, which makes that contact intermittent and averages the bias away, while
-    # 'signorini' holds the box down and feels it every step - hence the looser bound here. Restore the shared
-    # tolerance once the manifold is isotropic; a sphere, whose manifold is a single point, already brings both
-    # resolutions to 1e-6.
-    POSE_TOL = 2e-4 if contact_resolution == gs.contact_resolution.impedance else 1e-3
+    # FIXME(#3127): the box-cylinder manifold places its interior contact point at a yaw-dependent height, so the push
+    # carries an orientation-dependent lever arm that the friction model cannot undo. 'convex' keeps bouncing the box
+    # off the plane, which makes that contact intermittent and averages the bias away, while 'signorini' holds the box
+    # down and feels it every step - hence the looser bound here. Restore the shared tolerance once the manifold is
+    # isotropic; a sphere, whose manifold is a single point, already brings both resolutions to 1e-6.
+    POSE_TOL = 2e-4 if contact_resolution == gs.contact_resolution.convex else 1e-3
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(


### PR DESCRIPTION
## Description

Renames the `gs.contact_resolution.impedance` enum member to `gs.contact_resolution.convex`, together with the internal `_func_cone_middle_impedance` helper and the docstrings referring to the mode. `gs.contact_resolution.signorini` is unchanged, as is every behaviour: this is a naming change plus two documentation corrections.

## Related Issue

Follow-up to #3126, which introduced the option.

## Motivation and Context

`impedance` already means something specific, and different, in the same options object. `impratio` is documented as the "Ratio of tangential (friction) to normal constraint impedance at contacts", and the `solimp` model computes `diag = invweight * (1 - imp) / imp`. **Both** contact resolution modes use that impedance regularization and both honour `impratio`, so naming one of them `impedance` asserts a contrast that does not exist, and it collides with the surrounding comments where the word carries its regularization meaning.

`convex` names the property that actually separates the two modes: it poses the contact as a single convex program, whereas `signorini` resolves it as a complementarity problem by successive approximation and explicitly gives up that guarantee. The enum docstring already drew the contrast in those exact terms, so the name now matches the documentation.

`signorini` is kept. It names the condition that the mode restores, matches the internal `enable_signorini_contact` flag, and has no competing meaning in the codebase.

Two documentation fixes ride along:

- The `signorini` paragraph claimed the normal force is "set by penetration alone". The normal row's reference includes the approach-velocity term, so the force depends on penetration *and* normal velocity; what it never depends on is tangential demand. Restated accordingly.
- One dev comment said "joint cone" where every other site says "coupled cone". Aligned, since `joint` is a domain object in Genesis.

The old name has never appeared in a release - v1.3.0 was cut before #3126 landed - so no released API changes.

## How Has This Been / Can This Be Tested?

`pytest tests/rigid/test_friction.py` on cpu, which is the only suite referencing the enum (`test_elliptic_cone_push_isotropy` is parametrized over both modes).

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
