### PR TITLE
Align AMD Docker image with supported PyTorch

### DIFF
--- a/docker/Dockerfile.amdgpu
+++ b/docker/Dockerfile.amdgpu
@@ -1,5 +1,4 @@
-#FROM rocm/pytorch:rocm6.4.1_ubuntu22.04_py3.10_pytorch_release_2.4.1
-FROM rocm/pytorch:rocm6.4.1_ubuntu22.04_py3.10_pytorch_release_2.6.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.8.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -19,7 +18,7 @@ RUN usermod -aG video root
 # Necessary for visualisation on Wayland backed systems like Ubuntu
 ENV PYOPENGL_PLATFORM='glx'
 
-# Install Genesis verified against 0.2.1
+# Install Genesis with a supported PyTorch release
 RUN pip3 install genesis-world trimesh
 
 # Workaround for igl issue

--- a/docker/Dockerfile.amdgpu
+++ b/docker/Dockerfile.amdgpu
@@ -1,4 +1,4 @@
-FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.8.0
+FROM rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.8.0@sha256:880e126d83370e3502b069a39f85cbd7b1f6f7dbfbceb00b6fefbac03c5da091
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tests/core/test_packaging.py
+++ b/tests/core/test_packaging.py
@@ -1,0 +1,28 @@
+import ast
+import pathlib
+import re
+
+
+def test_amdgpu_docker_torch_version_is_supported():
+    module_root_dir = pathlib.Path(__file__).parents[2]
+    dockerfile = (module_root_dir / "docker" / "Dockerfile.amdgpu").read_text()
+    genesis_init = ast.parse((module_root_dir / "genesis" / "__init__.py").read_text())
+
+    active_from = next(line for line in dockerfile.splitlines() if line.startswith("FROM "))
+    version_match = re.fullmatch(
+        r"FROM rocm/pytorch:.*_pytorch_release_(\d+)\.(\d+)\.(\d+)",
+        active_from,
+    )
+    assert version_match is not None
+    image_version = tuple(map(int, version_match.groups()))
+
+    for node in genesis_init.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "_IS_OLD_TORCH" for target in node.targets
+        ):
+            torch_floor = ast.literal_eval(node.value.comparators[0])
+            break
+    else:
+        raise AssertionError("Genesis PyTorch version threshold not found")
+
+    assert image_version[: len(torch_floor)] >= torch_floor

--- a/tests/core/test_packaging.py
+++ b/tests/core/test_packaging.py
@@ -8,21 +8,38 @@ def test_amdgpu_docker_torch_version_is_supported():
     dockerfile = (module_root_dir / "docker" / "Dockerfile.amdgpu").read_text()
     genesis_init = ast.parse((module_root_dir / "genesis" / "__init__.py").read_text())
 
-    active_from = next(line for line in dockerfile.splitlines() if line.startswith("FROM "))
+    active_from = next(
+        (line for line in dockerfile.splitlines() if line.startswith("FROM ")),
+        None,
+    )
+    assert active_from is not None, "Dockerfile.amdgpu has no active FROM instruction"
     version_match = re.fullmatch(
-        r"FROM rocm/pytorch:.*_pytorch_release_(\d+)\.(\d+)\.(\d+)",
+        r"FROM rocm/pytorch:rocm7\.2\.4_ubuntu22\.04_py3\.10_pytorch_release_"
+        r"(\d+)\.(\d+)\.(\d+)@sha256:"
+        r"880e126d83370e3502b069a39f85cbd7b1f6f7dbfbceb00b6fefbac03c5da091",
         active_from,
     )
-    assert version_match is not None
+    assert version_match is not None, "AMD Docker image tag or digest is not the registered image"
     image_version = tuple(map(int, version_match.groups()))
 
-    for node in genesis_init.body:
-        if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == "_IS_OLD_TORCH" for target in node.targets
-        ):
-            torch_floor = ast.literal_eval(node.value.comparators[0])
-            break
-    else:
-        raise AssertionError("Genesis PyTorch version threshold not found")
+    old_torch_assign = next(
+        (
+            node
+            for node in genesis_init.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "_IS_OLD_TORCH"
+                for target in node.targets
+            )
+        ),
+        None,
+    )
+    assert isinstance(old_torch_assign, ast.Assign), "Genesis PyTorch version threshold assignment not found"
+    comparison = old_torch_assign.value
+    assert isinstance(comparison, ast.Compare), "_IS_OLD_TORCH must be a comparison"
+    assert len(comparison.comparators) == 1, "_IS_OLD_TORCH must have one comparator"
+    assert len(comparison.ops) == 1, "_IS_OLD_TORCH must have one comparison operator"
+    assert isinstance(comparison.ops[0], ast.Lt), "_IS_OLD_TORCH must use a less-than comparison"
+    torch_floor = ast.literal_eval(comparison.comparators[0])
 
     assert image_version[: len(torch_floor)] >= torch_floor


### PR DESCRIPTION
## Summary

- update the default AMD Docker base image to the official `rocm/pytorch:rocm7.2.4_ubuntu22.04_py3.10_pytorch_release_2.8.0` tag pinned by its immutable digest
- preserve Ubuntu 22.04 and Python 3.10 while aligning the image with Genesis's supported PyTorch range
- add a static regression test that parses both the active Docker `FROM` tag and Genesis's `_IS_OLD_TORCH` threshold

## Root cause

The official AMD Dockerfile currently selects PyTorch 2.6, while current Genesis explicitly warns that PyTorch versions below 2.8 are unsupported. This leaves the default AMD image below the version floor encoded by Genesis itself.

The replacement tag is published by AMD and has Docker Hub digest `sha256:880e126d83370e3502b069a39f85cbd7b1f6f7dbfbceb00b6fefbac03c5da091`.

## Validation

- `python -m py_compile tests/core/test_packaging.py` — passed (`rc=0`)
- targeted static regression test — `1 passed` (`rc=0`)
- `git diff --check` — passed (`rc=0`)
- old/new static comparison — PyTorch 2.6 fails the current 2.8 floor; PyTorch 2.8 passes

The 9.4 GB Docker image was not pulled or built, so this PR does not claim a successful full-image build or container runtime validation.
