### PR TITLE
[MISC] Fix flaky unit test.

### DIFF
--- a/tests/sensors/test_camera.py
+++ b/tests/sensors/test_camera.py
@@ -335,9 +335,9 @@ def test_rasterizer_attached_batched(show_viewer, png_snapshot, tol):
 
     # Verify camera pose matches the analytical formula
     offset_T = pos_lookat_up_to_T(
-        np.array(cam_pos, dtype=np.float32),
-        np.array(cam_lookat, dtype=np.float32),
-        np.array(cam_up, dtype=np.float32),
+        np.array(cam_pos, dtype=gs.np_float),
+        np.array(cam_lookat, dtype=gs.np_float),
+        np.array(cam_up, dtype=gs.np_float),
     )
     sphere_pos = tensor_to_array(sphere.get_pos())
     sphere_quat = tensor_to_array(sphere.get_quat())
@@ -577,11 +577,11 @@ def test_raytracer_attached_without_offset_T():
     scene.build()
 
     # Attach scene-level camera with equivalent offset_T
-    cam_lookat = np.array(camera_common_options["lookat"], dtype=np.float32)
-    cam_up = np.array(camera_common_options["up"], dtype=np.float32)
+    cam_lookat = np.array(camera_common_options["lookat"], dtype=gs.np_float)
+    cam_up = np.array(camera_common_options["up"], dtype=gs.np_float)
     scene_camera.attach(
         sphere.base_link,
-        offset_T=pos_lookat_up_to_T(np.array(CAM_POS, dtype=np.float32), cam_lookat, cam_up),
+        offset_T=pos_lookat_up_to_T(np.array(CAM_POS, dtype=gs.np_float), cam_lookat, cam_up),
     )
 
     scene.step()


### PR DESCRIPTION
## Description

The expected camera pose of the attached-camera tests was assembled from `np.float32` inputs, while the camera sensor itself assembles it with `dtype=gs.tc_float`. Both now use the simulation precision.

## Motivation and Context

The expectation was fp32-rounded whatever the simulation precision, so `test_rasterizer_attached_batched` compared an fp32 value against the fp64 pose the renderer actually holds, with the fp64 tolerance of `1e-9`: 18 of the 32 matrix entries mismatched, by 4.5e-8 absolute and 1.9e-7 relative, which is plain fp32 epsilon. The assertion could only pass when the two association orders happened to round to the same bits, and it was vacuous on the fp32 arm where the tolerance is `5e-5`.

## How Has This Been / Can This Be Tested?

`pytest tests/sensors/test_camera.py` covers it, on the cpu backend for the fp64 arm and on the gpu backend for the fp32 one. `test_rasterizer_attached_batched` fails before this change on the cpu backend and passes with it.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
