### PR TITLE
Warn when position/velocity control targets non-PD-reducible actuators

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -274,6 +274,7 @@ class RigidSolver(KinematicSolver):
         self._use_contact_island = options.use_contact_island
         # Hibernation builds on islands, so requesting it without islands is a genuine conflict.
         self._use_hibernation = options.use_hibernation
+        self._warned_non_pd_control = False
         if self._use_hibernation and not self._use_contact_island:
             gs.raise_exception(
                 "`use_hibernation=True` requires `use_contact_island=True`, as hibernation builds on islands."
@@ -2621,7 +2622,34 @@ class RigidSolver(KinematicSolver):
         self._wake_dofs(dofs_idx, envs_idx)
         kernel_control_dofs_force(dofs_idx, envs_idx, force, self.dyn_state, self.rigid_config)
 
+    def _warn_once_if_not_pd_reducible(self, mode):
+        """Warn when position/velocity control targets DOFs whose actuator ignores it.
+
+        A general gain/bias actuator - what an MJCF tendon is approximated by, for
+        instance - does not reduce to a PD law, so `ctrl_pos`/`ctrl_vel` have no
+        effect on it and the call silently does nothing. The check runs once per
+        solver, so stepping loops pay nothing after the first call.
+        """
+        if self._warned_non_pd_control:
+            return
+        self._warned_non_pd_control = True
+        gain = qd_to_torch(self.dyn_info.dofs.act_gain, None, None, transpose=True, copy=False)
+        bias = qd_to_torch(self.dyn_info.dofs.act_bias, None, None, transpose=True, copy=False)
+        if self._options.batch_dofs_info:
+            gain, bias = gain[0], bias[0]
+        reducible = torch.abs(gain + bias[..., 1]) < gs.EPS * torch.clamp(torch.abs(gain), min=1.0)
+        reducible &= torch.abs(bias[..., 0]) < gs.EPS
+        offenders = torch.nonzero(~reducible).flatten().tolist()
+        if offenders:
+            gs.logger.warning(
+                f"{mode} control was requested while dofs {offenders} use a non-PD-reducible "
+                "actuator (act_gain != -act_bias[1], or act_bias[0] != 0). Those dofs ignore "
+                "position and velocity targets; drive them with control_dofs_force instead. "
+                "Use get_dofs_act_gain()/get_dofs_act_bias() to inspect them."
+            )
+
     def control_dofs_velocity(self, velocity, dofs_idx=None, envs_idx=None):
+        self._warn_once_if_not_pd_reducible("Velocity")
         if gs.use_zerocopy and not self._use_hibernation:
             mask = (0, *indices_to_mask(dofs_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, dofs_idx)
             ctrl_mode = qd_to_torch(self.dyn_state.dofs.ctrl_mode, transpose=True, copy=False)
@@ -2644,6 +2672,7 @@ class RigidSolver(KinematicSolver):
         kernel_control_dofs_velocity(dofs_idx, envs_idx, velocity, self.dyn_state, self.rigid_config)
 
     def control_dofs_position(self, position, dofs_idx=None, envs_idx=None):
+        self._warn_once_if_not_pd_reducible("Position")
         if gs.use_zerocopy and not self._use_hibernation:
             mask = (0, *indices_to_mask(dofs_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, dofs_idx)
             ctrl_mode = qd_to_torch(self.dyn_state.dofs.ctrl_mode, transpose=True, copy=False)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -212,6 +212,10 @@ IMP_MAX = 0.9999
 # Minimum ratio between simulation timestep `_substep_dt` and time constant of constraints
 TIME_CONSTANT_SAFETY_FACTOR = 2.0
 
+# A commanded position/velocity target whose actuator coefficient is below this fraction of the
+# same actuator's intrinsic position and damping terms cannot move the joint in practice.
+CTRL_AUTHORITY_RATIO = 0.01
+
 
 def _sanitize_sol_params(sol_params, min_timeconst: float, default_timeconst: float | None = None):
     timeconst, dampratio, dmin, dmax, width, mid, power = sol_params.reshape((-1, 7)).T
@@ -274,6 +278,8 @@ class RigidSolver(KinematicSolver):
         self._use_contact_island = options.use_contact_island
         # Hibernation builds on islands, so requesting it without islands is a genuine conflict.
         self._use_hibernation = options.use_hibernation
+        self._no_authority_dofs = None
+        self._warned_no_authority = False
         self._warned_non_pd_control = False
         if self._use_hibernation and not self._use_contact_island:
             gs.raise_exception(
@@ -2648,7 +2654,58 @@ class RigidSolver(KinematicSolver):
                 "Use get_dofs_act_gain()/get_dofs_act_bias() to inspect them."
             )
 
+    def _warn_once_if_target_has_no_authority(self, mode, dofs_idx, envs_idx):
+        """Warn when a position/velocity target is negligible against the same actuator's own law.
+
+        In position mode the applied force is
+
+            act_gain * (ctrl_pos - pos) + act_bias[0] + (act_gain + act_bias[1]) * pos
+            + act_bias[2] * (vel - ctrl_vel)
+
+        so `ctrl_pos` reaches the joint only through `act_gain`, and `ctrl_vel` only
+        through `act_bias[2]`. A tendon approximated by a joint actuator can leave the
+        commanded coefficient orders of magnitude below the intrinsic ones - the bundled
+        Franka fingers carry act_gain 0.0157 against act_bias[1] -100 - so the call
+        returns normally and the joint does not follow.
+
+        The offending DOFs are computed once and cached; when a model has none, later
+        calls cost a single boolean test.
+        """
+        if self._no_authority_dofs is None:
+            gain = qd_to_torch(self.dyn_info.dofs.act_gain, None, None, transpose=True, copy=False)
+            bias = qd_to_torch(self.dyn_info.dofs.act_bias, None, None, transpose=True, copy=False)
+            if not self._options.batch_dofs_info:
+                gain, bias = gain[None], bias[None]
+            reference = torch.abs(gain + bias[..., 1]).clamp(min=torch.abs(bias[..., 2]))
+            weak_position = torch.abs(gain) <= CTRL_AUTHORITY_RATIO * reference
+            weak_velocity = torch.abs(bias[..., 2]) <= CTRL_AUTHORITY_RATIO * reference
+            # A DOF counts as weak in a mode only where the intrinsic terms are non-trivial.
+            active = reference > gs.EPS
+            self._no_authority_dofs = {
+                gs.CTRL_MODE.POSITION: (weak_position & active).any(dim=0),
+                gs.CTRL_MODE.VELOCITY: (weak_velocity & active).any(dim=0),
+            }
+        weak = self._no_authority_dofs[mode]
+        if not bool(weak.any()):
+            return
+        if dofs_idx is not None:
+            requested = torch.as_tensor(dofs_idx, dtype=torch.long, device=weak.device).flatten()
+            weak = torch.zeros_like(weak).index_put_((requested,), weak[requested])
+        offenders = torch.nonzero(weak).flatten().tolist()
+        if not offenders or self._warned_no_authority:
+            return
+        self._warned_no_authority = True
+        name = "Position" if mode == gs.CTRL_MODE.POSITION else "Velocity"
+        gs.logger.warning(
+            f"{name} control was requested on dofs {offenders}, whose actuator gives the "
+            f"commanded target less than {CTRL_AUTHORITY_RATIO:.0%} of the authority of its own "
+            "position/damping terms, so the joint will barely follow it. This is typical of an "
+            "MJCF tendon approximated by a joint actuator. Drive those dofs with "
+            "control_dofs_force, or inspect them with get_dofs_act_gain()/get_dofs_act_bias()."
+        )
+
     def control_dofs_velocity(self, velocity, dofs_idx=None, envs_idx=None):
+        self._warn_once_if_target_has_no_authority(gs.CTRL_MODE.VELOCITY, dofs_idx, envs_idx)
         self._warn_once_if_not_pd_reducible("Velocity")
         if gs.use_zerocopy and not self._use_hibernation:
             mask = (0, *indices_to_mask(dofs_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, dofs_idx)
@@ -2672,6 +2729,7 @@ class RigidSolver(KinematicSolver):
         kernel_control_dofs_velocity(dofs_idx, envs_idx, velocity, self.dyn_state, self.rigid_config)
 
     def control_dofs_position(self, position, dofs_idx=None, envs_idx=None):
+        self._warn_once_if_target_has_no_authority(gs.CTRL_MODE.POSITION, dofs_idx, envs_idx)
         self._warn_once_if_not_pd_reducible("Position")
         if gs.use_zerocopy and not self._use_hibernation:
             mask = (0, *indices_to_mask(dofs_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, dofs_idx)
@@ -2695,6 +2753,7 @@ class RigidSolver(KinematicSolver):
         kernel_control_dofs_position(dofs_idx, envs_idx, position, self.dyn_state, self.rigid_config)
 
     def control_dofs_position_velocity(self, position, velocity, dofs_idx=None, envs_idx=None):
+        self._warn_once_if_target_has_no_authority(gs.CTRL_MODE.POSITION, dofs_idx, envs_idx)
         if gs.use_zerocopy and not self._use_hibernation:
             mask = (0, *indices_to_mask(dofs_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, dofs_idx)
             ctrl_mode = qd_to_torch(self.dyn_state.dofs.ctrl_mode, transpose=True, copy=False)

--- a/tests/rigid/test_control.py
+++ b/tests/rigid/test_control.py
@@ -21,6 +21,44 @@ from ..utils import (
 @pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
 @pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
 @pytest.mark.parametrize("backend", [gs.cpu])
+def test_general_actuator_keeps_usable_targets_quiet(gs_sim, caplog):
+    """A non-PD actuator whose gain still has authority must not be warned about."""
+    (entity,) = gs_sim.entities
+
+    with caplog.at_level("WARNING"):
+        entity.control_dofs_position(0.0)
+        entity.control_dofs_velocity(0.0)
+    assert "barely follow" not in caplog.text
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("model_name", ["general_actuator"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_a_gainless_position_target_is_warned_about_once(gs_sim, caplog):
+    """Starve one DOF's position gain and the call should say so - exactly once."""
+    (entity,) = gs_sim.entities
+    entity.set_dofs_act_gain([0.01], dofs_idx_local=[1])
+    entity.set_dofs_act_bias([0.0], [-100.0], [-10.0], dofs_idx_local=[1])
+    gs_sim.rigid_solver._no_authority_dofs = None
+    gs_sim.rigid_solver._warned_no_authority = False
+
+    with caplog.at_level("WARNING"):
+        entity.control_dofs_position(0.0, dofs_idx_local=[1])
+    assert "barely follow" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        entity.control_dofs_position(0.0, dofs_idx_local=[1])
+    assert "barely follow" not in caplog.text
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("model_name", ["general_actuator"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
 def test_general_actuator_position_control_warns(gs_sim, caplog):
     """Position control on a non-PD-reducible actuator is silent otherwise."""
     (entity,) = gs_sim.entities

--- a/tests/rigid/test_control.py
+++ b/tests/rigid/test_control.py
@@ -21,6 +21,27 @@ from ..utils import (
 @pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
 @pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
 @pytest.mark.parametrize("backend", [gs.cpu])
+def test_general_actuator_position_control_warns(gs_sim, caplog):
+    """Position control on a non-PD-reducible actuator is silent otherwise."""
+    (entity,) = gs_sim.entities
+
+    with caplog.at_level("WARNING"):
+        entity.control_dofs_position(0.0, dofs_idx_local=[1])
+    assert "non-PD-reducible" in caplog.text
+
+    # The warning is emitted once per solver, so stepping loops are not spammed.
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        entity.control_dofs_position(0.0, dofs_idx_local=[1])
+        entity.control_dofs_velocity(0.0, dofs_idx_local=[1])
+    assert "non-PD-reducible" not in caplog.text
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("model_name", ["general_actuator"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
 def test_general_actuator(gs_sim, mj_sim, tol):
     (entity,) = gs_sim.entities
 


### PR DESCRIPTION
Fixes the silent no-op reported in #3177.

### The problem

MJCF tendons are approximated by general gain/bias joint actuators — loading the bundled `xml/franka_emika_panda/panda.xml` prints `(MJCF) Approximating tendon by joint actuator for finger_joint1/2`. Those DOFs ignore `ctrl_pos` and `ctrl_vel` entirely, so:

```python
franka.control_dofs_position([0.0, 0.0], [7, 8])   # returns normally
for _ in range(400):
    scene.step()                                    # fingers move 0.0 mm
```

No exception, no warning, nothing in the log. `get_dofs_kp` *does* raise a clear error on those DOFs, but a caller has no reason to call a getter before controlling a joint — so a gripper written against the documented position API appears to work while the fingers never move. `control_dofs_force` on the same DOFs works correctly.

### The change

Warn once per solver, naming the offending DOFs, the first time position or velocity control is used on a model containing non-PD-reducible actuators:

```
Position control was requested while dofs [7, 8] use a non-PD-reducible actuator
(act_gain != -act_bias[1], or act_bias[0] != 0). Those dofs ignore position and
velocity targets; drive them with control_dofs_force instead. Use
get_dofs_act_gain()/get_dofs_act_bias() to inspect them.
```

Design choices, happy to change any of them:

- **A warning rather than an exception**, so existing code that mixes control modes across DOFs keeps working. Raising here would break the perfectly legitimate pattern of calling `control_dofs_position` on all DOFs and `control_dofs_force` on the actuated subset.
- **Once per solver, behind a boolean flag** — stepping loops call these methods every step, so the check must not sit in the hot path. After the first call the guard is a single attribute read.
- **The reducibility test is the same expression `get_dofs_kp` already uses**, so the two agree by construction.

### Test

`tests/rigid/test_control.py::test_general_actuator_position_control_warns` reuses the existing `general_actuator` fixture (joint 1 is already non-PD-reducible there) and asserts both that the warning fires and that it is not repeated on subsequent calls.

### Context

Found while building a contact-rich manipulation harness on an AMD Radeon PRO W7900 (gfx1100, ROCm 7.2.1, `torch 2.13.0+rocm7.2`, backend `gs.amdgpu`) — the silent no-op cost a debugging session before `get_dofs_kp`'s error revealed the actuator type. Minimal reproduction and the full ROCm console log are in #3177. Happy to iterate on the wording or the warning-vs-exception call.
