### PR TITLE
[FEATURE][BREAKING] Set contact friction for a pair of materials.

### DIFF
--- a/examples/rigid/domain_randomization.py
+++ b/examples/rigid/domain_randomization.py
@@ -39,7 +39,7 @@ def main():
     scene.build(n_envs=n_envs)
 
     robot.set_friction_ratio(
-        friction_ratio=0.5 + torch.rand(scene.n_envs, robot.n_links),
+        sliding_ratio=0.5 + torch.rand(scene.n_envs, robot.n_links),
         links_idx_local=np.arange(0, robot.n_links),
     )
 

--- a/genesis/engine/couplers/sap_coupler.py
+++ b/genesis/engine/couplers/sap_coupler.py
@@ -3901,7 +3901,10 @@ class RigidRigidTetContactHandler(RigidRigidContactHandler):
                 pairs[i_p].link_idx1 = i_l1
                 sap_info[i_p].k = rigid_k
                 sap_info[i_p].phi0 = rigid_phi0
-                sap_info[i_p].mu = qd.sqrt(geoms_info.friction[i_g0] * geoms_info.friction[i_g1])
+                sap_info[i_p].mu = qd.sqrt(
+                    geoms_info.friction[i_g0][array_class.FrictionIdx.SLIDING]
+                    * geoms_info.friction[i_g1][array_class.FrictionIdx.SLIDING]
+                )
             else:
                 overflow = True
         return overflow

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -132,7 +132,7 @@ class FEMEntity(Entity):
         The simulation scene that this entity belongs to.
     solver : Solver
         The physics solver instance used for simulation.
-    material : Material
+    material : MaterialOptions
         The material properties defining elasticity, density, etc.
     morph : Morph
         The morph specification that defines the entity's shape.

--- a/genesis/engine/entities/mpm_entity.py
+++ b/genesis/engine/entities/mpm_entity.py
@@ -31,7 +31,7 @@ class MPMEntity(ParticleEntity):
         Scene object this entity belongs to.
     solver : Solver
         The solver responsible for simulating this entity.
-    material : Material
+    material : MaterialOptions
         Material used to determine physical behavior (e.g., Snow, Sand, Muscle).
     morph : Morph
         Shape description used for particle sampling.

--- a/genesis/engine/entities/particle_entity.py
+++ b/genesis/engine/entities/particle_entity.py
@@ -37,7 +37,7 @@ class ParticleEntity(Entity):
         The scene object that this entity belongs to.
     solver : Solver
         The physics solver responsible for simulating the entity's particles.
-    material : Material
+    material : MaterialOptions
         The material definition, including sampling strategy and physical properties.
     morph : Morph
         Geometry or volumetric shape used for sampling particles (e.g., mesh, primitive).

--- a/genesis/engine/entities/pbd_entity.py
+++ b/genesis/engine/entities/pbd_entity.py
@@ -160,7 +160,7 @@ class PBDTetEntity(PBDBaseEntity):
         The simulation scene this entity is part of.
     solver : Solver
         The PBD solver instance managing this entity.
-    material : Material
+    material : MaterialOptions
         Material model defining physical properties such as density and compliance.
     morph : Morph
         Morph object specifying shape and initial transform (position and rotation).
@@ -318,7 +318,7 @@ class PBD2DEntity(PBDTetEntity):
         The simulation scene this entity is part of.
     solver : Solver
         The PBD solver instance managing this entity.
-    material : Material
+    material : MaterialOptions
         Material model defining physical properties such as density and compliance.
     morph : Morph
         Morph object specifying shape and initial transform (position and rotation).
@@ -451,7 +451,7 @@ class PBD3DEntity(PBDTetEntity):
         The simulation scene this entity is part of.
     solver : Solver
         The PBD solver instance managing this entity.
-    material : Material
+    material : MaterialOptions
         Material model defining physical properties such as density and compliance.
     morph : Morph
         Morph object specifying shape and initial transform (position and rotation).
@@ -585,7 +585,7 @@ class PBDParticleEntity(PBDBaseEntity):
         The simulation scene this entity is part of.
     solver : Solver
         The PBD solver instance managing this entity.
-    material : Material
+    material : MaterialOptions
         Material model defining physical properties such as density and compliance.
     morph : Morph
         Morph object specifying shape and initial transform (position and rotation).
@@ -658,7 +658,7 @@ class PBDFreeParticleEntity(PBDBaseEntity):
         The simulation scene this entity is part of.
     solver : Solver
         The PBD solver instance managing this entity.
-    material : Material
+    material : MaterialOptions
         Material model defining physical properties such as density and compliance.
     morph : Morph
         Morph object specifying shape and initial transform (position and rotation).

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -12,6 +12,7 @@ import trimesh
 
 import genesis as gs
 from genesis.engine.materials.base import Material
+from genesis.engine.materials.rigid import RigidMaterial
 from genesis.engine.mesh import InertialProperties
 from genesis.options.morphs import Morph
 from genesis.options.surfaces import Surface
@@ -1241,7 +1242,7 @@ class KinematicEntity(Entity):
         # An explicitly set material density overrides any asset-authored per-geom density, as material friction does
         # for authored frictions. Dropping the keys up front keeps the align anchor, its all-or-none source check,
         # and the build-time inertial estimate consistently uniform-density.
-        if isinstance(self.material, gs.materials.Rigid) and self.material.rho is not None:
+        if isinstance(self.material, RigidMaterial) and self.material.rho is not None:
             for g_info in g_infos:
                 g_info.pop("density", None)
 
@@ -1340,7 +1341,7 @@ class KinematicEntity(Entity):
                 is_mass_explicit = None
 
         dynamics_hint = None
-        if isinstance(self.material, gs.materials.Rigid):
+        if isinstance(self.material, RigidMaterial):
             rho = self.material.rho
             if rho is None:
                 if self._solver._enable_mujoco_compatibility:

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -4497,31 +4497,43 @@ class RigidEntity(KinematicEntity):
     # ----------------------------------- friction ---------------------------------------
     # ------------------------------------------------------------------------------------
 
-    def set_friction_ratio(self, friction_ratio, links_idx_local=None, envs_idx=None):
+    def set_friction_ratio(
+        self,
+        sliding_ratio=None,
+        links_idx_local=None,
+        envs_idx=None,
+        *,
+        torsional_ratio=None,
+        rolling_ratio=None,
+    ):
         """
-        Set the friction ratio of the geoms of the specified links.
+        Scale the friction coefficients of the geoms of the specified links.
+
+        Each coefficient answers to its own ratio: giving one leaves the other two as they are, so lowering sliding
+        friction never disturbs the torsional or rolling resistance.
 
         Parameters
         ----------
-        friction_ratio : torch.Tensor, shape (n_envs, n_links)
-            The friction ratio
+        sliding_ratio : float | array_like, shape (n_envs, n_links), optional
+            Ratio applied to the sliding friction. If None, the sliding ratio keeps its current value. Defaults to
+            None.
         links_idx_local : array_like
-            The indices of the links to set friction ratio.
+            The indices of the links to scale.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        torsional_ratio : float | array_like, shape (n_envs, n_links), optional
+            Ratio applied to the torsional friction. If None, it keeps its current value. Defaults to None.
+        rolling_ratio : float | array_like, shape (n_envs, n_links), optional
+            Ratio applied to the rolling friction. If None, it keeps its current value. Defaults to None.
         """
-        links_idx_local = self._get_global_idx(links_idx_local, self.n_links, 0, unsafe=True)
-
-        links_n_geoms = torch.tensor(
-            [self._links[i_l].n_geoms for i_l in links_idx_local], dtype=gs.tc_int, device=gs.device
+        links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
+        self._solver.set_links_friction_ratio(
+            sliding_ratio,
+            links_idx,
+            envs_idx,
+            torsional_ratio=torsional_ratio,
+            rolling_ratio=rolling_ratio,
         )
-        links_friction_ratio = torch.as_tensor(friction_ratio, dtype=gs.tc_float, device=gs.device)
-        geoms_friction_ratio = torch.repeat_interleave(links_friction_ratio, links_n_geoms, dim=-1)
-        geoms_idx = [
-            i_g for i_l in links_idx_local for i_g in range(self._links[i_l].geom_start, self._links[i_l].geom_end)
-        ]
-
-        self._solver.set_geoms_friction_ratio(geoms_friction_ratio, geoms_idx, envs_idx)
 
     def set_friction(self, friction):
         """
@@ -4531,6 +4543,8 @@ class RigidEntity(KinematicEntity):
         ----
         The friction coefficient associated with a pair of geometries in contact is defined as the maximum between
         their respective values, so one must be careful the set the friction coefficient properly for both of them.
+        Declaring it for the two materials through 'RigidMaterial.set_friction_pair' fixes it for their contacts
+        instead, whatever either geometry carries.
 
         Warning
         -------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2578,13 +2578,13 @@ class RigidEntity(KinematicEntity):
         # Add collision geometries
         coup_links = self.material.coup_links
         for g_info in cg_infos:
-            friction = self.material.friction
+            friction = self.material.options.friction
             if friction is None:
                 friction = g_info.get("friction", gu.default_friction())
-            friction_torsional = self.material.friction_torsional
+            friction_torsional = self.material.options.friction_torsional
             if friction_torsional is None:
                 friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
-            friction_rolling = self.material.friction_rolling
+            friction_rolling = self.material.options.friction_rolling
             if friction_rolling is None:
                 friction_rolling = g_info.get("friction_rolling", gu.default_friction_rolling())
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
@@ -2844,13 +2844,13 @@ class RigidEntity(KinematicEntity):
         # Add collision geometries
         coup_links = self.material.coup_links
         for g_info in cg_infos:
-            friction = self.material.friction
+            friction = self.material.options.friction
             if friction is None:
                 friction = g_info.get("friction", gu.default_friction())
-            friction_torsional = self.material.friction_torsional
+            friction_torsional = self.material.options.friction_torsional
             if friction_torsional is None:
                 friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
-            friction_rolling = self.material.friction_rolling
+            friction_rolling = self.material.options.friction_rolling
             if friction_rolling is None:
                 friction_rolling = g_info.get("friction_rolling", gu.default_friction_rolling())
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -4569,8 +4569,9 @@ class RigidEntity(KinematicEntity):
         Note
         ----
         The torsional friction coefficient associated with a pair of geometries in contact is defined as the maximum
-        between their respective values (see 'gs.materials.Rigid'). Only effective when torsional friction is enabled
-        at the scene level (see 'RigidOptions.enable_torsional_friction').
+        between their respective values (see 'gs.materials.Rigid'). Declaring it for the two materials through
+        'RigidMaterial.set_friction_pair' fixes it for their contacts instead. Only effective when torsional friction
+        is enabled at the scene level (see 'RigidOptions.enable_torsional_friction').
 
         Parameters
         ----------
@@ -4590,8 +4591,9 @@ class RigidEntity(KinematicEntity):
         Note
         ----
         The rolling friction coefficient associated with a pair of geometries in contact is defined as the maximum
-        between their respective values (see 'gs.materials.Rigid'). Only effective when rolling friction is enabled
-        at the scene level (see 'RigidOptions.enable_rolling_friction').
+        between their respective values (see 'gs.materials.Rigid'). Declaring it for the two materials through
+        'RigidMaterial.set_friction_pair' fixes it for their contacts instead. Only effective when rolling friction is
+        enabled at the scene level (see 'RigidOptions.enable_rolling_friction').
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1,21 +1,25 @@
 import inspect
 import math
 import os
+from functools import wraps
 from itertools import chain
 from typing import TYPE_CHECKING, Literal, Any, Hashable
-from functools import wraps
 
-import quadrants as qd
 import numpy as np
 import torch
+
 import trimesh
+
+import quadrants as qd
 
 import genesis as gs
 from genesis.engine.materials.base import Material
 from genesis.engine.materials.rigid import RigidMaterial
 from genesis.engine.mesh import InertialProperties
+from genesis.engine.states.entities import RigidEntityState
 from genesis.options.morphs import Morph
 from genesis.options.surfaces import Surface
+from genesis.typing import UnitVec4FType, Vec3FType
 from genesis.utils import array_class
 from genesis.utils import geom as gu
 from genesis.utils import mesh as mu
@@ -23,8 +27,6 @@ from genesis.utils import mjcf as mju
 from genesis.utils import terrain as tu
 from genesis.utils import urdf as uu
 from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_numpy, qd_to_torch, tensor_to_array
-from genesis.typing import UnitVec4FType, Vec3FType
-from genesis.engine.states.entities import RigidEntityState
 
 from ..base_entity import Entity
 from .rigid_equality import RigidEquality

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -13,7 +13,7 @@ import trimesh
 import quadrants as qd
 
 import genesis as gs
-from genesis.engine.materials.base import Material
+from genesis.engine.materials.base import MaterialOptions
 from genesis.engine.materials.rigid import RigidMaterial
 from genesis.engine.mesh import InertialProperties
 from genesis.engine.states.entities import RigidEntityState
@@ -102,7 +102,7 @@ class KinematicEntity(Entity):
         self,
         scene: "Scene",
         solver: "KinematicSolver",
-        material: Material,
+        material: MaterialOptions,
         morph: Morph,
         surface: Surface,
         idx: int,
@@ -2513,7 +2513,7 @@ class RigidEntity(KinematicEntity):
         self,
         scene: "Scene",
         solver: "RigidSolver",
-        material: Material,
+        material: MaterialOptions,
         morph: Morph,
         surface: Surface,
         idx: int,

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -346,9 +346,41 @@ class RigidGeom(RBC):
             )
             self._solver.scene.draw_debug_mesh(boundary_mesh, T=T)
 
+    def set_material(self, material: "RigidMaterial"):
+        """
+        Assign a material to this geom, in place of the one inherited from its entity.
+
+        The material identifies the surface that contact parameters declared for a pair of materials apply to, so
+        one entity carries as many surfaces as its geoms have materials (see 'RigidMaterial.set_friction_pair'). It
+        must be assigned before the scene is built.
+
+        The geom takes every coefficient the material declares, and keeps the one it carries where a friction
+        coefficient is left None, as it keeps an asset-authored coefficient when its entity takes the material. The
+        SDF resolution stays the one the entity's material set, being fixed when the geom was created.
+        """
+        if self._solver.is_built:
+            gs.raise_exception("A geom's material must be assigned before the scene is built.")
+        self._material = material
+
+        options = material.options
+        if options.friction is not None:
+            self._friction = options.friction
+        if options.friction_torsional is not None:
+            self._friction_torsional = options.friction_torsional
+        if options.friction_rolling is not None:
+            self._friction_rolling = options.friction_rolling
+        coup_links = options.coup_links
+        self._needs_coup = options.needs_coup and (coup_links is None or self._link.name in coup_links)
+        self._coup_softness = options.coup_softness
+        self._coup_friction = options.coup_friction
+        self._coup_restitution = options.coup_restitution
+
     def set_friction(self, friction):
         """
         Set the friction coefficient of this geometry.
+
+        A contact takes the larger of the two geoms' coefficients, so it follows this one where this one is the
+        larger. See 'RigidMaterial.set_friction_pair' to fix it for a pair of materials outright.
         """
         if friction < 0:
             gs.raise_exception("`friction` must be non-negative.")
@@ -469,6 +501,13 @@ class RigidGeom(RBC):
         Get the type of the geom.
         """
         return self._type
+
+    @property
+    def material(self) -> "RigidMaterial":
+        """
+        Get the material of the geom, inherited from its entity unless assigned through 'set_material'.
+        """
+        return self._material
 
     @property
     def friction(self):

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -15,7 +15,7 @@ from genesis.repr_base import RBC
 from genesis.utils.misc import tensor_to_array, qd_to_torch, DeprecationError
 
 if TYPE_CHECKING:
-    from genesis.engine.materials.rigid import Rigid as RigidMaterial
+    from genesis.engine.materials.rigid import RigidMaterial
     from genesis.engine.mesh import Mesh
     from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
 

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -2,10 +2,11 @@ import os
 import pickle as pkl
 from typing import TYPE_CHECKING
 
-import igl
 import numpy as np
-import skimage
 import torch
+
+import igl
+import skimage
 import trimesh
 
 import genesis as gs

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -1035,6 +1035,9 @@ class RigidLink(KinematicLink):
     def set_friction(self, friction):
         """
         Set the friction of all the link's geoms.
+
+        A contact takes the larger of the two geoms' coefficients, so it follows this one where this one is the
+        larger. See 'RigidMaterial.set_friction_pair' to fix it for a pair of materials outright.
         """
         for geom in self._geoms:
             geom.set_friction(friction)

--- a/genesis/engine/entities/sph_entity.py
+++ b/genesis/engine/entities/sph_entity.py
@@ -17,7 +17,7 @@ class SPHEntity(ParticleEntity):
         The simulation scene.
     solver : Solver
         The solver handling the simulation logic.
-    material : Material
+    material : MaterialOptions
         Material properties (e.g., density, stiffness).
     morph : Morph
         Morphological configuration.

--- a/genesis/engine/materials/FEM/base.py
+++ b/genesis/engine/materials/FEM/base.py
@@ -6,14 +6,14 @@ from pydantic import Field, PrivateAttr, StrictBool
 import genesis as gs
 from genesis.typing import NonNegativeFloat, PositiveFloat, StrictInt, ValidFloat
 
-from ..base import Material
+from ..base import MaterialOptions
 
 if TYPE_CHECKING:
     from genesis.engine.entities.fem_entity import FEMEntity
 
 
 @qd.data_oriented
-class Base(Material["FEMEntity"]):
+class Base(MaterialOptions["FEMEntity"]):
     """
     The base class of FEM materials.
 

--- a/genesis/engine/materials/MPM/base.py
+++ b/genesis/engine/materials/MPM/base.py
@@ -10,7 +10,7 @@ from pydantic_core import PydanticCustomError
 import genesis as gs
 from genesis.typing import PositiveFloat, StrictInt, ValidFloat
 
-from ..base import Material
+from ..base import MaterialOptions
 
 if TYPE_CHECKING:
     from genesis.engine.entities.mpm_entity import MPMEntity
@@ -33,7 +33,7 @@ DEFAULT_SAMPLER = "pbs" if (sys.platform == "linux" and platform.machine() == "x
 
 
 @qd.data_oriented
-class Base(Material["MPMEntity"]):
+class Base(MaterialOptions["MPMEntity"]):
     """
     The base class of MPM materials.
 

--- a/genesis/engine/materials/PBD/base.py
+++ b/genesis/engine/materials/PBD/base.py
@@ -1,7 +1,7 @@
-from ..base import EntityT, Material
+from ..base import EntityT, MaterialOptions
 
 
-class Base(Material[EntityT]):
+class Base(MaterialOptions[EntityT]):
     """
     The base class of PBD materials.
 

--- a/genesis/engine/materials/SF/base.py
+++ b/genesis/engine/materials/SF/base.py
@@ -1,5 +1,5 @@
-from ..base import Material
+from ..base import MaterialOptions
 
 
-class Base(Material):
+class Base(MaterialOptions):
     pass

--- a/genesis/engine/materials/SPH/base.py
+++ b/genesis/engine/materials/SPH/base.py
@@ -2,7 +2,7 @@ import platform
 import sys
 from typing import TYPE_CHECKING, Literal
 
-from ..base import Material
+from ..base import MaterialOptions
 
 if TYPE_CHECKING:
     from genesis.engine.entities.sph_entity import SPHEntity
@@ -11,7 +11,7 @@ SamplerType = Literal["pbs", "random", "regular"]
 DEFAULT_SAMPLER: SamplerType = "pbs" if (sys.platform == "linux" and platform.machine() == "x86_64") else "random"
 
 
-class Base(Material["SPHEntity"]):
+class Base(MaterialOptions["SPHEntity"]):
     """
     The base class of SPH materials.
 

--- a/genesis/engine/materials/__init__.py
+++ b/genesis/engine/materials/__init__.py
@@ -1,5 +1,6 @@
 from . import FEM, MPM, PBD, SF, SPH
-from .kinematic import Kinematic
+from .base import Material, MaterialOptions
 from .hybrid import Hybrid
+from .kinematic import Kinematic
 from .rigid import Rigid
 from .tool import Tool

--- a/genesis/engine/materials/base.py
+++ b/genesis/engine/materials/base.py
@@ -69,6 +69,13 @@ class MaterialHandle(RBC, Generic[MaterialT]):
         return self._idx
 
     @property
+    def scene(self) -> "Scene":
+        """
+        Get the scene the material is registered on, which its index is numbered within.
+        """
+        return self._scene
+
+    @property
     def options(self) -> MaterialT:
         """
         Get the options this material was registered from.

--- a/genesis/engine/materials/base.py
+++ b/genesis/engine/materials/base.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 EntityT = TypeVar("EntityT", bound="Entity")
 
 
-class Material(Options, Generic[EntityT]):
+class MaterialOptions(Options, Generic[EntityT]):
     """
     The base class of materials.
 
@@ -25,10 +25,10 @@ class Material(Options, Generic[EntityT]):
     use_visual_raycasting: StrictBool = False
 
 
-MaterialT = TypeVar("MaterialT", bound=Material)
+MaterialOptionsT = TypeVar("MaterialOptionsT", bound=MaterialOptions)
 
 
-class MaterialHandle(RBC, Generic[MaterialT]):
+class Material(RBC, Generic[MaterialOptionsT]):
     """
     The base class of the materials registered on a scene through 'Scene.add_material'.
 
@@ -41,10 +41,10 @@ class MaterialHandle(RBC, Generic[MaterialT]):
     This class should *not* be instantiated directly.
     """
 
-    def __init__(self, scene: "Scene", idx: int, options: MaterialT):
+    def __init__(self, scene: "Scene", idx: int, options: MaterialOptionsT):
         self._scene: "Scene" = scene
         self._idx: int = idx
-        self._options: MaterialT = options
+        self._options: MaterialOptionsT = options
         self._uid = gs.UID()
 
     def _repr_brief(self):
@@ -76,7 +76,7 @@ class MaterialHandle(RBC, Generic[MaterialT]):
         return self._scene
 
     @property
-    def options(self) -> MaterialT:
+    def options(self) -> MaterialOptionsT:
         """
         Get the options this material was registered from.
         """

--- a/genesis/engine/materials/base.py
+++ b/genesis/engine/materials/base.py
@@ -2,10 +2,13 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from pydantic import StrictBool
 
+import genesis as gs
 from genesis.options.options import Options
+from genesis.repr_base import RBC
 
 if TYPE_CHECKING:
     from genesis.engine.entities.base_entity import Entity
+    from genesis.engine.scene import Scene
 
 EntityT = TypeVar("EntityT", bound="Entity")
 
@@ -20,3 +23,54 @@ class Material(Options, Generic[EntityT]):
     """
 
     use_visual_raycasting: StrictBool = False
+
+
+MaterialT = TypeVar("MaterialT", bound=Material)
+
+
+class MaterialHandle(RBC, Generic[MaterialT]):
+    """
+    The base class of the materials registered on a scene through 'Scene.add_material'.
+
+    A handle is the identity of one material: entities built from the same handle are known to share it, which is the
+    granularity parameters resolved between two materials are keyed on. Each family subclasses this to expose the
+    options it was registered from.
+
+    Note
+    ----
+    This class should *not* be instantiated directly.
+    """
+
+    def __init__(self, scene: "Scene", idx: int, options: MaterialT):
+        self._scene: "Scene" = scene
+        self._idx: int = idx
+        self._options: MaterialT = options
+        self._uid = gs.UID()
+
+    def _repr_brief(self):
+        return f"{self.__repr_name__()}: idx={self._idx}"
+
+    # ------------------------------------------------------------------------------------
+    # ----------------------------------- properties -------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    @property
+    def uid(self):
+        """
+        Get the unique ID of the material.
+        """
+        return self._uid
+
+    @property
+    def idx(self) -> int:
+        """
+        Get the index of the material in the scene, in registration order.
+        """
+        return self._idx
+
+    @property
+    def options(self) -> MaterialT:
+        """
+        Get the options this material was registered from.
+        """
+        return self._options

--- a/genesis/engine/materials/hybrid.py
+++ b/genesis/engine/materials/hybrid.py
@@ -4,21 +4,21 @@ from pydantic import StrictBool
 
 from genesis.typing import NonNegativeFloat, ValidFloat
 
-from .base import Material
+from .base import MaterialOptions
 
 if TYPE_CHECKING:
     from genesis.engine.entities.hybrid_entity import HybridEntity
 
 
-class Hybrid(Material["HybridEntity"]):
+class Hybrid(MaterialOptions["HybridEntity"]):
     """
     The class for hybrid body material (soft skin actuated by inner rigid skeleton).
 
     Parameters
     ----------
-    material_rigid : Material
+    material_rigid : MaterialOptions
         The material of the rigid body.
-    material_soft : Material
+    material_soft : MaterialOptions
         The material of the soft body.
     use_default_coupling : bool, optional
         Whether to use default solver coupling. Default is False.
@@ -36,8 +36,8 @@ class Hybrid(Material["HybridEntity"]):
         The function that determines the association of the rigid and the soft body. Default is None.
     """
 
-    material_rigid: Material = ...
-    material_soft: Material = ...
+    material_rigid: MaterialOptions = ...
+    material_soft: MaterialOptions = ...
     use_default_coupling: StrictBool = False
     damping: NonNegativeFloat = 0.0
     thickness: ValidFloat = 0.05

--- a/genesis/engine/materials/kinematic.py
+++ b/genesis/engine/materials/kinematic.py
@@ -1,7 +1,7 @@
-from .base import EntityT, Material
+from .base import EntityT, MaterialOptions
 
 
-class Kinematic(Material[EntityT]):
+class Kinematic(MaterialOptions[EntityT]):
     """
     Visualization-only material for ghost/reference entities.
 

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -158,12 +158,13 @@ class RigidMaterial(MaterialHandle[Rigid]):
     A rigid material registered on a scene, as returned by 'Scene.add_material' and held by 'entity.material'.
 
     Every entity built from the same handle shares one material identity, which is the granularity contact parameters
-    resolved between two materials are keyed on. The 'Rigid' options the handle was built from stay readable through
-    it, so 'entity.material.friction' and friends keep reading the declared value.
-    """
+    resolved between two materials are keyed on.
 
-    def _repr_brief(self):
-        return f"{self.__repr_name__()}: idx={self._idx}, friction={self.friction}"
+    The options the handle was built from are readable through it, except for the friction coefficients: what a
+    contact resolves to depends on the other material and on per-environment ratios, so a single number on one
+    material would misreport it. Read 'options.friction' for the declared value, 'geom.friction' for what a geom
+    carries, and 'entity.get_contacts()' for what a contact developed.
+    """
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
@@ -182,27 +183,6 @@ class RigidMaterial(MaterialHandle[Rigid]):
         Get the density used to estimate mass (see 'gs.materials.Rigid').
         """
         return self._options.rho
-
-    @property
-    def friction(self):
-        """
-        Get the friction coefficient (see 'gs.materials.Rigid').
-        """
-        return self._options.friction
-
-    @property
-    def friction_torsional(self):
-        """
-        Get the torsional friction coefficient (see 'gs.materials.Rigid').
-        """
-        return self._options.friction_torsional
-
-    @property
-    def friction_rolling(self):
-        """
-        Get the rolling friction coefficient (see 'gs.materials.Rigid').
-        """
-        return self._options.friction_rolling
 
     @property
     def needs_coup(self) -> bool:

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -33,7 +33,9 @@ class Rigid(Kinematic["RigidEntity"]):
         otherwise 600 kg/m^3 for basic rigid objects (mug, table...) vs 1500 kg/m^3 for poly-articulated
         robots. Default is None.
     friction : float, optional
-        Friction coefficient within the rigid solver. If None, a default of 1.0 may be used or parsed from file.
+        Friction coefficient within the rigid solver. A contact takes the larger of the two geoms' coefficients; to
+        fix what a contact resolves to outright, declare it for the two materials through
+        'RigidMaterial.set_friction_pair'. If None, a default of 1.0 may be used or parsed from file.
     friction_torsional : float, optional
         Torsional friction coefficient, resisting relative spin about the contact normal. Expressed in meters, as it
         stands for the effective contact patch radius over which sliding friction acts. Only effective when torsional
@@ -160,11 +162,38 @@ class RigidMaterial(MaterialHandle[Rigid]):
     Every entity built from the same handle shares one material identity, which is the granularity contact parameters
     resolved between two materials are keyed on.
 
-    The options the handle was built from are readable through it, except for the friction coefficients: what a
-    contact resolves to depends on the other material and on per-environment ratios, so a single number on one
-    material would misreport it. Read 'options.friction' for the declared value, 'geom.friction' for what a geom
-    carries, and 'entity.get_contacts()' for what a contact developed.
+    Every option of 'gs.materials.Rigid' is readable under its own name, carrying the meaning documented there, with
+    the friction coefficients as the exception: what a contact resolves to depends on the other material and on
+    per-environment ratios, so a single number on one material would misreport it. Read 'options.friction' for the
+    declared value, 'geom.friction' for what a geom carries, and 'entity.get_contacts()' for what a contact developed.
     """
+
+    def set_friction_pair(self, material, sliding_friction=None, torsional_friction=None, rolling_friction=None):
+        """
+        Pin the contact friction coefficients between this material and another, in place of the larger of the two
+        geoms' own coefficients.
+
+        A coefficient left None keeps following that maximum, so pinning sliding friction alone is enough for the
+        common case. The pair applies to every contact between geoms carrying the two materials, in both directions,
+        and a material may be paired against itself. Calling this again with the same two materials replaces the
+        coefficients, at any time before or after the scene is built.
+
+        Parameters
+        ----------
+        material : RigidMaterial
+            The other material of the pair.
+        sliding_friction : float | None, optional
+            Sliding friction coefficient of the pair. Default is None.
+        torsional_friction : float | None, optional
+            Torsional friction coefficient of the pair, effective when torsional friction is enabled at the scene
+            level (see 'RigidOptions.enable_torsional_friction'). Default is None.
+        rolling_friction : float | None, optional
+            Rolling friction coefficient of the pair, effective when rolling friction is enabled at the scene level
+            (see 'RigidOptions.enable_rolling_friction'). Default is None.
+        """
+        self._scene.sim.rigid_solver.set_friction_pair(
+            self, material, sliding_friction, torsional_friction, rolling_friction
+        )
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
@@ -172,105 +201,60 @@ class RigidMaterial(MaterialHandle[Rigid]):
 
     @property
     def use_visual_raycasting(self) -> bool:
-        """
-        Whether the visual mesh is exposed to raycasting consumers (see 'gs.materials.Rigid').
-        """
         return self._options.use_visual_raycasting
 
     @property
     def rho(self):
-        """
-        Get the density used to estimate mass (see 'gs.materials.Rigid').
-        """
         return self._options.rho
 
     @property
     def needs_coup(self) -> bool:
-        """
-        Whether the material participates in coupling with other solvers (see 'gs.materials.Rigid').
-        """
         return self._options.needs_coup
 
     @property
     def coup_friction(self) -> float:
-        """
-        Get the friction used during coupling (see 'gs.materials.Rigid').
-        """
         return self._options.coup_friction
 
     @property
     def coup_softness(self) -> float:
-        """
-        Get the softness of the coupling interaction (see 'gs.materials.Rigid').
-        """
         return self._options.coup_softness
 
     @property
     def coup_restitution(self) -> float:
-        """
-        Get the restitution coefficient in collision coupling (see 'gs.materials.Rigid').
-        """
         return self._options.coup_restitution
 
     @property
     def sdf_cell_size(self) -> float:
-        """
-        Get the target cell size of the SDF grid in meters (see 'gs.materials.Rigid').
-        """
         return self._options.sdf_cell_size
 
     @property
     def sdf_min_res(self) -> int:
-        """
-        Get the minimum resolution of the SDF grid (see 'gs.materials.Rigid').
-        """
         return self._options.sdf_min_res
 
     @property
     def sdf_max_res(self) -> int:
-        """
-        Get the maximum resolution of the SDF grid (see 'gs.materials.Rigid').
-        """
         return self._options.sdf_max_res
 
     @property
     def gravity_compensation(self) -> float:
-        """
-        Get the gravity compensation factor (see 'gs.materials.Rigid').
-        """
         return self._options.gravity_compensation
 
     @property
     def coup_type(self):
-        """
-        Get the IPC coupling mode (see 'gs.materials.Rigid').
-        """
         return self._options.coup_type
 
     @property
     def coup_links(self):
-        """
-        Get the names of the links participating in coupling (see 'gs.materials.Rigid').
-        """
         return self._options.coup_links
 
     @property
     def enable_coup_collision(self) -> bool:
-        """
-        Whether coupler collision is enabled for this material's links (see 'gs.materials.Rigid').
-        """
         return self._options.enable_coup_collision
 
     @property
     def coup_collision_links(self):
-        """
-        Get the names of the links whose geoms participate in coupler collision (see 'gs.materials.Rigid').
-        """
         return self._options.coup_collision_links
 
     @property
     def contact_resistance(self):
-        """
-        Get the IPC coupling contact resistance override (see 'gs.materials.Rigid').
-        """
         return self._options.contact_resistance

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -38,14 +38,15 @@ class Rigid(Kinematic["RigidEntity"]):
         'RigidMaterial.set_friction_pair'. If None, a default of 1.0 may be used or parsed from file.
     friction_torsional : float, optional
         Torsional friction coefficient, resisting relative spin about the contact normal. Expressed in meters, as it
-        stands for the effective contact patch radius over which sliding friction acts. Only effective when torsional
-        friction is enabled at the scene level (see 'RigidOptions.enable_torsional_friction'). If None, parsed from
-        file when available (MJCF), otherwise 0.005. Default is None.
+        stands for the effective contact patch radius over which sliding friction acts. Resolved for a contact as the
+        sliding coefficient is. Only effective when torsional friction is enabled at the scene level (see
+        'RigidOptions.enable_torsional_friction'). If None, parsed from file when available (MJCF), otherwise 0.005.
+        Default is None.
     friction_rolling : float, optional
         Rolling friction coefficient, resisting rolling about the two contact tangent axes. Expressed in meters, like
-        the torsional coefficient. Only effective when rolling friction is enabled at the scene level (see
-        'RigidOptions.enable_rolling_friction'). If None, parsed from file when available (MJCF), otherwise 0.0001.
-        Default is None.
+        the torsional coefficient, and resolved for a contact the same way. Only effective when rolling friction is
+        enabled at the scene level (see 'RigidOptions.enable_rolling_friction'). If None, parsed from file when
+        available (MJCF), otherwise 0.0001. Default is None.
     needs_coup : bool, optional
         Whether the material participates in coupling with other solvers. Default is True.
     coup_friction : float, optional

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -5,7 +5,7 @@ from pydantic import Field, StrictBool, model_validator
 import genesis as gs
 from genesis.typing import NonNegativeFloat, PositiveFloat, StrictInt, StrArrayType, ValidFloat
 
-from .base import MaterialHandle
+from .base import Material
 from .kinematic import Kinematic
 
 if TYPE_CHECKING:
@@ -155,7 +155,7 @@ class Rigid(Kinematic["RigidEntity"]):
             gs.logger.warning("Non-zero `coup_restitution` could lead to instability. Use with caution.")
 
 
-class RigidMaterial(MaterialHandle[Rigid]):
+class RigidMaterial(Material[Rigid]):
     """
     A rigid material registered on a scene, as returned by 'Scene.add_material' and held by 'entity.material'.
 

--- a/genesis/engine/materials/rigid.py
+++ b/genesis/engine/materials/rigid.py
@@ -5,6 +5,7 @@ from pydantic import Field, StrictBool, model_validator
 import genesis as gs
 from genesis.typing import NonNegativeFloat, PositiveFloat, StrictInt, StrArrayType, ValidFloat
 
+from .base import MaterialHandle
 from .kinematic import Kinematic
 
 if TYPE_CHECKING:
@@ -150,3 +151,146 @@ class Rigid(Kinematic["RigidEntity"]):
 
         if self.coup_restitution != 0:
             gs.logger.warning("Non-zero `coup_restitution` could lead to instability. Use with caution.")
+
+
+class RigidMaterial(MaterialHandle[Rigid]):
+    """
+    A rigid material registered on a scene, as returned by 'Scene.add_material' and held by 'entity.material'.
+
+    Every entity built from the same handle shares one material identity, which is the granularity contact parameters
+    resolved between two materials are keyed on. The 'Rigid' options the handle was built from stay readable through
+    it, so 'entity.material.friction' and friends keep reading the declared value.
+    """
+
+    def _repr_brief(self):
+        return f"{self.__repr_name__()}: idx={self._idx}, friction={self.friction}"
+
+    # ------------------------------------------------------------------------------------
+    # ----------------------------------- properties -------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    @property
+    def use_visual_raycasting(self) -> bool:
+        """
+        Whether the visual mesh is exposed to raycasting consumers (see 'gs.materials.Rigid').
+        """
+        return self._options.use_visual_raycasting
+
+    @property
+    def rho(self):
+        """
+        Get the density used to estimate mass (see 'gs.materials.Rigid').
+        """
+        return self._options.rho
+
+    @property
+    def friction(self):
+        """
+        Get the friction coefficient (see 'gs.materials.Rigid').
+        """
+        return self._options.friction
+
+    @property
+    def friction_torsional(self):
+        """
+        Get the torsional friction coefficient (see 'gs.materials.Rigid').
+        """
+        return self._options.friction_torsional
+
+    @property
+    def friction_rolling(self):
+        """
+        Get the rolling friction coefficient (see 'gs.materials.Rigid').
+        """
+        return self._options.friction_rolling
+
+    @property
+    def needs_coup(self) -> bool:
+        """
+        Whether the material participates in coupling with other solvers (see 'gs.materials.Rigid').
+        """
+        return self._options.needs_coup
+
+    @property
+    def coup_friction(self) -> float:
+        """
+        Get the friction used during coupling (see 'gs.materials.Rigid').
+        """
+        return self._options.coup_friction
+
+    @property
+    def coup_softness(self) -> float:
+        """
+        Get the softness of the coupling interaction (see 'gs.materials.Rigid').
+        """
+        return self._options.coup_softness
+
+    @property
+    def coup_restitution(self) -> float:
+        """
+        Get the restitution coefficient in collision coupling (see 'gs.materials.Rigid').
+        """
+        return self._options.coup_restitution
+
+    @property
+    def sdf_cell_size(self) -> float:
+        """
+        Get the target cell size of the SDF grid in meters (see 'gs.materials.Rigid').
+        """
+        return self._options.sdf_cell_size
+
+    @property
+    def sdf_min_res(self) -> int:
+        """
+        Get the minimum resolution of the SDF grid (see 'gs.materials.Rigid').
+        """
+        return self._options.sdf_min_res
+
+    @property
+    def sdf_max_res(self) -> int:
+        """
+        Get the maximum resolution of the SDF grid (see 'gs.materials.Rigid').
+        """
+        return self._options.sdf_max_res
+
+    @property
+    def gravity_compensation(self) -> float:
+        """
+        Get the gravity compensation factor (see 'gs.materials.Rigid').
+        """
+        return self._options.gravity_compensation
+
+    @property
+    def coup_type(self):
+        """
+        Get the IPC coupling mode (see 'gs.materials.Rigid').
+        """
+        return self._options.coup_type
+
+    @property
+    def coup_links(self):
+        """
+        Get the names of the links participating in coupling (see 'gs.materials.Rigid').
+        """
+        return self._options.coup_links
+
+    @property
+    def enable_coup_collision(self) -> bool:
+        """
+        Whether coupler collision is enabled for this material's links (see 'gs.materials.Rigid').
+        """
+        return self._options.enable_coup_collision
+
+    @property
+    def coup_collision_links(self):
+        """
+        Get the names of the links whose geoms participate in coupler collision (see 'gs.materials.Rigid').
+        """
+        return self._options.coup_collision_links
+
+    @property
+    def contact_resistance(self):
+        """
+        Get the IPC coupling contact resistance override (see 'gs.materials.Rigid').
+        """
+        return self._options.contact_resistance

--- a/genesis/engine/materials/tool.py
+++ b/genesis/engine/materials/tool.py
@@ -4,13 +4,13 @@ from pydantic import StrictBool
 
 from genesis.typing import NonNegativeFloat, PositiveInt
 
-from .base import Material
+from .base import MaterialOptions
 
 if TYPE_CHECKING:
     from genesis.engine.entities.tool_entity import ToolEntity
 
 
-class Tool(Material["ToolEntity"]):
+class Tool(MaterialOptions["ToolEntity"]):
     """
     Material for tool entities.
 

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -3,12 +3,14 @@ import os
 import pickle
 import sys
 import time
-import trimesh
 import weakref
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, overload
 
 import numpy as np
 import torch
+
+import trimesh
+
 import quadrants as qd
 from quadrants.lang import impl
 
@@ -36,15 +38,15 @@ from genesis.options import (
     VisOptions,
 )
 from genesis.options.morphs import Morph
-from genesis.options.surfaces import Surface
-from genesis.options.renderers import Rasterizer, RendererOptions
 from genesis.options.recorders import RecorderOptions
+from genesis.options.renderers import Rasterizer, RendererOptions
+from genesis.options.surfaces import Surface
 from genesis.recorders import RecorderManager
 from genesis.repr_base import RBC
+from genesis.utils.misc import sanitize_index, tensor_to_array
 from genesis.utils.tools import FPSTracker
-from genesis.utils.misc import tensor_to_array, sanitize_index
-from genesis.vis import Visualizer
 from genesis.utils.warnings import warn_once
+from genesis.vis import Visualizer
 
 if TYPE_CHECKING:
     from genesis.engine.entities.base_entity import Entity

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -16,7 +16,8 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 from genesis.engine.force_fields import ForceField
-from genesis.engine.materials.base import EntityT, Material
+from genesis.engine.materials.base import EntityT, Material, MaterialHandle, MaterialT
+from genesis.engine.materials.rigid import Rigid, RigidMaterial
 from genesis.engine.states.solvers import SimState
 from genesis.options import (
     KinematicOptions,
@@ -197,6 +198,12 @@ class Scene(RBC):
         # emitters
         self._emitters = gs.List()
 
+        # Registered materials, in registration order, and the id() of the options each was registered from.
+        # Registration is keyed on the options object rather than its field values, so two materials that happen to
+        # carry the same friction and density stay distinct identities.
+        self._materials: list[MaterialHandle] = []
+        self._material_idx: dict[int, int] = {}
+
         self._backward_ready = False
         self._forward_ready = False
 
@@ -309,6 +316,45 @@ class Scene(RBC):
             self._sim = None
 
     @overload
+    def add_material(self, material: Rigid) -> RigidMaterial: ...
+
+    @overload
+    def add_material(self, material: MaterialT) -> MaterialHandle[MaterialT]: ...
+
+    @gs.assert_unbuilt
+    def add_material(self, material):
+        """
+        Register a material on the scene and get back the handle to pass to `add_entity`.
+
+        Registration is idempotent: passing the same options object again returns the same handle, so every entity
+        built from it shares one material identity. Passing a freshly constructed material to `add_entity` instead
+        registers one of its own, which is why a material declared inline stays private to its entity.
+
+        A shared handle also shares the per-morph tuning `add_entity` applies to its options: a rigid material used by
+        both a `gs.morphs.Primitive` and another morph type carries the reduced SDF resolution of the primitive
+        throughout.
+
+        Parameters
+        ----------
+        material : gs.materials.Rigid
+            The options describing the material. Rigid materials are the ones carrying a handle today.
+
+        Returns
+        -------
+        material : RigidMaterial
+            The registered material.
+        """
+        if not isinstance(material, Rigid):
+            gs.raise_exception(f"Only 'gs.materials.Rigid' materials can be registered. Got {material}.")
+
+        idx = self._material_idx.get(id(material))
+        if idx is None:
+            idx = len(self._materials)
+            self._material_idx[id(material)] = idx
+            self._materials.append(RigidMaterial(self, idx, material))
+        return self._materials[idx]
+
+    @overload
     def add_entity(
         self,
         morph: Morph | Iterable[Morph],
@@ -318,6 +364,28 @@ class Scene(RBC):
         vis_mode: str | None = ...,
         name: str | None = ...,
     ) -> "RigidEntity": ...
+
+    @overload
+    def add_entity(
+        self,
+        morph: Morph | Iterable[Morph],
+        material: RigidMaterial = ...,
+        surface: Surface | None = ...,
+        visualize_contact: bool = ...,
+        vis_mode: str | None = ...,
+        name: str | None = ...,
+    ) -> "RigidEntity": ...
+
+    @overload
+    def add_entity(
+        self,
+        morph: Morph | Iterable[Morph],
+        material: MaterialHandle[Material[EntityT]] = ...,
+        surface: Surface | None = ...,
+        visualize_contact: bool = ...,
+        vis_mode: str | None = ...,
+        name: str | None = ...,
+    ) -> EntityT: ...
 
     @overload
     def add_entity(
@@ -334,7 +402,7 @@ class Scene(RBC):
     def add_entity(
         self,
         morph: Morph | Iterable[Morph],
-        material: Material | None = None,
+        material: Material | MaterialHandle | None = None,
         surface: Surface | None = None,
         visualize_contact: bool = False,
         vis_mode: str | None = None,
@@ -349,8 +417,9 @@ class Scene(RBC):
             The morph of the entity. If a list of morphs is provided, the entity will be heterogeneous
             (rigid only, single-link entities only). Each parallel environment will simulate a different
             geometry variant from the list.
-        material : gs.materials.Material | None, optional
-            The material of the entity. If None, use ``gs.materials.Rigid()``.
+        material : gs.materials.Material | MaterialHandle | None, optional
+            The material of the entity, either the options describing it or a material registered through
+            ``add_material`` and thereby shareable with other entities. If None, use ``gs.materials.Rigid()``.
         surface : gs.surfaces.Surface | None, optional
             The surface of the entity. If None, use ``gs.surfaces.Default()``.
         visualize_contact : bool
@@ -370,6 +439,11 @@ class Scene(RBC):
         """
         if material is None:
             material = gs.materials.Rigid()
+
+        # Every check and dispatch below keys on the material options, so an already-registered material is unwrapped
+        # here. The registration downstream is idempotent, restoring the very same handle for the entity.
+        if isinstance(material, MaterialHandle):
+            material = material.options
 
         if surface is None:
             # assign a local surface, otherwise modification will apply on global default surface

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -18,7 +18,7 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 from genesis.engine.force_fields import ForceField
-from genesis.engine.materials.base import EntityT, Material, MaterialHandle, MaterialT
+from genesis.engine.materials.base import EntityT, Material, MaterialHandle
 from genesis.engine.materials.rigid import Rigid, RigidMaterial
 from genesis.engine.states.solvers import SimState
 from genesis.options import (
@@ -200,9 +200,9 @@ class Scene(RBC):
         # emitters
         self._emitters = gs.List()
 
+        self._materials: list[MaterialHandle] = []
         # Keyed on the identity of the options object, so two materials carrying the same friction and density
         # stay distinct. See add_material for the registration contract.
-        self._materials: list[MaterialHandle] = []
         self._material_idx: dict[int, int] = {}
 
         self._backward_ready = False
@@ -354,14 +354,8 @@ class Scene(RBC):
             rolling_ratio=rolling_ratio,
         )
 
-    @overload
-    def add_material(self, material: Rigid) -> RigidMaterial: ...
-
-    @overload
-    def add_material(self, material: MaterialT) -> MaterialHandle[MaterialT]: ...
-
     @gs.assert_unbuilt
-    def add_material(self, material):
+    def add_material(self, material: Rigid) -> RigidMaterial:
         """
         Register a material on the scene and get back the handle to pass to `add_entity`.
 
@@ -414,17 +408,6 @@ class Scene(RBC):
         vis_mode: str | None = ...,
         name: str | None = ...,
     ) -> "RigidEntity": ...
-
-    @overload
-    def add_entity(
-        self,
-        morph: Morph | Iterable[Morph],
-        material: MaterialHandle[Material[EntityT]] = ...,
-        surface: Surface | None = ...,
-        visualize_contact: bool = ...,
-        vis_mode: str | None = ...,
-        name: str | None = ...,
-    ) -> EntityT: ...
 
     @overload
     def add_entity(

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -200,9 +200,8 @@ class Scene(RBC):
         # emitters
         self._emitters = gs.List()
 
-        # Registered materials, in registration order, and the id() of the options each was registered from.
-        # Registration is keyed on the options object rather than its field values, so two materials that happen to
-        # carry the same friction and density stay distinct identities.
+        # Keyed on the identity of the options object, so two materials carrying the same friction and density
+        # stay distinct. See add_material for the registration contract.
         self._materials: list[MaterialHandle] = []
         self._material_idx: dict[int, int] = {}
 
@@ -317,6 +316,44 @@ class Scene(RBC):
             self._sim.destroy()
             self._sim = None
 
+    @gs.assert_built
+    def set_friction_ratio(
+        self,
+        sliding_ratio=None,
+        links_idx=None,
+        envs_idx=None,
+        *,
+        torsional_ratio=None,
+        rolling_ratio=None,
+    ):
+        """
+        Scale the friction coefficients of every geom of the addressed links.
+
+        Each coefficient answers to its own ratio: giving one leaves the other two as they are. Addressing no link
+        scales every link in the scene, which is the whole-scene randomization sweep.
+
+        Parameters
+        ----------
+        sliding_ratio : float | array_like, shape (n_envs, n_links), optional
+            Ratio applied to the sliding friction. If None, the sliding ratio keeps its current value. Defaults to
+            None.
+        links_idx : array_like | None, optional
+            The global indices of the links to scale. If None, every link in the scene is scaled. Defaults to None.
+        envs_idx : array_like | None, optional
+            The indices of the environments. If None, all environments are considered. Defaults to None.
+        torsional_ratio : float | array_like, shape (n_envs, n_links), optional
+            Ratio applied to the torsional friction. If None, it keeps its current value. Defaults to None.
+        rolling_ratio : float | array_like, shape (n_envs, n_links), optional
+            Ratio applied to the rolling friction. If None, it keeps its current value. Defaults to None.
+        """
+        self._sim.rigid_solver.set_links_friction_ratio(
+            sliding_ratio,
+            links_idx,
+            envs_idx,
+            torsional_ratio=torsional_ratio,
+            rolling_ratio=rolling_ratio,
+        )
+
     @overload
     def add_material(self, material: Rigid) -> RigidMaterial: ...
 
@@ -339,7 +376,7 @@ class Scene(RBC):
         Parameters
         ----------
         material : gs.materials.Rigid
-            The options describing the material. Rigid materials are the ones carrying a handle today.
+            The options describing the material. Rigid materials are the ones that carry a handle.
 
         Returns
         -------

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -18,7 +18,7 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 from genesis.engine.force_fields import ForceField
-from genesis.engine.materials.base import EntityT, Material, MaterialHandle
+from genesis.engine.materials.base import EntityT, Material, MaterialOptions
 from genesis.engine.materials.rigid import Rigid, RigidMaterial
 from genesis.engine.states.solvers import SimState
 from genesis.options import (
@@ -200,7 +200,7 @@ class Scene(RBC):
         # emitters
         self._emitters = gs.List()
 
-        self._materials: list[MaterialHandle] = []
+        self._materials: list[Material] = []
         # Keyed on the identity of the options object, so two materials carrying the same friction and density
         # stay distinct. See add_material for the registration contract.
         self._material_idx: dict[int, int] = {}
@@ -413,7 +413,7 @@ class Scene(RBC):
     def add_entity(
         self,
         morph: Morph | Iterable[Morph],
-        material: Material[EntityT] = ...,
+        material: MaterialOptions[EntityT] = ...,
         surface: Surface | None = ...,
         visualize_contact: bool = ...,
         vis_mode: str | None = ...,
@@ -424,7 +424,7 @@ class Scene(RBC):
     def add_entity(
         self,
         morph: Morph | Iterable[Morph],
-        material: Material | MaterialHandle | None = None,
+        material: MaterialOptions | Material | None = None,
         surface: Surface | None = None,
         visualize_contact: bool = False,
         vis_mode: str | None = None,
@@ -439,7 +439,7 @@ class Scene(RBC):
             The morph of the entity. If a list of morphs is provided, the entity will be heterogeneous
             (rigid only, single-link entities only). Each parallel environment will simulate a different
             geometry variant from the list.
-        material : gs.materials.Material | MaterialHandle | None, optional
+        material : gs.materials.MaterialOptions | gs.materials.Material | None, optional
             The material of the entity, either the options describing it or a material registered through
             ``add_material`` and thereby shareable with other entities. If None, use ``gs.materials.Rigid()``.
         surface : gs.surfaces.Surface | None, optional
@@ -464,7 +464,7 @@ class Scene(RBC):
 
         # Every check and dispatch below keys on the material options, so an already-registered material is unwrapped
         # here. The registration downstream is idempotent, restoring the very same handle for the entity.
-        if isinstance(material, MaterialHandle):
+        if isinstance(material, Material):
             material = material.options
 
         if surface is None:
@@ -610,7 +610,7 @@ class Scene(RBC):
     def add_stage(
         self,
         morph: gs.morphs.USD,
-        material: Material | None = None,
+        material: MaterialOptions | None = None,
         surface: Surface | None = None,
         visualize_contact: bool = False,
         vis_mode: Literal["visual", "collision"] = "visual",
@@ -622,7 +622,7 @@ class Scene(RBC):
         ----------
         morph : gs.morphs.USD
             The stage to add to the scene.
-        material : gs.materials.Material | None, optional
+        material : gs.materials.MaterialOptions | None, optional
             The material of the stage. If None, use ``gs.materials.Rigid()`` for all morphs.
         surface : gs.surfaces.Surface | None, optional
             The surface of the stage. If None, use ``gs.surfaces.Default()`` for all morphs.
@@ -884,7 +884,7 @@ class Scene(RBC):
     @gs.assert_unbuilt
     def add_emitter(
         self,
-        material: Material,
+        material: MaterialOptions,
         max_particles=20000,
         surface: Surface | None = None,
     ):
@@ -893,7 +893,7 @@ class Scene(RBC):
 
         Parameters
         ----------
-        material : gs.materials.Material
+        material : gs.materials.MaterialOptions
             The material of the fluid to be emitted. Must be an instance of `gs.materials.MPM.Base`,
             `gs.materials.SPH.Base`, `gs.materials.PBD.Particle` or `gs.materials.PBD.Liquid`.
         max_particles : int

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -163,8 +163,10 @@ class Simulator(RBC):
         if isinstance(material, gs.materials.Tool):
             entity = self.tool_solver.add_entity(self.n_entities, material, morph, surface, name=name)
         elif isinstance(material, gs.materials.Rigid):
+            # Rigid entities hold the registered material rather than its options, so contact parameters resolved
+            # between two materials have a shared identity to key on.
             entity = self.rigid_solver.add_entity(
-                self.n_entities, material, morph, surface, visualize_contact, name=name
+                self.n_entities, self.scene.add_material(material), morph, surface, visualize_contact, name=name
             )
         elif isinstance(material, gs.materials.Kinematic):
             entity = self.kinematic_solver.add_entity(

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -163,8 +163,8 @@ class Simulator(RBC):
         if isinstance(material, gs.materials.Tool):
             entity = self.tool_solver.add_entity(self.n_entities, material, morph, surface, name=name)
         elif isinstance(material, gs.materials.Rigid):
-            # Rigid entities hold the registered material rather than its options, so contact parameters resolved
-            # between two materials have a shared identity to key on.
+            # Rigid entities hold the registered material, which is the identity contact parameters are keyed
+            # on. See RigidMaterial.
             entity = self.rigid_solver.add_entity(
                 self.n_entities, self.scene.add_material(material), morph, surface, visualize_contact, name=name
             )

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -124,7 +124,8 @@ def kernel_get_state(
 
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
     for i_l, i_b in qd.ndrange(n_geoms, _B):
-        friction_ratio[i_b, i_l] = dyn_state.geoms.friction_ratio[i_l, i_b]
+        for j in qd.static(range(3)):
+            friction_ratio[i_b, i_l, j] = dyn_state.geoms.friction_ratio[i_l, i_b][j]
 
 
 @qd.kernel(fastcache=True)
@@ -172,7 +173,8 @@ def kernel_set_state(
 
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
     for i_l, i_b_ in qd.ndrange(n_geoms, _B):
-        dyn_state.geoms.friction_ratio[i_l, envs_idx[i_b_]] = friction_ratio[envs_idx[i_b_], i_l]
+        for j in qd.static(range(3)):
+            dyn_state.geoms.friction_ratio[i_l, envs_idx[i_b_]][j] = friction_ratio[envs_idx[i_b_], i_l, j]
 
 
 @qd.kernel(fastcache=True)
@@ -533,7 +535,8 @@ def kernel_set_geoms_friction_ratio(
 ):
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
     for i_g_, i_b_ in qd.ndrange(geoms_idx.shape[0], envs_idx.shape[0]):
-        dyn_state.geoms.friction_ratio[geoms_idx[i_g_], envs_idx[i_b_]] = friction_ratio[i_b_, i_g_]
+        for j in qd.static(range(3)):
+            dyn_state.geoms.friction_ratio[geoms_idx[i_g_], envs_idx[i_b_]][j] = friction_ratio[i_b_, i_g_, j]
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1188,17 +1188,17 @@ def kernel_update_drone_propeller_vgeoms(
 
 @qd.kernel(fastcache=True)
 def kernel_set_geom_friction(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction: float):
-    dyn_info.geoms.friction[geoms_idx] = friction
+    dyn_info.geoms.friction[geoms_idx][array_class.FrictionIdx.SLIDING] = friction
 
 
 @qd.kernel(fastcache=True)
 def kernel_set_geom_friction_torsional(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_torsional: float):
-    dyn_info.geoms.friction_torsional[geoms_idx] = friction_torsional
+    dyn_info.geoms.friction[geoms_idx][array_class.FrictionIdx.TORSIONAL] = friction_torsional
 
 
 @qd.kernel(fastcache=True)
 def kernel_set_geom_friction_rolling(geoms_idx: qd.i32, dyn_info: array_class.DynInfo, friction_rolling: float):
-    dyn_info.geoms.friction_rolling[geoms_idx] = friction_rolling
+    dyn_info.geoms.friction[geoms_idx][array_class.FrictionIdx.ROLLING] = friction_rolling
 
 
 @qd.kernel(fastcache=True)
@@ -1210,31 +1210,8 @@ def kernel_set_geoms_friction(
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_g_ in range(geoms_idx.shape[0]):
-        dyn_info.geoms.friction[geoms_idx[i_g_]] = friction[i_g_]
-
-
-@qd.kernel(fastcache=True)
-def kernel_set_geoms_friction_torsional(
-    geoms_idx: qd.types.ndarray(),
-    friction_torsional: qd.types.ndarray(),
-    dyn_info: array_class.DynInfo,
-    rigid_config: qd.template(),
-):
-    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
-    for i_g_ in range(geoms_idx.shape[0]):
-        dyn_info.geoms.friction_torsional[geoms_idx[i_g_]] = friction_torsional[i_g_]
-
-
-@qd.kernel(fastcache=True)
-def kernel_set_geoms_friction_rolling(
-    geoms_idx: qd.types.ndarray(),
-    friction_rolling: qd.types.ndarray(),
-    dyn_info: array_class.DynInfo,
-    rigid_config: qd.template(),
-):
-    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
-    for i_g_ in range(geoms_idx.shape[0]):
-        dyn_info.geoms.friction_rolling[geoms_idx[i_g_]] = friction_rolling[i_g_]
+        for j in qd.static(range(3)):
+            dyn_info.geoms.friction[geoms_idx[i_g_]][j] = friction[i_g_, j]
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -623,7 +623,8 @@ def kernel_init_geom_fields(
 
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.PARTIAL))
     for i_g, i_b in qd.ndrange(n_geoms, _B):
-        dyn_state.geoms.friction_ratio[i_g, i_b] = 1.0
+        for j in qd.static(range(3)):
+            dyn_state.geoms.friction_ratio[i_g, i_b][j] = 1.0
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -513,8 +513,6 @@ def kernel_init_geom_fields(
     geoms_quat: qd.types.ndarray(),
     geoms_type: qd.types.ndarray(),
     geoms_friction: qd.types.ndarray(),
-    geoms_friction_torsional: qd.types.ndarray(),
-    geoms_friction_rolling: qd.types.ndarray(),
     geoms_sol_params: qd.types.ndarray(),
     geoms_data: qd.types.ndarray(),
     geoms_is_convex: qd.types.ndarray(),
@@ -565,9 +563,8 @@ def kernel_init_geom_fields(
 
         dyn_info.geoms.link_idx[i_g] = geoms_link_idx[i_g]
         dyn_info.geoms.type[i_g] = geoms_type[i_g]
-        dyn_info.geoms.friction[i_g] = geoms_friction[i_g]
-        dyn_info.geoms.friction_torsional[i_g] = geoms_friction_torsional[i_g]
-        dyn_info.geoms.friction_rolling[i_g] = geoms_friction_rolling[i_g]
+        for j in qd.static(range(3)):
+            dyn_info.geoms.friction[i_g][j] = geoms_friction[i_g, j]
 
         dyn_info.geoms.is_convex[i_g] = geoms_is_convex[i_g]
         dyn_info.geoms.is_hollow[i_g] = geoms_is_hollow[i_g]

--- a/genesis/engine/solvers/rigid/collider/broadphase.py
+++ b/genesis/engine/solvers/rigid/collider/broadphase.py
@@ -90,8 +90,6 @@ def func_collision_clear(
                         collider_state.contact_data.normal[i_c_hibernated, i_b] = collider_state.contact_data.normal[i_c, i_b]
                         collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
                         collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
-                        collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
-                        collider_state.contact_data.friction_rolling[i_c_hibernated, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
                         collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
                         collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
                         collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -254,6 +254,7 @@ class Collider:
             prune_deep_penetration_ratio=self._prune_deep_penetration_ratio,
         )
         self._init_collision_pair_idx(self._collision_pair_idx)
+        self.update_friction_override()
         self._init_valid_pairs()
         self._init_verts_connectivity(vert_neighbors, vert_neighbor_start, vert_n_neighbors)
         self._init_verts_spatial_grid()
@@ -654,6 +655,25 @@ class Collider:
             self._collider_info.collision_pair_idx.fill(-1)
             return
         self._collider_info.collision_pair_idx.from_numpy(collision_pair_idx)
+
+    def update_friction_override(self):
+        """Expand the declared material pairs onto the collision pairs whose two geoms carry those materials.
+
+        The runtime resolves a contact from this array alone, so materials exist only here and in the authoring
+        API. Re-runs whenever a pair's coefficients change.
+        """
+        friction_override = np.full((max(self._n_possible_pairs, 1), 3), fill_value=-1.0, dtype=gs.np_float)
+        geoms_idx_by_material = {}
+        for geom in self._solver.geoms:
+            geoms_idx_by_material.setdefault(geom.material.idx, []).append(geom.idx)
+        for pair in self._solver._friction_pairs:
+            coeffs = [-1.0 if coeff is None else coeff for coeff in pair.coefficients]
+            for i_ga in geoms_idx_by_material.get(pair.material_a.idx, ()):
+                for i_gb in geoms_idx_by_material.get(pair.material_b.idx, ()):
+                    i_pair = self._collision_pair_idx[min(i_ga, i_gb), max(i_ga, i_gb)]
+                    if i_pair >= 0:
+                        friction_override[i_pair] = coeffs
+        self._collider_info.friction_override.from_numpy(friction_override)
 
     def _init_valid_pairs(self):
         if len(self._valid_collision_pairs) > 0:

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -206,8 +206,6 @@ def func_collider_clear_env(
                     collider_state.contact_data.normal[i_c_hibernated, i_b] = collider_state.contact_data.normal[i_c, i_b]
                     collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
                     collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
-                    collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
-                    collider_state.contact_data.friction_rolling[i_c_hibernated, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
                     collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
                     collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
                     collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]
@@ -307,6 +305,29 @@ def collider_kernel_get_contacts(
 
 
 @qd.func
+def func_resolve_contact_friction(
+    i_ga,
+    i_gb,
+    i_b,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+):
+    """Sliding, torsional and rolling friction coefficients of a contact between two geoms.
+
+    Each coefficient is the larger of the two geoms' own, scaled by that geom's friction ratio. Sliding friction
+    carries a floor, so every contact resists tangentially.
+    """
+    frictions = qd.Vector.zero(gs.qd_float, 3)
+    for j in qd.static(range(3)):
+        frictions[j] = qd.max(
+            dyn_info.geoms.friction[i_ga][j] * dyn_state.geoms.friction_ratio[i_ga, i_b],
+            dyn_info.geoms.friction[i_gb][j] * dyn_state.geoms.friction_ratio[i_gb, i_b],
+        )
+    frictions[array_class.FrictionIdx.SLIDING] = qd.max(frictions[array_class.FrictionIdx.SLIDING], 1e-2)
+    return frictions
+
+
+@qd.func
 def func_add_contact(
     i_ga,
     i_gb,
@@ -328,12 +349,7 @@ def func_add_contact(
     else:
         i_c = collider_state.n_contacts[i_b]
     if i_c < collider_info.max_candidate_contacts[None]:
-        friction_a = dyn_info.geoms.friction[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
-        friction_b = dyn_info.geoms.friction[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
-        friction_torsional_a = dyn_info.geoms.friction_torsional[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
-        friction_torsional_b = dyn_info.geoms.friction_torsional[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
-        friction_rolling_a = dyn_info.geoms.friction_rolling[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
-        friction_rolling_b = dyn_info.geoms.friction_rolling[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
+        frictions = func_resolve_contact_friction(i_ga, i_gb, i_b, dyn_state, dyn_info)
 
         # b to a
         collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -341,9 +357,7 @@ def func_add_contact(
         collider_state.contact_data.normal[i_c, i_b] = normal
         collider_state.contact_data.pos[i_c, i_b] = contact_pos
         collider_state.contact_data.penetration[i_c, i_b] = penetration
-        collider_state.contact_data.friction[i_c, i_b] = qd.max(qd.max(friction_a, friction_b), 1e-2)
-        collider_state.contact_data.friction_torsional[i_c, i_b] = qd.max(friction_torsional_a, friction_torsional_b)
-        collider_state.contact_data.friction_rolling[i_c, i_b] = qd.max(friction_rolling_a, friction_rolling_b)
+        collider_state.contact_data.friction[i_c, i_b] = frictions
         collider_state.contact_data.sol_params[i_c, i_b] = 0.5 * (
             dyn_info.geoms.sol_params[i_ga] + dyn_info.geoms.sol_params[i_gb]
         )
@@ -376,12 +390,7 @@ def func_set_contact(
     Set the contact data for the contact [i_c]. This is used for the backward pass, which parallelizes over the entire
     contact data, and for the split narrowphase multi-contact writes.
     """
-    friction_a = dyn_info.geoms.friction[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
-    friction_b = dyn_info.geoms.friction[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
-    friction_torsional_a = dyn_info.geoms.friction_torsional[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
-    friction_torsional_b = dyn_info.geoms.friction_torsional[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
-    friction_rolling_a = dyn_info.geoms.friction_rolling[i_ga] * dyn_state.geoms.friction_ratio[i_ga, i_b]
-    friction_rolling_b = dyn_info.geoms.friction_rolling[i_gb] * dyn_state.geoms.friction_ratio[i_gb, i_b]
+    frictions = func_resolve_contact_friction(i_ga, i_gb, i_b, dyn_state, dyn_info)
 
     # b to a
     collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -389,9 +398,7 @@ def func_set_contact(
     collider_state.contact_data.normal[i_c, i_b] = normal
     collider_state.contact_data.pos[i_c, i_b] = contact_pos
     collider_state.contact_data.penetration[i_c, i_b] = penetration
-    collider_state.contact_data.friction[i_c, i_b] = qd.max(qd.max(friction_a, friction_b), 1e-2)
-    collider_state.contact_data.friction_torsional[i_c, i_b] = qd.max(friction_torsional_a, friction_torsional_b)
-    collider_state.contact_data.friction_rolling[i_c, i_b] = qd.max(friction_rolling_a, friction_rolling_b)
+    collider_state.contact_data.friction[i_c, i_b] = frictions
     collider_state.contact_data.sol_params[i_c, i_b] = 0.5 * (
         dyn_info.geoms.sol_params[i_ga] + dyn_info.geoms.sol_params[i_gb]
     )

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -311,18 +311,33 @@ def func_resolve_contact_friction(
     i_b,
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
+    collider_info: array_class.ColliderInfo,
 ):
     """Sliding, torsional and rolling friction coefficients of a contact between two geoms.
 
-    Each coefficient is the larger of the two geoms' own, scaled by that geom's friction ratio. Sliding friction
-    carries a floor, so every contact resists tangentially.
+    Each coefficient is the larger of the two geoms' own, scaled by that geom's friction ratio, unless the pair
+    carries a coefficient of its own (see ColliderInfo.friction_override). Sliding friction carries a floor, so every
+    contact resists tangentially.
+
+    The override is addressed by the dense pair index of the two geoms; the caller's pair index counts broadphase
+    output on some paths, which is a different space.
     """
+    override = collider_info.friction_override[
+        collider_info.collision_pair_idx[(i_gb, i_ga) if i_ga > i_gb else (i_ga, i_gb)]
+    ]
     frictions = qd.Vector.zero(gs.qd_float, 3)
     for j in qd.static(range(3)):
-        frictions[j] = qd.max(
-            dyn_info.geoms.friction[i_ga][j] * dyn_state.geoms.friction_ratio[i_ga, i_b],
-            dyn_info.geoms.friction[i_gb][j] * dyn_state.geoms.friction_ratio[i_gb, i_b],
-        )
+        ratio_a = dyn_state.geoms.friction_ratio[i_ga, i_b][j]
+        ratio_b = dyn_state.geoms.friction_ratio[i_gb, i_b][j]
+        if override[j] >= 0.0:
+            # A pair coefficient describes the two surfaces together and has no per-surface decomposition, so the
+            # geoms' ratios reach it through their geometric mean: scaling both by k scales the coefficient by k.
+            frictions[j] = override[j] * qd.sqrt(ratio_a * ratio_b)
+        else:
+            frictions[j] = qd.max(
+                dyn_info.geoms.friction[i_ga][j] * ratio_a,
+                dyn_info.geoms.friction[i_gb][j] * ratio_b,
+            )
     frictions[array_class.FrictionIdx.SLIDING] = qd.max(frictions[array_class.FrictionIdx.SLIDING], 1e-2)
     return frictions
 
@@ -349,7 +364,7 @@ def func_add_contact(
     else:
         i_c = collider_state.n_contacts[i_b]
     if i_c < collider_info.max_candidate_contacts[None]:
-        frictions = func_resolve_contact_friction(i_ga, i_gb, i_b, dyn_state, dyn_info)
+        frictions = func_resolve_contact_friction(i_ga, i_gb, i_b, dyn_state, dyn_info, collider_info)
 
         # b to a
         collider_state.contact_data.geom_a[i_c, i_b] = i_ga
@@ -390,7 +405,7 @@ def func_set_contact(
     Set the contact data for the contact [i_c]. This is used for the backward pass, which parallelizes over the entire
     contact data, and for the split narrowphase multi-contact writes.
     """
-    frictions = func_resolve_contact_friction(i_ga, i_gb, i_b, dyn_state, dyn_info)
+    frictions = func_resolve_contact_friction(i_ga, i_gb, i_b, dyn_state, dyn_info, collider_info)
 
     # b to a
     collider_state.contact_data.geom_a[i_c, i_b] = i_ga

--- a/genesis/engine/solvers/rigid/constraint/backward.py
+++ b/genesis/engine/solvers/rigid/constraint/backward.py
@@ -519,7 +519,7 @@ def kernel_manual_add_collision_constraints_bw(
             link_b = collider_state.contact_data.link_b[i_col, i_b]
             contact_pos = collider_state.contact_data.pos[i_col, i_b]
             normal = collider_state.contact_data.normal[i_col, i_b]
-            friction = collider_state.contact_data.friction[i_col, i_b]
+            friction = collider_state.contact_data.friction[i_col, i_b][array_class.FrictionIdx.SLIDING]
             sol_params = collider_state.contact_data.sol_params[i_col, i_b]
             penetration = collider_state.contact_data.penetration[i_col, i_b]
 

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -689,7 +689,7 @@ def _add_friction_constraint(
 
     contact_data_pos = collider_state.contact_data.pos[i_col, i_b]
     contact_data_normal = collider_state.contact_data.normal[i_col, i_b]
-    contact_data_friction = collider_state.contact_data.friction[i_col, i_b]
+    contact_data_friction = collider_state.contact_data.friction[i_col, i_b][array_class.FrictionIdx.SLIDING]
     contact_data_sol_params = collider_state.contact_data.sol_params[i_col, i_b]
     contact_data_penetration = collider_state.contact_data.penetration[i_col, i_b]
 
@@ -712,10 +712,14 @@ def _add_friction_constraint(
 
     contact_data_friction_torsional = gs.qd_float(0.0)
     if qd.static(rigid_config.enable_torsional_friction):
-        contact_data_friction_torsional = collider_state.contact_data.friction_torsional[i_col, i_b]
+        contact_data_friction_torsional = collider_state.contact_data.friction[i_col, i_b][
+            array_class.FrictionIdx.TORSIONAL
+        ]
     contact_data_friction_rolling = gs.qd_float(0.0)
     if qd.static(rigid_config.enable_rolling_friction):
-        contact_data_friction_rolling = collider_state.contact_data.friction_rolling[i_col, i_b]
+        contact_data_friction_rolling = collider_state.contact_data.friction[i_col, i_b][
+            array_class.FrictionIdx.ROLLING
+        ]
     n, n_ang = _func_contact_row_direction(
         i_friction,
         contact_data_normal,
@@ -899,7 +903,7 @@ def _add_collision_constraints_per_contact(
 
             contact_data_pos = collider_state.contact_data.pos[i_col, i_b]
             contact_data_normal = collider_state.contact_data.normal[i_col, i_b]
-            contact_data_friction = collider_state.contact_data.friction[i_col, i_b]
+            contact_data_friction = collider_state.contact_data.friction[i_col, i_b][array_class.FrictionIdx.SLIDING]
             contact_data_sol_params = collider_state.contact_data.sol_params[i_col, i_b]
             contact_data_penetration = collider_state.contact_data.penetration[i_col, i_b]
 
@@ -956,10 +960,14 @@ def _add_collision_constraints_per_contact(
 
             contact_data_friction_torsional = gs.qd_float(0.0)
             if qd.static(rigid_config.enable_torsional_friction):
-                contact_data_friction_torsional = collider_state.contact_data.friction_torsional[i_col, i_b]
+                contact_data_friction_torsional = collider_state.contact_data.friction[i_col, i_b][
+                    array_class.FrictionIdx.TORSIONAL
+                ]
             contact_data_friction_rolling = gs.qd_float(0.0)
             if qd.static(rigid_config.enable_rolling_friction):
-                contact_data_friction_rolling = collider_state.contact_data.friction_rolling[i_col, i_b]
+                contact_data_friction_rolling = collider_state.contact_data.friction[i_col, i_b][
+                    array_class.FrictionIdx.ROLLING
+                ]
 
             for i_friction in range(rows_per_contact):
                 n, n_ang = _func_contact_row_direction(
@@ -6626,7 +6634,7 @@ def func_update_contact_force(
         for i_c in range(collider_state.n_contacts[i_b]):
             i_col = collider_state.contact_sort_idx[i_c, i_b]
             contact_data_normal = collider_state.contact_data.normal[i_col, i_b]
-            contact_data_friction = collider_state.contact_data.friction[i_col, i_b]
+            contact_data_friction = collider_state.contact_data.friction[i_col, i_b][array_class.FrictionIdx.SLIDING]
             contact_data_link_a = collider_state.contact_data.link_a[i_col, i_b]
             contact_data_link_b = collider_state.contact_data.link_b[i_col, i_b]
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -3,9 +3,10 @@ import os
 import sys
 from typing import TYPE_CHECKING, Literal
 
-import quadrants as qd
 import numpy as np
 import torch
+
+import quadrants as qd
 
 import genesis as gs
 import genesis.utils.array_class as array_class

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1,7 +1,7 @@
 import math
 import os
 import sys
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 import numpy as np
 import torch
@@ -13,6 +13,7 @@ import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 from genesis.engine.entities import DroneEntity, RigidEntity
 from genesis.engine.entities.base_entity import Entity
+from genesis.engine.materials.rigid import RigidMaterial
 from genesis.engine.states import QueriedStates, RigidSolverState
 from genesis.options.solvers import RigidOptions
 from genesis.utils.misc import (
@@ -212,6 +213,17 @@ IMP_MAX = 0.9999
 TIME_CONSTANT_SAFETY_FACTOR = 2.0
 
 
+class FrictionPair(NamedTuple):
+    """Contact friction coefficients declared for one pair of materials.
+
+    A None coefficient is left to the maximum over the two geoms, so a pair may pin sliding friction alone.
+    """
+
+    material_a: RigidMaterial
+    material_b: RigidMaterial
+    coefficients: tuple[float | None, float | None, float | None]
+
+
 def _sanitize_sol_params(sol_params, min_timeconst: float, default_timeconst: float | None = None):
     timeconst, dampratio, dmin, dmax, width, mid, power = sol_params.reshape((-1, 7)).T
     if default_timeconst is None:
@@ -266,6 +278,10 @@ class RigidSolver(KinematicSolver):
         self._box_box_detection = options.box_box_detection
         self._requires_grad = self._sim.options.requires_grad
         self._enable_heterogeneous = False  # Set to True when any entity has heterogeneous morphs
+
+        # Friction pairs, in declaration order. See Collider.update_friction_override for how they reach the
+        # runtime.
+        self._friction_pairs: list[FrictionPair] = []
 
         # Contact islands are off by default (opt in explicitly). The gate further below still disables them under
         # requires_grad (the differentiable adjoint reads the dense global Hessian) and for single-island scenes
@@ -1826,7 +1842,7 @@ class RigidSolver(KinematicSolver):
                 cfrc_ang_dst.masked_fill_(envs_mask[:, None, None], 0.0)
                 torch.where(envs_mask[:, None], state.mass_shift, mass_dst, out=mass_dst)
                 if self.n_geoms:
-                    torch.where(envs_mask[:, None], state.friction_ratio, fric_dst, out=fric_dst)
+                    torch.where(envs_mask[:, None, None], state.friction_ratio, fric_dst, out=fric_dst)
                 if self._use_hibernation:
                     links_hibernated_dst.masked_fill_(envs_mask[:, None], 0)
                     awake_steps_dst.masked_fill_(envs_mask[:, None], 0)
@@ -2291,8 +2307,12 @@ class RigidSolver(KinematicSolver):
         kernel_adjust_link_inertia(links_idx, envs_idx, ratio, self.dyn_info, self.rigid_config)
 
     def set_geoms_friction_ratio(self, friction_ratio, geoms_idx=None, envs_idx=None):
+        """Set the sliding, torsional and rolling friction ratio of each geom, packed along the trailing axis.
+
+        Takes the three together, which set_links_friction_ratio builds on to write one coefficient at a time.
+        """
         friction_ratio, geoms_idx, envs_idx = self._sanitize_io_variables(
-            friction_ratio, geoms_idx, self.n_geoms, "geoms_idx", envs_idx, skip_allocation=True
+            friction_ratio, geoms_idx, self.n_geoms, "geoms_idx", envs_idx, element_shape=(3,), skip_allocation=True
         )
         if self.n_envs == 0:
             friction_ratio = friction_ratio[None]
@@ -2824,7 +2844,35 @@ class RigidSolver(KinematicSolver):
         tensor = qd_to_torch(self.dyn_info.links.invweight, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 and self._options.batch_links_info else tensor
 
+    def set_links_friction_ratio(
+        self,
+        sliding_ratio=None,
+        links_idx=None,
+        envs_idx=None,
+        *,
+        torsional_ratio=None,
+        rolling_ratio=None,
+    ):
+        """Scale the friction coefficients of every geom of the given links, addressed by global link index.
+
+        A coefficient left None keeps its current value. The three share one packed field, so the ones left unset are
+        read back and written unchanged.
+        """
+        links_idx = range(self.n_links) if links_idx is None else links_idx
+        geoms_idx = [i_g for i_l in links_idx for i_g in range(self.links[i_l].geom_start, self.links[i_l].geom_end)]
+        links_n_geoms = torch.tensor([self.links[i_l].n_geoms for i_l in links_idx], dtype=gs.tc_int, device=gs.device)
+
+        ratios = self.get_geoms_friction_ratio(geoms_idx, envs_idx)
+        for i_coeff, ratio in enumerate((sliding_ratio, torsional_ratio, rolling_ratio)):
+            if ratio is None:
+                continue
+            # A per-link ratio expands to the geoms of each link; a scalar already applies to all of them.
+            ratio = torch.as_tensor(ratio, dtype=gs.tc_float, device=gs.device)
+            ratios[..., i_coeff] = torch.repeat_interleave(ratio, links_n_geoms, dim=-1) if ratio.ndim else ratio
+        self.set_geoms_friction_ratio(ratios, geoms_idx, envs_idx)
+
     def get_geoms_friction_ratio(self, geoms_idx=None, envs_idx=None):
+        """Sliding, torsional and rolling friction ratio of each geom, packed along the trailing axis."""
         tensor = qd_to_torch(self.dyn_state.geoms.friction_ratio, envs_idx, geoms_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
 
@@ -3147,6 +3195,10 @@ class RigidSolver(KinematicSolver):
         kernel_set_geom_friction_rolling(geoms_idx, self.dyn_info, friction_rolling)
 
     def set_geoms_friction(self, friction, geoms_idx=None):
+        """Set the sliding, torsional and rolling friction coefficients of each geom, packed along the trailing axis.
+
+        Takes the three together, where the per-geom setters write one coefficient at a time.
+        """
         friction, geoms_idx, _ = self._sanitize_io_variables(
             friction,
             geoms_idx,
@@ -3158,6 +3210,42 @@ class RigidSolver(KinematicSolver):
             skip_allocation=True,
         )
         kernel_set_geoms_friction(geoms_idx, friction, self.dyn_info, self.rigid_config)
+
+    def set_friction_pair(
+        self, material_a, material_b, sliding_friction=None, torsional_friction=None, rolling_friction=None
+    ):
+        """Pin the contact friction coefficients between two registered materials.
+
+        The pair replaces the maximum over the two geoms wherever both materials meet, and declaring the same two
+        materials again replaces its coefficients.
+        """
+        for material in (material_a, material_b):
+            if not isinstance(material, RigidMaterial):
+                gs.raise_exception(
+                    "A friction pair is declared between two materials registered through 'scene.add_material'. "
+                    f"Got {material}."
+                )
+            # A material is numbered within the scene it was registered on, so one from another scene would key the
+            # pair on some unrelated material of this one.
+            if material.scene is not self.scene:
+                gs.raise_exception(f"Material {material} is registered on another scene than this solver's.")
+        # The same bounds the per-geom coefficients answer to, so a pair cannot silently land on the solver's floor.
+        if sliding_friction is not None and (sliding_friction < 1e-2 or sliding_friction > 5.0):
+            gs.raise_exception("`sliding_friction` must be in the range [1e-2, 5.0] for simulation stability.")
+        for name, coeff in (("torsional_friction", torsional_friction), ("rolling_friction", rolling_friction)):
+            if coeff is not None and coeff < 0.0:
+                gs.raise_exception(f"`{name}` must be non-negative.")
+
+        pair = FrictionPair(material_a, material_b, (sliding_friction, torsional_friction, rolling_friction))
+        key = {material_a.idx, material_b.idx}
+        for i_pair, other in enumerate(self._friction_pairs):
+            if {other.material_a.idx, other.material_b.idx} == key:
+                self._friction_pairs[i_pair] = pair
+                break
+        else:
+            self._friction_pairs.append(pair)
+        if self.is_built:
+            self.collider.update_friction_override()
 
     def add_weld_constraint(self, link1_idx, link2_idx, envs_idx=None):
         return self.constraint_solver.add_weld_constraint(link1_idx, link2_idx, envs_idx)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -174,8 +174,6 @@ from .abd.accessor import (
     kernel_set_geom_friction_rolling,
     kernel_set_geom_friction_torsional,
     kernel_set_geoms_friction,
-    kernel_set_geoms_friction_rolling,
-    kernel_set_geoms_friction_torsional,
     kernel_adjust_link_inertia,
 )
 from .abd.diff import (
@@ -1153,9 +1151,10 @@ class RigidSolver(KinematicSolver):
                 np.array(geoms_center, dtype=gs.np_float),
                 np.array([geom.init_quat for geom in geoms], dtype=gs.np_float),
                 np.array([geom.type for geom in geoms], dtype=gs.np_int),
-                np.array([geom.friction for geom in geoms], dtype=gs.np_float),
-                np.array([geom.friction_torsional for geom in geoms], dtype=gs.np_float),
-                np.array([geom.friction_rolling for geom in geoms], dtype=gs.np_float),
+                np.array(
+                    [(geom.friction, geom.friction_torsional, geom.friction_rolling) for geom in geoms],
+                    dtype=gs.np_float,
+                ),
                 geoms_sol_params,
                 np.array([geom.data for geom in geoms], dtype=gs.np_float),
                 np.array([geom.is_convex for geom in geoms], dtype=gs.np_bool),
@@ -3101,6 +3100,7 @@ class RigidSolver(KinematicSolver):
         return self.get_kinetic_energy(envs_idx=envs_idx) + self.get_potential_energy(envs_idx=envs_idx)
 
     def get_geoms_friction(self, geoms_idx=None):
+        """Sliding, torsional and rolling friction coefficients of each geom, packed along the trailing axis."""
         return qd_to_torch(self.dyn_info.geoms.friction, geoms_idx, copy=True)
 
     def get_AABB(self, entities_idx=None, envs_idx=None):
@@ -3148,21 +3148,16 @@ class RigidSolver(KinematicSolver):
 
     def set_geoms_friction(self, friction, geoms_idx=None):
         friction, geoms_idx, _ = self._sanitize_io_variables(
-            friction, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
+            friction,
+            geoms_idx,
+            self.n_geoms,
+            "geoms_idx",
+            envs_idx=None,
+            element_shape=(3,),
+            batched=False,
+            skip_allocation=True,
         )
         kernel_set_geoms_friction(geoms_idx, friction, self.dyn_info, self.rigid_config)
-
-    def set_geoms_friction_torsional(self, friction_torsional, geoms_idx=None):
-        friction_torsional, geoms_idx, _ = self._sanitize_io_variables(
-            friction_torsional, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
-        )
-        kernel_set_geoms_friction_torsional(geoms_idx, friction_torsional, self.dyn_info, self.rigid_config)
-
-    def set_geoms_friction_rolling(self, friction_rolling, geoms_idx=None):
-        friction_rolling, geoms_idx, _ = self._sanitize_io_variables(
-            friction_rolling, geoms_idx, self.n_geoms, "geoms_idx", envs_idx=None, batched=False, skip_allocation=True
-        )
-        kernel_set_geoms_friction_rolling(geoms_idx, friction_rolling, self.dyn_info, self.rigid_config)
 
     def add_weld_constraint(self, link1_idx, link2_idx, envs_idx=None):
         return self.constraint_solver.add_weld_constraint(link1_idx, link2_idx, envs_idx)

--- a/genesis/engine/states/solvers.py
+++ b/genesis/engine/states/solvers.py
@@ -103,7 +103,7 @@ class RigidSolverState:
         self.links_quat = gs.zeros((_B, scene.sim.rigid_solver.n_links, 4), **args)
         self.i_pos_shift = gs.zeros((_B, scene.sim.rigid_solver.n_links, 3), **args)
         self.mass_shift = gs.zeros((_B, scene.sim.rigid_solver.n_links), **args)
-        self.friction_ratio = gs.ones((_B, scene.sim.rigid_solver.n_geoms), **args)
+        self.friction_ratio = gs.ones((_B, scene.sim.rigid_solver.n_geoms, 3), **args)
 
     def serializable(self):
         self.scene = None

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -76,6 +76,18 @@ def V_SCALAR_FROM(dtype, value):
     return data
 
 
+# ======================================= Friction packing ========================================
+
+
+class FrictionIdx(IntEnum):
+    """Component order of every packed friction vector: GeomsInfo.friction, GeomsState.friction_ratio and
+    ContactData.friction all carry the coefficients in this order."""
+
+    SLIDING = 0
+    TORSIONAL = 1
+    ROLLING = 2
+
+
 # =========================================== ErrorCode ===========================================
 
 
@@ -694,9 +706,8 @@ class ContactData:
     penetration: qd.Tensor
     normal: qd.Tensor
     pos: qd.Tensor
+    # Sliding, torsional and rolling coefficients of the contact, packed in that order.
     friction: qd.Tensor
-    friction_torsional: qd.Tensor
-    friction_rolling: qd.Tensor
     sol_params: qd.Tensor
     force: qd.Tensor
     link_a: qd.Tensor
@@ -714,9 +725,7 @@ def get_contact_data(solver, max_candidate_contacts, requires_grad):
         normal=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
         pos=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
         penetration=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B), needs_grad=requires_grad),
-        friction=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
-        friction_torsional=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
-        friction_rolling=V(dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
+        friction=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B)),
         sol_params=V_VEC(7, dtype=gs.qd_float, shape=(max_candidate_contacts_, _B)),
         force=V(dtype=gs.qd_vec3, shape=(max_candidate_contacts_, _B)),
         link_a=V(dtype=gs.qd_int, shape=(max_candidate_contacts_, _B)),
@@ -1954,9 +1963,8 @@ class GeomsInfo:
     data: qd.Tensor
     link_idx: qd.Tensor
     type: qd.Tensor
+    # Sliding, torsional and rolling coefficients of the geom, packed in that order.
     friction: qd.Tensor
-    friction_torsional: qd.Tensor
-    friction_rolling: qd.Tensor
     sol_params: qd.Tensor
     vert_num: qd.Tensor
     vert_start: qd.Tensor
@@ -1991,9 +1999,7 @@ def get_geoms_info(solver, is_active=True):
         data=V(dtype=gs.qd_vec7, shape=shape),
         link_idx=V(dtype=gs.qd_int, shape=shape),
         type=V(dtype=gs.qd_int, shape=shape),
-        friction=V(dtype=gs.qd_float, shape=shape),
-        friction_torsional=V(dtype=gs.qd_float, shape=shape),
-        friction_rolling=V(dtype=gs.qd_float, shape=shape),
+        friction=V(dtype=gs.qd_vec3, shape=shape),
         sol_params=V(dtype=gs.qd_vec7, shape=shape),
         vert_num=V(dtype=gs.qd_int, shape=shape),
         vert_start=V(dtype=gs.qd_int, shape=shape),

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1556,6 +1556,10 @@ class ColliderInfo:
     # Post-pruning contact-point budget per environment, which sizes the contact constraint buffers (4 constraints per
     # contact point). Smaller than max_candidate_contacts when contact pruning is enabled or 'max_contacts' is set.
     max_contacts: qd.Tensor
+    # Friction coefficients declared for a pair of geoms, indexed by the dense pair index of collision_pair_idx and
+    # packed like GeomsInfo.friction. A component holds -1 where nothing was declared, so a pair may pin the sliding
+    # coefficient and leave the torsional and rolling ones to the maximum over the two geoms.
+    friction_override: qd.Tensor
     # Compact list of valid collision pairs. Used by all-vs-all broadphase to dispatch valid pairs to GPU threads.
     n_valid_pairs: qd.Tensor
     valid_collision_pairs: qd.Tensor
@@ -1611,6 +1615,7 @@ def get_collider_info(
         max_candidate_contacts=V(dtype=gs.qd_int, shape=()),
         max_collision_pairs_broad=V(dtype=gs.qd_int, shape=()),
         max_contacts=V(dtype=gs.qd_int, shape=()),
+        friction_override=V(dtype=gs.qd_vec3, shape=(max(n_valid_pairs, 1),)),
         n_valid_pairs=V_SCALAR_FROM(dtype=gs.qd_int, value=n_valid_pairs),
         valid_collision_pairs=V(dtype=gs.qd_ivec2, shape=(max(n_valid_pairs, 1),)),
         terrain_hf=V(dtype=gs.qd_float, shape=terrain_hf_shape),
@@ -2051,7 +2056,7 @@ def get_geoms_state(solver, is_active=True):
         min_buffer_idx=V(dtype=gs.qd_int, shape=shape),
         max_buffer_idx=V(dtype=gs.qd_int, shape=shape),
         is_hibernated=V(dtype=gs.qd_int, shape=shape),
-        friction_ratio=V(dtype=gs.qd_float, shape=shape),
+        friction_ratio=V(dtype=gs.qd_vec3, shape=shape),
     )
 
 

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -591,8 +591,7 @@ def test_registered_material_shared_between_entities():
     assert scene.add_material(rubber.options) is rubber
     assert inline_box.material.idx != rubber.idx
 
-    # The declared options remain readable through the material, so the geoms carry the declared coefficient.
-    assert_equal(rubber.friction, 1.2)
+    # The declared options remain readable through the material, which is where the geoms take their coefficient from.
     assert_equal([geom.friction for geom in shared_box.geoms], 1.2)
     assert_equal([geom.friction for geom in inline_box.geoms], 0.3)
 

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -595,8 +595,30 @@ def test_registered_material_shared_between_entities():
     assert_equal([geom.friction for geom in shared_box.geoms], 1.2)
     assert_equal([geom.friction for geom in inline_box.geoms], 0.3)
 
+    # A geom assigned a material of its own takes every coefficient that material declares, and keeps the one it
+    # carries where the material declares none.
+    steel = scene.add_material(
+        gs.materials.Rigid(
+            friction=0.9,
+            friction_torsional=0.05,
+        )
+    )
+    unspecified = scene.add_material(
+        gs.materials.Rigid(),
+    )
+    shared_box.geoms[0].set_material(steel)
+    inline_box.geoms[0].set_material(unspecified)
+    assert_equal(shared_box.geoms[0].friction, 0.9)
+    assert_equal(shared_box.geoms[0].friction_torsional, 0.05)
+    assert_equal(inline_box.geoms[0].friction, 0.3)
+
     with pytest.raises(gs.GenesisException):
         scene.add_material(gs.materials.MPM.Elastic())
+
+    # A material is numbered within the scene it was registered on, so pairing one against a material of another
+    # scene would key the pair on some unrelated material.
+    with pytest.raises(gs.GenesisException):
+        rubber.set_friction_pair(gs.Scene(show_viewer=False).add_material(gs.materials.Rigid()), sliding_friction=0.5)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -12,6 +12,7 @@ from genesis.utils.misc import qd_to_torch
 
 from ..utils import (
     assert_allclose,
+    assert_equal,
 )
 
 
@@ -550,6 +551,53 @@ def test_geom_pos_quat(n_envs, show_viewer):
             assert vgeom_quat.shape == (*batch_shape, 4)
             assert_allclose(geom_pos, vgeom_pos, atol=gs.EPS)
             assert_allclose(geom_quat, vgeom_quat, atol=gs.EPS)
+
+
+@pytest.mark.required
+def test_registered_material_shared_between_entities():
+    scene = gs.Scene(
+        show_viewer=False,
+    )
+    rubber = scene.add_material(
+        gs.materials.Rigid(
+            friction=1.2,
+        )
+    )
+    plane = scene.add_entity(
+        gs.morphs.Plane(),
+        material=rubber,
+    )
+    shared_box = scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 0.5),
+            size=(0.1, 0.1, 0.1),
+        ),
+        material=rubber,
+    )
+    inline_box = scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 1.0, 0.5),
+            size=(0.1, 0.1, 0.1),
+        ),
+        material=gs.materials.Rigid(
+            friction=0.3,
+        ),
+    )
+
+    # Entities built from one registered material report it as their identity, while a material passed inline is
+    # registered on the spot and stays private to its entity.
+    assert plane.material is rubber
+    assert shared_box.material is rubber
+    assert scene.add_material(rubber.options) is rubber
+    assert inline_box.material.idx != rubber.idx
+
+    # The declared options remain readable through the material, so the geoms carry the declared coefficient.
+    assert_equal(rubber.friction, 1.2)
+    assert_equal([geom.friction for geom in shared_box.geoms], 1.2)
+    assert_equal([geom.friction for geom in inline_box.geoms], 0.3)
+
+    with pytest.raises(gs.GenesisException):
+        scene.add_material(gs.materials.MPM.Elastic())
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -705,7 +705,7 @@ def test_friction_resolved_from_material_pair(n_envs, show_viewer):
     # matching the order their pairs were numbered in. A lookup keyed on the wrong one of those two then resolves
     # some other pair's coefficient.
     SPEEDS = (6.0, 8.0, 12.0, 20.0, 5.0, 9.0, 15.0, 7.0)
-    # Coefficient declared for the plane against each box's material. 0.8 sits above both surfaces' own coefficients
+    # Coefficient declared for the plane against each box's material. 0.6 sits above both surfaces' own coefficients
     # and 0.05 below both, so neither a maximum nor a minimum over the two reproduces them. Every one stays well
     # clear of the coefficient at which a cube tips over its leading edge, width / (2 * com_height), since approaching
     # it leans the contact force toward that edge and lifts the centre of mass. They are all distinct so that
@@ -776,9 +776,12 @@ def test_friction_resolved_from_material_pair(n_envs, show_viewer):
         boxes[i_box].geoms[0].set_material(own_material)
         plane_material.set_friction_pair(own_material, sliding_friction=pair_friction)
     plane_material.set_friction_pair(shared_material, sliding_friction=PAIR_HIGH)
-    plane_material.set_friction_pair(geom_material, sliding_friction=PAIR_LOW)
+    plane_material.set_friction_pair(geom_material, sliding_friction=PAIR_HIGH)
     scene.build(n_envs=n_envs)
 
+    # Retuning a declared pair on a built scene is what a system identification loop does. The fourth box slides at
+    # PAIR_LOW only if this reaches it, since it was declared at PAIR_HIGH above.
+    plane_material.set_friction_pair(geom_material, sliding_friction=PAIR_LOW)
     # The third box answers to the same declaration as the first two, scaled by its own sliding ratio alone.
     boxes[2].set_friction_ratio(sliding_ratio=SLIDING_RATIO)
     # The torsional ratio moves on the first box, which must leave its sliding deceleration untouched.

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -698,6 +698,116 @@ def test_elliptic_cone_push_isotropy(contact_resolution, show_viewer, tol):
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
+def test_friction_resolved_from_material_pair(n_envs, show_viewer):
+    GRAVITY = 9.81
+    SIZE = 0.1
+    # Distinct launch speeds spread the boxes apart as they slide, so the order broadphase reports them in stops
+    # matching the order their pairs were numbered in. A lookup keyed on the wrong one of those two then resolves
+    # some other pair's coefficient.
+    SPEEDS = (6.0, 8.0, 12.0, 20.0, 5.0, 9.0, 15.0, 7.0)
+    # Coefficient declared for the plane against each box's material. 0.8 sits above both surfaces' own coefficients
+    # and 0.05 below both, so neither a maximum nor a minimum over the two reproduces them. Every one stays well
+    # clear of the coefficient at which a cube tips over its leading edge, width / (2 * com_height), since approaching
+    # it leans the contact force toward that edge and lifts the centre of mass. They are all distinct so that
+    # resolving any contact from another pair's coefficient shows up.
+    PAIR_HIGH = 0.6
+    PAIR_LOW = 0.05
+    PAIR_OWN = (0.1, 0.15, 0.25, 0.35)
+    # Scaling one geom's sliding ratio reaches a pair coefficient through the geometric mean of the two geoms', so
+    # the plane's ratio of 1 leaves the square root of this factor.
+    SLIDING_RATIO = 0.25
+    N_SETTLE = 40
+    N_SLIDE = 40
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=0.005,
+            gravity=(0.0, 0.0, -GRAVITY),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=gs.friction_cone.elliptic,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.0, -1.0, 0.6),
+            camera_lookat=(1.0, 0.2, 0.05),
+        ),
+        show_viewer=show_viewer,
+    )
+    plane_material = scene.add_material(
+        gs.materials.Rigid(
+            friction=0.4,
+        )
+    )
+    scene.add_entity(
+        gs.morphs.Plane(),
+        material=plane_material,
+    )
+    # One material shared by the first two boxes, so a single declaration governs both; one material assigned on a
+    # geom rather than its entity, which is how one entity carries more than one surface.
+    shared_material = scene.add_material(
+        gs.materials.Rigid(
+            friction=0.4,
+        )
+    )
+    geom_material = scene.add_material(
+        gs.materials.Rigid(
+            friction=0.4,
+        )
+    )
+    # Spaced far enough apart never to interact, so each box is its own contact island.
+    boxes = [
+        scene.add_entity(
+            gs.morphs.Box(
+                pos=(0.0, 4.0 * SIZE * i_box, 0.5 * SIZE),
+                size=(SIZE, SIZE, SIZE),
+            ),
+            material=shared_material,
+        )
+        for i_box in range(len(SPEEDS))
+    ]
+    boxes[3].geoms[0].set_material(geom_material)
+    # The remaining boxes each carry their own material and coefficient.
+    for i_box, pair_friction in enumerate(PAIR_OWN, start=4):
+        own_material = scene.add_material(
+            gs.materials.Rigid(
+                friction=0.4,
+            )
+        )
+        boxes[i_box].geoms[0].set_material(own_material)
+        plane_material.set_friction_pair(own_material, sliding_friction=pair_friction)
+    plane_material.set_friction_pair(shared_material, sliding_friction=PAIR_HIGH)
+    plane_material.set_friction_pair(geom_material, sliding_friction=PAIR_LOW)
+    scene.build(n_envs=n_envs)
+
+    # The third box answers to the same declaration as the first two, scaled by its own sliding ratio alone.
+    boxes[2].set_friction_ratio(sliding_ratio=SLIDING_RATIO)
+    # The torsional ratio moves on the first box, which must leave its sliding deceleration untouched.
+    boxes[0].set_friction_ratio(torsional_ratio=0.5)
+
+    for _ in range(N_SETTLE):
+        scene.step()
+    for box, speed in zip(boxes, SPEEDS):
+        velocity = box.get_dofs_velocity()
+        velocity[..., 0] = speed
+        box.set_dofs_velocity(velocity)
+    speed_0 = torch.stack([box.get_dofs_velocity()[..., 0] for box in boxes])
+    for _ in range(N_SLIDE):
+        scene.step()
+    speed_1 = torch.stack([box.get_dofs_velocity()[..., 0] for box in boxes])
+
+    # Every box slides at the coefficient its pair declares, in place of the 0.4 both its own surfaces carry: the
+    # shared declaration for the first two, that same declaration scaled for the third, and the declaration made
+    # against the fourth box's geom material.
+    friction = torch.tensor(
+        [PAIR_HIGH, PAIR_HIGH, PAIR_HIGH * SLIDING_RATIO**0.5, PAIR_LOW, *PAIR_OWN],
+        device=gs.device,
+    ).reshape(-1, *(1,) * (n_envs > 0))
+    deceleration = (speed_0 - speed_1) / (N_SLIDE * scene.sim.dt)
+    assert_allclose(deceleration, (friction * GRAVITY).expand_as(deceleration), rtol=0.01)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
 def test_kinetic_friction(n_envs, show_viewer):
     GRAVITY = 9.81
     SIZE = 0.1


### PR DESCRIPTION
## Description

- `scene.add_material(gs.materials.Rigid(...))` registers the options and returns the `Material` that entities hold
  as their `material`. Passing one to several `add_entity` calls shares one surface; `geom.set_material` gives one
  entity more than one.
- `rubber.set_friction_pair(steel, sliding_friction=0.4)` pins the coefficients for that pair of materials in place
  of the maximum over the two geoms. A coefficient left `None` keeps following the maximum. Re-declaring the same two
  materials retunes them, before or after build.
- Materials stay an authoring concept. Declarations expand onto collision pairs at build, so no material indirection
  reaches a kernel; the override sits on `ColliderInfo`, keyed by the dense pair index `collision_pair_idx` already
  provides.
- `friction_ratio` is per-coefficient: `set_friction_ratio(sliding_ratio=..., torsional_ratio=...,
  rolling_ratio=...)` writes only what is passed. The two new arguments are keyword-only. Coefficients and ratios
  read as `<mode>_friction` and `<mode>_ratio` throughout.
- `array_class.py` loses three tensor fields. A geom's and a contact's friction coefficients are each packed into one
  vector, against the one field the override adds.

Breaking:

- `entity.material` is the registered `Material`, not the options. `entity.material.friction` and its torsional and
  rolling siblings are gone: read `material.options.friction` for the declared value or `geom.friction` for what a
  geom carries. The options base class is now `gs.materials.MaterialOptions`.
- `get_geoms_friction` / `set_geoms_friction`, the friction-ratio accessors, and `RigidSolverState.friction_ratio`
  carry the three coefficients on a trailing axis.
- `set_geoms_friction_torsional` / `_rolling` are subsumed by the packed setter.
- `entity.set_friction_ratio`'s first argument is `sliding_ratio` and scales sliding friction alone, where
  `friction_ratio` scaled all three.

Out of scope: `geom_priority`, MJCF `<pair>` import, anisotropic (5-coefficient) friction, `sol_params` averaging, and
the couplers' own friction rules.

## Related Issue

Addresses Genesis-Embodied-AI/genesis-world#2718. The `geom_priority` field proposed there is not added; a material
pair subsumes it without making users reason about which surface wins.

## Motivation and Context

Friction is a property of a pair of surfaces, so the maximum over two geoms is arbitrary: no per-surface value plus a
symmetric rule reproduces a real table. It also hides single-sided changes, since lowering only a robot's friction
against a default-1.0 ground is a no-op. The issue reports a Go2 sweep that reproduced its own baseline that way.

## How Has This Been / Can This Be Tested?

```
pytest tests/rigid/ -v
pytest tests/ipc/ -v -n0          # ipc needs a single worker on one GPU
```

`tests/rigid/test_friction.py::test_friction_resolved_from_material_pair`, over `n_envs=[0, 2]`, asserts
`deceleration == mu * g` for eight boxes on a plane:

- pair coefficients of 0.6 and 0.05 against surfaces that both declare 0.4, so neither a maximum nor a minimum over
  the two reproduces them
- two boxes sharing one material, one taking its material on the geom, one scaled by a sliding ratio
- distinct launch speeds, so the order broadphase reports the boxes in stops matching the order their pairs were
  numbered in

It is separate from `test_kinetic_friction` because that scene straddles the tipping threshold, where changing any one
coefficient flips an unrelated box between 176 and 0.1 degrees of tilt.

Locally `tests/rigid/` is 426 passed and `tests/ipc/` 47 passed. `test_physics_parity` and
`test_robot_grasp_fem[external_articulation]` fail identically on the merge-base.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Resolves SIM-329

