### PR TITLE
[FEATURE] Expose dofs limits setter on rigid entities.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -3965,6 +3965,28 @@ class RigidEntity(KinematicEntity):
         self._solver.set_dofs_force_range(lower, upper, dofs_idx, envs_idx)
 
     @gs.assert_built
+    def set_dofs_limit(self, lower, upper, dofs_idx_local=None, envs_idx=None):
+        """
+        Set the positional limits (min and max) for the entity's dofs.
+
+        Setting a different limit per environment requires `RigidOptions.batch_dofs_info` to be enabled, otherwise all
+        environments share a single value.
+
+        Parameters
+        ----------
+        lower : array_like
+            The lower bounds of the positional limits.
+        upper : array_like
+            The upper bounds of the positional limits.
+        dofs_idx_local : None | array_like, optional
+            The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        """
+        dofs_idx = self._get_global_idx(dofs_idx_local, self.n_dofs, self._dof_start, unsafe=True)
+        self._solver.set_dofs_limit(lower, upper, dofs_idx, envs_idx)
+
+    @gs.assert_built
     def set_dofs_stiffness(self, stiffness, dofs_idx_local=None, envs_idx=None):
         dofs_idx = self._get_global_idx(dofs_idx_local, self.n_dofs, self._dof_start, unsafe=True)
         self._solver.set_dofs_stiffness(stiffness, dofs_idx, envs_idx)

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -200,7 +200,7 @@ def test_data_accessor(n_envs, batched, tol):
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_velocity, gs_robot.set_dofs_velocity, None),
         (gs_robot.n_dofs, n_envs, gs_robot.get_dofs_position, gs_robot.set_dofs_position, None),
         (gs_robot.n_dofs, -1, gs_robot.get_dofs_force_range, gs_robot.set_dofs_force_range, None),
-        (gs_robot.n_dofs, -1, gs_robot.get_dofs_limit, None, None),
+        (gs_robot.n_dofs, -1, gs_robot.get_dofs_limit, gs_robot.set_dofs_limit, None),
         (gs_robot.n_dofs, -1, gs_robot.get_dofs_stiffness, None, None),
         (gs_robot.n_dofs, -1, gs_robot.get_dofs_invweight, None, None),
         (gs_robot.n_dofs, -1, gs_robot.get_dofs_armature, None, None),


### PR DESCRIPTION
## Description

`RigidEntity` gains `set_dofs_limit`, mirroring `set_dofs_force_range`: it converts local dof indices to global ones and forwards to `RigidSolver.set_dofs_limit`.

The entity row for `get_dofs_limit` in `test_data_accessor` now passes the setter, as the solver row for the same property already does.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3168

## Motivation and Context

`limit` was the only dof property with an entity getter and no entity setter, apart from `invweight`, whose removal is deliberate and documented in the method it raises from. Setting a per-environment joint limit therefore meant assembling scene-global dof indices by hand and calling `scene.rigid_solver` directly, so a caller that uses local indices everywhere else had to carry a second index array for this one property.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_api.py::test_data_accessor` now exercises the setter through the entity, under the same dof and environment masking combinations it already applies to every other row:

```bash
pytest -v --forked tests/rigid/test_api.py -k test_data_accessor
```

Checked manually on a 4-environment scene with `batch_dofs_info=True` and a model carrying two slide joints: a different `upper` per environment round-trips through `get_dofs_limit`, and driving every joint well past its limit leaves each environment stopped at its own value.

```python
upper = np.array([[0.060 + 0.01 * i, 0.090 + 0.01 * i] for i in range(4)])
entity.set_dofs_limit(np.zeros_like(upper), upper, dofs_idx_local=slide_dofs_idx_local)
assert np.allclose(entity.get_dofs_limit(dofs_idx_local=slide_dofs_idx_local)[1], upper)
```

I have not run the full suite locally, only the manual check above; `test_data_accessor` is expected to cover the new row exactly as it covers the solver row for the same property.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
