### PR TITLE
[MISC] Enable production cache cleanup without interrupting jobs.

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,6 +19,8 @@ env:
   # Note that secrets are not passed to workflows that are triggered by a pull request from a fork
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HF_HUB_DOWNLOAD_TIMEOUT: 60
+  # Increment to switch new jobs to fresh caches before deleting the previous version.
+  CACHE_VERSION: "1"
   GENESIS_IMAGE_VER: "1_25"
   TIMEOUT_MINUTES: 60
   FORCE_COLOR: 1
@@ -58,15 +60,19 @@ jobs:
                --container-name=${CONTAINER_NAME} \
                --container-mounts=\
           ${{ github.workspace }}:/root/workspace,\
-          ${HOME}/.cache/uv:/root/.cache/uv,\
-          ${HOME}/.cache/genesis:/root/.cache/genesis,\
-          ${HOME}/.cache/quadrants:/root/.cache/quadrants,\
-          ${HOME}/.cache/huggingface:/root/.cache/huggingface \
+          ${HOME}/.cache/${CACHE_VERSION}/uv:/root/.cache/uv,\
+          ${HOME}/.cache/${CACHE_VERSION}/genesis:/root/.cache/genesis,\
+          ${HOME}/.cache/${CACHE_VERSION}/quadrants:/root/.cache/quadrants,\
+          ${HOME}/.cache/${CACHE_VERSION}/huggingface:/root/.cache/huggingface \
                --no-container-mount-home \
                --container-workdir=/root/workspace"
           SLURM_ENV_VARS="NVIDIA_DRIVER_CAPABILITIES=all,BASH_ENV=/root/.bashrc,HF_TOKEN,GS_ENABLE_NDARRAY=${GS_ENABLE_NDARRAY}"
 
-          mkdir -p ${HOME}/.cache/uv ${HOME}/.cache/genesis ${HOME}/.cache/quadrants ${HOME}/.cache/huggingface
+          mkdir -p \
+            "${HOME}/.cache/${CACHE_VERSION}/uv" \
+            "${HOME}/.cache/${CACHE_VERSION}/genesis" \
+            "${HOME}/.cache/${CACHE_VERSION}/quadrants" \
+            "${HOME}/.cache/${CACHE_VERSION}/huggingface"
 
           JOBID_FIFO="${{ github.workspace }}/.slurm_job_id_fifo"
           [[ -e "$JOBID_FIFO" ]] && rm -f "$JOBID_FIFO"
@@ -145,14 +151,16 @@ jobs:
                --container-mounts=\
           /mnt/data/artifacts:/mnt/data/artifacts,\
           ${{ github.workspace }}:/root/workspace,\
-          ${HOME}/.cache/uv:/root/.cache/uv,\
-          ${HOME}/.cache/huggingface:/root/.cache/huggingface \
+          ${HOME}/.cache/${CACHE_VERSION}/uv:/root/.cache/uv,\
+          ${HOME}/.cache/${CACHE_VERSION}/huggingface:/root/.cache/huggingface \
                --no-container-mount-home \
                --container-workdir=/root/workspace"
           SLURM_ENV_VARS="NVIDIA_DRIVER_CAPABILITIES=all,BASH_ENV=/root/.bashrc,HF_TOKEN,GS_ENABLE_NDARRAY=${GS_ENABLE_NDARRAY}"
           if [[ "${{ github.repository }}" == 'Genesis-Embodied-AI/genesis-world' && "${{ github.ref }}" == 'refs/heads/main' ]] ; then
             SLURM_ENV_VARS="${SLURM_ENV_VARS},WANDB_API_KEY"
           fi
+
+          mkdir -p "${HOME}/.cache/${CACHE_VERSION}/uv" "${HOME}/.cache/${CACHE_VERSION}/huggingface"
 
           JOBID_FIFO="${{ github.workspace }}/.slurm_job_id_fifo"
           [[ -e "$JOBID_FIFO" ]] && rm -f "$JOBID_FIFO"


### PR DESCRIPTION
# Goal

Make it possible to reclaim the roughly 2 TB consumed by production caches on `/mnt/home` without interrupting
in-flight jobs or deleting cache data they are actively using.

## Description

Add a single `CACHE_VERSION` for the production workflow and mount the uv, Genesis, Quadrants, and Hugging Face caches from versioned host directories. Both production jobs create their required cache directories before starting Slurm containers.

## Related Issue

[TECH-278](https://linear.app/genesis-ai-company/issue/TECH-278/free-space-on-mntdata-in-the-coreweave-cluster)

## Plan post merge

Wait for all in-progress jobs to be finished, check the new caches are being populated, then delete the old folders.

Note that the first CI runs after this PR will be slower (empty cache), but this is acceptable.