### PR TITLE
[MISC] Report a clear error when EGL is unavailable for offscreen rendering.

### DIFF
--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -12,6 +12,8 @@ from .base import Platform
 EGL_PLATFORM_DEVICE_EXT = 0x313F
 EGL_DRM_DEVICE_FILE_EXT = 0x3233
 
+_EGL_LOAD_ERROR = "EGL is required to create an offscreen OpenGL context, and it is unavailable on this system."
+
 
 def _ensure_egl_loaded():
     plugin = OpenGL.platform.PlatformPlugin.by_name("egl")
@@ -22,6 +24,16 @@ def _ensure_egl_loaded():
     plugin.loaded = True
     # create instance of this platform implementation
     plugin = plugin_class()
+
+    # Probing the library here names EGL as the missing piece. A failed dlopen appears either as an ImportError or
+    # as a None library, the shape `install` below tolerates, and either one otherwise reaches the user from deep
+    # inside PyOpenGL, where the message mentions neither EGL nor Genesis.
+    try:
+        egl_library = plugin.EGL
+    except ImportError as e:
+        gs.raise_exception_from(_EGL_LOAD_ERROR, e)
+    if egl_library is None:
+        gs.raise_exception(_EGL_LOAD_ERROR)
 
     plugin.install(vars(OpenGL.platform))
 


### PR DESCRIPTION
Follow-up to #3129, which was closed as expected behaviour. This does not ask for OpenGL to become optional. It implements the detection described there, "we detect early if it is supported, and if not, it raises an exception", so that the exception names EGL.

`scene.build()` creates an offscreen OpenGL context on Linux whether or not anything is rendered, so images built for compute alone, which CUDA and ROCm images generally are, fail there. What the user sees comes from inside PyOpenGL and mentions neither EGL nor Genesis:

```
File "genesis/vis/rasterizer.py", line 40, in build
    self._renderer = pyrender.OffscreenRenderer(
File "OpenGL/raw/EGL/_types.py", line 87, in <module>
    raw_eglQueryString = _p.PLATFORM.EGL.eglQueryString
AttributeError: 'NoneType' object has no attribute 'eglQueryString'
```

With this change:

```
genesis.GenesisException: EGL is required to create an offscreen OpenGL context, and it is unavailable on this system.
```

The probe sits in `_ensure_egl_loaded`, beside the plugin check already there. The original error is kept as `__cause__`, so the paths `dlopen` tried are still in the traceback for anyone who needs them.

## Reproducing

On any image without an OpenGL runtime, for example `rocm/dev-ubuntu-24.04`:

```python
import genesis as gs

gs.init(backend=gs.cpu)
scene = gs.Scene(show_viewer=False)
scene.add_entity(gs.morphs.Plane())
scene.build(n_envs=1)
```

## Testing

Both branches were exercised by importing `genesis/ext/pyrender/platforms/egl.py` on a host with no `libEGL`: once as PyOpenGL reports it there, which is the `ImportError`, and once with PyOpenGL's `EGL` property forced to `None`. On `main` the second reproduces the `AttributeError` above exactly.

I have not added a unit test. Reaching either branch on a runner means removing `libEGL` from it or monkeypatching PyOpenGL's platform class, and the second is the kind of internals mocking the testing guidelines rule out. Glad to add one if you have a shape in mind.
