### PR TITLE
[MISC] Skip Quadrants memory allocation for inactive solvers.

### DIFF
--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -348,10 +348,6 @@ class FEMSolver(Solver):
         self._n_vverts = self.n_vverts
         self._n_vfaces = self.n_vfaces
 
-        # Every qd.field() below permanently consumes one of the process's SNode trees:
-        # Quadrants holds them in a fixed-size table and only qd.reset() gives one back, so
-        # allocating for a solver with nothing to simulate caps how many scenes a process can
-        # build. Nothing here is read unless this solver is active.
         if self.n_elements_max > 0:
             self.tet_wrong_order = qd.field(dtype=gs.qd_bool, shape=(), needs_grad=False)
 

--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -341,21 +341,27 @@ class FEMSolver(Solver):
 
         self.n_envs = self.sim.n_envs
         self._B = self.sim._B
-        self.tet_wrong_order = qd.field(dtype=gs.qd_bool, shape=(), needs_grad=False)
-
-        # batch fields
-        self.init_batch_fields()
-
-        # rendering
-        self.envs_offset = qd.Vector.field(3, dtype=qd.f32, shape=self._B)
-        self.envs_offset.from_numpy(self._scene.envs_offset.astype(np.float32))
 
         # elements and bodies
         self._n_elements_max = self.n_elements
         self._n_vertices_max = self.n_vertices
         self._n_vverts = self.n_vverts
         self._n_vfaces = self.n_vfaces
+
+        # Every qd.field() below permanently consumes one of the process's SNode trees:
+        # Quadrants holds them in a fixed-size table and only qd.reset() gives one back, so
+        # allocating for a solver with nothing to simulate caps how many scenes a process can
+        # build. Nothing here is read unless this solver is active.
         if self.n_elements_max > 0:
+            self.tet_wrong_order = qd.field(dtype=gs.qd_bool, shape=(), needs_grad=False)
+
+            # batch fields
+            self.init_batch_fields()
+
+            # rendering
+            self.envs_offset = qd.Vector.field(3, dtype=qd.f32, shape=self._B)
+            self.envs_offset.from_numpy(self._scene.envs_offset.astype(np.float32))
+
             self.init_element_fields()
             self.init_surface_fields()
             self.init_vvert_fields()
@@ -379,7 +385,8 @@ class FEMSolver(Solver):
             self.init_constraints()
 
         # FIXME: _gravity must be a raw qd.field() — see comment in mpm_solver.py
-        if self._gravity is not None:
+        # Only when active — see the SNode-tree note in mpm_solver.py.
+        if self.is_active and self._gravity is not None:
             gravity = self._gravity.to_numpy()
             self._gravity = qd.field(dtype=gs.qd_vec3, shape=(self._B,))
             self._gravity.from_numpy(gravity)

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -246,7 +246,10 @@ class MPMSolver(Solver):
         # @qd.data_oriented class, and Quadrants doesn't support Ndarray attrs on data_oriented in kernel scope. Fix by either:
         # (1) adding Ndarray support to data_oriented template resolution, or (2) migrating the solver to a frozen dataclass
         # so _predeclare_struct_ndarrays can register the Ndarray.
-        if self._gravity is not None:
+        # Only when active: the field costs an SNode tree that Quadrants never gives back short of
+        # qd.reset(), and nothing reads an inactive solver's gravity from kernel scope (`set_gravity`
+        # skips inactive solvers, and `SolverBase.set_gravity` / `get_gravity` accept the Ndarray).
+        if self.is_active and self._gravity is not None:
             gravity = self._gravity.to_numpy()
             self._gravity = qd.field(dtype=gs.qd_vec3, shape=(self._B,))
             self._gravity.from_numpy(gravity)

--- a/genesis/engine/solvers/pbd_solver.py
+++ b/genesis/engine/solvers/pbd_solver.py
@@ -230,7 +230,8 @@ class PBDSolver(Solver):
                 entity._add_to_solver()
 
         # FIXME: _gravity must be a raw qd.field() — see comment in mpm_solver.py
-        if self._gravity is not None:
+        # Only when active — see the SNode-tree note in mpm_solver.py.
+        if self.is_active and self._gravity is not None:
             gravity = self._gravity.to_numpy()
             self._gravity = qd.field(dtype=gs.qd_vec3, shape=(self._B,))
             self._gravity.from_numpy(gravity)

--- a/genesis/engine/solvers/sph_solver.py
+++ b/genesis/engine/solvers/sph_solver.py
@@ -159,7 +159,8 @@ class SPHSolver(Solver):
             self._density0 = self.particles_info[0].rho
 
         # FIXME: _gravity must be a raw qd.field() — see comment in mpm_solver.py
-        if self._gravity is not None:
+        # Only when active — see the SNode-tree note in mpm_solver.py.
+        if self.is_active and self._gravity is not None:
             gravity = self._gravity.to_numpy()
             self._gravity = qd.field(dtype=gs.qd_vec3, shape=(self._B,))
             self._gravity.from_numpy(gravity)


### PR DESCRIPTION
## Description

Solvers with nothing to simulate allocate Quadrants fields at `scene.build()` time, and those fields cost SNode trees the process can never get back. This gates the allocations on the solver being active.

Concretely, on a **rigid-only** scene today:

- `MPMSolver`, `SPHSolver` and `PBDSolver` each convert `_gravity` from an Ndarray to a raw `qd.field()` *outside* their `if self.is_active:` block;
- `FEMSolver` allocates `tet_wrong_order`, `init_batch_fields()` and `envs_offset` unconditionally, plus the same `_gravity` conversion.

That is 5 SNode trees per build, in solvers with zero entities. Quadrants keeps materialized trees in a fixed-size table of 512 and only `qd.reset()` gives one back, so the **102nd `scene.build()` in a process dies of SIGSEGV** inside whichever kernel launch comes next — no Python traceback, nothing catchable.

## Motivation and Context

Any loop that builds scenes in one process hits a hard ceiling at ~100 builds: parameter sweeps, dataset preprocessing, batched evaluation, and test suites. We found it because a 2600-test suite lost its last 17% to a segfault three quarters of the way through; the reported traceback pointed at the MPM solver build, which was a red herring — `mpm_solver.build()` runs for every scene, so it was simply the next kernel launch after the table filled.

The gating is safe because nothing reads those fields when the solver is inactive:

- `Simulator.set_gravity` already skips inactive solvers, and `SolverBase.set_gravity` / `get_gravity` handle either representation (`gravity_arg = self._gravity if type(...) is qd.VectorTensor else qd.wrap(...)`), so an inactive solver keeping its Ndarray is fine. The kernel-scope access the `FIXME` is about, `LegacyCoupler.mpm_grid_op`, only runs for an active MPM solver.
- FEM's `tet_wrong_order` / batch fields / `envs_offset` are read only from `_kernel_add_elements`, `batch_solve` and `_kernel_get_state_render`, all of which require elements. `_n_elements_max` / `_n_vertices_max` / `_n_vverts` / `_n_vfaces` move above the guard, since `is_active` is derived from them.

**This does not remove the underlying limit for active solvers.** A process building hundreds of *deformable* scenes still exhausts the table, because those solvers legitimately allocate (measured per build: MPM 2, SPH 3, PBD 3, FEM 7). Releasing trees in `Simulator.destroy()` — which today only destroys the sensor manager — would close that too, and seems worth doing separately.

## How Has This Been / Can This Be Tested?

Environment: Linux, CPU backend, Python 3.12, quadrants 1.2.0, branch based on `b1ddc20e`.

**The leak, before and after.** Build a minimal plane + box scene repeatedly and watch the live tree count (`qd.lang.impl.get_runtime().prog.get_snode_tree_size()`):

```python
import genesis as gs, quadrants as qd

gs.init(backend=gs.cpu)
trees = lambda: qd.lang.impl.get_runtime().prog.get_snode_tree_size()

for i in range(4):
    before = trees()
    scene = gs.Scene(sim_options=gs.options.SimOptions(dt=0.01), show_viewer=False)
    scene.add_entity(gs.morphs.Plane())
    scene.add_entity(gs.morphs.Box(size=(0.1, 0.1, 0.1), pos=(0, 0, 0.5)))
    scene.build(n_envs=2)
    print(f"build {i}: {before} -> {trees()}")
    del scene
```

| | build 0 | build 1 | build 2 | build 3 |
|---|---|---|---|---|
| `main` (b1ddc20e) | 0 → 6 | 6 → 11 | 11 → 16 | 16 → 21 |
| this branch | 0 → 1 | 1 → 1 | 1 → 1 | 1 → 1 |

Left to run, `main` segfaults on build #102 at 511 live trees; allocating and materializing one field at a time puts the wall exactly at the 513th tree. The same 5-trees-per-build was measured on 1.2.3, so this is not a recent regression.

**Existing tests**, all on the CPU backend with this branch:

- `pytest tests/deformable tests/particles` → 39 passed, 1 xfailed (`test_explicit_legacy_coupler_soft_constraint_box[64]`, pre-existing)
- `pytest tests/coupling tests/ipc` → 21 passed, 3 skipped (`uipc` not installed)
- `pytest tests/core` → 115 passed

A probe also builds an MPM, SPH, PBD and FEM scene each, steps 5 times and reads `get_state()` — all four still work, and their tree costs are unchanged.

## Related Issue

There is no filed issue for this yet — happy to open one with the repro above if you'd prefer the PR to track one.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes. <!-- happy to add a regression test asserting the tree count stays flat across repeated rigid builds — say the word and where it belongs -->
- [x] All new and existing tests passed. <!-- for the suites listed above -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDSHdyBtnPzLn9cfuRzWVF
