### PR TITLE
[MISC] Fix stale code comment in benchmarks.

### DIFF
--- a/examples/speed_benchmark/franka.py
+++ b/examples/speed_benchmark/franka.py
@@ -27,7 +27,7 @@ franka = scene.add_entity(
 )
 
 
-# create 20 parallel environments
+# create 30000 parallel environments
 B = 30000
 scene.build(n_envs=B, env_spacing=(1.0, 1.0))
 


### PR DESCRIPTION
## Description

The comment above `B = 30000` in `examples/speed_benchmark/franka.py` reads "create 20 parallel environments". The file follows `examples/tutorials/parallel_simulation.py`, where `B = 20` and the comment is accurate; the benchmark raised the count without updating the line. Line 5 of the same file already states 30000.

## How Has This Been / Can This Be Tested?

Comment only, no behavior change.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
