### PR TITLE
  [BUG FIX] Apply MeshSet poses to sampled particles.

### DIFF
--- a/genesis/engine/entities/particle_entity.py
+++ b/genesis/engine/entities/particle_entity.py
@@ -264,7 +264,11 @@ class ParticleEntity(Entity):
                         sampler=sampler,
                     )
 
-                particles_i += np.asarray(morph_i.pos, dtype=gs.np_float)
+                particles_i = gu.transform_by_trans_quat(
+                    particles_i,
+                    np.asarray(morph_i.pos, dtype=gs.np_float),
+                    np.asarray(morph_i.quat, dtype=gs.np_float),
+                )
                 particles.append(particles_i)
         elif isinstance(self._morph, (gs.options.morphs.Primitive, gs.options.morphs.Mesh)):
             particles = self._vmesh.particlize(self._particle_size, self.sampler)

--- a/tests/particles/test_mpm.py
+++ b/tests/particles/test_mpm.py
@@ -1,7 +1,35 @@
+import numpy as np
 import pytest
 import torch
+import trimesh
 
 import genesis as gs
+
+
+@pytest.mark.required
+def test_mesh_set_particle_transform(show_viewer):
+    pos = np.array((0.2, 0.1, 0.2))
+    mesh = trimesh.creation.box(extents=(0.04, 0.12, 0.04))
+    scene = gs.Scene(
+        mpm_options=gs.options.MPMOptions(
+            lower_bound=(-0.5, -0.5, -0.5),
+            upper_bound=(0.5, 0.5, 0.5),
+            particle_size=0.01,
+        ),
+        show_viewer=show_viewer,
+    )
+    entity = scene.add_entity(
+        morph=gs.morphs.MeshSet(
+            files=(mesh,),
+            poss=(pos,),
+            eulers=((0.0, 0.0, 90.0),),
+        ),
+        material=gs.materials.MPM.Elastic(sampler="regular"),
+    )
+
+    particles = entity.init_particles
+    np.testing.assert_allclose(particles.mean(axis=0), pos, atol=1e-6)
+    np.testing.assert_allclose(np.ptp(particles, axis=0), (0.11, 0.03, 0.03), atol=1e-6)
 
 
 @pytest.mark.required


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Please:

1. Follow our contributor guidelines:
   https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
2. Prepare your PR according to the "Submitting Code Changes"
   section of https://github.com/Genesis-Embodied-AI/Genesis/blob/main/.github/contributing/PULL_REQUESTS.md
3. Provide a concise summary of your changes in the Title above
4. Prefix the title according to the type of issue you are addressing. Use:
    - [BUG FIX] for non-breaking changes which fix an issue
    - [FEATURE] for non-breaking changes which add functionality
    - [MISC] for minor changes such as improved inline documentation or fixing typos
    - [CHANGING] for changes that will change simulation's behaviour
    - [BREAKING] **in addition to the above** for breaking changes, i.e., a fix or feature that would cause existing APIs or functionality to change
-->

## Description
<!--- Describe your changes in detail -->
Apply each MeshSet member's rotation and translation to its sampled particle positions. 

Previously, MeshSet particles were only translated, while the corresponding visual mesh received the complete pose.

Add an MPM regression test using an asymmetric mesh rotated by 90 degrees.
## Related Issue
<!--- This project only accepts pull requests related to open issues.
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.

Please link to the relevant issue here, e.g. via `Resolves <issue-url>`.
Cf. https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

Resolves Genesis-Embodied-AI/Genesis#3169

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Hybrid entities instantiate their soft parts through MeshSet. Ignoring each member's rotation caused particles generated from rotated URDF links to remain aligned with the original local axes instead of attaching to the links.

## How Has This Been / Can This Be Tested?
<!--- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
```bash
pytest -n 0 tests/particles/test_mpm.py
```
## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
