### PR TITLE
[BUG FIX] Fix sensor read delay crash and jitter returning undelayed data.

### DIFF
--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -741,8 +741,8 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
                 f"Sensor jitter must not exceed the simulation step dt={self._dt}; got "
                 f"jitter={tuple(jitter_np.ravel())}."
             )
-        # The return-space ring reserves the extra slot a jittered read reaches only for sensors declaring a delay at
-        # build time, so jitter stays bounded by the delay here just as it is at option level.
+        # Same bound as `SensorOptions.model_post_init`, enforced here because only a sensor declaring a delay at build
+        # time gets the ring slot a jittered read reaches (see `cls_delay_depth` in sensor_manager.py).
         if np.any(jitter_np > self._options.delay):
             gs.raise_exception(
                 f"Sensor jitter must not exceed the read delay={self._options.delay}; got "

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -759,9 +759,9 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         batch_size = self._manager._sim._B
 
         # Jitter must not exceed the simulation step so a single jittered read can only shift by at most one extra ring
-        # slot. The per-class return-space ring is sized at build to accommodate `max_delay + 1` slots; a larger jitter
-        # would wrap modulo the ring depth and silently return wrong-frame data. An EPS slack lets `jitter == dt` pass
-        # cleanly despite float quantization.
+        # slot, which is the margin the return-space ring is sized for (see `cls_delay_depth` in sensor_manager.py); a
+        # larger jitter would wrap modulo the ring depth and silently return wrong-frame data. An EPS slack lets
+        # `jitter == dt` pass cleanly despite float quantization.
         jitter_np = np.asarray(self._options.jitter, dtype=gs.np_float)
         if np.any(jitter_np >= self._dt + gs.EPS):
             gs.raise_exception(

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -741,6 +741,13 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
                 f"Sensor jitter must not exceed the simulation step dt={self._dt}; got "
                 f"jitter={tuple(jitter_np.ravel())}."
             )
+        # The return-space ring reserves the extra slot a jittered read reaches only for sensors declaring a delay at
+        # build time, so jitter stays bounded by the delay here just as it is at option level.
+        if np.any(jitter_np > self._options.delay):
+            gs.raise_exception(
+                f"Sensor jitter must not exceed the read delay={self._options.delay}; got "
+                f"jitter={tuple(jitter_np.ravel())}."
+            )
         self._set_metadata_field(jitter_np / self._dt, self._shared_metadata.jitter_ts, self._idx, 1, envs_idx)
         # Recompute the slow-path flag from the freshly-written class metadata. One GPU->CPU sync at setter call time;
         # setters are not hot path. The check covers partial envs_idx writes and other sensors.

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -758,10 +758,9 @@ class SimpleSensor(Sensor[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
 
         batch_size = self._manager._sim._B
 
-        # Jitter must not exceed the simulation step so a single jittered read can only shift by at most one extra ring
-        # slot, which is the margin the return-space ring is sized for (see `cls_delay_depth` in sensor_manager.py); a
-        # larger jitter would wrap modulo the ring depth and silently return wrong-frame data. An EPS slack lets
-        # `jitter == dt` pass cleanly despite float quantization.
+        # Jitter must not exceed the step, so a read shifts by at most one extra ring slot - the margin the return-space
+        # ring is sized for (see `cls_delay_depth` in sensor_manager.py). An EPS slack lets `jitter == dt` pass cleanly
+        # despite float quantization.
         jitter_np = np.asarray(self._options.jitter, dtype=gs.np_float)
         if np.any(jitter_np >= self._dt + gs.EPS):
             gs.raise_exception(

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -147,7 +147,8 @@ class SensorManager:
         max_history_per_dtype: dict[torch.dtype, int] = {}
         intermediate_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
         return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
-        # Per-class delay-depth (max sensor `_delay_ts + 1`) drives the return-space ring sizing for delay sampling.
+        # Per-class delay-depth (deepest sensor slot reachable by delay sampling, plus one) drives the return-space
+        # ring sizing.
         delay_depth_by_class: dict[type["Sensor"], int] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
             intermediate_dtype = sensor_cls._get_intermediate_dtype()
@@ -164,7 +165,9 @@ class SensorManager:
             for sensor in sensors:
                 sensor._cache_offset = cls_offset
                 cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
-                cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + 1)
+                # Jitter can push a read one slot past `_delay_ts`, so a jittered sensor needs that slot addressable;
+                # otherwise `at()` wraps it modulo the depth and returns the newest frame as if it were the oldest.
+                cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + (2 if sensor._options.jitter > 0.0 else 1))
                 hist = sensor._options.history_length
                 if hist > 0:
                     max_history_per_dtype[intermediate_dtype] = max(

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -164,9 +164,9 @@ class SensorManager:
             for sensor in sensors:
                 sensor._cache_offset = cls_offset
                 cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
-                # Jitter reaches one slot past `_delay_ts`; without it addressable, `at()` wraps modulo the depth and
-                # returns the newest frame as the oldest.
-                cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + (2 if sensor._options.jitter > 0.0 else 1))
+                # A delay reserves one slot past `_delay_ts` for the jitter shift, which `set_jitter` can raise at any
+                # time; without that slot, `at()` wraps modulo the depth and returns the newest frame as the oldest.
+                cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + (2 if sensor._options.delay > 0.0 else 1))
                 hist = sensor._options.history_length
                 if hist > 0:
                     max_history_per_dtype[intermediate_dtype] = max(

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -147,8 +147,7 @@ class SensorManager:
         max_history_per_dtype: dict[torch.dtype, int] = {}
         intermediate_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
         return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
-        # Per-class delay-depth (deepest sensor slot reachable by delay sampling, plus one) drives the return-space
-        # ring sizing.
+        # Deepest return-space slot delay sampling can reach, plus one.
         delay_depth_by_class: dict[type["Sensor"], int] = {}
         for sensor_cls, sensors in self._sensors_by_type.items():
             intermediate_dtype = sensor_cls._get_intermediate_dtype()
@@ -165,8 +164,8 @@ class SensorManager:
             for sensor in sensors:
                 sensor._cache_offset = cls_offset
                 cache_size_per_dtype[intermediate_dtype] += sensor._cache_size
-                # Jitter can push a read one slot past `_delay_ts`, so a jittered sensor needs that slot addressable;
-                # otherwise `at()` wraps it modulo the depth and returns the newest frame as if it were the oldest.
+                # Jitter reaches one slot past `_delay_ts`; without it addressable, `at()` wraps modulo the depth and
+                # returns the newest frame as the oldest.
                 cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + (2 if sensor._options.jitter > 0.0 else 1))
                 hist = sensor._options.history_length
                 if hist > 0:

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -111,11 +111,12 @@ class SensorOptions(Options, Generic[SensorT]):
         """
         assert scene.sim is not None
         if self.delay > 0:
-            delay_hz = self.delay / scene.sim.dt
-            if not np.isclose(delay_hz, round(delay_hz), atol=gs.EPS):
+            delay_ratio = self.delay / scene.sim.dt
+            delay_ts = round(delay_ratio)
+            if not np.isclose(delay_ratio, delay_ts, atol=gs.EPS):
                 gs.logger.warning(
                     f"{type(self).__name__}: Read delay should be a multiple of the simulation time step. Got "
-                    f"{self.delay} and {scene.sim.dt}. Actual read delay will be {1 / round(delay_hz)}."
+                    f"{self.delay} and {scene.sim.dt}. Actual read delay will be {delay_ts * scene.sim.dt}."
                 )
 
 

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -244,8 +244,8 @@ def test_pipeline_contract(tol):
     H = np.array([row[3] for row in paths], dtype=np.float32)
 
     # Companion simple sensor for the ring-allocation paths. No knobs, no overrides beyond raw write - the read
-    # just echoes the shared per-class step counter. Four instances cover (delay=0, history=0), history-only,
-    # delay-only, and (delay + history).
+    # just echoes the shared per-class step counter. Five instances cover (delay=0, history=0), history-only,
+    # delay-only, (delay + history), and (delay + jitter).
     @dataclass
     class FakeSimpleMetadata(SimpleSensorMetadata):
         step_counter: int = 0
@@ -288,6 +288,7 @@ def test_pipeline_contract(tol):
     s_history = scene.add_sensor(FakeSimpleOptions(history_length=HISTORY_LEN))
     s_delay = scene.add_sensor(FakeSimpleOptions(delay=DELAY_STEPS * DT))
     s_both = scene.add_sensor(FakeSimpleOptions(history_length=HISTORY_LEN, delay=DELAY_STEPS * DT))
+    s_jitter = scene.add_sensor(FakeSimpleOptions(delay=DELAY_STEPS * DT, jitter=DT))
     scene.build()
     scene.reset()  # zero the build-warmup counter increment so step 1 sees raw = 1.
 
@@ -298,6 +299,7 @@ def test_pipeline_contract(tol):
     history_observed = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
     delay_observed = np.zeros(n_steps, dtype=np.float32)
     both_observed = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
+    jitter_observed = np.zeros(n_steps, dtype=np.float32)
     for i in range(n_steps):
         scene.step()
         gt_observed[i] = tensor_to_array(sensor.read_ground_truth()).reshape(-1)
@@ -306,6 +308,7 @@ def test_pipeline_contract(tol):
         history_observed[i] = tensor_to_array(s_history.read()).reshape(-1)
         delay_observed[i] = tensor_to_array(s_delay.read()).item()
         both_observed[i] = tensor_to_array(s_both.read()).reshape(-1)
+        jitter_observed[i] = tensor_to_array(s_jitter.read()).item()
 
     # Analytical expectation for the vector sensor, per component. Let raw[k] = k, and (P, M, A, H) be the per-
     # component vectors.
@@ -347,6 +350,11 @@ def test_pipeline_contract(tol):
     # The combined delay + history sensor returns the same history as the history-only sensor (delay is bypassed
     # by the ring-gather history path); verify they match.
     assert_allclose(both_observed, expected_history, tol=tol)
+    # `jitter == dt` shifts a read by exactly zero or one extra slot, so every jittered sample is bracketed by the
+    # raw values `DELAY_STEPS` and `DELAY_STEPS + 1` back. The upper bound is the un-jittered delayed sequence; a
+    # read fresher than it means the deepest slot wrapped around the ring onto the newest one.
+    jitter_lo = np.where(raw - DELAY_STEPS - 1 >= 1, raw - DELAY_STEPS - 1, 0.0)
+    assert ((jitter_observed >= jitter_lo) & (jitter_observed <= expected_delay)).all()
 
 
 @pytest.mark.required

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -272,6 +272,7 @@ def test_pipeline_contract(tol):
 
     DT = 1e-2
     DELAY_STEPS = 2
+    DEEP_DELAY_STEPS = 3
     HISTORY_LEN = 3
     scene = gs.Scene(sim_options=gs.options.SimOptions(dt=DT), show_viewer=False)
     scene.add_entity(gs.morphs.Plane())  # minimum scene; the sensors do not depend on any physics.
@@ -288,8 +289,14 @@ def test_pipeline_contract(tol):
     s_delay = scene.add_sensor(FakeSimpleOptions(delay=DELAY_STEPS * DT))
     s_both = scene.add_sensor(FakeSimpleOptions(history_length=HISTORY_LEN, delay=DELAY_STEPS * DT))
     s_jitter = scene.add_sensor(FakeSimpleOptions(delay=DELAY_STEPS * DT, jitter=DT))
+    s_late_jitter = scene.add_sensor(FakeSimpleOptions(delay=DEEP_DELAY_STEPS * DT))
     scene.build()
     scene.reset()  # zero the build-warmup counter increment so step 1 sees raw = 1.
+    # `set_jitter` enables jitter on a sensor built without it, so the ring reservation keys off the delay.
+    # `s_late_jitter` holds the class's deepest delay, so its sampling is what wraps if the extra slot is missing.
+    s_late_jitter.set_jitter(DT)
+    with pytest.raises(Exception, match="read delay"):
+        s_baseline.set_jitter(DT)
 
     n_steps = 8
     gt_observed = np.zeros((n_steps, len(paths)), dtype=np.float32)
@@ -299,6 +306,7 @@ def test_pipeline_contract(tol):
     delay_observed = np.zeros(n_steps, dtype=np.float32)
     both_observed = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
     jitter_observed = np.zeros(n_steps, dtype=np.float32)
+    late_jitter_observed = np.zeros(n_steps, dtype=np.float32)
     for i in range(n_steps):
         scene.step()
         gt_observed[i] = tensor_to_array(sensor.read_ground_truth()).reshape(-1)
@@ -308,6 +316,7 @@ def test_pipeline_contract(tol):
         delay_observed[i] = tensor_to_array(s_delay.read()).item()
         both_observed[i] = tensor_to_array(s_both.read()).reshape(-1)
         jitter_observed[i] = tensor_to_array(s_jitter.read()).item()
+        late_jitter_observed[i] = tensor_to_array(s_late_jitter.read()).item()
 
     # Analytical expectation for the vector sensor, per component. Let raw[k] = k, and (P, M, A, H) be the per-
     # component vectors.
@@ -351,8 +360,10 @@ def test_pipeline_contract(tol):
     assert_allclose(both_observed, expected_history, tol=tol)
     # `jitter == dt` shifts a read by zero or one extra slot, so every sample is bracketed by the delayed sequence and
     # the raw value one step older.
-    jitter_lo = np.where(raw - DELAY_STEPS - 1 >= 1, raw - DELAY_STEPS - 1, 0.0)
-    assert ((jitter_observed >= jitter_lo) & (jitter_observed <= expected_delay)).all()
+    for observed, delay_steps in ((jitter_observed, DELAY_STEPS), (late_jitter_observed, DEEP_DELAY_STEPS)):
+        hi = np.where(raw - delay_steps >= 1, raw - delay_steps, 0.0)
+        lo = np.where(raw - delay_steps - 1 >= 1, raw - delay_steps - 1, 0.0)
+        assert ((observed >= lo) & (observed <= hi)).all()
 
 
 @pytest.mark.required

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -244,8 +244,7 @@ def test_pipeline_contract(tol):
     H = np.array([row[3] for row in paths], dtype=np.float32)
 
     # Companion simple sensor for the ring-allocation paths. No knobs, no overrides beyond raw write - the read
-    # just echoes the shared per-class step counter. Five instances cover (delay=0, history=0), history-only,
-    # delay-only, (delay + history), and (delay + jitter).
+    # just echoes the shared per-class step counter.
     @dataclass
     class FakeSimpleMetadata(SimpleSensorMetadata):
         step_counter: int = 0
@@ -350,9 +349,8 @@ def test_pipeline_contract(tol):
     # The combined delay + history sensor returns the same history as the history-only sensor (delay is bypassed
     # by the ring-gather history path); verify they match.
     assert_allclose(both_observed, expected_history, tol=tol)
-    # `jitter == dt` shifts a read by exactly zero or one extra slot, so every jittered sample is bracketed by the
-    # raw values `DELAY_STEPS` and `DELAY_STEPS + 1` back. The upper bound is the un-jittered delayed sequence; a
-    # read fresher than it means the deepest slot wrapped around the ring onto the newest one.
+    # `jitter == dt` shifts a read by zero or one extra slot, so every sample is bracketed by the delayed sequence and
+    # the raw value one step older.
     jitter_lo = np.where(raw - DELAY_STEPS - 1 >= 1, raw - DELAY_STEPS - 1, 0.0)
     assert ((jitter_observed >= jitter_lo) & (jitter_observed <= expected_delay)).all()
 

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -150,10 +150,10 @@ def test_pipeline_contract(tol):
     #     (physics_imp, measured_only_imp, transform_alpha, hardware_imp) path, so GT-cleanliness, physics
     #     propagation through transform recurrence, the `is_measured` gate on `_apply_transform`, and HW non-
     #     compounding are all verified in one batched pass.
-    #   * `FakeSimpleSensor` instances cover the three return-space ring allocation paths: no-ring (delay=0,
-    #     history=0), history-only ring, and delay+history ring. All four instances of `FakeSimpleSensor` share
-    #     the same per-class step counter, so they all see the same raw value at each step and the expected
-    #     outputs are simple shifts / windows of that sequence.
+    #   * `FakeSimpleSensor` instances cover the return-space ring allocation paths: no-ring (delay=0,
+    #     history=0), history-only ring, delay+history ring, sub-step delay, and jitter declared at build or
+    #     enabled afterwards. Every instance shares the same per-class step counter, so they all see the same
+    #     raw value at each step and the expected outputs are simple shifts / windows of that sequence.
     from dataclasses import dataclass
 
     from genesis.engine.sensors.base_sensor import SimpleSensor, SimpleSensorMetadata
@@ -290,6 +290,7 @@ def test_pipeline_contract(tol):
     s_both = scene.add_sensor(FakeSimpleOptions(history_length=HISTORY_LEN, delay=DELAY_STEPS * DT))
     s_jitter = scene.add_sensor(FakeSimpleOptions(delay=DELAY_STEPS * DT, jitter=DT))
     s_late_jitter = scene.add_sensor(FakeSimpleOptions(delay=DEEP_DELAY_STEPS * DT))
+    s_substep_delay = scene.add_sensor(FakeSimpleOptions(delay=DT / 4))
     scene.build()
     scene.reset()  # zero the build-warmup counter increment so step 1 sees raw = 1.
     # `set_jitter` enables jitter on a sensor built without it, so the ring reservation keys off the delay.
@@ -307,6 +308,7 @@ def test_pipeline_contract(tol):
     both_observed = np.zeros((n_steps, HISTORY_LEN), dtype=np.float32)
     jitter_observed = np.zeros(n_steps, dtype=np.float32)
     late_jitter_observed = np.zeros(n_steps, dtype=np.float32)
+    substep_delay_observed = np.zeros(n_steps, dtype=np.float32)
     for i in range(n_steps):
         scene.step()
         gt_observed[i] = tensor_to_array(sensor.read_ground_truth()).reshape(-1)
@@ -317,6 +319,7 @@ def test_pipeline_contract(tol):
         both_observed[i] = tensor_to_array(s_both.read()).reshape(-1)
         jitter_observed[i] = tensor_to_array(s_jitter.read()).item()
         late_jitter_observed[i] = tensor_to_array(s_late_jitter.read()).item()
+        substep_delay_observed[i] = tensor_to_array(s_substep_delay.read()).item()
 
     # Analytical expectation for the vector sensor, per component. Let raw[k] = k, and (P, M, A, H) be the per-
     # component vectors.
@@ -353,6 +356,8 @@ def test_pipeline_contract(tol):
             expected_history[k - 1, h] = past_step if past_step >= 1 else 0.0
 
     assert_allclose(baseline_observed, expected_baseline, tol=tol)
+    # A delay under half a step rounds to zero slots, so the read is undelayed.
+    assert_allclose(substep_delay_observed, expected_baseline, tol=tol)
     assert_allclose(delay_observed, expected_delay, tol=tol)
     assert_allclose(history_observed, expected_history, tol=tol)
     # The combined delay + history sensor returns the same history as the history-only sensor (delay is bypassed


### PR DESCRIPTION
## Description
The two bugs:
- The warning for a delay that is not a multiple of `dt`  was incorrect and could cause div by 0 error.
- Sensor with jitter intermittently returns undelayed data.

## Related Issue

## How Has This Been / Can This Be Tested?

`tests/sensors/test_pipeline_contract`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.