### PR TITLE
[BUG FIX] Fix orientation-dependent contact detection.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/box_contact.py
+++ b/genesis/engine/solvers/rigid/collider/box_contact.py
@@ -118,7 +118,7 @@ def func_plane_box_contact(
     plane_dir = qd.Vector(
         [dyn_info.geoms.data[i_ga][0], dyn_info.geoms.data[i_ga][1], dyn_info.geoms.data[i_ga][2]], dt=gs.qd_float
     )
-    plane_dir = gu.qd_transform_by_quat(plane_dir, ga_quat)
+    plane_dir = gu.qd_transform_by_quat_fast(plane_dir, ga_quat)
     normal = -plane_dir.normalized()
 
     v1, _, _ = support_field._func_support_box(i_gb, normal, gb_pos, gb_quat, dyn_info)
@@ -152,7 +152,7 @@ def func_plane_box_contact(
                 # Plane-box pairs are sized with the convex cap (they are not in the large-contact mask), so the
                 # emission must stay within it to avoid overflowing a buffer allocated as a convex pair.
                 if n_con < qd.static(collider_static_config.n_contacts_per_convex_pair):
-                    pos_corner = gu.qd_transform_by_trans_quat(dyn_info.verts.init_pos[i_v], gb_pos, gb_quat)
+                    pos_corner = gu.qd_transform_by_trans_quat_fast(dyn_info.verts.init_pos[i_v], gb_pos, gb_quat)
                     penetration = normal.dot(pos_corner - ga_pos)
                     if penetration > 0.0:
                         contact_pos = pos_corner - 0.5 * penetration * normal

--- a/genesis/engine/solvers/rigid/collider/support_field.py
+++ b/genesis/engine/solvers/rigid/collider/support_field.py
@@ -140,9 +140,9 @@ def _func_support_world(
     support position for a world direction
     """
 
-    d_mesh = gu.qd_transform_by_quat(d, gu.qd_inv_quat(quat))
+    d_mesh = gu.qd_transform_by_quat_fast(d, gu.qd_inv_quat(quat))
     v_, vid = _func_support_mesh(i_g, d_mesh, collider_info)
-    v = gu.qd_transform_by_trans_quat(v_, pos, quat)
+    v = gu.qd_transform_by_trans_quat_fast(v_, pos, quat)
     return v, v_, vid
 
 
@@ -333,7 +333,7 @@ def _func_support_box(i_g, d, pos: qd.types.vector(3), quat: qd.types.vector(4),
     )
     vid = (v_[0] > 0.0) * 1 + (v_[1] > 0.0) * 2 + (v_[2] > 0.0) * 4
     vid += dyn_info.geoms.vert_start[i_g]
-    v = gu.qd_transform_by_trans_quat(v_, pos, quat)
+    v = gu.qd_transform_by_trans_quat_fast(v_, pos, quat)
     return v, v_, vid
 
 
@@ -343,7 +343,7 @@ def _func_count_supports_world(i_g, d, quat: qd.types.vector(4), collider_info: 
     Count the number of valid support points for the given world direction.
     Only needs quat since counting doesn't depend on position.
     """
-    d_mesh = gu.qd_transform_by_quat(d, gu.qd_inv_quat(quat))
+    d_mesh = gu.qd_transform_by_quat_fast(d, gu.qd_inv_quat(quat))
     return _func_count_supports_mesh(i_g, d_mesh, collider_info)
 
 

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -33,6 +33,15 @@ def qd_k_cross_vec(vec):
 @qd.func
 def qd_transform_by_quat_fast(v, quat):
     """
+    Rotate a vector by a quaternion that is already normalized.
+
+    Prefer this over the general form whenever the quaternion is known to be a unit one, for exactness rather than for
+    speed: the general form divides by the squared norm, which is a no-op for a unit quaternion in exact arithmetic
+    yet leaves a component that should be untouched a few units in the last place off, by an amount that depends on
+    the rotation. A body resting flat on a plane then reports a height that varies with its orientation about the
+    plane's normal, and the sign of that variation decides whether it is in contact at all. The two cross products
+    here contribute exactly zero to a component the rotation preserves, so it comes back bit for bit.
+
     Assumptions:
     - quat must be normalized
     """
@@ -40,6 +49,14 @@ def qd_transform_by_quat_fast(v, quat):
     u = qd.Vector([q_x, q_y, q_z])
     t = 2.0 * u.cross(v)
     return v + q_w * t + u.cross(t)
+
+
+@qd.func
+def qd_transform_by_trans_quat_fast(pos, trans, quat):
+    """
+    Place a point by a translation and a quaternion that is already normalized. See qd_transform_by_quat_fast.
+    """
+    return qd_transform_by_quat_fast(pos, quat) + trans
 
 
 @qd.func


### PR DESCRIPTION
## Description
Rotating a vector by a quaternion divides by its squared norm, which is a no-op for a unit quaternion in exact arithmetic but not in floating point: a component the rotation preserves comes back a few units in the last place off, by an amount that depends on the rotation. A body resting flat on a plane then reports a height that varies with its orientation about the plane's normal, and that height is what its penetration is measured from, so the variation decides whether it is in contact at all. Support points, the directions they are taken along, a plane's normal and the corners measured against it now use the form that assumes a unit quaternion, which the solver's always are, and a resting height comes back bit for bit at any orientation.

## Motivation and Context
On Apple GPU, eight copies of one scene differing only by a yaw resolved their ground contacts differently, so bodies that should have been identical sat a step of free fall apart, 2.5e-04.

## How Has This Been / Can This Be Tested?
```bash
pytest tests/rigid/test_friction.py::test_elliptic_cone_push_isotropy --backend gpu
```
That test compares eight yawed copies of one scene at every step; it fails on Apple GPU without this change, on contact depth at the first step, and passes on both backends with it. Rotating a resting corner through the eight yaws spreads its height by 3.7e-09 through the normalising form and by exactly 0 through this one.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
