### PR TITLE
[BREAKING][FEATURE] Support applying an external wrench at any local point on a link.

### DIFF
--- a/examples/ipc/ipc_momentum.py
+++ b/examples/ipc/ipc_momentum.py
@@ -90,7 +90,9 @@ def main():
         rigid_solver = scene.sim.rigid_solver
 
         # Rigid body linear momentum.
-        cube_vel = tensor_to_array(rigid_cube.get_links_vel(links_idx_local=0, ref="link_com")[..., 0, :])
+        cube_vel = tensor_to_array(
+            rigid_cube.get_links_vel(links_idx_local=0, ref=gs.link_ref_frame.link_COM)[..., 0, :]
+        )
         rigid_linear_momentum = cube_mass * cube_vel
 
         # FEM body linear momentum.

--- a/examples/rigid/apply_external_wrench.py
+++ b/examples/rigid/apply_external_wrench.py
@@ -38,11 +38,9 @@ def main():
     for i in range(1000):
         cube_pos = scene.sim.rigid_solver.get_links_pos(link_idx)
         cube_pos[:, :, 2] -= 1
-        force = -100 * cube_pos
-        scene.sim.rigid_solver.apply_links_external_force(force=force, links_idx=link_idx)
-
-        torque = [[[0, 0, rotation_direction * 5]]]
-        scene.sim.rigid_solver.apply_links_external_torque(torque=torque, links_idx=link_idx)
+        scene.sim.rigid_solver.apply_links_external_wrench(
+            force=-100 * cube_pos, torque=[[[0, 0, rotation_direction * 5]]], links_idx=link_idx
+        )
 
         scene.step()
 

--- a/examples/rigid/apply_external_wrench.py
+++ b/examples/rigid/apply_external_wrench.py
@@ -39,7 +39,9 @@ def main():
         cube_pos = scene.sim.rigid_solver.get_links_pos(link_idx)
         cube_pos[:, :, 2] -= 1
         scene.sim.rigid_solver.apply_links_external_wrench(
-            force=-100 * cube_pos, torque=[[[0, 0, rotation_direction * 5]]], links_idx=link_idx
+            force=-100 * cube_pos,
+            torque=[0, 0, rotation_direction * 5],
+            links_idx=link_idx,
         )
 
         scene.step()

--- a/examples/rigid/apply_external_wrench.py
+++ b/examples/rigid/apply_external_wrench.py
@@ -39,9 +39,7 @@ def main():
         cube_pos = scene.sim.rigid_solver.get_links_pos(link_idx)
         cube_pos[:, :, 2] -= 1
         scene.sim.rigid_solver.apply_links_external_wrench(
-            force=-100 * cube_pos,
-            torque=[0, 0, rotation_direction * 5],
-            links_idx=link_idx,
+            force=-100 * cube_pos, torque=[0, 0, rotation_direction * 5], links_idx=link_idx
         )
 
         scene.step()

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -495,7 +495,6 @@ from .constants import (
     GEOM_TYPE,
     EQUALITY_TYPE,
     CTRL_MODE,
-    LINK_REF_FRAME,
     PARA_LEVEL,
     ACTIVE,
     INACTIVE,
@@ -504,6 +503,7 @@ from .constants import (
     friction_cone,
     contact_resolution,
     broadphase_traversal,
+    link_ref_frame,
 )
 
 from .utils.uid import UID

--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -495,6 +495,7 @@ from .constants import (
     GEOM_TYPE,
     EQUALITY_TYPE,
     CTRL_MODE,
+    LINK_REF_FRAME,
     PARA_LEVEL,
     ACTIVE,
     INACTIVE,

--- a/genesis/constants.py
+++ b/genesis/constants.py
@@ -47,13 +47,6 @@ class CTRL_MODE(IntEnum):
     FORCE = 2
 
 
-# reference frame at which a per-link quantity is expressed in the rigid solver
-class LINK_REF_FRAME(IntEnum):
-    ROOT_COM = 0
-    LINK_COM = 1
-    LINK_ORIGIN = 2
-
-
 ######### User accessible constants do not capitalize #########
 # rigid solver intergrator
 class integrator(IntEnum):
@@ -151,6 +144,22 @@ class broadphase_traversal(IntEnum):
 
     SAP = 0
     ALL_VS_ALL = 1
+
+
+class link_ref_frame(IntEnum):
+    """
+    Reference frame at which a per-link quantity is expressed.
+
+    Each member fixes an origin, about which spatial quantities are translated, together with an orientation, by which
+    quantities given in local coordinates are rotated. 'root_COM' is the center of mass of the whole kinematic tree the
+    link belongs to, with world-aligned axes; the solver stores link velocities and generalized forces there natively,
+    so it is the only frame reached without a moment arm. 'link_COM' is the center of mass of the link, with the axes of
+    its inertial frame. 'link_origin' is the origin of the link, with the axes of the link frame.
+    """
+
+    root_COM = 0
+    link_COM = 1
+    link_origin = 2
 
 
 # backend

--- a/genesis/constants.py
+++ b/genesis/constants.py
@@ -47,6 +47,13 @@ class CTRL_MODE(IntEnum):
     FORCE = 2
 
 
+# reference frame at which a per-link quantity is expressed in the rigid solver
+class LINK_REF_FRAME(IntEnum):
+    ROOT_COM = 0
+    LINK_COM = 1
+    LINK_ORIGIN = 2
+
+
 ######### User accessible constants do not capitalize #########
 # rigid solver intergrator
 class integrator(IntEnum):

--- a/genesis/engine/couplers/ipc_coupler/coupler.py
+++ b/genesis/engine/couplers/ipc_coupler/coupler.py
@@ -1133,13 +1133,8 @@ class IPCCoupler(RBC):
                 "the simulation timestep."
             )
 
-        self.rigid_solver.apply_links_external_force(
+        self.rigid_solver.apply_links_external_wrench(
             self._coupling_data.out_forces if self.sim.n_envs > 0 else self._coupling_data.out_forces[0],
-            links_idx=self._coupling_data.links_idx,
-            local=False,
-        )
-        self.rigid_solver.apply_links_external_torque(
             self._coupling_data.out_torques if self.sim.n_envs > 0 else self._coupling_data.out_torques[0],
             links_idx=self._coupling_data.links_idx,
-            local=False,
         )

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -10,12 +10,13 @@ import torch
 import trimesh
 
 import genesis as gs
+from genesis.constants import link_ref_frame
 from genesis.engine.materials.base import Material
 from genesis.engine.mesh import InertialProperties
 from genesis.engine.states.entities import RigidEntityState
 from genesis.options.morphs import Morph
 from genesis.options.surfaces import Surface
-from genesis.typing import LinkFrameType, LinkRefFrameType, UnitVec4FType, Vec3FType
+from genesis.typing import UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
 from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
@@ -3462,7 +3463,7 @@ class RigidEntity(KinematicEntity):
         links_idx_local=None,
         envs_idx=None,
         *,
-        ref: LinkRefFrameType = "link_origin",
+        ref: link_ref_frame = link_ref_frame.link_origin,
         relative=True,
     ):
         """
@@ -3474,15 +3475,15 @@ class RigidEntity(KinematicEntity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com"
-            The reference point being used to express the position of each link.
-            * "root_com": center of mass of the sub-entities to which the link belongs. As a reminder, a single
-              kinematic tree (aka. 'RigidEntity') may compromise multiple "physical" entities, i.e. a kinematic tree
-              that may have at most one free joint, at its root.
+        ref: gs.link_ref_frame, optional
+            The reference point used to express the position of each link: its origin ('link_origin'), its center of
+            mass ('link_COM'), or the center of mass of the sub-entity it belongs to ('root_COM'). A single
+            'RigidEntity' may comprise several physical sub-entities, each a kinematic sub-tree with at most one free
+            joint at its root. Defaults to 'link_origin'.
         relative : bool, optional
             If True, strip the morph pose offset to return the user-frame position; this only affects
-            ref="link_origin", since the offset is defined on the link origin. If False, return the world frame.
-            Defaults to True.
+            ref=gs.link_ref_frame.link_origin, since the offset is defined on the link origin. If False, return the
+            world frame. Defaults to True.
 
         Returns
         -------
@@ -3493,7 +3494,7 @@ class RigidEntity(KinematicEntity):
         return self._solver.get_links_pos(links_idx, envs_idx, ref=ref, relative=relative)
 
     @gs.assert_built
-    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, ref: LinkFrameType = "link_origin"):
+    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin):
         """
         Returns linear velocity of all the entity's links expressed at a given reference position in world coordinates.
 
@@ -3503,9 +3504,9 @@ class RigidEntity(KinematicEntity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com"
-            The reference point being used to expressed the velocity of each link.
-
+        ref: gs.link_ref_frame, optional
+            The reference point used to express the velocity of each link: its origin ('link_origin') or its center of
+            mass ('link_COM'). Defaults to 'link_origin'.
         Returns
         -------
         vel : torch.Tensor, shape (n_links, 3) or (n_envs, n_links, 3)
@@ -3533,7 +3534,7 @@ class RigidEntity(KinematicEntity):
         envs_idx=None,
         *,
         pos=None,
-        ref: LinkFrameType = "link_origin",
+        ref: link_ref_frame = link_ref_frame.link_origin,
         local: bool = False,
     ):
         """
@@ -3544,25 +3545,22 @@ class RigidEntity(KinematicEntity):
         force : None | array_like, optional
             The linear force to apply. None for a pure torque. Defaults to None.
         torque : None | array_like, optional
-            The torque to apply, on top of the moment induced by the linear force. None for a pure force. Defaults to
-            None.
+            The torque to apply, on top of the moment induced by the linear force. Defaults to None.
         links_idx_local : None | array_like, optional
             The indices of the links. None to specify all the entity's links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         pos : None | array_like, optional
-            The point at which the linear force is applied, which sets the moment arm of the induced torque. None to
-            apply it at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from
-            that origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
-            Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
-            of `force` and `torque`. Defaults to None.
-        ref: "link_origin" | "link_com", optional
-            The reference frame on which the wrench will be applied. "link_origin" refers to the origin of each link and
-            "link_com" refers to the center of mass of each link. This argument only selects the frame of the input
-            coordinates unless a linear force is applied at the origin of that frame, ie without specifying `pos`.
+            Where the linear force is applied, which sets the moment arm of the induced torque. With `local=True`, an
+            offset from the origin of the `ref` frame, so the point follows each link as it moves; otherwise a world
+            position. None applies the force at the origin of the `ref` frame. Defaults to None.
+        ref: gs.link_ref_frame, optional
+            The reference frame: the origin of each link ('link_origin'), or its center of mass ('link_COM'). It fixes
+            where the linear force acts when `pos` is None, and the axes of the input coordinates when `local=True`.
+            Defaults to 'link_origin'.
         local: bool, optional
-            Whether the wrench and the application point are expressed in the local coordinates associated with the
-            reference frame instead of world frame.
+            Whether `force`, `torque` and `pos` are expressed in the coordinates of the `ref` frame rather than the
+            world frame. Defaults to False.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
         self._solver.apply_links_external_wrench(force, torque, links_idx, envs_idx, pos=pos, ref=ref, local=local)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -9,16 +9,13 @@ import numpy as np
 import torch
 import trimesh
 
-import quadrants as qd
-
 import genesis as gs
 from genesis.engine.materials.base import Material
 from genesis.engine.mesh import InertialProperties
 from genesis.engine.states.entities import RigidEntityState
 from genesis.options.morphs import Morph
 from genesis.options.surfaces import Surface
-from genesis.typing import LinkRefFrameType, UnitVec4FType, Vec3FType
-from genesis.utils import array_class
+from genesis.typing import LinkFrameType, LinkRefFrameType, UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
 from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
@@ -3496,7 +3493,7 @@ class RigidEntity(KinematicEntity):
         return self._solver.get_links_pos(links_idx, envs_idx, ref=ref, relative=relative)
 
     @gs.assert_built
-    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, ref: LinkRefFrameType = "link_origin"):
+    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, ref: LinkFrameType = "link_origin"):
         """
         Returns linear velocity of all the entity's links expressed at a given reference position in world coordinates.
 
@@ -3506,7 +3503,7 @@ class RigidEntity(KinematicEntity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com"
+        ref: "link_origin" | "link_com"
             The reference point being used to expressed the velocity of each link.
 
         Returns
@@ -3528,74 +3525,47 @@ class RigidEntity(KinematicEntity):
         return self._solver.get_links_acc_ang(links_idx, envs_idx)
 
     @gs.assert_built
-    def apply_links_external_force(
+    def apply_links_external_wrench(
         self,
-        force,
+        force=None,
+        torque=None,
         links_idx_local=None,
         envs_idx=None,
         *,
         pos=None,
-        ref: LinkRefFrameType = "link_origin",
+        ref: LinkFrameType = "link_origin",
         local: bool = False,
     ):
         """
-        Apply external linear force over one simulation step on a set of the entity's links.
+        Apply an external wrench over one simulation step on a set of the entity's links.
 
         Parameters
         ----------
-        force : array_like
-            The force to apply.
+        force : None | array_like, optional
+            The linear force to apply. None for a pure torque. Defaults to None.
+        torque : None | array_like, optional
+            The torque to apply, on top of the moment induced by the linear force. None for a pure force. Defaults to
+            None.
         links_idx_local : None | array_like, optional
             The indices of the links. None to specify all the entity's links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         pos : None | array_like, optional
-            The point at which the force is applied, which sets the moment arm of the induced torque. None to apply it
-            at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from that
-            origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
+            The point at which the linear force is applied, which sets the moment arm of the induced torque. None to
+            apply it at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from
+            that origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
             Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
-            of `force`. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of each
-            link, "link_com" refers to the center of mass of each link, and "root_com" refers to the center of mass of
-            the entire kinematic tree to which a link belongs.
+            of `force` and `torque`. Defaults to None.
+        ref: "link_origin" | "link_com", optional
+            The reference frame on which the wrench will be applied. "link_origin" refers to the origin of each link and
+            "link_com" refers to the center of mass of each link. This argument only selects the frame of the input
+            coordinates unless a linear force is applied at the origin of that frame, ie without specifying `pos`.
         local: bool, optional
-            Whether the force and the application point are expressed in the local coordinates associated with the
-            reference frame instead of world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+            Whether the wrench and the application point are expressed in the local coordinates associated with the
+            reference frame instead of world frame.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        self._solver.apply_links_external_force(force, links_idx, envs_idx, pos=pos, ref=ref, local=local)
-
-    @gs.assert_built
-    def apply_links_external_torque(
-        self,
-        torque,
-        links_idx_local=None,
-        envs_idx=None,
-        *,
-        ref: LinkRefFrameType = "link_origin",
-        local: bool = False,
-    ):
-        """
-        Apply external torque over one simulation step on a set of the entity's links.
-
-        Parameters
-        ----------
-        torque : array_like
-            The torque to apply.
-        links_idx_local : None | array_like, optional
-            The indices of the links. None to specify all the entity's links. Defaults to None.
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame whose coordinates the torque is expressed in. This argument has no effect unless
-            `local=True`, a torque being a couple that acts the same wherever it is attached.
-        local: bool, optional
-            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
-            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
-        """
-        links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        self._solver.apply_links_external_torque(torque, links_idx, envs_idx, ref=ref, local=local)
+        self._solver.apply_links_external_wrench(force, torque, links_idx, envs_idx, pos=pos, ref=ref, local=local)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------- links mass properties --------------------------------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -3526,6 +3526,76 @@ class RigidEntity(KinematicEntity):
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
         return self._solver.get_links_acc_ang(links_idx, envs_idx)
 
+    @gs.assert_built
+    def apply_links_external_force(
+        self,
+        force,
+        links_idx_local=None,
+        envs_idx=None,
+        *,
+        pos=None,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        local: bool = False,
+    ):
+        """
+        Apply external linear force over one simulation step on a set of the entity's links.
+
+        Parameters
+        ----------
+        force : array_like
+            The force to apply.
+        links_idx_local : None | array_like, optional
+            The indices of the links. None to specify all the entity's links. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        pos : None | array_like, optional
+            The point at which the force is applied, which sets the moment arm of the induced torque. None to apply it
+            at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from that
+            origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
+            Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
+            of `force`. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com", optional
+            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of each
+            link, "link_com" refers to the center of mass of each link, and "root_com" refers to the center of mass of
+            the entire kinematic tree to which a link belongs.
+        local: bool, optional
+            Whether the force and the application point are expressed in the local coordinates associated with the
+            reference frame instead of world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        """
+        links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
+        self._solver.apply_links_external_force(force, links_idx, envs_idx, pos=pos, ref=ref, local=local)
+
+    @gs.assert_built
+    def apply_links_external_torque(
+        self,
+        torque,
+        links_idx_local=None,
+        envs_idx=None,
+        *,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        local: bool = False,
+    ):
+        """
+        Apply external torque over one simulation step on a set of the entity's links.
+
+        Parameters
+        ----------
+        torque : array_like
+            The torque to apply.
+        links_idx_local : None | array_like, optional
+            The indices of the links. None to specify all the entity's links. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com", optional
+            The reference frame whose coordinates the torque is expressed in. This argument has no effect unless
+            `local=True`, a torque being a couple that acts the same wherever it is attached.
+        local: bool, optional
+            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
+            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        """
+        links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
+        self._solver.apply_links_external_torque(torque, links_idx, envs_idx, ref=ref, local=local)
+
     # ------------------------------------------------------------------------------------
     # ----------------------------- links mass properties --------------------------------
     # ------------------------------------------------------------------------------------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -3507,6 +3507,7 @@ class RigidEntity(KinematicEntity):
         ref: gs.link_ref_frame, optional
             The reference point used to express the velocity of each link: its origin ('link_origin') or its center of
             mass ('link_COM'). Defaults to 'link_origin'.
+
         Returns
         -------
         vel : torch.Tensor, shape (n_links, 3) or (n_envs, n_links, 3)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1,27 +1,30 @@
 import inspect
 import math
 import os
-from itertools import chain
-from typing import TYPE_CHECKING, Literal, Any, Hashable
 from functools import wraps
+from itertools import chain
+from typing import TYPE_CHECKING, Any, Hashable
 
 import numpy as np
 import torch
 import trimesh
 
+import quadrants as qd
+
 import genesis as gs
 from genesis.engine.materials.base import Material
 from genesis.engine.mesh import InertialProperties
+from genesis.engine.states.entities import RigidEntityState
 from genesis.options.morphs import Morph
 from genesis.options.surfaces import Surface
+from genesis.typing import LinkRefFrameType, UnitVec4FType, Vec3FType
+from genesis.utils import array_class
 from genesis.utils import geom as gu
 from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
 from genesis.utils import terrain as tu
 from genesis.utils import urdf as uu
 from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_numpy, qd_to_torch, tensor_to_array
-from genesis.typing import UnitVec4FType, Vec3FType
-from genesis.engine.states.entities import RigidEntityState
 
 from ..base_entity import Entity
 from .rigid_equality import RigidEquality
@@ -3462,7 +3465,7 @@ class RigidEntity(KinematicEntity):
         links_idx_local=None,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         relative=True,
     ):
         """
@@ -3493,9 +3496,7 @@ class RigidEntity(KinematicEntity):
         return self._solver.get_links_pos(links_idx, envs_idx, ref=ref, relative=relative)
 
     @gs.assert_built
-    def get_links_vel(
-        self, links_idx_local=None, envs_idx=None, *, ref: Literal["link_origin", "link_com"] = "link_origin"
-    ):
+    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, ref: LinkRefFrameType = "link_origin"):
         """
         Returns linear velocity of all the entity's links expressed at a given reference position in world coordinates.
 
@@ -3505,7 +3506,7 @@ class RigidEntity(KinematicEntity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com"
+        ref: "link_origin" | "link_com" | "root_com"
             The reference point being used to expressed the velocity of each link.
 
         Returns
@@ -3534,7 +3535,7 @@ class RigidEntity(KinematicEntity):
         envs_idx=None,
         *,
         pos=None,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         local: bool = False,
     ):
         """
@@ -3572,7 +3573,7 @@ class RigidEntity(KinematicEntity):
         links_idx_local=None,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         local: bool = False,
     ):
         """

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -1,5 +1,5 @@
 from itertools import starmap
-from typing import TYPE_CHECKING, Literal, NamedTuple, Sequence
+from typing import TYPE_CHECKING, NamedTuple, Sequence
 
 import numpy as np
 import torch
@@ -7,7 +7,7 @@ import torch
 import genesis as gs
 from genesis.engine.mesh import InertialProperties
 from genesis.repr_base import RBC
-from genesis.typing import LaxPositiveFArrayType, Matrix3x3Type, UnitVec4FType, Vec3FType
+from genesis.typing import LaxPositiveFArrayType, LinkRefFrameType, Matrix3x3Type, UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
 from genesis.utils.misc import DeprecationError, qd_to_torch, tensor_to_array
 
@@ -992,7 +992,7 @@ class RigidLink(KinematicLink):
         envs_idx=None,
         *,
         pos=None,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         local: bool = False,
     ):
         """
@@ -1026,7 +1026,7 @@ class RigidLink(KinematicLink):
         torque,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         local: bool = False,
     ):
         """

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -5,9 +5,10 @@ import numpy as np
 import torch
 
 import genesis as gs
+from genesis.constants import link_ref_frame
 from genesis.engine.mesh import InertialProperties
 from genesis.repr_base import RBC
-from genesis.typing import LaxPositiveFArrayType, LinkFrameType, Matrix3x3Type, UnitVec4FType, Vec3FType
+from genesis.typing import LaxPositiveFArrayType, Matrix3x3Type, UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
 from genesis.utils.misc import DeprecationError, qd_to_torch, tensor_to_array
 
@@ -993,7 +994,7 @@ class RigidLink(KinematicLink):
         envs_idx=None,
         *,
         pos=None,
-        ref: LinkFrameType = "link_origin",
+        ref: link_ref_frame = link_ref_frame.link_origin,
         local: bool = False,
     ):
         """
@@ -1004,41 +1005,40 @@ class RigidLink(KinematicLink):
         force : None | array_like, optional
             The linear force to apply. None for a pure torque. Defaults to None.
         torque : None | array_like, optional
-            The torque to apply, on top of the moment induced by the linear force. None for a pure force. Defaults to
-            None.
+            The torque to apply, on top of the moment induced by the linear force. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         pos : None | array_like, optional
-            The point at which the linear force is applied, which sets the moment arm of the induced torque. None to
-            apply it at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from
-            that origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
-            Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
-            of `force` and `torque`. Defaults to None.
-        ref: "link_origin" | "link_com", optional
-            The reference frame on which the wrench will be applied. "link_origin" refers to the origin of the link and
-            "link_com" refers to the center of mass of the link. This argument only selects the frame of the input
-            coordinates unless a linear force is applied at the origin of that frame, ie without specifying `pos`.
+            Where the linear force is applied, which sets the moment arm of the induced torque. With `local=True`, an
+            offset from the origin of the `ref` frame, so the point follows the link as it moves; otherwise a world
+            position. None applies the force at the origin of the `ref` frame. Defaults to None.
+        ref: gs.link_ref_frame, optional
+            The reference frame: the origin of the link ('link_origin'), or its center of mass ('link_COM'). It fixes
+            where the linear force acts when `pos` is None, and the axes of the input coordinates when `local=True`.
+            Defaults to 'link_origin'.
         local: bool, optional
-            Whether the wrench and the application point are expressed in the local coordinates associated with the
-            reference frame instead of world frame.
+            Whether `force`, `torque` and `pos` are expressed in the coordinates of the `ref` frame rather than the
+            world frame. Defaults to False.
         """
         self._solver.apply_links_external_wrench(force, torque, self._idx, envs_idx, pos=pos, ref=ref, local=local)
 
     def apply_external_force(
-        self, force, envs_idx=None, *, pos=None, ref: LinkFrameType = "link_origin", local: bool = False
+        self, force, envs_idx=None, *, pos=None, ref: link_ref_frame = link_ref_frame.link_origin, local: bool = False
     ):
         """
         Apply an external linear force over one simulation step on the link.
 
-        See `RigidLink.apply_external_wrench` documentation for details about the arguments.
+        Refer to `RigidLink.apply_external_wrench` for details.
         """
         self.apply_external_wrench(force, envs_idx=envs_idx, pos=pos, ref=ref, local=local)
 
-    def apply_external_torque(self, torque, envs_idx=None, *, ref: LinkFrameType = "link_origin", local: bool = False):
+    def apply_external_torque(
+        self, torque, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin, local: bool = False
+    ):
         """
         Apply an external torque over one simulation step on the link.
 
-        See `RigidLink.apply_external_wrench` documentation for details about the arguments.
+        Refer to `RigidLink.apply_external_wrench` for details.
         """
         self.apply_external_wrench(torque=torque, envs_idx=envs_idx, ref=ref, local=local)
 

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -1,5 +1,5 @@
 from itertools import starmap
-from typing import TYPE_CHECKING, NamedTuple, Sequence
+from typing import TYPE_CHECKING, Literal, NamedTuple, Sequence
 
 import numpy as np
 import torch
@@ -984,6 +984,68 @@ class RigidLink(KinematicLink):
 
         verts = self.get_verts()
         return torch.stack((verts.min(dim=-2).values, verts.max(dim=-2).values), dim=-2)
+
+    @gs.assert_built
+    def apply_external_force(
+        self,
+        force,
+        envs_idx=None,
+        *,
+        pos=None,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        local: bool = False,
+    ):
+        """
+        Apply external linear force over one simulation step on the link.
+
+        Parameters
+        ----------
+        force : array_like
+            The force to apply.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        pos : None | array_like, optional
+            The point at which the force is applied, which sets the moment arm of the induced torque. None to apply it
+            at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from that
+            origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
+            Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
+            of `force`. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com", optional
+            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of the
+            link, "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
+            the entire kinematic tree to which the link belongs.
+        local: bool, optional
+            Whether the force and the application point are expressed in the local coordinates associated with the
+            reference frame instead of world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        """
+        self._solver.apply_links_external_force(force, (self._idx,), envs_idx, pos=pos, ref=ref, local=local)
+
+    @gs.assert_built
+    def apply_external_torque(
+        self,
+        torque,
+        envs_idx=None,
+        *,
+        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        local: bool = False,
+    ):
+        """
+        Apply external torque over one simulation step on the link.
+
+        Parameters
+        ----------
+        torque : array_like
+            The torque to apply.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        ref: "link_origin" | "link_com" | "root_com", optional
+            The reference frame whose coordinates the torque is expressed in. This argument has no effect unless
+            `local=True`, a torque being a couple that acts the same wherever it is attached.
+        local: bool, optional
+            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
+            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        """
+        self._solver.apply_links_external_torque(torque, (self._idx,), envs_idx, ref=ref, local=local)
 
     @gs.assert_built
     def set_mass(self, mass: LaxPositiveFArrayType):

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -7,7 +7,7 @@ import torch
 import genesis as gs
 from genesis.engine.mesh import InertialProperties
 from genesis.repr_base import RBC
-from genesis.typing import LaxPositiveFArrayType, LinkRefFrameType, Matrix3x3Type, UnitVec4FType, Vec3FType
+from genesis.typing import LaxPositiveFArrayType, LinkFrameType, Matrix3x3Type, UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
 from genesis.utils.misc import DeprecationError, qd_to_torch, tensor_to_array
 
@@ -986,66 +986,61 @@ class RigidLink(KinematicLink):
         return torch.stack((verts.min(dim=-2).values, verts.max(dim=-2).values), dim=-2)
 
     @gs.assert_built
-    def apply_external_force(
+    def apply_external_wrench(
         self,
-        force,
+        force=None,
+        torque=None,
         envs_idx=None,
         *,
         pos=None,
-        ref: LinkRefFrameType = "link_origin",
+        ref: LinkFrameType = "link_origin",
         local: bool = False,
     ):
         """
-        Apply external linear force over one simulation step on the link.
+        Apply an external wrench over one simulation step on the link.
 
         Parameters
         ----------
-        force : array_like
-            The force to apply.
+        force : None | array_like, optional
+            The linear force to apply. None for a pure torque. Defaults to None.
+        torque : None | array_like, optional
+            The torque to apply, on top of the moment induced by the linear force. None for a pure force. Defaults to
+            None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         pos : None | array_like, optional
-            The point at which the force is applied, which sets the moment arm of the induced torque. None to apply it
-            at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from that
-            origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
+            The point at which the linear force is applied, which sets the moment arm of the induced torque. None to
+            apply it at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from
+            that origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
             Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
-            of `force`. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of the
-            link, "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
-            the entire kinematic tree to which the link belongs.
+            of `force` and `torque`. Defaults to None.
+        ref: "link_origin" | "link_com", optional
+            The reference frame on which the wrench will be applied. "link_origin" refers to the origin of the link and
+            "link_com" refers to the center of mass of the link. This argument only selects the frame of the input
+            coordinates unless a linear force is applied at the origin of that frame, ie without specifying `pos`.
         local: bool, optional
-            Whether the force and the application point are expressed in the local coordinates associated with the
-            reference frame instead of world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+            Whether the wrench and the application point are expressed in the local coordinates associated with the
+            reference frame instead of world frame.
         """
-        self._solver.apply_links_external_force(force, (self._idx,), envs_idx, pos=pos, ref=ref, local=local)
+        self._solver.apply_links_external_wrench(force, torque, self._idx, envs_idx, pos=pos, ref=ref, local=local)
 
-    @gs.assert_built
-    def apply_external_torque(
-        self,
-        torque,
-        envs_idx=None,
-        *,
-        ref: LinkRefFrameType = "link_origin",
-        local: bool = False,
+    def apply_external_force(
+        self, force, envs_idx=None, *, pos=None, ref: LinkFrameType = "link_origin", local: bool = False
     ):
         """
-        Apply external torque over one simulation step on the link.
+        Apply an external linear force over one simulation step on the link.
 
-        Parameters
-        ----------
-        torque : array_like
-            The torque to apply.
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame whose coordinates the torque is expressed in. This argument has no effect unless
-            `local=True`, a torque being a couple that acts the same wherever it is attached.
-        local: bool, optional
-            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
-            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+        See `RigidLink.apply_external_wrench` documentation for details about the arguments.
         """
-        self._solver.apply_links_external_torque(torque, (self._idx,), envs_idx, ref=ref, local=local)
+        self.apply_external_wrench(force, envs_idx=envs_idx, pos=pos, ref=ref, local=local)
+
+    def apply_external_torque(self, torque, envs_idx=None, *, ref: LinkFrameType = "link_origin", local: bool = False):
+        """
+        Apply an external torque over one simulation step on the link.
+
+        See `RigidLink.apply_external_wrench` documentation for details about the arguments.
+        """
+        self.apply_external_wrench(torque=torque, envs_idx=envs_idx, ref=ref, local=local)
 
     @gs.assert_built
     def set_mass(self, mass: LaxPositiveFArrayType):

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1157,9 +1157,9 @@ class KinematicSolver(Solver):
         )
         assert _tensor is not None
         tensor = _tensor[None] if self.n_envs == 0 else _tensor
-        # The frame is passed as a plain int, see 'RigidSolver._convert_ref_to_frame'.
+        # The frame is passed as a plain int, see 'RigidSolver._sanitize_ref_frame'.
         kernel_get_links_vel(
-            links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=int(gs.LINK_REF_FRAME.LINK_ORIGIN)
+            links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=int(gs.link_ref_frame.link_origin)
         )
         return _tensor
 

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1157,7 +1157,10 @@ class KinematicSolver(Solver):
         )
         assert _tensor is not None
         tensor = _tensor[None] if self.n_envs == 0 else _tensor
-        kernel_get_links_vel(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=2)
+        # The frame is passed as a plain int, see 'RigidSolver._convert_ref_to_frame'.
+        kernel_get_links_vel(
+            links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=int(gs.LINK_REF_FRAME.LINK_ORIGIN)
+        )
         return _tensor
 
     def get_links_ang(self, links_idx=None, envs_idx=None):

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1010,11 +1010,11 @@ def kernel_get_links_vel(
         vel = dyn_state.links.cd_vel[links_idx[i_l_], envs_idx[i_b_]]  # entity's CoM
 
         # Translate to get the velocity expressed at a different position if necessary link-position
-        if qd.static(ref == gs.LINK_REF_FRAME.LINK_COM):
+        if qd.static(ref == gs.link_ref_frame.link_COM):
             vel = vel + dyn_state.links.cd_ang[links_idx[i_l_], envs_idx[i_b_]].cross(
                 dyn_state.links.i_pos[links_idx[i_l_], envs_idx[i_b_]]
             )
-        if qd.static(ref == gs.LINK_REF_FRAME.LINK_ORIGIN):
+        if qd.static(ref == gs.link_ref_frame.link_origin):
             vel = vel + dyn_state.links.cd_ang[links_idx[i_l_], envs_idx[i_b_]].cross(
                 dyn_state.links.pos[links_idx[i_l_], envs_idx[i_b_]]
                 - dyn_state.links.root_COM[links_idx[i_l_], envs_idx[i_b_]]
@@ -1175,7 +1175,7 @@ def kernel_set_drone_rpm(
                 force,
                 torque,
                 dyn_state,
-                ref=gs.LINK_REF_FRAME.LINK_COM,
+                ref=gs.link_ref_frame.link_COM,
                 local=True,
                 has_pos=False,
             )

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1168,8 +1168,8 @@ def kernel_set_drone_rpm(
             if invert:
                 torque = -torque
 
-            func_apply_link_external_force(i_l, i_b, qd.Vector.zero(gs.qd_float, 3), force, dyn_state, 1, 1, 0)
-            func_apply_link_external_torque(i_l, i_b, torque, dyn_state, 1, 1)
+            func_apply_link_external_force(i_l, i_b, qd.Vector.zero(gs.qd_float, 3), force, dyn_state, 1, True, False)
+            func_apply_link_external_torque(i_l, i_b, torque, dyn_state, 1, True)
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1168,7 +1168,7 @@ def kernel_set_drone_rpm(
             if invert:
                 torque = -torque
 
-            func_apply_link_external_force(i_l, i_b, force, dyn_state, 1, 1)
+            func_apply_link_external_force(i_l, i_b, qd.Vector.zero(gs.qd_float, 3), force, dyn_state, 1, 1, 0)
             func_apply_link_external_torque(i_l, i_b, torque, dyn_state, 1, 1)
 
 

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -17,7 +17,7 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 
-from .misc import func_apply_link_external_force, func_apply_link_external_torque, func_wakeup_island
+from .misc import func_apply_link_external_wrench, func_wakeup_island
 
 
 class ConstraintType(IntEnum):
@@ -1010,11 +1010,11 @@ def kernel_get_links_vel(
         vel = dyn_state.links.cd_vel[links_idx[i_l_], envs_idx[i_b_]]  # entity's CoM
 
         # Translate to get the velocity expressed at a different position if necessary link-position
-        if qd.static(ref == 1):  # link's CoM
+        if qd.static(ref == gs.LINK_REF_FRAME.LINK_COM):
             vel = vel + dyn_state.links.cd_ang[links_idx[i_l_], envs_idx[i_b_]].cross(
                 dyn_state.links.i_pos[links_idx[i_l_], envs_idx[i_b_]]
             )
-        if qd.static(ref == 2):  # link's origin
+        if qd.static(ref == gs.LINK_REF_FRAME.LINK_ORIGIN):
             vel = vel + dyn_state.links.cd_ang[links_idx[i_l_], envs_idx[i_b_]].cross(
                 dyn_state.links.pos[links_idx[i_l_], envs_idx[i_b_]]
                 - dyn_state.links.root_COM[links_idx[i_l_], envs_idx[i_b_]]
@@ -1168,8 +1168,17 @@ def kernel_set_drone_rpm(
             if invert:
                 torque = -torque
 
-            func_apply_link_external_force(i_l, i_b, qd.Vector.zero(gs.qd_float, 3), force, dyn_state, 1, True, False)
-            func_apply_link_external_torque(i_l, i_b, torque, dyn_state, 1, True)
+            func_apply_link_external_wrench(
+                i_l,
+                i_b,
+                qd.Vector.zero(gs.qd_float, 3),
+                force,
+                torque,
+                dyn_state,
+                ref=gs.LINK_REF_FRAME.LINK_COM,
+                local=True,
+                has_pos=False,
+            )
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -744,30 +744,10 @@ def kernel_init_equality_fields(
 
 
 @qd.kernel(fastcache=True)
-def kernel_apply_links_external_force(
+def kernel_apply_links_external_wrench(
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
-    pos: qd.types.ndarray(),
     force: qd.types.ndarray(),
-    dyn_state: array_class.DynState,
-    rigid_config: qd.template(),
-    ref: qd.template(),
-    local: qd.template(),
-    has_pos: qd.template(),
-):
-    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
-    for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-        pos_i = qd.Vector.zero(gs.qd_float, 3)
-        if qd.static(has_pos):
-            pos_i = qd.Vector([pos[i_b_, i_l_, 0], pos[i_b_, i_l_, 1], pos[i_b_, i_l_, 2]], dt=gs.qd_float)
-        force_i = qd.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.qd_float)
-        func_apply_link_external_force(links_idx[i_l_], envs_idx[i_b_], pos_i, force_i, dyn_state, ref, local, has_pos)
-
-
-@qd.kernel(fastcache=True)
-def kernel_apply_links_external_torque(
-    links_idx: qd.types.ndarray(),
-    envs_idx: qd.types.ndarray(),
     torque: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     rigid_config: qd.template(),
@@ -776,8 +756,41 @@ def kernel_apply_links_external_torque(
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
+        force_i = qd.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.qd_float)
         torque_i = qd.Vector([torque[i_b_, i_l_, 0], torque[i_b_, i_l_, 1], torque[i_b_, i_l_, 2]], dt=gs.qd_float)
-        func_apply_link_external_torque(links_idx[i_l_], envs_idx[i_b_], torque_i, dyn_state, ref, local)
+        func_apply_link_external_wrench(
+            links_idx[i_l_],
+            envs_idx[i_b_],
+            qd.Vector.zero(gs.qd_float, 3),
+            force_i,
+            torque_i,
+            dyn_state,
+            ref,
+            local,
+            has_pos=False,
+        )
+
+
+@qd.kernel(fastcache=True)
+def kernel_apply_links_external_wrench_at_pos(
+    links_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    pos: qd.types.ndarray(),
+    force: qd.types.ndarray(),
+    torque: qd.types.ndarray(),
+    dyn_state: array_class.DynState,
+    rigid_config: qd.template(),
+    ref: qd.template(),
+    local: qd.template(),
+):
+    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
+        pos_i = qd.Vector([pos[i_b_, i_l_, 0], pos[i_b_, i_l_, 1], pos[i_b_, i_l_, 2]], dt=gs.qd_float)
+        force_i = qd.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.qd_float)
+        torque_i = qd.Vector([torque[i_b_, i_l_, 0], torque[i_b_, i_l_, 1], torque[i_b_, i_l_, 2]], dt=gs.qd_float)
+        func_apply_link_external_wrench(
+            links_idx[i_l_], envs_idx[i_b_], pos_i, force_i, torque_i, dyn_state, ref, local, has_pos=True
+        )
 
 
 @qd.func
@@ -821,30 +834,36 @@ def kernel_wakeup_coupled_links(
 
 
 @qd.func
-def func_apply_link_external_force(
+def func_apply_link_external_wrench(
     link_idx,
     env_idx,
     pos,
     force,
+    torque,
     dyn_state: array_class.DynState,
     ref: qd.template(),
     local: qd.template(),
     has_pos: qd.template(),
 ):
-    # The generalized force is expressed about the root COM, so every case reduces to the lever arm going from the root
-    # COM to the point where the force is applied.
+    # The generalized force is expressed about the root COM, so the linear force contributes the moment of the lever arm
+    # going from the root COM to the point where it is applied, while the torque acts as a couple wherever it is
+    # attached.
     arm = qd.Vector.zero(gs.qd_float, 3)
-    if qd.static(ref == 1):  # link's CoM
+    if qd.static(ref == gs.LINK_REF_FRAME.LINK_COM):
         if qd.static(local):
-            force = gu.qd_transform_by_quat(force, dyn_state.links.i_quat[link_idx, env_idx])
+            i_quat = dyn_state.links.i_quat[link_idx, env_idx]
+            force = gu.qd_transform_by_quat(force, i_quat)
+            torque = gu.qd_transform_by_quat(torque, i_quat)
             if qd.static(has_pos):
-                pos = gu.qd_transform_by_quat(pos, dyn_state.links.i_quat[link_idx, env_idx])
+                pos = gu.qd_transform_by_quat(pos, i_quat)
         arm = dyn_state.links.i_pos[link_idx, env_idx]
-    if qd.static(ref == 2):  # link's origin
+    if qd.static(ref == gs.LINK_REF_FRAME.LINK_ORIGIN):
         if qd.static(local):
-            force = gu.qd_transform_by_quat(force, dyn_state.links.quat[link_idx, env_idx])
+            quat = dyn_state.links.quat[link_idx, env_idx]
+            force = gu.qd_transform_by_quat(force, quat)
+            torque = gu.qd_transform_by_quat(torque, quat)
             if qd.static(has_pos):
-                pos = gu.qd_transform_by_quat(pos, dyn_state.links.quat[link_idx, env_idx])
+                pos = gu.qd_transform_by_quat(pos, quat)
         arm = dyn_state.links.pos[link_idx, env_idx] - dyn_state.links.root_COM[link_idx, env_idx]
     if qd.static(has_pos):
         # A local point is an offset from the reference frame origin, whose own arm has just been computed, while a
@@ -855,24 +874,7 @@ def func_apply_link_external_force(
             arm = pos - dyn_state.links.root_COM[link_idx, env_idx]
 
     dyn_state.links.cfrc_applied_vel[link_idx, env_idx] -= force
-    dyn_state.links.cfrc_applied_ang[link_idx, env_idx] -= arm.cross(force)
-
-
-@qd.func
-def func_apply_external_torque(self, link_idx, env_idx, torque):
-    self.dyn_state.links.cfrc_applied_ang[link_idx, env_idx] -= torque
-
-
-@qd.func
-def func_apply_link_external_torque(
-    link_idx, env_idx, torque, dyn_state: array_class.DynState, ref: qd.template(), local: qd.template()
-):
-    if qd.static(ref == 1 and local == 1):  # link's CoM
-        torque = gu.qd_transform_by_quat(torque, dyn_state.links.i_quat[link_idx, env_idx])
-    if qd.static(ref == 2 and local == 1):  # link's origin
-        torque = gu.qd_transform_by_quat(torque, dyn_state.links.quat[link_idx, env_idx])
-
-    dyn_state.links.cfrc_applied_ang[link_idx, env_idx] -= torque
+    dyn_state.links.cfrc_applied_ang[link_idx, env_idx] -= torque + arm.cross(force)
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -747,8 +747,8 @@ def kernel_init_equality_fields(
 def kernel_apply_links_external_force(
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
-    force: qd.types.ndarray(),
     pos: qd.types.ndarray(),
+    force: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     rigid_config: qd.template(),
     ref: qd.template(),
@@ -757,10 +757,10 @@ def kernel_apply_links_external_force(
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-        force_i = qd.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.qd_float)
         pos_i = qd.Vector.zero(gs.qd_float, 3)
         if qd.static(has_pos):
             pos_i = qd.Vector([pos[i_b_, i_l_, 0], pos[i_b_, i_l_, 1], pos[i_b_, i_l_, 2]], dt=gs.qd_float)
+        force_i = qd.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.qd_float)
         func_apply_link_external_force(links_idx[i_l_], envs_idx[i_b_], pos_i, force_i, dyn_state, ref, local, has_pos)
 
 

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -845,11 +845,10 @@ def func_apply_link_external_wrench(
     local: qd.template(),
     has_pos: qd.template(),
 ):
-    # The generalized force is expressed about the root COM, so the linear force contributes the moment of the lever arm
-    # going from the root COM to the point where it is applied, while the torque acts as a couple wherever it is
-    # attached.
+    # The generalized force is expressed about the root COM, so a linear force adds the moment of the arm going from
+    # the root COM to its application point, while a torque is a free couple.
     arm = qd.Vector.zero(gs.qd_float, 3)
-    if qd.static(ref == gs.LINK_REF_FRAME.LINK_COM):
+    if qd.static(ref == gs.link_ref_frame.link_COM):
         if qd.static(local):
             i_quat = dyn_state.links.i_quat[link_idx, env_idx]
             force = gu.qd_transform_by_quat(force, i_quat)
@@ -857,7 +856,7 @@ def func_apply_link_external_wrench(
             if qd.static(has_pos):
                 pos = gu.qd_transform_by_quat(pos, i_quat)
         arm = dyn_state.links.i_pos[link_idx, env_idx]
-    if qd.static(ref == gs.LINK_REF_FRAME.LINK_ORIGIN):
+    if qd.static(ref == gs.link_ref_frame.link_origin):
         if qd.static(local):
             quat = dyn_state.links.quat[link_idx, env_idx]
             force = gu.qd_transform_by_quat(force, quat)

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -748,15 +748,20 @@ def kernel_apply_links_external_force(
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
     force: qd.types.ndarray(),
+    pos: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     rigid_config: qd.template(),
     ref: qd.template(),
     local: qd.template(),
+    has_pos: qd.template(),
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
         force_i = qd.Vector([force[i_b_, i_l_, 0], force[i_b_, i_l_, 1], force[i_b_, i_l_, 2]], dt=gs.qd_float)
-        func_apply_link_external_force(links_idx[i_l_], envs_idx[i_b_], force_i, dyn_state, ref, local)
+        pos_i = qd.Vector.zero(gs.qd_float, 3)
+        if qd.static(has_pos):
+            pos_i = qd.Vector([pos[i_b_, i_l_, 0], pos[i_b_, i_l_, 1], pos[i_b_, i_l_, 2]], dt=gs.qd_float)
+        func_apply_link_external_force(links_idx[i_l_], envs_idx[i_b_], pos_i, force_i, dyn_state, ref, local, has_pos)
 
 
 @qd.kernel(fastcache=True)
@@ -817,20 +822,40 @@ def kernel_wakeup_coupled_links(
 
 @qd.func
 def func_apply_link_external_force(
-    link_idx, env_idx, force, dyn_state: array_class.DynState, ref: qd.template(), local: qd.template()
+    link_idx,
+    env_idx,
+    pos,
+    force,
+    dyn_state: array_class.DynState,
+    ref: qd.template(),
+    local: qd.template(),
+    has_pos: qd.template(),
 ):
-    torque = qd.Vector.zero(gs.qd_float, 3)
+    # The generalized force is expressed about the root COM, so every case reduces to the lever arm going from the root
+    # COM to the point where the force is applied.
+    arm = qd.Vector.zero(gs.qd_float, 3)
     if qd.static(ref == 1):  # link's CoM
         if qd.static(local):
             force = gu.qd_transform_by_quat(force, dyn_state.links.i_quat[link_idx, env_idx])
-        torque = dyn_state.links.i_pos[link_idx, env_idx].cross(force)
+            if qd.static(has_pos):
+                pos = gu.qd_transform_by_quat(pos, dyn_state.links.i_quat[link_idx, env_idx])
+        arm = dyn_state.links.i_pos[link_idx, env_idx]
     if qd.static(ref == 2):  # link's origin
         if qd.static(local):
-            force = gu.qd_transform_by_quat(force, dyn_state.links.i_quat[link_idx, env_idx])
-        torque = (dyn_state.links.pos[link_idx, env_idx] - dyn_state.links.root_COM[link_idx, env_idx]).cross(force)
+            force = gu.qd_transform_by_quat(force, dyn_state.links.quat[link_idx, env_idx])
+            if qd.static(has_pos):
+                pos = gu.qd_transform_by_quat(pos, dyn_state.links.quat[link_idx, env_idx])
+        arm = dyn_state.links.pos[link_idx, env_idx] - dyn_state.links.root_COM[link_idx, env_idx]
+    if qd.static(has_pos):
+        # A local point is an offset from the reference frame origin, whose own arm has just been computed, while a
+        # world point already locates the application point and makes the reference frame irrelevant.
+        if qd.static(local):
+            arm = arm + pos
+        else:
+            arm = pos - dyn_state.links.root_COM[link_idx, env_idx]
 
     dyn_state.links.cfrc_applied_vel[link_idx, env_idx] -= force
-    dyn_state.links.cfrc_applied_ang[link_idx, env_idx] -= torque
+    dyn_state.links.cfrc_applied_ang[link_idx, env_idx] -= arm.cross(force)
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -15,7 +15,7 @@ from genesis.engine.entities import DroneEntity, RigidEntity
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.states import QueriedStates, RigidSolverState
 from genesis.options.solvers import RigidOptions
-from genesis.typing import LinkRefFrameType
+from genesis.typing import LinkFrameType, LinkRefFrameType
 from genesis.utils.misc import (
     DeprecationError,
     assign_indexed_tensor,
@@ -45,17 +45,14 @@ from .constraint.backward import (
 from .abd.misc import (
     func_add_safe_backward,
     func_apply_coupling_force,
-    func_apply_external_torque,
-    func_apply_link_external_force,
-    func_apply_link_external_torque,
     func_atomic_add_if,
     func_check_index_range,
     func_clear_external_force,
     func_read_field_if,
     func_write_and_read_field_if,
     func_write_field_if,
-    kernel_apply_links_external_force,
-    kernel_apply_links_external_torque,
+    kernel_apply_links_external_wrench,
+    kernel_apply_links_external_wrench_at_pos,
     kernel_bit_reduction,
     kernel_clear_external_force,
     kernel_init_dof_fields,
@@ -1601,119 +1598,70 @@ class RigidSolver(KinematicSolver):
             envs_idx, self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config, force_update_fixed_geoms
         )
 
-    def apply_links_external_force(
+    def apply_links_external_wrench(
         self,
-        force,
+        force=None,
+        torque=None,
         links_idx=None,
         envs_idx=None,
         *,
         pos=None,
-        ref: LinkRefFrameType = "link_origin",
+        ref: LinkFrameType = "link_origin",
         local: bool = False,
     ):
         """
-        Apply external linear force over one simulation step on a set of links.
+        Apply an external wrench over one simulation step on a set of links.
 
         Parameters
         ----------
-        force : array_like
-            The force to apply.
+        force : None | array_like, optional
+            The linear force to apply. None for a pure torque. Defaults to None.
+        torque : None | array_like, optional
+            The torque to apply, on top of the moment induced by the linear force. None for a pure force. Defaults to
+            None.
         links_idx : None | array_like, optional
-            The indices of the links on which to apply force. None to specify all links. Default to None.
+            The indices of the links on which to apply the wrench. None to specify all links. Default to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         pos : None | array_like, optional
-            The point at which the force is applied, which sets the moment arm of the induced torque. None to apply it
-            at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from that
-            origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
+            The point at which the linear force is applied, which sets the moment arm of the induced torque. None to
+            apply it at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from
+            that origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
             Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
-            of `force`. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame on which the linear force will be applied. "link_origin" refers to the origin of the
-            link, "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
-            the entire kinematic tree to which a link belong (see `get_links_root_COM` for details).
+            of `force` and `torque`. Defaults to None.
+        ref: "link_origin" | "link_com", optional
+            The reference frame on which the wrench will be applied. "link_origin" refers to the origin of the link and
+            "link_com" refers to the center of mass of the link. This argument only selects the frame of the input
+            coordinates unless a linear force is applied at the origin of that frame, ie without specifying `pos`.
         local: bool, optional
-            Whether the force and the application point are expressed in the local coordinates associated with the
-            reference frame instead of world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+            Whether the wrench and the application point are expressed in the local coordinates associated with the
+            reference frame instead of world frame.
         """
-        has_pos = pos is not None
-        if has_pos:
+        if force is None and torque is None:
+            gs.raise_exception("Either 'force' or 'torque' must be specified.")
+        if force is None and pos is not None:
+            gs.raise_exception("'pos' requires 'force', as a torque acts the same wherever it is applied.")
+        ref_frame = self._convert_ref_to_frame(ref, has_root_com=False)
+
+        if pos is not None:
             pos, _, _ = self._sanitize_io_variables(
                 pos, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
             )
-            if self.n_envs == 0:
-                pos = pos[None]
-        force, links_idx, envs_idx = self._sanitize_io_variables(
+        # An absent wrench component contributes nothing, which the kernel spells out as zeros.
+        force = 0.0 if force is None else force
+        torque = 0.0 if torque is None else torque
+        force, _, _ = self._sanitize_io_variables(
             force, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
         )
-        if self.n_envs == 0:
-            force = force[None]
-        if not has_pos:
-            # The kernel cannot fabricate the array it only reads when an application point is provided, so hand it a
-            # zero-length view rather than paying for a fresh allocation on every call.
-            pos = force[:0]
-
-        if ref == "root_com" and local:
-            raise ValueError("'local=True' not compatible with ref='root_com'.")
-        ref_idx = self._convert_ref_to_idx(ref)
-
-        # A force on a sleeping body must revive it, otherwise the input is silently dropped.
-        if self._use_hibernation:
-            kernel_wake_up_entities_by_links(
-                links_idx,
-                envs_idx,
-                self.dyn_state,
-                self.constraint_solver.constraint_state,
-                self.dyn_info,
-                self.rigid_info,
-                self.rigid_config,
-            )
-
-        kernel_apply_links_external_force(
-            links_idx, envs_idx, pos, force, self.dyn_state, self.rigid_config, ref_idx, local, has_pos
-        )
-
-    def apply_links_external_torque(
-        self,
-        torque,
-        links_idx=None,
-        envs_idx=None,
-        *,
-        ref: LinkRefFrameType = "link_origin",
-        local: bool = False,
-    ):
-        """
-        Apply external torque over one simulation step on a set of links.
-
-        Parameters
-        ----------
-        torque : array_like
-            The torque to apply.
-        links_idx : None | array_like, optional
-            The indices of the links on which to apply torque. None to specify all links. Default to None.
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments will be considered. Defaults to None.
-        ref: "link_origin" | "link_com" | "root_com", optional
-            The reference frame on which the torque will be applied. "link_origin" refers to the origin of the link,
-            "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
-            the entire kinematic tree to which a link belong (see `get_links_root_COM` for details). Note that this
-            argument has no effect unless `local=True`, a torque being a couple that acts the same wherever it is
-            attached.
-        local: bool, optional
-            Whether the torque is expressed in the local coordinates associated with the reference frame instead of
-            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
-        """
         torque, links_idx, envs_idx = self._sanitize_io_variables(
             torque, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
         )
         if self.n_envs == 0:
-            torque = torque[None]
+            force, torque = force[None], torque[None]
+            if pos is not None:
+                pos = pos[None]
 
-        if ref == "root_com" and local:
-            raise ValueError("'local=True' not compatible with ref='root_com'.")
-        ref_idx = self._convert_ref_to_idx(ref)
-
-        # A torque on a sleeping body must revive it, otherwise the input is silently dropped.
+        # A wrench on a sleeping body must revive it, otherwise the input is silently dropped.
         if self._use_hibernation:
             kernel_wake_up_entities_by_links(
                 links_idx,
@@ -1725,9 +1673,14 @@ class RigidSolver(KinematicSolver):
                 self.rigid_config,
             )
 
-        kernel_apply_links_external_torque(
-            links_idx, envs_idx, torque, self.dyn_state, self.rigid_config, ref_idx, local
-        )
+        if pos is None:
+            kernel_apply_links_external_wrench(
+                links_idx, envs_idx, force, torque, self.dyn_state, self.rigid_config, ref_frame, local
+            )
+        else:
+            kernel_apply_links_external_wrench_at_pos(
+                links_idx, envs_idx, pos, force, torque, self.dyn_state, self.rigid_config, ref_frame, local
+            )
 
     def substep_pre_coupling(self, f):
         if self.is_active:
@@ -2902,15 +2855,20 @@ class RigidSolver(KinematicSolver):
         return tensor
 
     @staticmethod
-    def _convert_ref_to_idx(ref: LinkRefFrameType):
-        if ref == "root_com":
-            return 0
+    def _convert_ref_to_frame(ref: LinkRefFrameType, *, has_root_com: bool = True) -> int:
+        """Map a user-facing reference frame name onto its 'gs.LINK_REF_FRAME' value.
+
+        The value is returned as a plain int rather than the enum member itself because quadrants' fastcache holds a
+        weak reference to template arguments, which enum members do not support.
+        """
+        if ref == "link_origin":
+            return int(gs.LINK_REF_FRAME.LINK_ORIGIN)
         elif ref == "link_com":
-            return 1
-        elif ref == "link_origin":
-            return 2
-        else:
-            gs.raise_exception("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
+            return int(gs.LINK_REF_FRAME.LINK_COM)
+        elif ref == "root_com" and has_root_com:
+            return int(gs.LINK_REF_FRAME.ROOT_COM)
+        refs = "'link_origin', 'link_com', or 'root_com'" if has_root_com else "'link_origin' or 'link_com'"
+        gs.raise_exception(f"'ref' must be either {refs}.")
 
     def get_links_pos(
         self,
@@ -2925,20 +2883,18 @@ class RigidSolver(KinematicSolver):
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
             )
 
-        ref_idx = self._convert_ref_to_idx(ref)
-        if ref_idx == 0:
+        ref_frame = self._convert_ref_to_frame(ref)
+        if ref_frame == gs.LINK_REF_FRAME.ROOT_COM:
             tensor = qd_to_torch(self.dyn_state.links.root_COM, envs_idx, links_idx, transpose=True, copy=True)
-        elif ref_idx == 1:
+        elif ref_frame == gs.LINK_REF_FRAME.LINK_COM:
             i_pos = qd_to_torch(self.dyn_state.links.i_pos, envs_idx, links_idx, transpose=True)
             root_COM = qd_to_torch(self.dyn_state.links.root_COM, envs_idx, links_idx, transpose=True)
             tensor = i_pos + root_COM
-        elif ref_idx == 2:
-            tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
         else:
-            gs.raise_exception("'ref' must be either 'link_origin', 'link_com', or 'root_com'.")
+            tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
 
         # The pose offset is defined on the link origin, so it is only stripped for the 'link_origin' reference.
-        if relative and ref_idx == 2 and self._links_offset_pos is not None:
+        if relative and ref_frame == gs.LINK_REF_FRAME.LINK_ORIGIN and self._links_offset_pos is not None:
             quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
@@ -2946,14 +2902,13 @@ class RigidSolver(KinematicSolver):
 
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_links_vel(self, links_idx=None, envs_idx=None, *, ref: LinkRefFrameType = "link_origin"):
+    def get_links_vel(self, links_idx=None, envs_idx=None, *, ref: LinkFrameType = "link_origin"):
+        ref_frame = self._convert_ref_to_frame(ref, has_root_com=False)
         if gs.use_zerocopy:
             mask = (0, *indices_to_mask(links_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
-            if ref == "root_com":
-                return cd_vel[mask]
             cd_ang = qd_to_torch(self.dyn_state.links.cd_ang, transpose=True)
-            if ref == "link_com":
+            if ref_frame == gs.LINK_REF_FRAME.LINK_COM:
                 i_pos = qd_to_torch(self.dyn_state.links.i_pos, transpose=True)
                 delta = i_pos[mask]
             else:
@@ -2967,8 +2922,7 @@ class RigidSolver(KinematicSolver):
         )
         assert _tensor is not None
         tensor = _tensor[None] if self.n_envs == 0 else _tensor
-        ref_idx = self._convert_ref_to_idx(ref)
-        kernel_get_links_vel(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref_idx)
+        kernel_get_links_vel(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref_frame)
         return _tensor
 
     def get_links_acc(self, links_idx=None, envs_idx=None):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1670,15 +1670,7 @@ class RigidSolver(KinematicSolver):
             )
 
         kernel_apply_links_external_force(
-            links_idx,
-            envs_idx,
-            pos,
-            force,
-            self.dyn_state,
-            self.rigid_config,
-            ref_idx,
-            1 if local else 0,
-            1 if has_pos else 0,
+            links_idx, envs_idx, pos, force, self.dyn_state, self.rigid_config, ref_idx, local, has_pos
         )
 
     def apply_links_external_torque(
@@ -1734,7 +1726,7 @@ class RigidSolver(KinematicSolver):
             )
 
         kernel_apply_links_external_torque(
-            links_idx, envs_idx, torque, self.dyn_state, self.rigid_config, ref_idx, 1 if local else 0
+            links_idx, envs_idx, torque, self.dyn_state, self.rigid_config, ref_idx, local
         )
 
     def substep_pre_coupling(self, f):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1,11 +1,12 @@
 import math
 import os
 import sys
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
-import quadrants as qd
 import numpy as np
 import torch
+
+import quadrants as qd
 
 import genesis as gs
 import genesis.utils.array_class as array_class
@@ -14,98 +15,99 @@ from genesis.engine.entities import DroneEntity, RigidEntity
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.states import QueriedStates, RigidSolverState
 from genesis.options.solvers import RigidOptions
+from genesis.typing import LinkRefFrameType
 from genesis.utils.misc import (
     DeprecationError,
-    qd_to_torch,
-    qd_to_numpy,
-    qd_zero_grad,
-    indices_to_mask,
-    broadcast_tensor,
-    sanitize_indexed_tensor,
     assign_indexed_tensor,
-    get_gpu_core_count,
+    broadcast_tensor,
     fits_in_gpu_shared_memory,
+    get_gpu_core_count,
+    indices_to_mask,
+    qd_to_numpy,
+    qd_to_torch,
+    qd_zero_grad,
+    sanitize_indexed_tensor,
 )
 from genesis.utils.sdf import SDF
 
 from ..base_solver import MutatedLinks, Solver, StateChange, mutates
-from ..kinematic_solver import KinematicSolver, _select_links_offset, _offset_world_shift, _fill_base_link_geom_offsets
+from ..kinematic_solver import KinematicSolver, _fill_base_link_geom_offsets, _offset_world_shift, _select_links_offset
 from .collider import Collider
 from .constraint import ConstraintSolver
 from .constraint.backward import (
-    kernel_manual_add_collision_constraints_bw,
-    kernel_manual_add_frictionloss_constraints_bw,
-    kernel_manual_add_equality_constraints_bw,
     kernel_accumulate_constraint_solver_grads,
     kernel_load_dL_dqacc_from_acc_grad,
+    kernel_manual_add_collision_constraints_bw,
+    kernel_manual_add_equality_constraints_bw,
+    kernel_manual_add_frictionloss_constraints_bw,
     kernel_manual_add_joint_limit_constraints_bw,
 )
 from .abd.misc import (
     func_add_safe_backward,
     func_apply_coupling_force,
-    func_apply_link_external_force,
     func_apply_external_torque,
+    func_apply_link_external_force,
     func_apply_link_external_torque,
     func_atomic_add_if,
     func_check_index_range,
     func_clear_external_force,
     func_read_field_if,
-    func_write_field_if,
     func_write_and_read_field_if,
-    kernel_init_invweight,
-    kernel_init_meaninertia,
-    kernel_wakeup_coupled_links,
-    kernel_init_dof_fields,
-    kernel_reset_hibernation,
-    kernel_init_link_fields,
-    kernel_update_heterogeneous_link_info,
-    kernel_init_joint_fields,
-    kernel_init_vert_fields,
-    kernel_init_vvert_fields,
-    kernel_init_geom_fields,
-    kernel_init_vgeom_fields,
-    kernel_init_entity_fields,
-    kernel_init_equality_fields,
+    func_write_field_if,
     kernel_apply_links_external_force,
     kernel_apply_links_external_torque,
-    kernel_update_geoms_render_T,
-    kernel_update_vgeoms_render_T,
     kernel_bit_reduction,
-    kernel_set_zero,
     kernel_clear_external_force,
+    kernel_init_dof_fields,
+    kernel_init_entity_fields,
+    kernel_init_equality_fields,
+    kernel_init_geom_fields,
+    kernel_init_invweight,
+    kernel_init_joint_fields,
+    kernel_init_link_fields,
+    kernel_init_meaninertia,
+    kernel_init_vert_fields,
+    kernel_init_vgeom_fields,
+    kernel_init_vvert_fields,
+    kernel_reset_hibernation,
+    kernel_set_zero,
+    kernel_update_geoms_render_T,
+    kernel_update_heterogeneous_link_info,
+    kernel_update_vgeoms_render_T,
+    kernel_wakeup_coupled_links,
 )
 from .abd.forward_kinematics import (
     func_aggregate_awake_entities,
     func_COM_links,
     func_COM_links_entity,
-    func_forward_kinematics_entity,
     func_forward_kinematics_batch,
-    func_forward_velocity_entity,
-    func_forward_velocity_batch,
+    func_forward_kinematics_entity,
     func_forward_velocity,
+    func_forward_velocity_batch,
+    func_forward_velocity_entity,
     func_hibernate__for_all_awake_islands_either_hiberanate_or_update_aabb_sort_buffer,
-    func_update_geoms_entity,
-    func_update_geoms_batch,
     func_update_all_verts,
     func_update_cartesian_space,
-    func_update_cartesian_space_entity,
     func_update_cartesian_space_batch,
+    func_update_cartesian_space_entity,
     func_update_geoms,
+    func_update_geoms_batch,
+    func_update_geoms_entity,
     func_update_verts_for_geom,
-    kernel_forward_kinematics_links_geoms,
-    kernel_masked_forward_kinematics_links_geoms,
-    kernel_forward_velocity,
-    kernel_masked_forward_velocity,
-    kernel_forward_kinematics_entity,
-    kernel_update_geoms,
-    kernel_update_verts_for_geoms,
-    kernel_update_all_verts,
-    kernel_update_geom_aabbs,
-    kernel_update_vgeoms,
     kernel_COM_links_replay,
-    kernel_update_cartesian_space,
+    kernel_forward_kinematics_entity,
+    kernel_forward_kinematics_links_geoms,
     kernel_forward_kinematics_replay,
+    kernel_forward_velocity,
+    kernel_masked_forward_kinematics_links_geoms,
+    kernel_masked_forward_velocity,
+    kernel_update_all_verts,
+    kernel_update_cartesian_space,
+    kernel_update_geom_aabbs,
+    kernel_update_geoms,
     kernel_update_geoms_replay,
+    kernel_update_verts_for_geoms,
+    kernel_update_vgeoms,
 )
 from .abd.forward_dynamics import (
     func_actuation,
@@ -114,69 +116,69 @@ from .abd.forward_dynamics import (
     func_compute_qacc,
     func_factor_mass,
     func_forward_dynamics,
-    func_solve_mass_entity,
-    func_solve_mass_batch,
+    func_implicit_damping,
+    func_integrate,
     func_solve_mass,
+    func_solve_mass_batch,
+    func_solve_mass_entity,
     func_torque_and_passive_force,
     func_update_acc,
     func_update_force,
-    func_integrate,
-    func_implicit_damping,
     func_vel_at_point,
     kernel_compute_mass_matrix,
     kernel_forward_dynamics,
-    kernel_update_acc,
     kernel_forward_dynamics_without_qacc,
+    kernel_update_acc,
     update_qacc_from_qvel_delta,
     update_qvel,
 )
 from .abd.accessor import (
     ConstraintType,
+    kernel_adjust_link_inertia,
+    kernel_control_dofs_force,
+    kernel_control_dofs_position,
+    kernel_control_dofs_position_velocity,
+    kernel_control_dofs_velocity,
+    kernel_get_dofs_control_force,
+    kernel_get_links_acc,
+    kernel_get_links_vel,
     kernel_get_state,
-    kernel_set_state,
-    kernel_set_links_pos,
-    kernel_set_links_quat,
-    kernel_set_links_mass_shift,
-    kernel_set_links_COM_shift,
-    kernel_set_links_inertial_mass,
-    kernel_wake_up_entities_by_links,
-    kernel_wake_up_entities_by_dofs,
-    kernel_wake_up_entities_by_qs,
-    kernel_wake_up_entities_on_new_contact,
-    kernel_set_geoms_friction_ratio,
-    kernel_set_qpos,
-    kernel_set_global_sol_params,
-    kernel_set_sol_params,
-    kernel_set_dofs_kp,
-    kernel_set_dofs_kv,
-    kernel_set_dofs_act_gain,
     kernel_set_dofs_act_bias,
-    kernel_set_dofs_force_range,
-    kernel_set_dofs_stiffness,
+    kernel_set_dofs_act_gain,
     kernel_set_dofs_armature,
     kernel_set_dofs_damping,
+    kernel_set_dofs_force_range,
     kernel_set_dofs_frictionloss,
+    kernel_set_dofs_kp,
+    kernel_set_dofs_kv,
     kernel_set_dofs_limit,
+    kernel_set_dofs_position,
+    kernel_set_dofs_stiffness,
     kernel_set_dofs_velocity,
     kernel_set_dofs_velocity_grad,
     kernel_set_dofs_zero_velocity,
-    kernel_set_dofs_position,
-    kernel_control_dofs_force,
-    kernel_control_dofs_velocity,
-    kernel_control_dofs_position,
-    kernel_control_dofs_position_velocity,
-    kernel_get_links_vel,
-    kernel_get_links_acc,
-    kernel_get_dofs_control_force,
     kernel_set_drone_rpm,
-    kernel_update_drone_propeller_vgeoms,
     kernel_set_geom_friction,
     kernel_set_geom_friction_rolling,
     kernel_set_geom_friction_torsional,
     kernel_set_geoms_friction,
+    kernel_set_geoms_friction_ratio,
     kernel_set_geoms_friction_rolling,
     kernel_set_geoms_friction_torsional,
-    kernel_adjust_link_inertia,
+    kernel_set_global_sol_params,
+    kernel_set_links_COM_shift,
+    kernel_set_links_inertial_mass,
+    kernel_set_links_mass_shift,
+    kernel_set_links_pos,
+    kernel_set_links_quat,
+    kernel_set_qpos,
+    kernel_set_sol_params,
+    kernel_set_state,
+    kernel_update_drone_propeller_vgeoms,
+    kernel_wake_up_entities_by_dofs,
+    kernel_wake_up_entities_by_links,
+    kernel_wake_up_entities_by_qs,
+    kernel_wake_up_entities_on_new_contact,
 )
 from .abd.diff import (
     func_copy_cartesian_space,
@@ -186,11 +188,11 @@ from .abd.diff import (
     func_is_grad_valid,
     func_load_adjoint_cache,
     func_save_adjoint_cache,
-    kernel_save_adjoint_cache,
-    kernel_prepare_backward_substep,
     kernel_begin_backward_substep,
     kernel_copy_acc,
     kernel_copy_next_to_curr_no_check,
+    kernel_prepare_backward_substep,
+    kernel_save_adjoint_cache,
 )
 from .abd.manual_bw import (
     kernel_manual_compute_qacc_bw,
@@ -1606,7 +1608,7 @@ class RigidSolver(KinematicSolver):
         envs_idx=None,
         *,
         pos=None,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         local: bool = False,
     ):
         """
@@ -1685,7 +1687,7 @@ class RigidSolver(KinematicSolver):
         links_idx=None,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         local: bool = False,
     ):
         """
@@ -2908,7 +2910,7 @@ class RigidSolver(KinematicSolver):
         return tensor
 
     @staticmethod
-    def _convert_ref_to_idx(ref: Literal["link_origin", "link_com", "root_com"]):
+    def _convert_ref_to_idx(ref: LinkRefFrameType):
         if ref == "root_com":
             return 0
         elif ref == "link_com":
@@ -2923,7 +2925,7 @@ class RigidSolver(KinematicSolver):
         links_idx=None,
         envs_idx=None,
         *,
-        ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
+        ref: LinkRefFrameType = "link_origin",
         relative=False,
     ):
         if not gs.use_zerocopy:
@@ -2952,9 +2954,7 @@ class RigidSolver(KinematicSolver):
 
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_links_vel(
-        self, links_idx=None, envs_idx=None, *, ref: Literal["link_origin", "link_com", "root_com"] = "link_origin"
-    ):
+    def get_links_vel(self, links_idx=None, envs_idx=None, *, ref: LinkRefFrameType = "link_origin"):
         if gs.use_zerocopy:
             mask = (0, *indices_to_mask(links_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1672,8 +1672,8 @@ class RigidSolver(KinematicSolver):
         kernel_apply_links_external_force(
             links_idx,
             envs_idx,
-            force,
             pos,
+            force,
             self.dyn_state,
             self.rigid_config,
             ref_idx,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -11,11 +11,11 @@ import quadrants as qd
 import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
+from genesis.constants import link_ref_frame
 from genesis.engine.entities import DroneEntity, RigidEntity
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.states import QueriedStates, RigidSolverState
 from genesis.options.solvers import RigidOptions
-from genesis.typing import LinkFrameType, LinkRefFrameType
 from genesis.utils.misc import (
     DeprecationError,
     assign_indexed_tensor,
@@ -1606,7 +1606,7 @@ class RigidSolver(KinematicSolver):
         envs_idx=None,
         *,
         pos=None,
-        ref: LinkFrameType = "link_origin",
+        ref: link_ref_frame = link_ref_frame.link_origin,
         local: bool = False,
     ):
         """
@@ -1617,31 +1617,28 @@ class RigidSolver(KinematicSolver):
         force : None | array_like, optional
             The linear force to apply. None for a pure torque. Defaults to None.
         torque : None | array_like, optional
-            The torque to apply, on top of the moment induced by the linear force. None for a pure force. Defaults to
-            None.
+            The torque to apply, on top of the moment induced by the linear force. Defaults to None.
         links_idx : None | array_like, optional
             The indices of the links on which to apply the wrench. None to specify all links. Default to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         pos : None | array_like, optional
-            The point at which the linear force is applied, which sets the moment arm of the induced torque. None to
-            apply it at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from
-            that origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
-            Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
-            of `force` and `torque`. Defaults to None.
-        ref: "link_origin" | "link_com", optional
-            The reference frame on which the wrench will be applied. "link_origin" refers to the origin of the link and
-            "link_com" refers to the center of mass of the link. This argument only selects the frame of the input
-            coordinates unless a linear force is applied at the origin of that frame, ie without specifying `pos`.
+            Where the linear force is applied, which sets the moment arm of the induced torque. With `local=True`, an
+            offset from the origin of the `ref` frame, so the point follows each link as it moves; otherwise a world
+            position. None applies the force at the origin of the `ref` frame. Defaults to None.
+        ref: gs.link_ref_frame, optional
+            The reference frame: the origin of each link ('link_origin'), or its center of mass ('link_COM'). It fixes
+            where the linear force acts when `pos` is None, and the axes of the input coordinates when `local=True`.
+            Defaults to 'link_origin'.
         local: bool, optional
-            Whether the wrench and the application point are expressed in the local coordinates associated with the
-            reference frame instead of world frame.
+            Whether `force`, `torque` and `pos` are expressed in the coordinates of the `ref` frame rather than the
+            world frame. Defaults to False.
         """
         if force is None and torque is None:
             gs.raise_exception("Either 'force' or 'torque' must be specified.")
         if force is None and pos is not None:
             gs.raise_exception("'pos' requires 'force', as a torque acts the same wherever it is applied.")
-        ref_frame = self._convert_ref_to_frame(ref, has_root_com=False)
+        ref_frame = self._sanitize_ref_frame(ref, has_root_COM=False)
 
         if pos is not None:
             pos, _, _ = self._sanitize_io_variables(
@@ -2855,27 +2852,24 @@ class RigidSolver(KinematicSolver):
         return tensor
 
     @staticmethod
-    def _convert_ref_to_frame(ref: LinkRefFrameType, *, has_root_com: bool = True) -> int:
-        """Map a user-facing reference frame name onto its 'gs.LINK_REF_FRAME' value.
+    def _sanitize_ref_frame(ref: link_ref_frame, *, has_root_COM: bool = True) -> int:
+        """Check that a reference frame is supported and return it as a plain int.
 
         The value is returned as a plain int rather than the enum member itself because quadrants' fastcache holds a
         weak reference to template arguments, which enum members do not support.
         """
-        if ref == "link_origin":
-            return int(gs.LINK_REF_FRAME.LINK_ORIGIN)
-        elif ref == "link_com":
-            return int(gs.LINK_REF_FRAME.LINK_COM)
-        elif ref == "root_com" and has_root_com:
-            return int(gs.LINK_REF_FRAME.ROOT_COM)
-        refs = "'link_origin', 'link_com', or 'root_com'" if has_root_com else "'link_origin' or 'link_com'"
-        gs.raise_exception(f"'ref' must be either {refs}.")
+        frames = tuple(link_ref_frame) if has_root_COM else (link_ref_frame.link_origin, link_ref_frame.link_COM)
+        if not isinstance(ref, link_ref_frame) or ref not in frames:
+            refs = ", ".join(f"'gs.link_ref_frame.{frame.name}'" for frame in frames)
+            gs.raise_exception(f"'ref' must be one of {refs}.")
+        return int(ref)
 
     def get_links_pos(
         self,
         links_idx=None,
         envs_idx=None,
         *,
-        ref: LinkRefFrameType = "link_origin",
+        ref: link_ref_frame = link_ref_frame.link_origin,
         relative=False,
     ):
         if not gs.use_zerocopy:
@@ -2883,10 +2877,10 @@ class RigidSolver(KinematicSolver):
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
             )
 
-        ref_frame = self._convert_ref_to_frame(ref)
-        if ref_frame == gs.LINK_REF_FRAME.ROOT_COM:
+        ref_frame = self._sanitize_ref_frame(ref)
+        if ref_frame == link_ref_frame.root_COM:
             tensor = qd_to_torch(self.dyn_state.links.root_COM, envs_idx, links_idx, transpose=True, copy=True)
-        elif ref_frame == gs.LINK_REF_FRAME.LINK_COM:
+        elif ref_frame == link_ref_frame.link_COM:
             i_pos = qd_to_torch(self.dyn_state.links.i_pos, envs_idx, links_idx, transpose=True)
             root_COM = qd_to_torch(self.dyn_state.links.root_COM, envs_idx, links_idx, transpose=True)
             tensor = i_pos + root_COM
@@ -2894,7 +2888,7 @@ class RigidSolver(KinematicSolver):
             tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
 
         # The pose offset is defined on the link origin, so it is only stripped for the 'link_origin' reference.
-        if relative and ref_frame == gs.LINK_REF_FRAME.LINK_ORIGIN and self._links_offset_pos is not None:
+        if relative and ref_frame == link_ref_frame.link_origin and self._links_offset_pos is not None:
             quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
@@ -2902,13 +2896,13 @@ class RigidSolver(KinematicSolver):
 
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_links_vel(self, links_idx=None, envs_idx=None, *, ref: LinkFrameType = "link_origin"):
-        ref_frame = self._convert_ref_to_frame(ref, has_root_com=False)
+    def get_links_vel(self, links_idx=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin):
+        ref_frame = self._sanitize_ref_frame(ref, has_root_COM=False)
         if gs.use_zerocopy:
             mask = (0, *indices_to_mask(links_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
             cd_ang = qd_to_torch(self.dyn_state.links.cd_ang, transpose=True)
-            if ref_frame == gs.LINK_REF_FRAME.LINK_COM:
+            if ref_frame == link_ref_frame.link_COM:
                 i_pos = qd_to_torch(self.dyn_state.links.i_pos, transpose=True)
                 delta = i_pos[mask]
             else:
@@ -3208,7 +3202,7 @@ class RigidSolver(KinematicSolver):
         potential_energy : torch.Tensor, shape () or (n_envs,)
         """
         gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
-        links_pos = self.get_links_pos(links_idx, envs_idx, ref="link_com")  # (..., n_links, 3)
+        links_pos = self.get_links_pos(links_idx, envs_idx, ref=link_ref_frame.link_COM)  # (..., n_links, 3)
         # `get_links_inertial_mass` only accepts `envs_idx` when links info is batched, since all the environments
         # share the very same link masses otherwise.
         links_mass = self.get_links_inertial_mass(links_idx, envs_idx if self._options.batch_links_info else None)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1605,11 +1605,12 @@ class RigidSolver(KinematicSolver):
         links_idx=None,
         envs_idx=None,
         *,
+        pos=None,
         ref: Literal["link_origin", "link_com", "root_com"] = "link_origin",
         local: bool = False,
     ):
         """
-        Apply some external linear force on a set of links.
+        Apply external linear force over one simulation step on a set of links.
 
         Parameters
         ----------
@@ -1619,19 +1620,36 @@ class RigidSolver(KinematicSolver):
             The indices of the links on which to apply force. None to specify all links. Default to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        pos : None | array_like, optional
+            The point at which the force is applied, which sets the moment arm of the induced torque. None to apply it
+            at the origin of the reference frame designated by `ref`. With `local=True`, it is an offset from that
+            origin expressed in the coordinates of that frame, hence a point that follows the link as it moves.
+            Otherwise, it is a world position that locates the point on its own, leaving `ref` to only select the frame
+            of `force`. Defaults to None.
         ref: "link_origin" | "link_com" | "root_com", optional
             The reference frame on which the linear force will be applied. "link_origin" refers to the origin of the
             link, "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
             the entire kinematic tree to which a link belong (see `get_links_root_COM` for details).
         local: bool, optional
-            Whether the force is expressed in the local coordinates associated with the reference frame instead of
-            world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
+            Whether the force and the application point are expressed in the local coordinates associated with the
+            reference frame instead of world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.
         """
+        has_pos = pos is not None
+        if has_pos:
+            pos, _, _ = self._sanitize_io_variables(
+                pos, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
+            )
+            if self.n_envs == 0:
+                pos = pos[None]
         force, links_idx, envs_idx = self._sanitize_io_variables(
             force, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
         )
         if self.n_envs == 0:
             force = force[None]
+        if not has_pos:
+            # The kernel cannot fabricate the array it only reads when an application point is provided, so hand it a
+            # zero-length view rather than paying for a fresh allocation on every call.
+            pos = force[:0]
 
         if ref == "root_com" and local:
             raise ValueError("'local=True' not compatible with ref='root_com'.")
@@ -1650,7 +1668,15 @@ class RigidSolver(KinematicSolver):
             )
 
         kernel_apply_links_external_force(
-            links_idx, envs_idx, force, self.dyn_state, self.rigid_config, ref_idx, 1 if local else 0
+            links_idx,
+            envs_idx,
+            force,
+            pos,
+            self.dyn_state,
+            self.rigid_config,
+            ref_idx,
+            1 if local else 0,
+            1 if has_pos else 0,
         )
 
     def apply_links_external_torque(
@@ -1663,7 +1689,7 @@ class RigidSolver(KinematicSolver):
         local: bool = False,
     ):
         """
-        Apply some external torque on a set of links.
+        Apply external torque over one simulation step on a set of links.
 
         Parameters
         ----------
@@ -1677,7 +1703,8 @@ class RigidSolver(KinematicSolver):
             The reference frame on which the torque will be applied. "link_origin" refers to the origin of the link,
             "link_com" refers to the center of mass of the link, and "root_com" refers to the center of mass of
             the entire kinematic tree to which a link belong (see `get_links_root_COM` for details). Note that this
-            argument has no effect unless `local=True`.
+            argument has no effect unless `local=True`, a torque being a couple that acts the same wherever it is
+            attached.
         local: bool, optional
             Whether the torque is expressed in the local coordinates associated with the reference frame instead of
             world frame. Only supported for `ref="link_origin"` or `ref="link_com"`.

--- a/genesis/typing.py
+++ b/genesis/typing.py
@@ -1,6 +1,6 @@
 import math
 from pathlib import PurePath
-from typing import TYPE_CHECKING, Annotated, Any, Mapping, Sequence, TypeVar, get_args
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, Sequence, TypeVar, get_args
 
 import numpy as np
 from frozendict import frozendict
@@ -205,3 +205,8 @@ else:
     ]
     PathType = Annotated[str, BeforeValidator(lambda v: str(v) if isinstance(v, PurePath) else v)]
     FrozenDictType = Annotated[frozendict[_K, _V], _FrozenDictValidator]
+
+
+# The frame at which a per-link quantity is expressed: the origin of the link, the center of mass of the link, or the
+# center of mass of the whole kinematic tree the link belongs to (see 'RigidSolver.get_links_root_COM').
+LinkRefFrameType = Literal["link_origin", "link_com", "root_com"]

--- a/genesis/typing.py
+++ b/genesis/typing.py
@@ -207,6 +207,8 @@ else:
     FrozenDictType = Annotated[frozendict[_K, _V], _FrozenDictValidator]
 
 
-# The frame at which a per-link quantity is expressed: the origin of the link, the center of mass of the link, or the
-# center of mass of the whole kinematic tree the link belongs to (see 'RigidSolver.get_links_root_COM').
+# The frame at which a per-link quantity is expressed: the origin of the link, or the center of mass of the link.
+LinkFrameType = Literal["link_origin", "link_com"]
+# The frames of 'LinkFrameType', extended with the center of mass of the whole kinematic tree the link belongs to (see
+# 'RigidSolver.get_links_root_COM').
 LinkRefFrameType = Literal["link_origin", "link_com", "root_com"]

--- a/genesis/typing.py
+++ b/genesis/typing.py
@@ -1,6 +1,6 @@
 import math
 from pathlib import PurePath
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, Sequence, TypeVar, get_args
+from typing import TYPE_CHECKING, Annotated, Any, Mapping, Sequence, TypeVar, get_args
 
 import numpy as np
 from frozendict import frozendict
@@ -205,10 +205,3 @@ else:
     ]
     PathType = Annotated[str, BeforeValidator(lambda v: str(v) if isinstance(v, PurePath) else v)]
     FrozenDictType = Annotated[frozendict[_K, _V], _FrozenDictValidator]
-
-
-# The frame at which a per-link quantity is expressed: the origin of the link, or the center of mass of the link.
-LinkFrameType = Literal["link_origin", "link_com"]
-# The frames of 'LinkFrameType', extended with the center of mass of the whole kinematic tree the link belongs to (see
-# 'RigidSolver.get_links_root_COM').
-LinkRefFrameType = Literal["link_origin", "link_com", "root_com"]

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -383,4 +383,4 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             total_impulse[i % 3] += impulse
 
         # The force acts at the grabbed point, so its moment about the center of mass swings the body to the cursor.
-        self._held_link.apply_external_force(total_impulse / dt, envs_idx, pos=held_point_env_local)
+        self._held_link.apply_external_wrench(total_impulse / dt, envs_idx=envs_idx, pos=held_point_env_local)

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -383,9 +383,4 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             total_impulse[i % 3] += impulse
 
         # The force acts at the grabbed point, so its moment about the center of mass swings the body to the cursor.
-        self._held_link.solver.apply_links_external_force(
-            total_impulse / dt,
-            (self._held_link.idx,),
-            envs_idx=envs_idx,
-            pos=held_point_env_local,
-        )
+        self._held_link.apply_external_force(total_impulse / dt, envs_idx, pos=held_point_env_local)

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -355,7 +355,6 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         inv_mass = 1.0 / float(self._held_link.get_mass())
 
         total_impulse = np.zeros(3, dtype=gs.np_float)
-        total_torque_impulse = np.zeros(3, dtype=gs.np_float)
 
         # Approximate spring-damper in each axis
         for i in range(3):
@@ -382,20 +381,11 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             ang_vel += inv_inertia_world @ (arm_x_dir * impulse)
 
             total_impulse[i % 3] += impulse
-            total_torque_impulse += arm_x_dir * impulse
 
-        # Apply the new force
+        # The force acts at the grabbed point, so its moment about the center of mass swings the body to the cursor.
         self._held_link.solver.apply_links_external_force(
             total_impulse / dt,
             (self._held_link.idx,),
             envs_idx=envs_idx,
-            ref="link_com",
-            local=False,
-        )
-        self._held_link.solver.apply_links_external_torque(
-            total_torque_impulse / dt,
-            (self._held_link.idx,),
-            envs_idx=envs_idx,
-            ref="link_com",
-            local=False,
+            pos=held_point_env_local,
         )

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -21,25 +21,43 @@ if TYPE_CHECKING:
 
 
 MIN_PICKABLE_MASS = 1e-3  # kg - links below this threshold are skipped to avoid numerical instability
+GRAB_ACC = 10.0  # m/s^2 - acceleration a grab pulls with at one 'spring_slack' from the cursor
 
 
 class MouseInteractionPlugin(RaycasterViewerPlugin):
     """
-    Basic interactive viewer plugin that enables using mouse to apply spring force on rigid entities.
+    Drag rigid entities around with the mouse, by a spring attached where the cursor grabbed them.
 
-    See RaycasterViewerPlugin for `use_visual_geom`.
+    Parameters
+    ----------
+    use_force : bool, optional
+        Drag the grabbed link with a spring force, leaving the solver to resolve it against gravity, contacts and the
+        rest of the kinematic tree, so the drag never breaks the physics. False instead moves the link onto the cursor
+        outright, which tracks exactly but drives it through anything in the way and jolts whatever it is attached to.
+        Default is True.
+    spring_slack : float, optional
+        How far below the cursor a grabbed link hangs once it settles, in meters. The stiffness of the spring follows
+        from this and the mass of the link, so heavy and light entities are equally responsive. Lower it for a grab
+        that tracks the cursor closely, at the cost of pushing entities through whatever they touch on the way; raise
+        it to let contacts win instead, at the cost of trailing behind a fast cursor. The distance is quoted at
+        standard gravity; a weaker-gravity scene holds its links closer still. Only used when `use_force` is True.
+        Default is 0.02.
+    color : tuple of float, optional
+        RGBA color of the line, handle and drag plane drawn while an entity is held. Default is (0.2, 0.8, 0.8, 0.6).
+    use_visual_geom : bool, optional
+        See `RaycasterViewerPlugin`. Default is False.
     """
 
     def __init__(
         self,
         use_force: bool = True,
-        spring_const: float = 1000.0,
+        spring_slack: float = 0.02,
         color: tuple[float, float, float, float] = (0.2, 0.8, 0.8, 0.6),
         use_visual_geom: bool = False,
     ) -> None:
         super().__init__(use_visual_geom)
         self.use_force = bool(use_force)
-        self.spring_const = float(spring_const)
+        self.spring_slack = float(spring_slack)
         self.color = tuple(color)
 
         self._lock: Lock = Lock()
@@ -352,7 +370,14 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         inv_inertia_world = np.linalg.inv(inertia_world)
 
         pos_err_v = control_point_env_local - held_point_env_local
-        inv_mass = 1.0 / float(self._held_link.get_mass())
+        mass = float(self._held_link.get_mass())
+        inv_mass = 1.0 / mass
+
+        # A link at rest hangs below its center of mass with the spring carrying its whole weight, so the slack alone
+        # fixes the natural frequency. The correction offsets the step of free fall the softened solve settles short.
+        nominal_freq = np.sqrt(GRAB_ACC / self.spring_slack)
+        natural_freq = nominal_freq / max(1.0 - dt * nominal_freq, gs.EPS)
+        spring_const = mass * natural_freq**2
 
         total_impulse = np.zeros(3, dtype=gs.np_float)
 
@@ -362,7 +387,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             vel_err_v = -body_point_vel
 
             direction = np.zeros(3, dtype=gs.np_float)
-            direction[i % 3] = 1.0
+            direction[i] = 1.0
 
             pos_err = np.dot(direction, pos_err_v)
             vel_err = np.dot(direction, vel_err_v)
@@ -373,14 +398,28 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             virtual_mass = 1.0 / (inv_mass + rot_mass + gs.EPS)
 
             # Critical damping
-            damping_coeff = 2.0 * np.sqrt(self.spring_const * virtual_mass)
-            # Impulse: J = F*dt = k*x*dt + c*v*dt
-            impulse = (self.spring_const * pos_err + damping_coeff * vel_err) * dt
+            damping_coeff = 2.0 * np.sqrt(spring_const * virtual_mass)
+            # Solving for the impulse that lands the end-of-step velocity on the spring-damper response holds that
+            # damping ratio at any stiffness; a held force would only do so while dt stays below 1 / frequency.
+            softness = 1.0 / (dt * (damping_coeff + dt * spring_const))
+            bias_rate = spring_const / (damping_coeff + dt * spring_const)
+            impulse = (vel_err + bias_rate * pos_err) / (inv_mass + rot_mass + softness)
 
             lin_vel += direction * impulse * inv_mass
             ang_vel += inv_inertia_world @ (arm_x_dir * impulse)
 
-            total_impulse[i % 3] += impulse
+            total_impulse[i] = impulse
+
+        # A rotation about the grabbed point leaves that point where it is, so the spring-damper above is blind to the
+        # pendulum swinging under the cursor. Twice its frequency damps it critically at worst, never under, and the
+        # cap keeps a grab near the center of mass, where the pendulum degenerates, from freezing rotation outright.
+        arm_length = np.linalg.norm(arm_in_world)
+        swing_freq = min(2.0 * np.sqrt(GRAB_ACC / (arm_length + gs.EPS)), natural_freq)
+        # That swing pivots about the grabbed point, hence the inertia about it, and solving for the end-of-step
+        # angular velocity keeps the decay from overshooting when the two inertias differ widely.
+        swing_inertia = inertia_world + mass * (arm_length**2 * np.eye(3) - np.outer(arm_in_world, arm_in_world))
+        ang_vel_next = np.linalg.solve(inertia_world + dt * swing_freq * swing_inertia, inertia_world @ ang_vel)
+        torque = -swing_freq * (swing_inertia @ ang_vel_next)
 
         # The force acts at the grabbed point, so its moment about the center of mass swings the body to the cursor.
-        self._held_link.apply_external_wrench(total_impulse / dt, envs_idx=envs_idx, pos=held_point_env_local)
+        self._held_link.apply_external_wrench(total_impulse / dt, torque, envs_idx=envs_idx, pos=held_point_env_local)

--- a/tests/ipc/test_rigid.py
+++ b/tests/ipc/test_rigid.py
@@ -633,7 +633,9 @@ def test_momentum_conservation(n_envs, show_viewer):
     dist_min = np.array(float("inf"))
     fem_positions_prev = None  # FEM initial velocity is zero
     for step in range(int(DURATION / DT)):
-        cube_vel = tensor_to_array(rigid_cube.get_links_vel(links_idx_local=0, ref="link_com")[..., 0, :])
+        cube_vel = tensor_to_array(
+            rigid_cube.get_links_vel(links_idx_local=0, ref=gs.link_ref_frame.link_COM)[..., 0, :]
+        )
         rigid_linear_momentum = cube_mass * cube_vel
 
         fem_proc_geo = get_ipc_merged_geometry(scene, solver_type="fem", idx=fem_entity_idx, env_idx=0)

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -11,6 +11,7 @@ import genesis as gs
 from genesis.options.sensors import RasterizerCameraOptions
 from genesis.utils.misc import tensor_to_array
 from genesis.vis.keybindings import Key, KeyAction, Keybind, KeyMod, MouseButton
+from genesis.vis.viewer_plugins.plugins.mouse_interaction import GRAB_ACC
 
 from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE, SKIP_NO_IMGUI_BUNDLE, SKIP_NO_VIEWER, is_imgui_bundle_supported
 from ..utils.assertions import assert_allclose
@@ -297,7 +298,7 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     BOX_LENGTH = 0.2
     STEPS = 20
     DRAG_DY = 8
-    SPRING_CONST = 1000.0
+    SPRING_SLACK = 0.02
     CAM_FOV = 30
     # Probe lanes parked along y, clear of the drag: envs are spaced along x only, so a lane is one env's alone.
     DECOY_SIZE = 0.4
@@ -401,7 +402,7 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     scene.viewer.add_plugin(
         gs.vis.viewer_plugins.MouseInteractionPlugin(
             use_force=True,
-            spring_const=SPRING_CONST,
+            spring_slack=SPRING_SLACK,
             use_visual_geom=use_visual_geom,
         )
     )
@@ -524,7 +525,7 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     # FIXME: Use a more accurate model to predict final velocity.
     total_sim_time = STEPS * DT
     avg_mouse_velocity = total_world_displacement / total_sim_time
-    num_tau = total_sim_time * np.sqrt(SPRING_CONST / MASS)
+    num_tau = total_sim_time * np.sqrt(GRAB_ACC / SPRING_SLACK)
     velocity_fraction = 1.0 - (1.0 + num_tau) * np.exp(-num_tau)
     expected_vel_z = avg_mouse_velocity * velocity_fraction
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -813,10 +813,10 @@ def test_mesh_primitive_COM(show_viewer):
         scene.step()
     scene.rigid_solver.update_vgeoms()
 
-    _, bunny_COM, cube_COM = rigid.get_links_pos(ref="link_com")
-    _, root_bunny_COM, root_cube_COM = rigid.get_links_pos(ref="root_com")
-    assert_allclose(bunny_COM, bunny.get_links_pos(links_idx_local=[0], ref="link_com"), atol=gs.EPS)
-    assert_allclose(cube_COM, cube.get_links_pos(links_idx_local=[0], ref="link_com"), atol=gs.EPS)
+    _, bunny_COM, cube_COM = rigid.get_links_pos(ref=gs.link_ref_frame.link_COM)
+    _, root_bunny_COM, root_cube_COM = rigid.get_links_pos(ref=gs.link_ref_frame.root_COM)
+    assert_allclose(bunny_COM, bunny.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_COM), atol=gs.EPS)
+    assert_allclose(cube_COM, cube.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_COM), atol=gs.EPS)
     assert_allclose(root_bunny_COM, bunny_COM, atol=gs.EPS)
     assert_allclose(root_cube_COM, cube_COM, atol=gs.EPS)
 
@@ -905,8 +905,8 @@ def test_align_mesh(show_viewer, tol):
     assert_allclose(mango.get_quat(relative=True), gu.identity_quat(), tol=tol)
     # The world-frame base pose places the link frame at the geometry COM and principal axes.
     assert_allclose(
-        mango.get_links_pos(links_idx_local=[0], ref="link_com", relative=False),
-        mango.get_links_pos(links_idx_local=[0], ref="link_origin", relative=False),
+        mango.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_COM, relative=False),
+        mango.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_origin, relative=False),
         tol=tol,
     )
     geom_inertia_i = qd_to_numpy(scene.rigid_solver.dyn_state.links.cinr_inertial, transpose=True)[0, 1]
@@ -920,8 +920,10 @@ def test_align_mesh(show_viewer, tol):
         assert_allclose(het_obj.get_pos(relative=True, envs_idx=i_env), HET_POS, tol=tol)
         assert_allclose(het_obj.get_quat(relative=True, envs_idx=i_env), gu.identity_quat(), tol=tol)
         assert_allclose(
-            het_obj.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env, relative=False),
-            het_obj.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env, relative=False),
+            het_obj.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_COM, envs_idx=i_env, relative=False),
+            het_obj.get_links_pos(
+                links_idx_local=[0], ref=gs.link_ref_frame.link_origin, envs_idx=i_env, relative=False
+            ),
             tol=tol,
         )
 
@@ -993,7 +995,7 @@ def test_align_urdf(show_viewer, tol):
     # The relative (user-frame) base pose strips the alignment back to the morph pose, while the world-frame base
     # pose has its link frame origin at the collision geometry COM (auto-align for basic rigid objects).
     assert_allclose(fork.get_pos(relative=True), INIT_POS, tol=tol)
-    assert_allclose(fork.get_links_pos(ref="link_com"), fork.get_pos(relative=False), tol=tol)
+    assert_allclose(fork.get_links_pos(ref=gs.link_ref_frame.link_COM), fork.get_pos(relative=False), tol=tol)
 
     # Same qpos on rigid and kinematic entities must yield matching vAABB
     qpos = (0.3, -0.2, 1.0, 0.6, 0.5, 0.3, 0.0)
@@ -1338,8 +1340,10 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     # with the COM, and the relative getter strips the alignment back to the user pose.
     for i_env in (0, 2):
         assert_allclose(
-            free_het.get_links_pos(links_idx_local=[0], ref="link_com", envs_idx=i_env, relative=False),
-            free_het.get_links_pos(links_idx_local=[0], ref="link_origin", envs_idx=i_env, relative=False),
+            free_het.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_COM, envs_idx=i_env, relative=False),
+            free_het.get_links_pos(
+                links_idx_local=[0], ref=gs.link_ref_frame.link_origin, envs_idx=i_env, relative=False
+            ),
             tol=tol,
         )
         assert_allclose(free_het.get_pos(relative=True, envs_idx=i_env), FREE_POS, tol=tol)
@@ -1347,8 +1351,8 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     # The duplicate-variant entity takes the broadcast offset path; its relative getter must still strip the shared COM
     # anchoring back to the user pose in every env (a non-anchored base offset would leave it COM-shifted).
     assert_allclose(
-        free_dup.get_links_pos(links_idx_local=[0], ref="link_com", relative=False),
-        free_dup.get_links_pos(links_idx_local=[0], ref="link_origin", relative=False),
+        free_dup.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_COM, relative=False),
+        free_dup.get_links_pos(links_idx_local=[0], ref=gs.link_ref_frame.link_origin, relative=False),
         tol=tol,
     )
     assert_allclose(free_dup.get_pos(relative=True), FREE_POS, tol=tol)
@@ -1408,8 +1412,8 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     assert_allclose(mass[0], sphere_base_mass + sphere_moving_mass, tol=tol)
 
     # CoM position: variant B should match explicit URDF inertial origin_xyz
-    com_pos = het_obj.get_links_pos(ref="link_com", relative=False)
-    origin_pos = het_obj.get_links_pos(ref="link_origin", relative=False)
+    com_pos = het_obj.get_links_pos(ref=gs.link_ref_frame.link_COM, relative=False)
+    origin_pos = het_obj.get_links_pos(ref=gs.link_ref_frame.link_origin, relative=False)
     com_offset = com_pos - origin_pos
     # Variant A: CoM offset matches URDF inertial origin
     assert_allclose(com_offset[0, 0], sphere_base_com, tol=tol)
@@ -1491,7 +1495,7 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     assert_allclose(het_obj.get_links_acc()[..., 2], GRAVITY, tol=tol)
     het_obj.zero_all_dofs_velocity()
     for _ in range(10):
-        scene.rigid_solver.apply_links_external_wrench(force, links_idx=links_idx, ref="link_com")
+        scene.rigid_solver.apply_links_external_wrench(force, links_idx=links_idx, ref=gs.link_ref_frame.link_COM)
         scene.step()
         assert_allclose(het_obj.get_links_acc(), 0.0, tol=tol)
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -1491,7 +1491,7 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     assert_allclose(het_obj.get_links_acc()[..., 2], GRAVITY, tol=tol)
     het_obj.zero_all_dofs_velocity()
     for _ in range(10):
-        scene.rigid_solver.apply_links_external_force(force, links_idx=links_idx, ref="link_com")
+        scene.rigid_solver.apply_links_external_wrench(force, links_idx=links_idx, ref="link_com")
         scene.step()
         assert_allclose(het_obj.get_links_acc(), 0.0, tol=tol)
 

--- a/tests/rigid/test_collision_nonconvex.py
+++ b/tests/rigid/test_collision_nonconvex.py
@@ -661,7 +661,7 @@ def test_mesh_repair(convexify, show_viewer, gjk_collision):
     scene.build()
 
     if show_viewer:
-        obj_com = obj.get_links_pos(ref="link_com")[0]
+        obj_com = obj.get_links_pos(ref=gs.link_ref_frame.link_COM)[0]
         scene.draw_debug_sphere(pos=obj_com, radius=0.003, color=(1, 1, 1, 1))
         scene.visualizer.update(force=True)
 
@@ -778,7 +778,7 @@ def test_convexify(euler, show_viewer, gjk_collision):
         scene.step()
         # cam.render()
         if i > N_SETTLE:
-            vel_lin_all.append(gs_sim.rigid_solver.get_links_vel(ref="link_com"))
+            vel_lin_all.append(gs_sim.rigid_solver.get_links_vel(ref=gs.link_ref_frame.link_COM))
             vel_ang_all.append(gs_sim.rigid_solver.get_links_ang())
     # cam.stop_recording(save_to_filename="video.mp4", fps=60)
     # FIXME: There is spurious residual motion on both paths that prevents the objects from truly settling
@@ -911,7 +911,7 @@ def test_many_objects_collision(convexify, show_viewer, tol):
         scene.step()
         energy_trace.append(tensor_to_array(scene.rigid_solver.get_total_energy()))
         if show_viewer:
-            vmax_trace.append(scene.rigid_solver.get_links_vel(ref="link_com").norm(dim=-1).max())
+            vmax_trace.append(scene.rigid_solver.get_links_vel(ref=gs.link_ref_frame.link_COM).norm(dim=-1).max())
             wmax_trace.append(scene.rigid_solver.get_links_ang().norm(dim=-1).max())
 
     # The pile has settled at rest, fully contained in the tank (no ground/tank penetration, no ejection)
@@ -937,8 +937,8 @@ def test_many_objects_collision(convexify, show_viewer, tol):
     contact_energy = {}
     for i in range(100):
         scene.step()
-        com_pos = scene.rigid_solver.get_links_pos(ref="link_com")
-        com_vel = scene.rigid_solver.get_links_vel(ref="link_com")
+        com_pos = scene.rigid_solver.get_links_pos(ref=gs.link_ref_frame.link_COM)
+        com_vel = scene.rigid_solver.get_links_vel(ref=gs.link_ref_frame.link_COM)
         ang = scene.rigid_solver.get_links_ang()
         vel_lin_all.append(com_vel.norm(dim=-1))
         vel_ang_all.append(ang.norm(dim=-1))

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -266,13 +266,13 @@ def test_apply_external_wrench(xml_path, show_viewer):
             force=duck_force_local,
             torque=-np.cross(duck_lever_arm, duck_force_local),
             pos=duck_lever_arm,
-            ref="link_com",
+            ref=gs.link_ref_frame.link_COM,
             local=True,
         )
         robot.apply_links_external_wrench(force=force, torque=torque, links_idx_local=end_effector_link_idx_local)
         scene.step()
 
-    duck.base_link.apply_external_torque((0, 1, 0), ref="link_com", local=True)
+    duck.base_link.apply_external_torque((0, 1, 0), ref=gs.link_ref_frame.link_COM, local=True)
     assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[duck_link_idx, 0], 0, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[duck_link_idx, 0], -duck_init_link_R[:, 1], tol=gs.EPS
@@ -284,7 +284,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
     assert not np.allclose(base_link.inertial_quat, (1.0, 0.0, 0.0, 0.0))
     base_link_pos = tensor_to_array(rigid_solver.get_links_pos(base_link.idx)[0])
     base_link_quat = tensor_to_array(rigid_solver.get_links_quat(base_link.idx)[0])
-    base_link_com = tensor_to_array(rigid_solver.get_links_pos(base_link.idx, ref="link_com")[0])
+    base_link_com = tensor_to_array(rigid_solver.get_links_pos(base_link.idx, ref=gs.link_ref_frame.link_COM)[0])
     base_root_COM = tensor_to_array(rigid_solver.get_links_root_COM(base_link.idx)[0])
     base_link_R = gu.quat_to_R(base_link_quat)
     base_inertial_R = gu.quat_to_R(gu.transform_quat_by_quat(base_link.inertial_quat, base_link_quat))
@@ -293,7 +293,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
 
     rigid_solver.clear_external_force()
     rigid_solver.apply_links_external_wrench(
-        force=force_local, links_idx=base_link.idx, pos=lever_arm, ref="link_origin", local=True
+        force=force_local, links_idx=base_link.idx, pos=lever_arm, ref=gs.link_ref_frame.link_origin, local=True
     )
     force_world = base_link_R @ force_local
     point_world = base_link_pos + base_link_R @ lever_arm
@@ -316,7 +316,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
 
     rigid_solver.clear_external_force()
     rigid_solver.apply_links_external_wrench(
-        force=force_local, links_idx=base_link.idx, pos=lever_arm, ref="link_com", local=True
+        force=force_local, links_idx=base_link.idx, pos=lever_arm, ref=gs.link_ref_frame.link_COM, local=True
     )
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -base_inertial_R @ force_local, tol=gs.EPS
@@ -327,8 +327,10 @@ def test_apply_external_wrench(xml_path, show_viewer):
         tol=gs.EPS,
     )
 
-    with pytest.raises(gs.GenesisException, match="'ref' must be either"):
-        rigid_solver.apply_links_external_wrench(force=(0, 0, 0), links_idx=duck_link_idx, ref="root_com")
+    with pytest.raises(gs.GenesisException, match="'ref' must be one of"):
+        rigid_solver.apply_links_external_wrench(
+            force=(0, 0, 0), links_idx=duck_link_idx, ref=gs.link_ref_frame.root_COM
+        )
     with pytest.raises(gs.GenesisException, match="Either 'force' or 'torque'"):
         rigid_solver.apply_links_external_wrench(links_idx=duck_link_idx)
     with pytest.raises(gs.GenesisException, match="'pos' requires 'force'"):

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -189,7 +189,7 @@ def test_many_boxes_dynamics(box_box_detection, gjk_collision, dynamics, show_vi
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 @pytest.mark.parametrize("model_name", ["double_ball_pendulum"])
-def test_apply_external_forces(xml_path, show_viewer):
+def test_apply_external_wrench(xml_path, show_viewer):
     GRAVITY = 2.0
 
     scene = gs.Scene(
@@ -237,9 +237,9 @@ def test_apply_external_forces(xml_path, show_viewer):
     duck_lever_arm = (0.2, -0.15, 0.1)
     duck_force_local = duck_mass * GRAVITY * duck_init_link_R[2]
     for step in range(801):
-        ee_pos = rigid_solver.get_links_pos([end_effector_link_idx])[0]
-        duck_pos = rigid_solver.get_links_pos([duck_link_idx])[0]
-        duck_quat = rigid_solver.get_links_quat([duck_link_idx])[0]
+        ee_pos = rigid_solver.get_links_pos(end_effector_link_idx)[0]
+        duck_pos = rigid_solver.get_links_pos(duck_link_idx)[0]
+        duck_quat = rigid_solver.get_links_quat(duck_link_idx)[0]
         if step == 0:
             assert_allclose(ee_pos, (0.8, 0.0, 0.02), tol=1e-4)
         elif step in (500, 600):
@@ -262,19 +262,17 @@ def test_apply_external_forces(xml_path, show_viewer):
             force = [0.0, 0.0, 0.0]
             torque = [0.0, 0.0, 0.0]
 
-        duck.base_link.apply_external_force(force=duck_force_local, pos=duck_lever_arm, ref="link_com", local=True)
-        duck.base_link.apply_external_torque(
-            torque=-np.cross(duck_lever_arm, duck_force_local), ref="link_com", local=True
+        duck.base_link.apply_external_wrench(
+            force=duck_force_local,
+            torque=-np.cross(duck_lever_arm, duck_force_local),
+            pos=duck_lever_arm,
+            ref="link_com",
+            local=True,
         )
-        robot.apply_links_external_force(
-            force=force, links_idx_local=[end_effector_link_idx_local], ref="link_origin", local=False
-        )
-        robot.apply_links_external_torque(
-            torque=torque, links_idx_local=[end_effector_link_idx_local], ref="link_origin", local=False
-        )
+        robot.apply_links_external_wrench(force=force, torque=torque, links_idx_local=end_effector_link_idx_local)
         scene.step()
 
-    rigid_solver.apply_links_external_torque(torque=(0, 1, 0), links_idx=[duck_link_idx], ref="link_com", local=True)
+    duck.base_link.apply_external_torque((0, 1, 0), ref="link_com", local=True)
     assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[duck_link_idx, 0], 0, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[duck_link_idx, 0], -duck_init_link_R[:, 1], tol=gs.EPS
@@ -284,18 +282,18 @@ def test_apply_external_forces(xml_path, show_viewer):
     # shows on a link whose inertial frame is rotated with respect to its own frame.
     base_link = robot.get_link("base")
     assert not np.allclose(base_link.inertial_quat, (1.0, 0.0, 0.0, 0.0))
-    base_link_pos = tensor_to_array(rigid_solver.get_links_pos([base_link.idx])[0])
-    base_link_quat = tensor_to_array(rigid_solver.get_links_quat([base_link.idx])[0])
-    base_link_com = tensor_to_array(rigid_solver.get_links_pos([base_link.idx], ref="link_com")[0])
-    base_root_COM = tensor_to_array(rigid_solver.get_links_root_COM([base_link.idx])[0])
+    base_link_pos = tensor_to_array(rigid_solver.get_links_pos(base_link.idx)[0])
+    base_link_quat = tensor_to_array(rigid_solver.get_links_quat(base_link.idx)[0])
+    base_link_com = tensor_to_array(rigid_solver.get_links_pos(base_link.idx, ref="link_com")[0])
+    base_root_COM = tensor_to_array(rigid_solver.get_links_root_COM(base_link.idx)[0])
     base_link_R = gu.quat_to_R(base_link_quat)
     base_inertial_R = gu.quat_to_R(gu.transform_quat_by_quat(base_link.inertial_quat, base_link_quat))
     lever_arm = (0.0, 0.0, 0.1)
     force_local = (0.0, 1.0, 0.0)
 
     rigid_solver.clear_external_force()
-    rigid_solver.apply_links_external_force(
-        force=force_local, links_idx=[base_link.idx], pos=lever_arm, ref="link_origin", local=True
+    rigid_solver.apply_links_external_wrench(
+        force=force_local, links_idx=base_link.idx, pos=lever_arm, ref="link_origin", local=True
     )
     force_world = base_link_R @ force_local
     point_world = base_link_pos + base_link_R @ lever_arm
@@ -308,7 +306,7 @@ def test_apply_external_forces(xml_path, show_viewer):
 
     # A world application point locates the point on its own, so it reproduces the local one it is derived from.
     rigid_solver.clear_external_force()
-    rigid_solver.apply_links_external_force(force=force_world, links_idx=[base_link.idx], pos=point_world)
+    base_link.apply_external_force(force_world, pos=point_world)
     assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -force_world, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
@@ -317,8 +315,8 @@ def test_apply_external_forces(xml_path, show_viewer):
     )
 
     rigid_solver.clear_external_force()
-    rigid_solver.apply_links_external_force(
-        force=force_local, links_idx=[base_link.idx], pos=lever_arm, ref="link_com", local=True
+    rigid_solver.apply_links_external_wrench(
+        force=force_local, links_idx=base_link.idx, pos=lever_arm, ref="link_com", local=True
     )
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -base_inertial_R @ force_local, tol=gs.EPS
@@ -329,12 +327,12 @@ def test_apply_external_forces(xml_path, show_viewer):
         tol=gs.EPS,
     )
 
-    with np.testing.assert_raises(ValueError):
-        rigid_solver.apply_links_external_force(force=(0, 0, 0), links_idx=[duck_link_idx], ref="root_com", local=True)
-    with np.testing.assert_raises(ValueError):
-        rigid_solver.apply_links_external_torque(
-            torque=(0, 0, 0), links_idx=[duck_link_idx], ref="root_com", local=True
-        )
+    with pytest.raises(gs.GenesisException, match="'ref' must be either"):
+        rigid_solver.apply_links_external_wrench(force=(0, 0, 0), links_idx=duck_link_idx, ref="root_com")
+    with pytest.raises(gs.GenesisException, match="Either 'force' or 'torque'"):
+        rigid_solver.apply_links_external_wrench(links_idx=duck_link_idx)
+    with pytest.raises(gs.GenesisException, match="'pos' requires 'force'"):
+        rigid_solver.apply_links_external_wrench(torque=(0, 0, 0), links_idx=duck_link_idx, pos=lever_arm)
 
 
 @pytest.mark.required

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -227,12 +227,19 @@ def test_apply_external_forces(xml_path, show_viewer):
     rigid_solver = scene.rigid_solver
 
     end_effector_link_idx = robot.links[-1].idx
+    end_effector_link_idx_local = robot.links[-1].idx_local
     duck_link_idx = duck.links[0].idx
     duck_mass = duck.get_mass()
     duck_init_link_pos, duck_init_link_R = duck.base_link.pos, gu.quat_to_R(duck.base_link.quat)
+    # The duck is held at rest by cancelling gravity, but the cancelling force is applied away from its center of mass
+    # so that the moment arm of 'pos' is exercised: the spurious torque it generates is undone by an opposite torque
+    # about the very same frame, hence any error in the arm leaves the duck accelerating.
+    duck_lever_arm = (0.2, -0.15, 0.1)
+    duck_force_local = duck_mass * GRAVITY * duck_init_link_R[2]
     for step in range(801):
         ee_pos = rigid_solver.get_links_pos([end_effector_link_idx])[0]
         duck_pos = rigid_solver.get_links_pos([duck_link_idx])[0]
+        duck_quat = rigid_solver.get_links_quat([duck_link_idx])[0]
         if step == 0:
             assert_allclose(ee_pos, (0.8, 0.0, 0.02), tol=1e-4)
         elif step in (500, 600):
@@ -240,6 +247,7 @@ def test_apply_external_forces(xml_path, show_viewer):
         elif step == 800:
             assert_allclose(ee_pos, (-0.8 / math.sqrt(2), 0.8 / math.sqrt(2), 0.02), tol=0.02)
         assert_allclose(duck_pos, duck_init_link_pos, tol=1e-3)
+        assert_allclose(duck_quat, duck.base_link.quat, tol=1e-3)
 
         if step >= 600:
             force = [-4.0, 4.0, 0.0]
@@ -254,14 +262,15 @@ def test_apply_external_forces(xml_path, show_viewer):
             force = [0.0, 0.0, 0.0]
             torque = [0.0, 0.0, 0.0]
 
-        rigid_solver.apply_links_external_force(
-            force=duck_mass * GRAVITY * duck_init_link_R[2], links_idx=[duck_link_idx], ref="link_com", local=True
+        duck.base_link.apply_external_force(force=duck_force_local, pos=duck_lever_arm, ref="link_com", local=True)
+        duck.base_link.apply_external_torque(
+            torque=-np.cross(duck_lever_arm, duck_force_local), ref="link_com", local=True
         )
-        rigid_solver.apply_links_external_force(
-            force=force, links_idx=[end_effector_link_idx], ref="link_origin", local=False
+        robot.apply_links_external_force(
+            force=force, links_idx_local=[end_effector_link_idx_local], ref="link_origin", local=False
         )
-        rigid_solver.apply_links_external_torque(
-            torque=torque, links_idx=[end_effector_link_idx], ref="link_origin", local=False
+        robot.apply_links_external_torque(
+            torque=torque, links_idx_local=[end_effector_link_idx_local], ref="link_origin", local=False
         )
         scene.step()
 
@@ -269,6 +278,55 @@ def test_apply_external_forces(xml_path, show_viewer):
     assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[duck_link_idx, 0], 0, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[duck_link_idx, 0], -duck_init_link_R[:, 1], tol=gs.EPS
+    )
+
+    # A local force and a local application point are both expressed in the frame that 'ref' designates, which only
+    # shows on a link whose inertial frame is rotated with respect to its own frame.
+    base_link = robot.get_link("base")
+    assert not np.allclose(base_link.inertial_quat, (1.0, 0.0, 0.0, 0.0))
+    base_link_pos = tensor_to_array(rigid_solver.get_links_pos([base_link.idx])[0])
+    base_link_quat = tensor_to_array(rigid_solver.get_links_quat([base_link.idx])[0])
+    base_link_com = tensor_to_array(rigid_solver.get_links_pos([base_link.idx], ref="link_com")[0])
+    base_root_COM = tensor_to_array(rigid_solver.get_links_root_COM([base_link.idx])[0])
+    base_link_R = gu.quat_to_R(base_link_quat)
+    base_inertial_R = gu.quat_to_R(gu.transform_quat_by_quat(base_link.inertial_quat, base_link_quat))
+    lever_arm = (0.0, 0.0, 0.1)
+    force_local = (0.0, 1.0, 0.0)
+
+    rigid_solver.clear_external_force()
+    rigid_solver.apply_links_external_force(
+        force=force_local, links_idx=[base_link.idx], pos=lever_arm, ref="link_origin", local=True
+    )
+    force_world = base_link_R @ force_local
+    point_world = base_link_pos + base_link_R @ lever_arm
+    assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -force_world, tol=gs.EPS)
+    assert_allclose(
+        rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
+        -np.cross(point_world - base_root_COM, force_world),
+        tol=gs.EPS,
+    )
+
+    # A world application point locates the point on its own, so it reproduces the local one it is derived from.
+    rigid_solver.clear_external_force()
+    rigid_solver.apply_links_external_force(force=force_world, links_idx=[base_link.idx], pos=point_world)
+    assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -force_world, tol=gs.EPS)
+    assert_allclose(
+        rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
+        -np.cross(point_world - base_root_COM, force_world),
+        tol=gs.EPS,
+    )
+
+    rigid_solver.clear_external_force()
+    rigid_solver.apply_links_external_force(
+        force=force_local, links_idx=[base_link.idx], pos=lever_arm, ref="link_com", local=True
+    )
+    assert_allclose(
+        rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -base_inertial_R @ force_local, tol=gs.EPS
+    )
+    assert_allclose(
+        rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
+        -np.cross(base_link_com + base_inertial_R @ lever_arm - base_root_COM, base_inertial_R @ force_local),
+        tol=gs.EPS,
     )
 
     with np.testing.assert_raises(ValueError):

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -281,15 +281,16 @@ def test_apply_external_wrench(xml_path, show_viewer):
     # A local force and a local application point are both expressed in the frame that 'ref' designates, which only
     # shows on a link whose inertial frame is rotated with respect to its own frame.
     base_link = robot.get_link("base")
-    assert not np.allclose(base_link.inertial_quat, (1.0, 0.0, 0.0, 0.0))
-    base_link_pos = tensor_to_array(rigid_solver.get_links_pos(base_link.idx)[0])
-    base_link_quat = tensor_to_array(rigid_solver.get_links_quat(base_link.idx)[0])
-    base_link_com = tensor_to_array(rigid_solver.get_links_pos(base_link.idx, ref=gs.link_ref_frame.link_COM)[0])
-    base_root_COM = tensor_to_array(rigid_solver.get_links_root_COM(base_link.idx)[0])
+    assert not np.allclose(base_link.inertial_quat, gu.identity_quat())
+    base_inertial_quat = torch.as_tensor(base_link.inertial_quat, device=gs.device)
+    base_link_pos = rigid_solver.get_links_pos(base_link.idx)
+    base_link_quat = rigid_solver.get_links_quat(base_link.idx)
+    base_link_COM = rigid_solver.get_links_pos(base_link.idx, ref=gs.link_ref_frame.link_COM)
+    base_root_COM = rigid_solver.get_links_root_COM(base_link.idx)
     base_link_R = gu.quat_to_R(base_link_quat)
-    base_inertial_R = gu.quat_to_R(gu.transform_quat_by_quat(base_link.inertial_quat, base_link_quat))
-    lever_arm = (0.0, 0.0, 0.1)
-    force_local = (0.0, 1.0, 0.0)
+    base_inertial_R = gu.quat_to_R(gu.transform_quat_by_quat(base_inertial_quat, base_link_quat))
+    lever_arm = torch.tensor((0.0, 0.0, 0.1), dtype=gs.tc_float, device=gs.device)
+    force_local = torch.tensor((0.0, 1.0, 0.0), dtype=gs.tc_float, device=gs.device)
 
     rigid_solver.clear_external_force()
     rigid_solver.apply_links_external_wrench(
@@ -300,7 +301,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
     assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -force_world, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
-        -np.cross(point_world - base_root_COM, force_world),
+        -torch.linalg.cross(point_world - base_root_COM, force_world),
         tol=gs.EPS,
     )
 
@@ -310,7 +311,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
     assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -force_world, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
-        -np.cross(point_world - base_root_COM, force_world),
+        -torch.linalg.cross(point_world - base_root_COM, force_world),
         tol=gs.EPS,
     )
 
@@ -318,12 +319,12 @@ def test_apply_external_wrench(xml_path, show_viewer):
     rigid_solver.apply_links_external_wrench(
         force=force_local, links_idx=base_link.idx, pos=lever_arm, ref=gs.link_ref_frame.link_COM, local=True
     )
-    assert_allclose(
-        rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -base_inertial_R @ force_local, tol=gs.EPS
-    )
+    force_world = base_inertial_R @ force_local
+    point_world = base_link_COM + base_inertial_R @ lever_arm
+    assert_allclose(rigid_solver.dyn_state.links.cfrc_applied_vel[base_link.idx, 0], -force_world, tol=gs.EPS)
     assert_allclose(
         rigid_solver.dyn_state.links.cfrc_applied_ang[base_link.idx, 0],
-        -np.cross(base_link_com + base_inertial_R @ lever_arm - base_root_COM, base_inertial_R @ force_local),
+        -torch.linalg.cross(point_world - base_root_COM, force_world),
         tol=gs.EPS,
     )
 

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -699,7 +699,7 @@ def test_hibernation_wakes_on_user_input(show_viewer, n_envs):
 
     z0 = z_of(box_force)
     for _ in range(6):
-        solver.apply_links_external_force([0.0, 0.0, 40.0], links_idx=[box_force.base_link_idx])
+        solver.apply_links_external_wrench([0.0, 0.0, 40.0], links_idx=box_force.base_link_idx)
         scene.step()
     assert not asleep(box_force) and (z_of(box_force) > z0 + 0.02).all()
     assert all(map(asleep, (box_pos, box_vel, box_qpos, box_cforce, box_cvel, box_cpos)))
@@ -876,7 +876,7 @@ def test_hibernation_wakes_on_daisy_chain(show_viewer, n_envs):
         scene.step()
     assert asleep(box_a) and asleep(box_b) and asleep(box_far)
 
-    solver.apply_links_external_force([20.0, 0.0, 0.0], links_idx=[box_a.base_link_idx])
+    solver.apply_links_external_wrench([20.0, 0.0, 0.0], links_idx=box_a.base_link_idx)
     scene.step()
     assert not asleep(box_a)
     assert not asleep(box_b)

--- a/tests/rigid/test_kinematics.py
+++ b/tests/rigid/test_kinematics.py
@@ -57,8 +57,8 @@ def test_link_velocity(gs_sim, tol):
             0.0,
         ]
     )
-    link_COM0 = gs_sim.rigid_solver.get_links_pos(ref="link_com")[0]
-    link_COM1 = gs_sim.rigid_solver.get_links_pos(ref="link_com")[1]
+    link_COM0 = gs_sim.rigid_solver.get_links_pos(ref=gs.link_ref_frame.link_COM)[0]
+    link_COM1 = gs_sim.rigid_solver.get_links_pos(ref=gs.link_ref_frame.link_COM)[1]
 
     assert_allclose(link_COM0, COM_0, tol=tol)
     assert_allclose(link_COM1, COM_1, tol=tol)
@@ -80,7 +80,7 @@ def test_link_velocity(gs_sim, tol):
     assert_allclose(xvel_0, 0.0, tol=tol)
     xvel_1_ = omega_0 * np.array([-xpos_1[1], xpos_1[0], 0.0])
     assert_allclose(xvel_1, xvel_1_, tol=tol)
-    civel_0, civel_1 = gs_sim.rigid_solver.get_links_vel(ref="link_com")
+    civel_0, civel_1 = gs_sim.rigid_solver.get_links_vel(ref=gs.link_ref_frame.link_COM)
     civel_0_ = omega_0 * np.array([-COM_0[1], COM_0[0], 0.0])
     assert_allclose(civel_0, civel_0_, tol=tol)
     civel_1_ = omega_0 * np.array([-COM_1[1], COM_1[0], 0.0]) + (omega_1 - omega_0) * np.array(

--- a/tests/rigid/test_kinematics.py
+++ b/tests/rigid/test_kinematics.py
@@ -57,8 +57,7 @@ def test_link_velocity(gs_sim, tol):
             0.0,
         ]
     )
-    link_COM0 = gs_sim.rigid_solver.get_links_pos(ref=gs.link_ref_frame.link_COM)[0]
-    link_COM1 = gs_sim.rigid_solver.get_links_pos(ref=gs.link_ref_frame.link_COM)[1]
+    link_COM0, link_COM1 = gs_sim.rigid_solver.get_links_pos(ref=gs.link_ref_frame.link_COM)
 
     assert_allclose(link_COM0, COM_0, tol=tol)
     assert_allclose(link_COM1, COM_1, tol=tol)

--- a/tests/sensors/test_contact.py
+++ b/tests/sensors/test_contact.py
@@ -135,7 +135,7 @@ def test_gravity_force(n_envs, show_viewer, tol):
         scene.step()
 
     # Make sure that box CoM is valid
-    assert_allclose(box.get_links_pos(ref="root_com")[..., :2], box_com_offset[:2], tol=tol)
+    assert_allclose(box.get_links_pos(ref=gs.link_ref_frame.root_COM)[..., :2], box_com_offset[:2], tol=tol)
 
     assert not bool_sensor_floor.read().any(), "ContactSensor for floor should not detect any contact yet."
     assert not bool_sensor_box_2.read().any(), "ContactSensor for box_2 should not detect any contact yet."


### PR DESCRIPTION
## Description
- `RigidSolver.apply_links_external_{force,torque}` are replaced by a single `apply_links_external_wrench(force=None, torque=None, ..., pos=None, ref=..., local=False)`, mirrored by `RigidEntity.apply_links_external_wrench` and `RigidLink.apply_external_wrench`.
- `RigidLink.apply_external_{force,torque}` are shortcuts over the link wrench, for the common case of pushing or twisting a single link. Their docstrings refer to `apply_external_wrench` rather than restating it.
- `pos=` applies the linear force at an arbitrary point of the link, world or link-local, which is what a grab / drag interaction needs.
- Fixes bug: `ref="link_origin", local=True` rotated the force by the principal-inertia frame instead of the link frame.
- `ref` now takes a `gs.link_ref_frame` member rather than a string literal, and `gs.link_ref_frame.root_COM` is no longer accepted for wrenches nor for `get_links_vel`, where it had no use.
- Updates `MouseInteractionPlugin` to use the new `apply_external_wrench` at the mouse point.

## Related Issue
Resolves https://github.com/Genesis-Embodied-AI/genesis-world/issues/1921
Docs https://github.com/Genesis-Embodied-AI/genesis-doc/pull/145

## Motivation and Context
Better for mouse interaction, playing with the physics, useful in applications.

At kernel level a single `func_apply_link_external_wrench` does the frame and moment-arm math, reached through two top-level kernels: one applying the wrench at the reference frame origin, one reading a per-link application point. The reference frame reaches them as a plain int, because quadrants' fastcache holds a weak reference to template arguments and enum members do not support weakrefs.

The `doc` submodule pointer is bumped to genesis-doc#145, which rewrites `user_guide/getting_started/control_your_robot.md` around the new API, and genesis-doc#147, which quotes the enum there and documents it on the `RigidSolver` reference page.

## How Has This Been / Can This Be Tested?
`tests/rigid/test_dynamics.py::test_apply_external_wrench`

## Screenshots (if appropriate):

Updated the `MouseInteractionPlugin` so that it feels much nicer by default!
 
`python examples/viewer_plugin/mouse_interaction.py --use-visual-geom --use-force`

BEFORE

https://github.com/user-attachments/assets/41c29166-cb08-4a2b-8bc0-15052bbfcb77

AFTER

https://github.com/user-attachments/assets/20ad5c01-b989-4c9e-a773-d20699a41db6


## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly https://github.com/Genesis-Embodied-AI/genesis-doc/pull/145
- [x] I tested my changes and added instructions on how to test it for reviewers.

Resolves SIM-313



