### PR TITLE
[MISC] Add documentation issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report, please make sure to [search for existing issues](https://github.com/Genesis-Embodied-AI/Genesis/issues) before filing a new one!
+        Thanks for taking the time to fill out this bug report, please make sure to [search for existing issues](https://github.com/Genesis-Embodied-AI/genesis-world/issues) before filing a new one!
   - type: textarea
     id: bug-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,0 +1,35 @@
+name: "📚 Documentation Issue"
+description: Report something wrong, unclear, or missing in the documentation
+title: "[Docs]: "
+labels: ["documentation", "triage-needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Documentation issues are tracked here, even though the pages themselves live in [genesis-doc](https://github.com/Genesis-Embodied-AI/genesis-doc). Please make sure to [search for existing issues](https://github.com/Genesis-Embodied-AI/genesis-world/issues) before filing a new one!
+  - type: input
+    id: page
+    attributes:
+      label: Affected Page
+      placeholder: "Link to the page on https://genesis-world.readthedocs.io, or the path of the source file in genesis-doc."
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+      placeholder: |
+        A clear and concise description of the problem, e.g. an example that no longer runs, an API signature that does not
+        match the code, a step that is impossible to follow, or a topic that is not covered at all.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      placeholder: "If you already know what the page should say instead, describe it here."
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      placeholder: "Add any other context, screenshots, or log output here."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
 - name: "💬 Support & Questions - Github Community Support"
-  url: https://github.com/Genesis-Embodied-AI/Genesis/discussions
+  url: https://github.com/Genesis-Embodied-AI/genesis-world/discussions
   about: Please ask and answer questions here.
-- name: "⚠️ Documentation Issues"
-  url: https://github.com/Genesis-Embodied-AI/genesis-doc/issues
-  about: Please report issues in our documentation here.


### PR DESCRIPTION
## Description
`genesis-doc` already links to `genesis-world` for opening issues. But currently `genesis-world` links back to `genesis-doc` creating a loop 😅

## Related Issue
Partially addresses https://github.com/Genesis-Embodied-AI/genesis-world/issues/3181

## Motivation and Context
Community

## How Has This Been / Can This Be Tested?

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I read the **CONTRIBUTING** document.
- [ ] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [ ] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [ ] I tested my changes and added instructions on how to test it for reviewers.