### PR TITLE
[BUG FIX] Fix viewer picking and raycast sensors missing hits.

### DIFF
--- a/genesis/utils/raycast.py
+++ b/genesis/utils/raycast.py
@@ -18,6 +18,8 @@ class RayHit(NamedTuple):
     position: np.ndarray  # (3,)
     normal: np.ndarray  # (3,)
     geom: "RigidGeom | RigidVisGeom | None"
+    # Env holding the geometry that was hit, None for a cast that is not per-env, e.g. against an analytical plane.
+    env_idx: int | None = None
 
 
 def plane_raycast(normal: np.ndarray, distance: float, ray: Ray) -> RayHit | None:

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -73,10 +73,15 @@ def bvh_ray_cast(
     closest_distance = gs.qd_float(max_range)
     hit_normal = qd.math.vec3(0.0, 0.0, 0.0)
 
+    axes, shear, is_valid_dir = ray_projection(ray_dir, eps)
+
     # Stack for non-recursive BVH traversal
     node_stack = qd.Vector.zero(gs.qd_int, qd.static(STACK_SIZE))
     node_stack[0] = 0  # Start at root node
     stack_idx = 1
+    if not is_valid_dir:
+        # A direction too short to define a ray leaves the stack empty, reporting no hit.
+        stack_idx = 0
 
     while stack_idx > 0:
         stack_idx -= 1
@@ -98,10 +103,10 @@ def bvh_ray_cast(
                 v0, v1, v2 = tri_vertices[:, 0], tri_vertices[:, 1], tri_vertices[:, 2]
 
                 # Perform ray-triangle intersection
-                hit_result = ray_triangle_intersection(ray_start, ray_dir, v0, v1, v2, eps)
+                hit_distance = ray_triangle_intersection(axes, ray_start, shear, v0, v1, v2, eps)
 
-                if hit_result.w > 0.0 and hit_result.x < closest_distance and hit_result.x >= 0.0:
-                    closest_distance = hit_result.x
+                if hit_distance >= 0.0 and hit_distance < closest_distance:
+                    closest_distance = hit_distance
                     hit_face = i_f
                     hit_normal = triangle_face_normal(v0, v1, v2)
             else:  # Internal node
@@ -115,72 +120,96 @@ def bvh_ray_cast(
 
 
 @qd.func
+def ray_projection(ray_dir: qd.types.vector(3), eps: float):
+    """
+    Axis permutation and shear mapping a ray onto +Z, shared by every triangle test of that ray.
+
+    The transform is a function of the ray alone, so two triangles sharing an edge project that edge's vertices to
+    bit-identical coordinates, leaving their tests of it identical up to the order of the two products. Permuting the
+    largest absolute direction component last bounds the shear, and swapping the first two axes when that component is
+    negative preserves the triangle winding.
+
+    Returns
+    -------
+    axes : gs.qd_ivec3
+        Permuted axis indices: the last one carries the ray, the first two span the plane the edge tests run in.
+    shear : qd.math.vec3
+        Shear along the first two axes, then the 1 / ray_dir[axes[2]] scale keeping hit distances in ray_dir units.
+    is_valid : bool
+        False for a direction too short to define a ray, whose traversal must report no hit.
+    """
+    dir_abs = qd.abs(ray_dir)
+    kz = 0
+    if dir_abs[1] > dir_abs[0]:
+        kz = 1
+    if dir_abs[2] > dir_abs[kz]:
+        kz = 2
+    kx = (kz + 1) % 3
+    ky = (kx + 1) % 3
+    if ray_dir[kz] < 0.0:
+        k_swap = kx
+        kx = ky
+        ky = k_swap
+
+    shear = qd.math.vec3(0.0, 0.0, 0.0)
+    is_valid = dir_abs[kz] > eps
+    if is_valid:
+        shear = qd.math.vec3(ray_dir[kx], ray_dir[ky], 1.0) / ray_dir[kz]
+
+    return gs.qd_ivec3(kx, ky, kz), shear, is_valid
+
+
+@qd.func
 def ray_triangle_intersection(
+    axes: qd.types.vector(3),
     ray_start: qd.types.vector(3),
-    ray_dir: qd.types.vector(3),
+    shear: qd.types.vector(3),
     v0: qd.types.vector(3),
     v1: qd.types.vector(3),
     v2: qd.types.vector(3),
     eps: float,
 ):
     """
-    Moller-Trumbore ray-triangle intersection.
+    Watertight ray-triangle intersection in the ray frame produced by ray_projection.
+
+    The ray is inside the triangle when its three edge tests agree in sign, a test within its own rounding bound
+    counting for either side. A ray crossing an edge shared by two triangles is therefore taken by both of them rather
+    than dropped through the surface, which is what an inside test on barycentric coordinates does whenever rounding
+    places the ray just outside both neighbours at once. The triangles are widened by the uncertainty of their own edge
+    tests, and by no more than that.
 
     Returns
     -------
-    result : qd.math.vec4
-        (t, u, v, hit) where hit=1.0 if intersection found, 0.0 otherwise
+    hit_distance : gs.qd_float
+        Distance along the ray to the intersection, -1.0 if the ray misses the triangle.
     """
-    result = qd.Vector.zero(gs.qd_float, 4)
+    hit_distance = gs.qd_float(-1.0)
 
-    edge1 = v1 - v0
-    edge2 = v2 - v0
+    # Vertices relative to the ray origin, sheared so the ray becomes +Z and the edge tests become 2D. Each of the
+    # three vectors below holds one projected coordinate of all three vertices.
+    verts_rel = qd.Matrix.cols([v0 - ray_start, v1 - ray_start, v2 - ray_start])
+    verts_along = verts_rel[axes[2], :]
+    verts_x = verts_rel[axes[0], :] - shear[0] * verts_along
+    verts_y = verts_rel[axes[1], :] - shear[1] * verts_along
+    verts_z = shear[2] * verts_along
 
-    # Begin calculating determinant - also used to calculate u parameter
-    h = ray_dir.cross(edge2)
-    a = edge1.dot(h)
+    # Twice the signed area the ray forms with each edge, weighting the vertex that edge faces and vanishing when the
+    # ray crosses it, together with the bound its two products may cancel down to. That cancellation reaches the point
+    # where the sign comes from rounding alone: each of the two triangles holding an edge rounds its own copy of the
+    # value, all the more freely as the backend compiler may contract either product into a fused multiply-add. Hence
+    # the bound, which lets an area within it count as a crossing - the verdict both triangles then reach.
+    edge_areas = verts_y.cross(verts_x)
+    edge_bound = 2.0 * eps * verts_x.norm() * verts_y.norm()
 
-    # Check all conditions in sequence without early returns
-    valid = True
+    is_crossing = not ((edge_areas < -edge_bound).any() and (edge_areas > edge_bound).any())
+    det = edge_areas.sum()
+    if is_crossing and det != 0.0:
+        # A zero determinant means the ray runs within the triangle plane, where it has no single crossing point.
+        t = edge_areas.dot(verts_z) / det
+        if t > eps:
+            hit_distance = t
 
-    t = gs.qd_float(0.0)
-    u = gs.qd_float(0.0)
-    v = gs.qd_float(0.0)
-    f = gs.qd_float(0.0)
-    s = qd.Vector.zero(gs.qd_float, 3)
-    q = qd.Vector.zero(gs.qd_float, 3)
-
-    # If determinant is near zero, ray lies in plane of triangle
-    if qd.abs(a) < eps:
-        valid = False
-
-    if valid:
-        f = gs.qd_float(1.0) / a
-        s = ray_start - v0
-        u = f * s.dot(h)
-
-        if u < 0.0 or u > 1.0:
-            valid = False
-
-    if valid:
-        q = s.cross(edge1)
-        v = f * ray_dir.dot(q)
-
-        if v < 0.0 or u + v > 1.0:
-            valid = False
-
-    if valid:
-        # At this stage we can compute t to find out where the intersection point is on the line
-        t = f * edge2.dot(q)
-
-        # Ray intersection
-        if t <= eps:
-            valid = False
-
-    if valid:
-        result = qd.math.vec4(t, u, v, gs.qd_float(1.0))
-
-    return result
+    return hit_distance
 
 
 @qd.func
@@ -194,14 +223,18 @@ def ray_aabb_intersection(
     """
     Fast ray-AABB intersection test.
 
+    Culling stays conservative, i.e. a box the ray does touch is never rejected, so that the watertight triangle test
+    of ray_triangle_intersection is reached for every crossing of the surface.
+
     Returns the t value of intersection, or -1.0 if no intersection.
     """
     result = -1.0
 
-    # Use the slab method for ray-AABB intersection
+    # Use the slab method for ray-AABB intersection. The direction is floored only to keep its reciprocal finite, at a
+    # magnitude far below any meaningful direction component: flooring at a comparable magnitude instead would
+    # overstate how fast the ray leaves the slab of a near-parallel axis, cutting the interval short of a real hit.
     sign = qd.select(ray_dir >= 0.0, 1.0, -1.0)
-    ray_dir = sign * qd.max(qd.abs(ray_dir), eps)
-    inv_dir = 1.0 / ray_dir
+    inv_dir = sign / qd.max(qd.abs(ray_dir), eps * eps)
 
     t1 = (aabb_min - ray_start) * inv_dir
     t2 = (aabb_max - ray_start) * inv_dir
@@ -216,7 +249,10 @@ def ray_aabb_intersection(
     # treats that as covering all space (t_near=0 <= t_far=+inf), so the box must be checked non-empty for the sentinel
     # to be a definitive miss regardless of platform NaN/inf comparison behavior.
     is_non_empty = aabb_min.x <= aabb_max.x and aabb_min.y <= aabb_max.y and aabb_min.z <= aabb_max.z
-    if is_non_empty and t_near <= t_far:
+    # The slab bounds carry the rounding of two operations each, so widening the interval by that much keeps culling
+    # conservative: a triangle grazed at a corner of its own box stays a candidate, which is what makes the watertight
+    # triangle test of ray_triangle_intersection reach every crossing of the surface.
+    if is_non_empty and t_near * (1.0 - 2.0 * eps) <= t_far * (1.0 + 2.0 * eps):
         result = t_near
 
     return result
@@ -484,9 +520,13 @@ def bvh_ray_cast_visual(
     closest_distance = gs.qd_float(max_range)
     hit_normal = qd.math.vec3(0.0, 0.0, 0.0)
 
+    axes, shear, is_valid_dir = ray_projection(ray_dir, eps)
+
     node_stack = qd.Vector.zero(gs.qd_int, qd.static(STACK_SIZE))
     node_stack[0] = 0
     stack_idx = 1
+    if not is_valid_dir:
+        stack_idx = 0
 
     while stack_idx > 0:
         stack_idx -= 1
@@ -503,10 +543,10 @@ def bvh_ray_cast_visual(
                 tri_vertices = get_visual_triangle_vertices(i_f, i_b, dyn_state, dyn_info)
                 v0, v1, v2 = tri_vertices[:, 0], tri_vertices[:, 1], tri_vertices[:, 2]
 
-                hit_result = ray_triangle_intersection(ray_start, ray_dir, v0, v1, v2, eps)
+                hit_distance = ray_triangle_intersection(axes, ray_start, shear, v0, v1, v2, eps)
 
-                if hit_result.w > 0.0 and hit_result.x < closest_distance and hit_result.x >= 0.0:
-                    closest_distance = hit_result.x
+                if hit_distance >= 0.0 and hit_distance < closest_distance:
+                    closest_distance = hit_distance
                     hit_face = i_f
                     hit_normal = triangle_face_normal(v0, v1, v2)
             else:

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -109,7 +109,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             # kinematic solver, whose links carry no mass.
             if ray_hit.geom is not None and isinstance(ray_hit.geom.link, RigidLink) and not ray_hit.geom.link.is_fixed:
                 link = ray_hit.geom.link
-                hit_env_idx = self._get_last_raycast_env_idx()
+                hit_env_idx = ray_hit.env_idx
                 mass = float(link.get_mass())
 
                 # Validate mass is not too small to prevent numerical instability
@@ -321,9 +321,6 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
 
         # Set the drag plane (perpendicular to surface normal)
         self._mouse_drag_plane = (plane_normal, -np.dot(plane_normal, self._prev_mouse_scene_pos))
-
-    def _get_last_raycast_env_idx(self) -> int | None:
-        return self._raycaster.last_hit_env_idx
 
     def _apply_spring_force(self, control_point: np.ndarray, dt: float) -> None:
         if not self._held_link:

--- a/genesis/vis/viewer_plugins/raycast.py
+++ b/genesis/vis/viewer_plugins/raycast.py
@@ -1,3 +1,4 @@
+from threading import Lock
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
@@ -6,7 +7,7 @@ from typing_extensions import override
 
 import genesis as gs
 from genesis.ext.pyrender.camera import OrthographicCamera
-from genesis.utils.misc import qd_to_numpy, qd_to_torch
+from genesis.utils.misc import qd_to_numpy, qd_to_torch, with_lock
 from genesis.utils.raycast import Ray, RayHit
 
 from .base import ViewerPlugin
@@ -38,7 +39,9 @@ class Raycaster:
     reduces across envs in torch to pick the closest hit. Cross-env reduction is intentionally a viewer-side concern,
     not part of the kernel, because parallel envs are otherwise meant to be isolated.
 
-    After each `cast()`, `last_hit_env_idx` exposes the env that produced the returned `RayHit` (None when no hit).
+    Casts are serialized and each outcome travels entirely in the returned `RayHit`: all callers share the result
+    buffers the kernel writes into, so the viewer thread picking under the cursor and the stepping thread casting its
+    own rays would otherwise read each other's hit.
 
     Parameters
     ----------
@@ -58,8 +61,8 @@ class Raycaster:
 
         self.scene = scene
         self.envs_idx = scene._envs_idx
-        self.last_hit_env_idx: int | None = None
         self.targets: list[RaycastTarget] = []
+        self._lock = Lock()
 
         n_envs_max = len(self.envs_idx)
         # Visual meshes exist on both solvers, while collision geometry is the rigid solver's alone.
@@ -100,6 +103,7 @@ class Raycaster:
         # Pre-compile to avoid a race condition with Quadrants on the first interactive cast.
         self.cast(ray_origin=np.zeros(3, dtype=gs.np_float), ray_direction=np.zeros(3, dtype=gs.np_float))
 
+    @with_lock
     def update(self) -> None:
         """Refresh per-env vertex positions, AABBs and rebuild every BVH."""
         from genesis.utils.raycast_qd import kernel_update_verts_and_aabbs, kernel_update_visual_aabbs
@@ -119,11 +123,14 @@ class Raycaster:
                 kernel_update_verts_and_aabbs(solver.dyn_state, target.aabb, solver.dyn_info, solver.rigid_config)
             target.bvh.build()
 
+    @with_lock
     def cast(
         self, ray_origin: np.ndarray, ray_direction: np.ndarray, max_range: float = 1000.0, envs_idx=None
     ) -> RayHit | None:
         """
         Cast a single ray against the BVH of each env in parallel and return the closest hit across envs and solvers.
+
+        `RayHit.env_idx` reports the env the hit comes from, None when the scene holds no parallel envs.
 
         Parameters
         ----------
@@ -141,7 +148,6 @@ class Raycaster:
         ray_origin = np.ascontiguousarray(ray_origin, dtype=gs.np_float)
         ray_direction = np.ascontiguousarray(ray_direction, dtype=gs.np_float)
         closest_hit: RayHit | None = None
-        self.last_hit_env_idx = None
         for target in self.targets:
             solver = target.solver
             is_visual = target.vfaces_mask is not None
@@ -171,13 +177,14 @@ class Raycaster:
                 continue
 
             distance = float(distances[winner])
-            position = qd_to_numpy(target.result.hit_point, row_mask=winner, keepdim=False, transpose=True)
-            normal = qd_to_numpy(target.result.normal, row_mask=winner, keepdim=False, transpose=True)
+            # These two escape into the returned hit, which outlives the lock, while the buffers they come from are
+            # rewritten by the next cast.
+            position = qd_to_numpy(target.result.hit_point, row_mask=winner, keepdim=False, transpose=True, copy=True)
+            normal = qd_to_numpy(target.result.normal, row_mask=winner, keepdim=False, transpose=True, copy=True)
             geoms = solver.vgeoms if is_visual else solver.geoms
             geom = geoms[geom_idx] if 0 <= geom_idx < len(geoms) else None
 
-            closest_hit = RayHit(distance, position, normal, geom)
-            self.last_hit_env_idx = winner if self.scene.n_envs > 0 else None
+            closest_hit = RayHit(distance, position, normal, geom, winner if self.scene.n_envs > 0 else None)
         return closest_hit
 
 

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import threading
 import time
 
 import numpy as np
@@ -304,6 +305,7 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     KINEMATIC_LANE_Y = 2.0
     OPTOUT_LANE_Y = 2.5
     PROBE_Z = 3.0
+    CONCURRENT_PROBES = 200
     RAY_T = 0.35
     target_offset = np.asarray(target_offset, dtype=gs.np_float)
     CAM_POS = (target_offset[0], 0.6, 1.2)
@@ -514,14 +516,46 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     )
 
     probe_dir = (0.0, 0.0, -1.0)
-    stack_hit = plugin._raycaster.cast((target_offset[0], STACK_LANE_Y, PROBE_Z), probe_dir)
+    stack_probe = (target_offset[0], STACK_LANE_Y, PROBE_Z)
+    stack_entity = target if use_visual_geom else decoy
+    stack_distance = PROBE_Z - ((TARGET_Z + 0.5 * TARGET_SIZE) if use_visual_geom else (DECOY_Z + 0.5 * DECOY_SIZE))
+    stack_position = (*stack_probe[:2], PROBE_Z - stack_distance)
+    stack_hit = plugin._raycaster.cast(stack_probe, probe_dir)
+    assert stack_hit.geom.entity is stack_entity
+    assert_allclose(stack_hit.distance, stack_distance, tol=1e-6)
+    assert_allclose(stack_hit.position, stack_position, tol=1e-6)
+
+    # A hit stays the answer to its own ray once a later cast has run, both reading the same buffers.
+    plugin._raycaster.cast((target_offset[0], OPTOUT_LANE_Y, PROBE_Z), probe_dir)
+    assert_allclose(stack_hit.position, stack_position, tol=1e-6)
+    assert stack_hit.env_idx == target_env_idx
+
+    # The plugin casts a hover ray of its own on every frame the viewer draws, which overlaps a cast issued from here
+    # wherever the viewer runs in a thread. Casting the opt-out lane alongside reproduces that overlap on every
+    # platform: it answers with another entity in one cast mode and with nothing in the other, both of which the probes
+    # below report should two casts share the hit they read back.
+    is_hovering = True
+
+    def hover():
+        while is_hovering:
+            plugin._raycaster.cast((target_offset[0], OPTOUT_LANE_Y, PROBE_Z), probe_dir)
+
+    hover_thread = threading.Thread(target=hover)
+    hover_thread.start()
+    try:
+        for _ in range(CONCURRENT_PROBES):
+            stack_hit = plugin._raycaster.cast(stack_probe, probe_dir)
+            assert stack_hit.geom.entity is stack_entity
+            assert_allclose(stack_hit.distance, stack_distance, tol=1e-6)
+        # A hover cast raising would leave the probes above running alone, hence unable to catch anything.
+        assert hover_thread.is_alive()
+    finally:
+        is_hovering = False
+        hover_thread.join()
+
     if not use_visual_geom:
-        assert stack_hit.geom.entity is decoy
-        assert_allclose(stack_hit.distance, PROBE_Z - (DECOY_Z + 0.5 * DECOY_SIZE), tol=1e-6)
         return
 
-    assert stack_hit.geom.entity is target
-    assert_allclose(stack_hit.distance, PROBE_Z - (TARGET_Z + 0.5 * TARGET_SIZE), tol=1e-6)
     kinematic_hit = plugin._raycaster.cast((target_offset[0], KINEMATIC_LANE_Y, PROBE_Z), probe_dir)
     assert kinematic_hit.geom.entity is kinematic
     assert_allclose(kinematic_hit.distance, PROBE_Z - BOX_LENGTH, tol=1e-6)

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -304,6 +304,10 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
     STACK_LANE_Y = 1.5
     KINEMATIC_LANE_Y = 2.0
     OPTOUT_LANE_Y = 2.5
+    EDGE_LANE_Y = 4.0
+    # Kept within half the env spacing, so that the probes below reach this env's copy alone.
+    EDGE_RADIUS = 0.15
+    EDGE_PROBE_RANGE = 0.05
     PROBE_Z = 3.0
     CONCURRENT_PROBES = 200
     RAY_T = 0.35
@@ -376,6 +380,17 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
             size=(TARGET_SIZE,) * 3,
             fixed=True,
             collision=False,
+        ),
+    )
+    # Rotated so that none of its triangle edges lines up with a coordinate plane, which is what puts a probe aimed at
+    # an edge within rounding of it. Parked far enough along y for the probes to reach it without crossing anything,
+    # and high enough that the ones coming from below still start above the ground.
+    edge_target = scene.add_entity(
+        morph=gs.morphs.Sphere(
+            pos=(0.0, EDGE_LANE_Y, EDGE_RADIUS + 2.0 * EDGE_PROBE_RANGE),
+            quat=(0.5, 0.5, 0.5, 0.5),
+            radius=EDGE_RADIUS,
+            fixed=True,
         ),
     )
     scene.viewer.add_plugin(
@@ -554,6 +569,23 @@ def test_mouse_interaction_plugin(n_envs, env_spacing, n_envs_per_row, target_en
         hover_thread.join()
 
     if not use_visual_geom:
+        # A ray crossing the surface exactly on an edge shared by two triangles must be reported as a hit: the two
+        # inside tests disagree there, so rounding can place the ray outside both triangles at once and let it through
+        # the surface. Every edge of a closed mesh is shared, and aiming radially at each midpoint of a convex one
+        # meets that edge first.
+        edge_geom = edge_target.geoms[0]
+        edge_verts = tensor_to_array(edge_geom.get_verts())
+        if target_env_idx is not None:
+            edge_verts = edge_verts[target_env_idx] + target_offset
+        edge_center = edge_verts.mean(axis=0)
+        for face in edge_geom.init_faces:
+            for i_v0, i_v1 in ((face[0], face[1]), (face[1], face[2]), (face[2], face[0])):
+                midpoint = 0.5 * (edge_verts[i_v0] + edge_verts[i_v1])
+                outward = midpoint - edge_center
+                outward /= np.linalg.norm(outward)
+                edge_hit = plugin._raycaster.cast(midpoint + EDGE_PROBE_RANGE * outward, -outward)
+                assert edge_hit is not None and edge_hit.geom.entity is edge_target
+                assert_allclose(edge_hit.distance, EDGE_PROBE_RANGE, tol=5e-6)
         return
 
     kinematic_hit = plugin._raycaster.cast((target_offset[0], KINEMATIC_LANE_Y, PROBE_Z), probe_dir)

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -22,6 +22,8 @@ def test_hits(show_viewer, n_envs, enable_mujoco_compatibility):
     RAYCAST_BOX_SIZE = 0.1
     RAYCAST_GRID_SIZE_X = 1.0
     RAYCAST_HEIGHT = 1.0
+    GRAZE_FACE_Z = 1.0
+    GRAZE_RANGE = 1.0
 
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
@@ -108,6 +110,37 @@ def test_hits(show_viewer, n_envs, enable_mujoco_compatibility):
         ),
     )
 
+    # A ray grazing a face from just below must still find it. The face sits on a power of two, so a mount one float
+    # under it starts within half an eps, and the ray rises through the face only ten hit-distances later.
+    scene.add_entity(
+        gs.morphs.Box(
+            size=(BOX_SIZE, BOX_SIZE, GRAZE_FACE_Z),
+            pos=(0.0, -RAYCAST_GRID_SIZE_X, 0.5 * GRAZE_FACE_Z),
+            fixed=True,
+        ),
+    )
+    graze_origin_z = np.nextafter(gs.np_float(GRAZE_FACE_Z), gs.np_float(0.0))
+    graze_sensor = scene.add_entity(
+        gs.morphs.Box(
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+            pos=(-(GRAZE_RANGE + 0.5 * BOX_SIZE), -RAYCAST_GRID_SIZE_X, graze_origin_z),
+            collision=False,
+            fixed=True,
+        ),
+    )
+    graze_raycaster = scene.add_sensor(
+        gs.sensors.Raycaster(
+            pattern=gs.sensors.raycaster.GridPattern(
+                resolution=1.0,
+                size=(0.0, 0.0),
+                direction=(1.0, 0.0, 0.1 * (GRAZE_FACE_Z - graze_origin_z) / GRAZE_RANGE),
+            ),
+            entity_idx=graze_sensor.idx,
+            max_range=2.0 * GRAZE_RANGE,
+            no_hit_value=-1.0,
+        )
+    )
+
     obstacle_1 = scene.add_entity(
         gs.morphs.Box(
             size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
@@ -166,6 +199,8 @@ def test_hits(show_viewer, n_envs, enable_mujoco_compatibility):
         grid_distances_ref = torch.full((*batch_shape, *NUM_RAYS_XY), RAYCAST_HEIGHT)
         grid_distances_ref[(..., *hit_ij)] = RAYCAST_HEIGHT - obstacle_pos[..., 2] - 0.5 * BOX_SIZE
         assert_allclose(grid_distances, grid_distances_ref, tol=gs.EPS)
+
+    assert_allclose(graze_raycaster.read().distances, GRAZE_RANGE, tol=gs.EPS)
 
     # Validate spherical raycast
     spherical_distances = spherical_raycaster.read().distances


### PR DESCRIPTION
## Description

`Raycaster.cast()` shared its result buffers between callers, so a cast from the stepping thread could report the hit of the hover ray the mouse plugin casts on the viewer thread - 666 of 2000 probes wrong on Linux aarch64. Casts are serialized now, the hit point and normal are copied out of those buffers rather than viewing them, and the env index travels in `RayHit` instead of an attribute read after the fact.

Two triangles sharing an edge tested it through different expressions, so rounding could place a ray outside both at once and let it through the surface - exactly where a ray aimed at the centre of a box face lands. Each edge test is now compared against its own rounding bound (Woop-Benthin-Wald projection), widening a triangle by the uncertainty of its own tests and no more: a sweep of 1938 shared-edge rays leaked 129 on macOS CPU, 115 on Linux aarch64 and 142 on Metal, and none now. AABB culling was non-conservative for a related reason - flooring the ray direction at `eps` cut the slab of a near-parallel axis short of a real hit.

## Motivation and Context

`test_mouse_interaction_plugin` fails intermittently on Linux (runs 30546878240, 30539724428, 30570928535), where the viewer runs in a thread. The edge defect equally affects the raycaster sensors, where a lidar ray grazing a face can miss it.

## How Has This Been / Can This Be Tested?

```bash
pytest -v tests/rendering/test_interactive_viewer.py tests/sensors/test_raycaster.py tests/core/test_bvh.py
```

Passes on macOS CPU, Metal, and Linux aarch64 in both array modes. The three added assertions each fail without the fix.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
