### PR TITLE
fix(urdf): add missing inertial blocks to panda_slider_mobile base links

### DIFF
--- a/genesis/assets/urdf/panda_bullet/panda_slider_mobile.urdf
+++ b/genesis/assets/urdf/panda_bullet/panda_slider_mobile.urdf
@@ -4,10 +4,33 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="panda" xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <link name="basex"/>
-  <link name="basey"/>
-  <link name="basez"/>
+  <link name="basex">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+  </link>
+  <link name="basey">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+  </link>
+  <link name="basez">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+  </link>
   <link name="base">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="20.0"/>
+      <inertia ixx="0.5" ixy="0" ixz="0" iyy="0.5" iyz="0" izz="0.5"/>
+    </inertial>
     <visual>
       <origin xyz="0 0 -0.26"/>
       <geometry>


### PR DESCRIPTION
## Problem
The planar-base intermediate links (`basex`, `basey`, `basez`, `base`) in `panda_slider_mobile.urdf` are self-closing elements with **no `<inertial>` blocks**. The Genesis legacy parser assigns `gs.EPS` (~1e-15) mass to these movable links, causing numerical instability when the Franka arm accelerates while gripping a payload.

## Reproduction (ROCm/HIP 7.2, gfx1100, Genesis 1.3.0)
The URDF at `genesis/assets/urdf/panda_bullet/panda_slider_mobile.urdf` has 4 links with no inertial and non-fixed joints:
- `basex` / `basey` / `basez`: prismatic slider intermediate links
- `base`: base plate supporting the robot arm

Genesis warns: `Moving link basex has no mass, inertia or geometry... Setting its mass to gs.EPS.` — then at runtime, EPS-mass links create unstable force propagation through the kinematic chain during payload transport.

## Fix
Added `<inertial>` blocks with reasonable default mass values:
- **basex/basey/basez**: 1.0 kg each (intermediate prismatic sliders)
- **base**: 20.0 kg (base plate supporting the ~18kg Franka arm + payload)

The arm links (panda_link0-8, hand, fingers) already have proper inertial blocks — no changes needed there.

## Verification
Tested the fixed URDF with the RadeonHome mobile manipulation pipeline (ROCm/HIP 7.2, AMD Radeon PRO W7900, Genesis 1.3.0). The EPS-mass warnings are eliminated and payload transport runs stably.

## Context
Discovered during RadeonHome development (Track 3, AMD AI DevMaster Hackathon 2026).
Original workaround: https://github.com/520lake/RadeonHome/blob/main/radeon_home/mobile_scene.py#L56-L80

Closes #3185