### PR TITLE
[MISC] Share mesh cache between re-exports of the same asset.

### DIFF
--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -1,5 +1,4 @@
 import os
-import pickle as pkl
 from itertools import chain
 from typing import Any, NamedTuple
 
@@ -183,19 +182,12 @@ class Mesh(RBC):
         """
         Remesh for tetrahedralization.
         """
-        rm_file_path = mu.get_remesh_path(self.verts, self.faces, edge_len_abs, edge_len_ratio, fix)
+        cache = mu.get_remesh_cache(self.verts, self.faces, edge_len_abs, edge_len_ratio, fix)
 
-        is_cached_loaded = False
-        if os.path.exists(rm_file_path):
+        remeshed = cache.load()
+        if remeshed is not None:
             gs.logger.debug("Remeshed file (`.rm`) found in cache.")
-            try:
-                with open(rm_file_path, "rb") as file:
-                    verts, faces = pkl.load(file)
-                is_cached_loaded = True
-            except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-                gs.logger.info("Ignoring corrupted cache.")
-
-        if not is_cached_loaded:
+        else:
             # Importing pymeshlab is very slow and not used very often. Let's delay import.
             with open(os.devnull, "w") as stderr, redirect_libc_stderr(stderr):
                 import pymeshlab
@@ -208,14 +200,13 @@ class Mesh(RBC):
             else:
                 ms.meshing_isotropic_explicit_remeshing(targetlen=pymeshlab.PercentageValue(edge_len_ratio * 100))
             m = ms.current_mesh()
-            verts, faces = m.vertex_matrix(), m.face_matrix()
+            remeshed = (m.vertex_matrix(), m.face_matrix())
             # Maybe we need to fix the mesh in some extreme cases with open3d
             # if fix:
             #     verts, faces = pymeshfix.clean_from_arrays(verts, faces)
-            os.makedirs(os.path.dirname(rm_file_path), exist_ok=True)
-            with open(rm_file_path, "wb") as file:
-                pkl.dump((verts, faces), file)
+            cache.save(remeshed)
 
+        verts, faces = remeshed
         self._mesh = trimesh.Trimesh(vertices=verts, faces=faces)
         self._invalidate_geometry_cache()
         self.clear_visuals()

--- a/genesis/utils/element.py
+++ b/genesis/utils/element.py
@@ -1,6 +1,3 @@
-import os
-import pickle as pkl
-
 import numpy as np
 import igl
 
@@ -11,28 +8,18 @@ from . import mesh as mu
 
 def mesh_to_elements(mesh, tet_cfg=dict()):
     """Tetrahedralize a surface trimesh, with the result cached on disk keyed on vertices, faces and configuration."""
-    tet_file_path = mu.get_tet_path(mesh.vertices, mesh.faces, tet_cfg)
+    cache = mu.get_tet_cache(mesh.vertices, mesh.faces, tet_cfg)
 
     # loading pre-computed cache if available
-    is_cached_loaded = False
-    if os.path.exists(tet_file_path):
+    elements = cache.load()
+    if elements is not None:
         gs.logger.debug("Tetrahedra file (`.tet`) found in cache.")
-        try:
-            with open(tet_file_path, "rb") as tet_file:
-                verts, elems = pkl.load(tet_file)
-            is_cached_loaded = True
-        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-            gs.logger.info("Ignoring corrupted cache.")
+        return elements
 
-    if not is_cached_loaded:
-        with gs.logger.timer(f"Tetrahedralization with configuration {tet_cfg} and generating `.tet` file:"):
-            verts, elems = mu.tetrahedralize_mesh(mesh, tet_cfg)
-
-            os.makedirs(os.path.dirname(tet_file_path), exist_ok=True)
-            with open(tet_file_path, "wb") as tet_file:
-                pkl.dump((verts, elems), tet_file)
-
-    return verts, elems
+    with gs.logger.timer(f"Tetrahedralization with configuration {tet_cfg} and generating `.tet` file:"):
+        elements = mu.tetrahedralize_mesh(mesh, tet_cfg)
+        cache.save(elements)
+    return elements
 
 
 def split_all_surface_tets(verts, elems):

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -20,7 +20,6 @@ import genesis as gs
 from . import geom as gu
 from .misc import (
     SizeCappedCache,
-    register_cache_clear,
     get_assets_dir,
     get_cvx_cache_dir,
     get_exr_cache_dir,
@@ -33,10 +32,14 @@ from .misc import (
     get_usd_cache_dir,
     get_wt_cache_dir,
     get_wth_cache_dir,
+    register_cache_clear,
 )
 
 MESH_REPAIR_ERROR_THRESHOLD = 0.01
-CVX_PATH_QUANTIZE_FACTOR = 1e-6
+# Largest coordinate discrepancy, as a fraction of the bounding-box diagonal, under which two meshes are considered
+# identical by the on-disk caches. Orders of magnitude below the spacing of genuinely distinct geometry, and orders of
+# magnitude above the last-significant-digit noise separating two exports of the same model.
+MESH_CACHE_MATCH_RTOL = 1e-6
 # Vertex welding quantum: co-located vertices are authored with identical coordinates, so a tight absolute quantum
 # absorbs sub-nanometer parsing noise while keeping genuinely distinct vertices separate.
 VERT_WELD_QUANTIZE_FACTOR = 1e-8
@@ -49,10 +52,6 @@ DEFAULT_PLANE_TEXTURE_PATH = "textures/checker.png"  # use checkerboard texture 
 WT_CACHE_VERSION = 7
 # Bumped when the wall-thickness estimate changes for a fixed (mesh, quantile): forces a cache miss on stale entries.
 WTH_CACHE_VERSION = 1
-
-
-def discretize_array_for_hashing(arr: np.ndarray) -> np.ndarray:
-    return np.round(arr / CVX_PATH_QUANTIZE_FACTOR).astype(np.int64)
 
 
 def color_f32_to_u8(color) -> np.ndarray:
@@ -85,13 +84,10 @@ def get_wall_thickness(verts: np.ndarray, faces: np.ndarray, quantile: float = 0
     any one axis to the thickness of the walls facing it measurably degrades the certified pens of every wall
     tangent to it, and no bound-side search can recover the loss (the lateral sample offset is a lattice property).
     """
-    cache_path = get_wth_path(verts, faces, quantile)
-    if os.path.exists(cache_path):
-        try:
-            with open(cache_path, "rb") as file:
-                return pkl.load(file)
-        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-            gs.logger.info("Ignoring corrupted wall-thickness cache.")
+    cache = get_wth_cache(verts, faces, quantile)
+    wall_thickness = cache.load()
+    if wall_thickness is not None:
+        return wall_thickness
 
     mesh = trimesh.Trimesh(verts, faces, process=False)
     if not mesh.is_watertight:
@@ -111,9 +107,7 @@ def get_wall_thickness(verts: np.ndarray, faces: np.ndarray, quantile: float = 0
     areas_cum = np.cumsum(areas[order])
     wall_thickness = thickness[order][np.searchsorted(areas_cum, quantile * areas_cum[-1])]
 
-    os.makedirs(get_wth_cache_dir(), exist_ok=True)
-    with open(cache_path, "wb") as file:
-        pkl.dump(wall_thickness, file, protocol=pkl.HIGHEST_PROTOCOL)
+    cache.save(wall_thickness)
     return wall_thickness
 
 
@@ -198,34 +192,28 @@ def get_gnd_path(name, subterrain_types, subterrain_size, horizontal_scale, vert
     return os.path.join(get_gnd_cache_dir(), f"{hashkey}.gnd")
 
 
-def get_cvx_path(verts, faces, coacd_options):
-    hashkey = get_hashkey(verts, faces, coacd_options.__dict__)
-    return os.path.join(get_cvx_cache_dir(), f"{hashkey}.cvx")
+def get_cvx_cache(verts, faces, coacd_options):
+    return MeshCache(get_cvx_cache_dir(), "cvx", verts, faces, coacd_options.__dict__)
 
 
-def get_ptc_path(verts, faces, p_size, sampler):
-    hashkey = get_hashkey(verts, faces, p_size, sampler)
-    return os.path.join(get_ptc_cache_dir(), f"{hashkey}.ptc")
+def get_ptc_cache(verts, faces, p_size, sampler):
+    return MeshCache(get_ptc_cache_dir(), "ptc", verts, faces, p_size, sampler)
 
 
-def get_tet_path(verts, faces, tet_cfg):
-    hashkey = get_hashkey(verts, faces, tet_cfg)
-    return os.path.join(get_tet_cache_dir(), f"{hashkey}.tet")
+def get_tet_cache(verts, faces, tet_cfg):
+    return MeshCache(get_tet_cache_dir(), "tet", verts, faces, tet_cfg)
 
 
-def get_remesh_path(verts, faces, edge_len_abs, edge_len_ratio, fix):
-    hashkey = get_hashkey(verts, faces, edge_len_abs, edge_len_ratio, fix)
-    return os.path.join(get_remesh_cache_dir(), f"{hashkey}.rm")
+def get_remesh_cache(verts, faces, edge_len_abs, edge_len_ratio, fix):
+    return MeshCache(get_remesh_cache_dir(), "rm", verts, faces, edge_len_abs, edge_len_ratio, fix)
 
 
-def get_wt_path(verts, faces, aggressiveness):
-    hashkey = get_hashkey(verts, faces, aggressiveness, WT_CACHE_VERSION)
-    return os.path.join(get_wt_cache_dir(), f"{hashkey}.wt")
+def get_wt_cache(verts, faces, aggressiveness):
+    return MeshCache(get_wt_cache_dir(), "wt", verts, faces, aggressiveness, WT_CACHE_VERSION)
 
 
-def get_wth_path(verts, faces, quantile):
-    hashkey = get_hashkey(verts, faces, quantile, WTH_CACHE_VERSION)
-    return os.path.join(get_wth_cache_dir(), f"{hashkey}.wth")
+def get_wth_cache(verts, faces, quantile):
+    return MeshCache(get_wth_cache_dir(), "wth", verts, faces, quantile, WTH_CACHE_VERSION)
 
 
 def get_exr_path(file_path):
@@ -258,6 +246,70 @@ def get_hashkey(*args):
                 arg = marshal.dumps(arg)
         hasher.update(arg)
     return hasher.hexdigest()
+
+
+class MeshCache:
+    """On-disk cache of data derived from a mesh, keyed on its geometry up to the noise of a re-export.
+
+    Exporting the same model twice from an authoring tool perturbs its coordinates in the last significant digits,
+    which changes any exact hash of them and forces every derived artifact to be recomputed from scratch. Rounding
+    the coordinates onto a grid before hashing does not fix this: a coordinate lying near a grid boundary changes
+    bucket under an arbitrarily small perturbation, and a single such coordinate out of the tens of thousands of a
+    mesh already changes the key. Entries are therefore grouped into buckets keyed on what is exactly reproducible -
+    the vertex count, the face connectivity and the generation parameters - and a lookup that misses the exact vertex
+    key scans its bucket, accepting the first candidate matching within 'MESH_CACHE_MATCH_RTOL'. Both arms compare
+    the vertices, so a hit is always verified rather than inferred from a key.
+
+    An entry stores its reference vertices ahead of the payload in the same file, so the scan deserializes only that
+    leading record for the candidates it rejects.
+
+    Parameters
+    ----------
+    cache_dir : str
+        Directory holding the buckets of this kind of derived data.
+    ext : str
+        Extension of the cache files, identifying the kind of derived data they hold.
+    verts : np.ndarray
+        Vertices identifying the mesh, in the frame the derived data is expressed in. Pass them normalized whenever
+        the derived data is invariant to a transform, so that meshes related by one share a single entry.
+    faces : np.ndarray
+        Face connectivity identifying the mesh.
+    *params
+        Every generation parameter the derived data depends on. Must be exactly reproducible across runs.
+    """
+
+    def __init__(self, cache_dir: str, ext: str, verts: np.ndarray, faces: np.ndarray, *params):
+        self._verts = np.ascontiguousarray(verts)
+        bucket_key = get_hashkey(len(self._verts), np.ascontiguousarray(faces), *params)
+        self._bucket_dir = os.path.join(cache_dir, bucket_key)
+        self._filename = f"{get_hashkey(self._verts)}.{ext}"
+
+    def load(self):
+        """Return the payload of the matching entry, or None if this bucket holds none."""
+        if not os.path.isdir(self._bucket_dir):
+            return None
+        atol = MESH_CACHE_MATCH_RTOL * np.linalg.norm(self._verts.max(axis=0) - self._verts.min(axis=0))
+        # Trying the exact key first keeps an unchanged asset from ever paying for the scan.
+        for filename in sorted(os.listdir(self._bucket_dir), key=lambda name: name != self._filename):
+            try:
+                with open(os.path.join(self._bucket_dir, filename), "rb") as file:
+                    # Each record needs its own unpickler: one reused across both would carry its memo from the
+                    # vertices into the payload and misread it.
+                    verts_ref = pkl.load(file)
+                    if verts_ref.shape != self._verts.shape or (np.abs(self._verts - verts_ref) > atol).any():
+                        continue
+                    return pkl.load(file)
+            except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
+                gs.logger.info("Ignoring corrupted cache.")
+        return None
+
+    def save(self, payload) -> None:
+        """Store the payload as the entry of this mesh. It must not be None, which 'load' reserves for a miss."""
+        assert payload is not None
+        os.makedirs(self._bucket_dir, exist_ok=True)
+        with open(os.path.join(self._bucket_dir, self._filename), "wb") as file:
+            pkl.dump(self._verts, file, protocol=pkl.HIGHEST_PROTOCOL)
+            pkl.dump(payload, file, protocol=pkl.HIGHEST_PROTOCOL)
 
 
 def load_mesh(file):
@@ -359,35 +411,27 @@ def surface_uvs_to_trimesh_visual(surface, uvs=None, n_verts=None):
 
 
 def convex_decompose(mesh, coacd_options):
-    # rescale mesh vertices to remove scale factor, and quantize to int to prevent cache miss due to rounding errors
+    # The decomposition of a scaled mesh is the decomposition of the mesh scaled, so the cache is keyed on vertices
+    # normalized by the mesh scale and the hulls are rescaled on the way out: every scaled copy of an asset shares a
+    # single entry.
     mesh_scale = float(np.linalg.norm(mesh.extents))
     assert not (np.isinf(mesh_scale) or np.isnan(mesh_scale) or mesh_scale <= 0.0)
-    discretized_vertices = discretize_array_for_hashing(mesh.vertices / mesh_scale)
-
-    # compute file name via hashing for caching
-    cvx_path = get_cvx_path(discretized_vertices, mesh.faces, coacd_options)
+    cache = get_cvx_cache(mesh.vertices / mesh_scale, mesh.faces, coacd_options)
 
     # loading pre-computed cache if available
     is_cached_loaded = False
-    if os.path.exists(cvx_path):
+    loaded_cache = cache.load()
+    if loaded_cache is not None:
         gs.logger.debug("Convex decomposition file (.cvx) found in cache.")
-        try:
-            with open(cvx_path, "rb") as file:
-                loaded_cache = pkl.load(file)
-            mesh_parts = loaded_cache["mesh_parts"]
-            cached_mesh_scale = loaded_cache["mesh_scale"]
+        mesh_parts = loaded_cache["mesh_parts"]
+        cached_mesh_scale = loaded_cache["mesh_scale"]
 
-            # rescale loaded mesh parts
-            if not (np.isinf(cached_mesh_scale) or np.isnan(cached_mesh_scale) or cached_mesh_scale <= 0.0):
-                rescale_factor = mesh_scale / cached_mesh_scale
-                for mesh_part in mesh_parts:
-                    mesh_part.vertices *= rescale_factor
-                is_cached_loaded = True
-            else:
-                # if cached mesh scale is invalid, ignore cache
-                is_cached_loaded = False
-        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-            gs.logger.info("Ignoring corrupted cache.")
+        # rescale loaded mesh parts
+        if not (np.isinf(cached_mesh_scale) or np.isnan(cached_mesh_scale) or cached_mesh_scale <= 0.0):
+            rescale_factor = mesh_scale / cached_mesh_scale
+            for mesh_part in mesh_parts:
+                mesh_part.vertices *= rescale_factor
+            is_cached_loaded = True
 
     if not is_cached_loaded:
         with gs.logger.timer("Running convex decomposition."):
@@ -415,13 +459,7 @@ def convex_decompose(mesh, coacd_options):
             mesh_parts = []
             for vs, fs in result:
                 mesh_parts.append(trimesh.Trimesh(vs, fs))
-            cache = {
-                "mesh_parts": mesh_parts,
-                "mesh_scale": mesh_scale,
-            }
-            os.makedirs(os.path.dirname(cvx_path), exist_ok=True)
-            with open(cvx_path, "wb") as file:
-                pkl.dump(cache, file)
+            cache.save({"mesh_parts": mesh_parts, "mesh_scale": mesh_scale})
 
     return mesh_parts
 
@@ -443,14 +481,18 @@ def postprocess_collision_geoms(
 ):
     # Convexification / decomposition of a collision mesh (convex hull and coacd decomposition) is the dominant cost of
     # adding a file-based entity, and a scene built from many copies of the same asset would otherwise redo it for every
-    # entity. The result is memoized on the geometry of the input collision meshes (quantized vertices and faces) and on
-    # every option / per-geom field that can change the outcome. The processed meshes are immutable (their vertices are
-    # only read downstream, alignment is folded into the link frame), so the cached ones are shared across entities,
-    # which also collapses their memory footprint. Only fresh g_info dicts are handed back so the caller can re-express
-    # the per-geom pose in place without corrupting the template.
+    # entity. The result is memoized on the geometry of the input collision meshes and on every option / per-geom field
+    # that can change the outcome. The processed meshes are immutable (their vertices are only read downstream,
+    # alignment is folded into the link frame), so the cached ones are shared across entities, which also collapses
+    # their memory footprint. Only fresh g_info dicts are handed back so the caller can re-express the per-geom pose in
+    # place without corrupting the template.
     if not g_infos:
         return []
 
+    # Keyed on the vertices themselves rather than matched within a tolerance the way the on-disk caches are: one
+    # entry per distinct input keeps every variant of a same topology evictable on its own, which is what bounds the
+    # footprint of this cache. Re-exports of one asset are what tolerant matching buys, and they cost nothing here
+    # since the expensive steps this memoizes hit their own tolerant on-disk cache anyway.
     key_parts = [
         bool(decimate),
         int(decimate_face_num),
@@ -467,7 +509,7 @@ def postprocess_collision_geoms(
         density = g_info.get("density")
         sol_params = g_info.get("sol_params")
         key_parts += [
-            discretize_array_for_hashing(mesh.verts),
+            np.ascontiguousarray(mesh.verts),
             np.ascontiguousarray(mesh.faces),
             -1 if geom_type is None else int(geom_type),
             int(g_info.get("contype", 0)),
@@ -713,23 +755,13 @@ def _postprocess_collision_geoms_impl(
                 continue
 
             # On-disk cache keyed by (vertices, faces, aggressiveness): a repeated build on the same geom is a file read
-            # instead of a multi-second SDF + DC + QEM rebuild. The reader tolerates corruption (partial writes, stale
-            # pickles, missing modules) by falling back to a fresh compute, matching the pattern used by get_cvx_path.
-            cache_path = get_wt_path(tmesh.vertices, tmesh.faces, watertighten)
-            is_cached_loaded = False
-            v_out = f_out = None
-            if os.path.exists(cache_path):
-                try:
-                    with open(cache_path, "rb") as fp:
-                        v_out, f_out = pkl.load(fp)
-                    is_cached_loaded = True
-                except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-                    gs.logger.info("Ignoring corrupted watertighten cache.")
-            if not is_cached_loaded:
-                v_out, f_out = watertighten_mesh(tmesh.vertices, tmesh.faces, aggressiveness=watertighten)
-                os.makedirs(get_wt_cache_dir(), exist_ok=True)
-                with open(cache_path, "wb") as fp:
-                    pkl.dump((v_out, f_out), fp, protocol=pkl.HIGHEST_PROTOCOL)
+            # instead of a multi-second SDF + DC + QEM rebuild.
+            cache = get_wt_cache(tmesh.vertices, tmesh.faces, watertighten)
+            cached_mesh = cache.load()
+            if cached_mesh is None:
+                cached_mesh = watertighten_mesh(tmesh.vertices, tmesh.faces, aggressiveness=watertighten)
+                cache.save(cached_mesh)
+            v_out, f_out = cached_mesh
             fused = trimesh.Trimesh(vertices=v_out, faces=f_out, process=False)
             metadata = g_info["mesh"].metadata.copy()
             metadata["watertightened"] = True

--- a/genesis/utils/particle.py
+++ b/genesis/utils/particle.py
@@ -1,6 +1,5 @@
 import ctypes
 import os
-import pickle as pkl
 import platform
 import subprocess
 import sys
@@ -52,32 +51,24 @@ def trimesh_to_particles_simple(mesh, p_size, sampler):
     assert sampler in ("random", "regular")
 
     # compute file name via hashing for caching
-    ptc_file_path = msu.get_ptc_path(mesh.vertices, mesh.faces, p_size, sampler)
+    cache = msu.get_ptc_cache(mesh.vertices, mesh.faces, p_size, sampler)
 
     # loading pre-computed cache if available
-    is_cached_loaded = False
-    if os.path.exists(ptc_file_path):
+    positions = cache.load()
+    if positions is not None:
         gs.logger.debug("Sampled particles file (`.ptc`) found in cache.")
-        try:
-            with open(ptc_file_path, "rb") as file:
-                positions = pkl.load(file)
-            is_cached_loaded = True
-        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-            gs.logger.info("Ignoring corrupted cache.")
+        return positions
 
-    if not is_cached_loaded:
-        with gs.logger.timer(f"Sampling particles with ~<{sampler}>~ sampler and generating `.ptc` file:"):
-            # sample a cube first
-            box_size = mesh.bounds[1] - mesh.bounds[0]
-            box_center = (mesh.bounds[1] + mesh.bounds[0]) / 2
-            positions = _box_to_particles(p_size=p_size, pos=box_center, size=box_size, sampler=sampler)
-            # reject out-of-boundary particles
-            sd, *_ = igl.signed_distance(positions, mesh.vertices, mesh.faces)
-            positions = positions[sd < 0.0]
+    with gs.logger.timer(f"Sampling particles with ~<{sampler}>~ sampler and generating `.ptc` file:"):
+        # sample a cube first
+        box_size = mesh.bounds[1] - mesh.bounds[0]
+        box_center = (mesh.bounds[1] + mesh.bounds[0]) / 2
+        positions = _box_to_particles(p_size=p_size, pos=box_center, size=box_size, sampler=sampler)
+        # reject out-of-boundary particles
+        sd, *_ = igl.signed_distance(positions, mesh.vertices, mesh.faces)
+        positions = positions[sd < 0.0]
 
-            os.makedirs(os.path.dirname(ptc_file_path), exist_ok=True)
-            with open(ptc_file_path, "wb") as file:
-                pkl.dump(positions, file)
+        cache.save(positions)
 
     return positions
 
@@ -94,20 +85,13 @@ def trimesh_to_particles_pbs(mesh, p_size, sampler, pos=(0, 0, 0)):
         gs.raise_exception(f"Physics-based particle sampler '{sampler}' is only supported on Linux x86.")
 
     # compute file name via hashing for caching
-    ptc_file_path = msu.get_ptc_path(mesh.vertices, mesh.faces, p_size, sampler)
+    cache = msu.get_ptc_cache(mesh.vertices, mesh.faces, p_size, sampler)
 
     # loading pre-computed cache if available
-    is_cached_loaded = False
-    if os.path.exists(ptc_file_path):
+    positions = cache.load()
+    if positions is not None:
         gs.logger.debug("Sampled particles file (`.ptc`) found in cache.")
-        try:
-            with open(ptc_file_path, "rb") as file:
-                positions = pkl.load(file)
-            is_cached_loaded = True
-        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError):
-            gs.logger.info("Ignoring corrupted cache.")
-
-    if not is_cached_loaded:
+    else:
         with gs.logger.timer(f"Sampling particles with ~<{sampler}>~ sampler and generating `.ptc` file:"):
             sdf_res = int(sampler.split("-")[-1])
 
@@ -168,9 +152,7 @@ def trimesh_to_particles_pbs(mesh, p_size, sampler, pos=(0, 0, 0)):
                 shutil.rmtree(output_dir, ignore_errors=True)
 
             # Cache the generated positions
-            os.makedirs(os.path.dirname(ptc_file_path), exist_ok=True)
-            with open(ptc_file_path, "wb") as file:
-                pkl.dump(positions, file)
+            cache.save(positions)
 
     positions += np.asarray(pos)
 

--- a/genesis/utils/point_cloud.py
+++ b/genesis/utils/point_cloud.py
@@ -2,9 +2,6 @@
 Furthest point sampling (FPS) on triangle mesh surfaces.
 """
 
-import os
-import pickle as pkl
-
 import numpy as np
 import trimesh
 
@@ -14,11 +11,8 @@ from . import mesh as msu
 from .misc import get_fps_pc_cache_dir
 
 
-def get_fps_pc_path(verts, faces, n_points: int, n_candidates: int, return_normals: bool, seed: int):
-    """Cache path for FPS samples; hashing matches ``sample_mesh_point_cloud`` (dtypes + n_candidates rules)."""
-    disc_verts = msu.discretize_array_for_hashing(verts)
-    hashkey = msu.get_hashkey(disc_verts, faces, n_points, n_candidates, return_normals, seed)
-    return os.path.join(get_fps_pc_cache_dir(), f"{hashkey}.fps_pc")
+def get_fps_pc_cache(verts, faces, n_points: int, n_candidates: int, return_normals: bool, seed: int):
+    return msu.MeshCache(get_fps_pc_cache_dir(), "fps_pc", verts, faces, n_points, n_candidates, return_normals, seed)
 
 
 def _furthest_point_sample_impl(
@@ -132,21 +126,16 @@ def sample_mesh_point_cloud(
     if seed is None:
         seed = int(np.random.SeedSequence().entropy)
 
-    cache_path = get_fps_pc_path(verts, faces, n_points, n_candidates, return_normals, seed)
+    cache = get_fps_pc_cache(verts, faces, n_points, n_candidates, return_normals, seed)
 
-    if use_cache and os.path.exists(cache_path):
-        gs.logger.debug("FPS point cloud cache file found.")
-        try:
-            with open(cache_path, "rb") as f:
-                data = pkl.load(f)
-            if return_normals and isinstance(data, tuple) and len(data) == 2:
+    if use_cache:
+        data = cache.load()
+        if data is not None:
+            gs.logger.debug("FPS point cloud cache file found.")
+            if return_normals:
                 pts, nrm = data
                 return pts.astype(gs.np_float, copy=False), nrm.astype(gs.np_float, copy=False)
-            if not return_normals and not isinstance(data, tuple):
-                return data.astype(gs.np_float, copy=False)
-            gs.logger.info("Ignoring FPS point cloud cache (payload shape mismatches return_normals).")
-        except (EOFError, ModuleNotFoundError, pkl.UnpicklingError, TypeError, MemoryError, ValueError):
-            gs.logger.info("Ignoring corrupted FPS point cloud cache.")
+            return data.astype(gs.np_float, copy=False)
 
     tmesh = trimesh.Trimesh(vertices=verts, faces=faces, process=False)
     candidates, face_idx = trimesh.sample.sample_surface(tmesh, n_candidates, seed=seed)
@@ -162,8 +151,6 @@ def sample_mesh_point_cloud(
         output = _furthest_point_sample_impl(candidates, n_points, fps_rng, return_indices=False)
 
     if use_cache:
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with open(cache_path, "wb") as f:
-            pkl.dump(output, f)
+        cache.save(output)
 
     return output

--- a/genesis/utils/usd/usd_context.py
+++ b/genesis/utils/usd/usd_context.py
@@ -248,7 +248,9 @@ class UsdContext:
         Compute the local-to-world transformation matrix for a prim.
         """
         transform = self._xform_cache.GetLocalToWorldTransform(prim)
-        T_usd = np.asarray(transform, dtype=np.float32)  # translation on the bottom row
+        # USD composes transforms in double precision, so the matrix is kept as authored and only narrowed to the
+        # simulation precision once the pose reaches the entity: rounding it here costs the pose its last digits.
+        T_usd = np.asarray(transform)  # translation on the bottom row
         if self._is_yup:
             T_usd @= mu.Y_UP_TRANSFORM
         T_usd[:, :3] *= self._meter_scale

--- a/genesis/utils/usd/usd_geometry.py
+++ b/genesis/utils/usd/usd_geometry.py
@@ -292,7 +292,7 @@ def parse_prim_geoms(
             elif prim.IsA(UsdGeom.Cube):
                 cube_prim = UsdGeom.Cube(prim)
                 size = cube_prim.GetSizeAttr().Get()
-                extents = np.array([size, size, size], dtype=np.float32)
+                extents = np.array([size, size, size])
                 tmesh = trimesh.creation.box(extents=extents)
                 geom_data = extents * geom_S_diag
                 geom_surface.smooth = False

--- a/tests/core/test_misc.py
+++ b/tests/core/test_misc.py
@@ -317,26 +317,25 @@ def test_fps_mesh_sampling_end_to_end():
     assert_allclose(np.abs(normals).max(axis=1), 1.0, tol=1e-4)
 
 
+@pytest.mark.cache(False)
 @pytest.mark.required
 def test_fps_cache_round_trip():
     mesh = trimesh.creation.box((1.0, 1.0, 1.0))
-    # Run both `return_normals` paths: first call writes the cache; second call hits it; outputs identical.
+    # Samples lie on the surface, so they follow any move of the vertices. Perturbing the mesh the way re-exporting it
+    # would, then getting the very samples of the original back, is what proves they were read from the cache.
+    reexported_verts = mesh.vertices + np.random.uniform(-1e-7, 1e-7, mesh.vertices.shape)
+    # Run both `return_normals` paths: first call writes the cache; the others hit it; outputs identical.
     for return_normals in (True, False):
         kwargs = dict(
-            verts=mesh.vertices,
             faces=mesh.faces,
             n_points=5,
             n_candidates=10,
             return_normals=return_normals,
             seed=7,
         )
-        path = pc.get_fps_pc_path(**kwargs)
-        if os.path.exists(path):
-            os.remove(path)
-        first = pc.sample_mesh_point_cloud(**kwargs, use_cache=True)
-        assert os.path.exists(path)
-        cached = pc.sample_mesh_point_cloud(**kwargs, use_cache=True)
-        assert_equal(first, cached)
+        first = pc.sample_mesh_point_cloud(verts=mesh.vertices, **kwargs, use_cache=True)
+        assert_equal(first, pc.sample_mesh_point_cloud(verts=mesh.vertices, **kwargs, use_cache=True))
+        assert_equal(first, pc.sample_mesh_point_cloud(verts=reexported_verts, **kwargs, use_cache=True))
 
 
 @pytest.mark.required

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -1,6 +1,7 @@
 import io
 import os
 import xml.etree.ElementTree as ET
+from functools import partial
 
 import numpy as np
 import pygltflib
@@ -45,6 +46,13 @@ USD_COLOR_TOL = 1e-07
 
 
 USD_NORMALS_TOL = 1e-02
+
+
+# UsdPhysics declares every joint attribute as single precision, so an anchor, a limit or a drive gain authored in
+# double comes back rounded from a USD file and no parser can recover it. Comparing joints against the model they were
+# authored from is bounded by that rounding, whatever precision the simulation itself runs at, which is why they are
+# the only quantities not held to the session tolerance.
+USD_PHYSICS_TOL = 5e-07
 
 
 def extract_mesh(gs_mesh):
@@ -245,8 +253,8 @@ def compare_links(compared_links, usd_links, tol):
             assert_allclose(compared_link.inertial_i, usd_link.inertial_i, atol=tol, err_msg=err_msg)
 
 
-def compare_joints(compared_joints, usd_joints, tol):
-    """Compare joints between two scenes."""
+def compare_joints(compared_joints, usd_joints):
+    """Compare joints between two scenes, within what UsdPhysics can represent (see USD_PHYSICS_TOL)."""
     # Check number of joints
     assert len(compared_joints) == len(usd_joints)
 
@@ -267,34 +275,33 @@ def compare_joints(compared_joints, usd_joints, tol):
         # Compare joint properties
         assert compared_joint.type == usd_joint.type
         err_msg = f"Properties mismatched for joint type {compared_joint.type}"
+        assert_joint_allclose = partial(assert_allclose, tol=USD_PHYSICS_TOL, err_msg=err_msg)
 
-        assert_allclose(compared_joint.pos, usd_joint.pos, tol=tol, err_msg=err_msg)
-        assert_allclose(compared_joint.quat, usd_joint.quat, tol=tol, err_msg=err_msg)
+        assert_joint_allclose(compared_joint.pos, usd_joint.pos)
+        assert_joint_allclose(compared_joint.quat, usd_joint.quat)
         assert compared_joint.n_qs == usd_joint.n_qs, err_msg
         assert compared_joint.n_dofs == usd_joint.n_dofs, err_msg
 
         # Compare initial qpos
-        assert_allclose(compared_joint.init_qpos, usd_joint.init_qpos, tol=tol, err_msg=err_msg)
+        assert_joint_allclose(compared_joint.init_qpos, usd_joint.init_qpos)
 
         # Skip mass/inertia-dependent property checks for fixed joints - they're not used in simulation
         if compared_joint.type != gs.JOINT_TYPE.FIXED:
             # Compare dof limits
-            assert_allclose(compared_joint.dofs_limit, usd_joint.dofs_limit, tol=tol, err_msg=err_msg)
+            assert_joint_allclose(compared_joint.dofs_limit, usd_joint.dofs_limit)
 
             # Compare dof motion properties
-            assert_allclose(compared_joint.dofs_motion_ang, usd_joint.dofs_motion_ang, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_motion_vel, usd_joint.dofs_motion_vel, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_frictionloss, usd_joint.dofs_frictionloss, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_stiffness, usd_joint.dofs_stiffness, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_frictionloss, usd_joint.dofs_frictionloss, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_force_range, usd_joint.dofs_force_range, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_damping, usd_joint.dofs_damping, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_armature, usd_joint.dofs_armature, tol=tol, err_msg=err_msg)
+            assert_joint_allclose(compared_joint.dofs_motion_ang, usd_joint.dofs_motion_ang)
+            assert_joint_allclose(compared_joint.dofs_motion_vel, usd_joint.dofs_motion_vel)
+            assert_joint_allclose(compared_joint.dofs_frictionloss, usd_joint.dofs_frictionloss)
+            assert_joint_allclose(compared_joint.dofs_stiffness, usd_joint.dofs_stiffness)
+            assert_joint_allclose(compared_joint.dofs_force_range, usd_joint.dofs_force_range)
+            assert_joint_allclose(compared_joint.dofs_damping, usd_joint.dofs_damping)
+            assert_joint_allclose(compared_joint.dofs_armature, usd_joint.dofs_armature)
 
             # Compare dof control properties
-            assert_allclose(compared_joint.dofs_act_gain, usd_joint.dofs_act_gain, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_act_bias, usd_joint.dofs_act_bias, tol=tol, err_msg=err_msg)
-            assert_allclose(compared_joint.dofs_force_range, usd_joint.dofs_force_range, tol=tol, err_msg=err_msg)
+            assert_joint_allclose(compared_joint.dofs_act_gain, usd_joint.dofs_act_gain)
+            assert_joint_allclose(compared_joint.dofs_act_bias, usd_joint.dofs_act_bias)
 
 
 def compare_geoms(compared_geoms, usd_geoms, tol):
@@ -355,7 +362,7 @@ def compare_scene(compared_scene: gs.Scene, usd_scene: gs.Scene, tol: float):
 
     compared_joints = [joint for entity in compared_entities for joint in entity.joints]
     usd_joints = [joint for entity in usd_entities for joint in entity.joints]
-    compare_joints(compared_joints, usd_joints, tol=tol)
+    compare_joints(compared_joints, usd_joints)
 
     compared_links = [link for entity in compared_entities for link in entity.links]
     usd_links = [link for entity in usd_entities for link in entity.links]
@@ -903,6 +910,7 @@ def all_joints_mjcf():
         name="/worldbody/base/prismatic_box_joint",
         type="slide",
         axis="0. 0. 1.",
+        pos="0.03 -0.02 0.05",
         range="-0.1 0.4",
         stiffness="50.0",
         damping="5.0",
@@ -921,6 +929,7 @@ def all_joints_mjcf():
         name="/worldbody/base/revolute_box_joint",
         type="hinge",
         axis="0. 0. 1.",
+        pos="-0.04 0.06 -0.01",
         range="-45 45",
         stiffness="50.0",
         damping="5.0",
@@ -999,6 +1008,8 @@ def all_joints_usd(asset_tmp_path, all_joints_mjcf: ET.ElementTree, request):
     prismatic_box_size = to_array(prismatic_box_geom.get("size"))
     prismatic_joint = prismatic_box_body.find("joint[@name='/worldbody/base/prismatic_box_joint']")
     prismatic_range = to_array(prismatic_joint.get("range"))
+    # MJCF anchors the joint in the child body frame; USD wants that same point in each of the two body frames.
+    prismatic_anchor = to_array(prismatic_joint.get("pos"))
 
     # Revolute box
     revolute_box_body = base_body.find("body[@name='/worldbody/base/revolute_box']")
@@ -1008,6 +1019,7 @@ def all_joints_usd(asset_tmp_path, all_joints_mjcf: ET.ElementTree, request):
     revolute_box_size = to_array(revolute_box_geom.get("size"))
     revolute_joint = revolute_box_body.find("joint[@name='/worldbody/base/revolute_box_joint']")
     revolute_range = to_array(revolute_joint.get("range"))
+    revolute_anchor = to_array(revolute_joint.get("pos"))
 
     # Spherical box
     spherical_box_body = base_body.find("body[@name='/worldbody/base/spherical_box']")
@@ -1073,8 +1085,8 @@ def all_joints_usd(asset_tmp_path, all_joints_mjcf: ET.ElementTree, request):
     prismatic_joint_prim.CreateAxisAttr().Set("Z")
     prismatic_joint_prim.CreateLowerLimitAttr().Set(prismatic_range[0])
     prismatic_joint_prim.CreateUpperLimitAttr().Set(prismatic_range[1])
-    prismatic_joint_prim.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
-    prismatic_joint_prim.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+    prismatic_joint_prim.CreateLocalPos0Attr().Set(Gf.Vec3f(*(prismatic_box_pos + prismatic_anchor)))
+    prismatic_joint_prim.CreateLocalPos1Attr().Set(Gf.Vec3f(*prismatic_anchor))
     prismatic_joint_prim.GetPrim().CreateAttribute("linear:stiffness", Sdf.ValueTypeNames.Float).Set(50.0)
     prismatic_joint_prim.GetPrim().CreateAttribute("linear:damping", Sdf.ValueTypeNames.Float).Set(5.0)
     prismatic_drive_api = UsdPhysics.DriveAPI.Apply(prismatic_joint_prim.GetPrim(), "linear")
@@ -1095,8 +1107,8 @@ def all_joints_usd(asset_tmp_path, all_joints_mjcf: ET.ElementTree, request):
     revolute_joint_prim.CreateAxisAttr().Set("Z")
     revolute_joint_prim.CreateLowerLimitAttr().Set(revolute_range[0])
     revolute_joint_prim.CreateUpperLimitAttr().Set(revolute_range[1])
-    revolute_joint_prim.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
-    revolute_joint_prim.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+    revolute_joint_prim.CreateLocalPos0Attr().Set(Gf.Vec3f(*(revolute_box_pos + revolute_anchor)))
+    revolute_joint_prim.CreateLocalPos1Attr().Set(Gf.Vec3f(*revolute_anchor))
     revolute_joint_prim.GetPrim().CreateAttribute("stiffness", Sdf.ValueTypeNames.Float).Set(50.0)
     revolute_joint_prim.GetPrim().CreateAttribute("angular:damping", Sdf.ValueTypeNames.Float).Set(5.0)
     revolute_drive_api = UsdPhysics.DriveAPI.Apply(revolute_joint_prim.GetPrim(), "angular")

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -8,6 +8,8 @@ import pytest
 import trimesh
 from PIL import Image
 
+import coacd
+
 import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.gltf as gltf_utils
@@ -842,20 +844,21 @@ def test_splashsurf_surface_reconstruction(show_viewer):
 
 
 # FIXME: This test is taking too much time on some platform (~1200s)
+# Counting the decompositions requires a cache that no earlier run has populated.
+@pytest.mark.cache(False)
 # @pytest.mark.required
-def test_convex_decompose_cache(monkeypatch):
-    # Check if the convex decomposition cache is correctly tracked regardless of the scale
+def test_convex_decompose_cache(monkeypatch, asset_tmp_path):
+    # A single decomposition must serve every mesh describing the same shape, whatever its placement: rescaled copies,
+    # and re-exports of the model whose coordinates differ only in their last significant digits.
+    n_coacd_runs = 0
+    real_run_coacd = coacd.run_coacd
 
-    # Monkeypatch the get_cvx_path function to track the cache path
-    seen_paths = []
-    real_get_cvx_path = mu.get_cvx_path
+    def counted_run_coacd(*args, **kwargs):
+        nonlocal n_coacd_runs
+        n_coacd_runs += 1
+        return real_run_coacd(*args, **kwargs)
 
-    def wrapped_get_cvx_path(verts, faces, opts):
-        path = real_get_cvx_path(verts, faces, opts)
-        seen_paths.append(path)
-        return path
-
-    monkeypatch.setattr(mu, "get_cvx_path", wrapped_get_cvx_path)
+    monkeypatch.setattr(coacd, "run_coacd", counted_run_coacd)
 
     # Monkeypatch the convex_decompose function to track the convex decomposition result
     seen_results = []
@@ -868,48 +871,44 @@ def test_convex_decompose_cache(monkeypatch):
 
     monkeypatch.setattr(mu, "convex_decompose", wrapped_convex_decompose)
 
-    # First scene building to create the cache
-    scene = gs.Scene(
-        show_viewer=False,
-    )
-    first_scale = 2.0
-    scene.add_entity(
-        morph=gs.morphs.Mesh(
-            file="meshes/duck.obj",
-            scale=first_scale,
-            pos=(0, 0, 1.0),
-            quat=(0, 0, 0, 1),
-        ),
-    )
-    scene.build()
+    # Stretching the duck along one axis gives a shape the rest of the suite never builds, so the decomposition
+    # counted here cannot be one the in-process cache already holds. Perturbing by a fraction of the coordinate
+    # resolution of the file format then reproduces what re-exporting the model from an authoring tool does to it,
+    # while leaving the vertices welded exactly as the original ones are.
+    authored = trimesh.load_mesh(mu.get_asset_path("meshes/duck.obj"), force="mesh")
+    authored.vertices *= (1.0, 1.0, 1.37)
+    authored_path = str(asset_tmp_path / "duck_stretched.obj")
+    authored.export(authored_path)
+    reexported = authored.copy()
+    reexported.vertices += np.random.uniform(-1e-7, 1e-7, reexported.vertices.shape)
+    reexported_path = str(asset_tmp_path / "duck_stretched_reexported.obj")
+    reexported.export(reexported_path)
 
-    # Second scene building, duck with different scale, translation, and rotation
-    scene = gs.Scene(
-        show_viewer=False,
-    )
-    second_scale = 4.0
-    scene.add_entity(
-        morph=gs.morphs.Mesh(
-            file="meshes/duck.obj",
-            scale=second_scale,
-            pos=(1.0, 0, 1.0),
-            quat=(1, 0, 0, 0),
-        ),
-    )
-    scene.build()
+    SCALES = (2.0, 4.0, 8.0)
+    files = (authored_path, authored_path, reexported_path)
+    POSES = ((0.0, 0.0, 1.0), (1.0, 0.0, 1.0), (0.0, 1.0, 1.0))
+    QUATS = ((0.0, 0.0, 0.0, 1.0), (1.0, 0.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0))
+    for file, scale, pos, quat in zip(files, SCALES, POSES, QUATS):
+        scene = gs.Scene(
+            show_viewer=False,
+        )
+        scene.add_entity(
+            morph=gs.morphs.Mesh(
+                file=file,
+                scale=scale,
+                pos=pos,
+                quat=quat,
+            ),
+        )
+        scene.build()
 
-    assert len(seen_paths) == 2
-    assert len(seen_results) == 2
+    assert n_coacd_runs == 1
+    assert len(seen_results) == len(SCALES)
 
-    # scaled mesh should have the same cache path as the original mesh
-    cached_path = seen_paths[0]
-    scaled_path = seen_paths[-1]
-    assert cached_path == scaled_path
-
-    # check if the scaled parts match the scaled version of the original parts
+    # check if the parts of every reused decomposition match the scaled version of the original parts
     cached_parts = seen_results[0]
-    scaled_parts = seen_results[-1]
-    assert len(scaled_parts) == len(cached_parts)
-    for scaled_part, cached_part in zip(scaled_parts, cached_parts):
-        assert_allclose(scaled_part.vertices, cached_part.vertices * (second_scale / first_scale), rtol=1e-6)
-        assert_equal(scaled_part.faces, cached_part.faces)
+    for scale, parts in zip(SCALES[1:], seen_results[1:]):
+        assert len(parts) == len(cached_parts)
+        for part, cached_part in zip(parts, cached_parts):
+            assert_allclose(part.vertices, cached_part.vertices * (scale / SCALES[0]), rtol=1e-6)
+            assert_equal(part.faces, cached_part.faces)


### PR DESCRIPTION
## Description

Mesh-derived caches (convex decomposition, tetrahedralization, remeshing, watertightening, wall thickness, particle and point-cloud sampling) are now matched on the geometry itself rather than on an exact hash of the vertex coordinates, so two exports of the same model share a single entry. Entries are grouped in buckets keyed on what is exactly reproducible - vertex count, face connectivity, generation parameters - and a lookup that misses the exact key compares the candidate vertices of its bucket, accepting one only within a relative tolerance. A second commit fixes two places where the USD parser truncated double-precision values to single.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#1339

## Motivation and Context

Re-exporting an asset from a CAD tool perturbs its coordinates in the last significant digits, which was enough to recompute a 22 s convex decomposition on every run. Rounding the coordinates onto a grid before hashing, as the cache did, cannot fix this: a coordinate near a grid boundary changes bucket under an arbitrarily small perturbation, and one such coordinate out of the tens of thousands of a mesh already changes the key. On a 10k-vertex mesh perturbed by 1e-8, 154 coordinates flip at the previous 1e-6 quantum; surviving it would take a quantum of about 1% of the bounding diagonal, far too coarse to identify a mesh. Both lookup arms compare vertices, so a hit is verified rather than inferred from a key.

The USD parser truncated the `double` size of a `UsdGeom.Cube` and the double-precision composed transform of every prim to single precision, losing the last digits of geometry sizes and poses for no reason.

## How Has This Been / Can This Be Tested?

```bash
pytest -v ./tests/parsers/test_mesh.py::test_convex_decompose_cache ./tests/core/test_misc.py::test_fps_cache_round_trip ./tests/parsers/test_usd.py
```

`test_convex_decompose_cache` now counts the actual CoACD invocations while building the same duck three times - rescaled, then re-exported with last-digit noise - and requires exactly one; it fails on `main` with `assert 2 == 1`. `test_fps_cache_round_trip` requires a perturbed mesh to return the samples of the original, which only the cache can produce since samples follow the surface. The USD joint fixture now authors real joint anchors instead of zeros, so the pose comparison stops holding trivially.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
