### PR TITLE
[MISC] Document rigid model-info batching options.

### DIFF
--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -439,6 +439,19 @@ class RigidOptions(Options):
     IK_max_targets : int, optional
         Maximum number of IK targets. Increasing this doesn't affect IK solving speed, but will increase memory usage.
         Defaults to 6.
+    batch_links_info : bool, optional
+        Whether link model information, such as mass and inertia, is stored separately for every parallel environment.
+        When enabled, related getters and setters include a leading environment dimension and accept environment-specific
+        values. Leave disabled when all environments share link properties to reduce memory usage. Defaults to False.
+    batch_joints_info : bool, optional
+        Whether joint model information, such as solver parameters, is stored separately for every parallel environment.
+        When enabled, related getters and setters include a leading environment dimension and accept environment-specific
+        values. Leave disabled when all environments share joint properties to reduce memory usage. Defaults to False.
+    batch_dofs_info : bool, optional
+        Whether degree-of-freedom model information, such as gains, damping, and force ranges, is stored separately for
+        every parallel environment. When enabled, related getters and setters include a leading environment dimension and
+        accept environment-specific values. Leave disabled when all environments share DOF properties to reduce memory
+        usage. Defaults to False.
     constraint_solver : gs.constraint_solver, optional
         Constraint solver type. Current supported constraint solvers are 'gs.constraint_solver.CG' (conjugate gradient)
         and 'gs.constraint_solver.Newton' (Newton's method). Defaults to 'Newton'.


### PR DESCRIPTION
## Description

Document the three `RigidOptions` flags that control per-environment storage of
link, joint, and DOF model information. The new descriptions explain the public
shape behavior, environment-specific updates, memory tradeoff, and default.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#2988

## Motivation and Context

Without these entries, batched-scene users can reasonably interpret shared
getter shapes as missing functionality. The runtime already supports the
behavior; this change makes the opt-in contract discoverable from the public
options documentation.

## How Has This Been / Can This Be Tested?

```bash
uvx --from ruff==0.14.11 ruff check genesis/options/solvers.py
uvx --from ruff==0.14.11 ruff format --check genesis/options/solvers.py
python3 -m compileall -q genesis/options/solvers.py
git diff --check
```

All commands pass locally on macOS. Existing
`tests/rigid/test_api.py::test_batched_info` covers the described shape
behavior.

## Screenshots (if appropriate):

Not applicable.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly; no separate genesis-doc change is needed for this inline API documentation.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes. (Documentation-only; existing tests cover the behavior.)
- [x] All relevant existing tests passed.
