### PR TITLE
[MISC] Rotate production caches weekly to bound disk use.

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,8 +19,6 @@ env:
   # Note that secrets are not passed to workflows that are triggered by a pull request from a fork
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HF_HUB_DOWNLOAD_TIMEOUT: 60
-  # Increment to switch new jobs to fresh caches before deleting the previous version.
-  CACHE_VERSION: "1"
   GENESIS_IMAGE_VER: "1_25"
   TIMEOUT_MINUTES: 60
   FORCE_COLOR: 1
@@ -51,6 +49,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Sets CACHE_VERSION to the UTC ISO week bucket; retention policy is in production_rotate_cache.sh.
+      - name: Rotate production caches
+        run: bash .github/workflows/scripts/production_rotate_cache.sh
+
       - name: Spawn Slurm job
         if: github.event_name == 'pull_request'
         run: |
@@ -67,12 +69,6 @@ jobs:
                --no-container-mount-home \
                --container-workdir=/root/workspace"
           SLURM_ENV_VARS="NVIDIA_DRIVER_CAPABILITIES=all,BASH_ENV=/root/.bashrc,HF_TOKEN,GS_ENABLE_NDARRAY=${GS_ENABLE_NDARRAY}"
-
-          mkdir -p \
-            "${HOME}/.cache/${CACHE_VERSION}/uv" \
-            "${HOME}/.cache/${CACHE_VERSION}/genesis" \
-            "${HOME}/.cache/${CACHE_VERSION}/quadrants" \
-            "${HOME}/.cache/${CACHE_VERSION}/huggingface"
 
           JOBID_FIFO="${{ github.workspace }}/.slurm_job_id_fifo"
           [[ -e "$JOBID_FIFO" ]] && rm -f "$JOBID_FIFO"
@@ -142,6 +138,10 @@ jobs:
           # tracking thereby making it impossible to detect whether a commit is contained in upstream main.
           fetch-depth: 0
 
+      # Sets CACHE_VERSION to the UTC ISO week bucket; retention policy is in production_rotate_cache.sh.
+      - name: Rotate production caches
+        run: bash .github/workflows/scripts/production_rotate_cache.sh
+
       - name: Spawn Slurm job
         run: |
           SLURM_JOB_NAME="$(uuidgen)_$(date +%Y%m%d_%H%M%S)"
@@ -159,8 +159,6 @@ jobs:
           if [[ "${{ github.repository }}" == 'Genesis-Embodied-AI/genesis-world' && "${{ github.ref }}" == 'refs/heads/main' ]] ; then
             SLURM_ENV_VARS="${SLURM_ENV_VARS},WANDB_API_KEY"
           fi
-
-          mkdir -p "${HOME}/.cache/${CACHE_VERSION}/uv" "${HOME}/.cache/${CACHE_VERSION}/huggingface"
 
           JOBID_FIFO="${{ github.workspace }}/.slurm_job_id_fifo"
           [[ -e "$JOBID_FIFO" ]] && rm -f "$JOBID_FIFO"

--- a/.github/workflows/scripts/production_rotate_cache.sh
+++ b/.github/workflows/scripts/production_rotate_cache.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+CACHE_ROOT="${HOME}/.cache"
+CACHE_VERSION="$(date -u +%GW%V)"
+# Retain previous ISO week on Monday (ISO weekday 1); safe while jobs stay within TIMEOUT_MINUTES (60).
+if [[ "$(date -u +%u)" -eq 1 ]]; then
+  PREV_VERSION="$(date -u -d '7 days ago' +%GW%V)"
+else
+  PREV_VERSION=""
+fi
+
+mkdir -p \
+  "${CACHE_ROOT}/${CACHE_VERSION}/uv" \
+  "${CACHE_ROOT}/${CACHE_VERSION}/genesis" \
+  "${CACHE_ROOT}/${CACHE_VERSION}/quadrants" \
+  "${CACHE_ROOT}/${CACHE_VERSION}/huggingface"
+
+# CACHE_ROOT is shared across concurrent runs of this script.
+(
+  flock 200
+  shopt -s nullglob
+  for dir in "${CACHE_ROOT}"/[0-9][0-9][0-9][0-9]W[0-9][0-9]; do
+    base="$(basename "${dir}")"
+    if [[ "${base}" != "${CACHE_VERSION}" && "${base}" != "${PREV_VERSION}" ]]; then
+      echo "Removing expired production cache directory: ${dir}"
+      rm -rf "${dir}"
+    else
+      echo "Keeping production cache directory: ${dir}"
+    fi
+  done
+) 200>"${CACHE_ROOT}/.rotate.lock"
+
+echo "CACHE_VERSION=${CACHE_VERSION}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Why

Production caches on `/mnt/home` keep growing across CI runs. Manual `CACHE_VERSION` bumps work for one-off cleanup ([#3192](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3192)), but we need ongoing rotation so abandoned trees are removed without another PR each time. Related: [TECH-278](https://linear.app/genesis-ai-company/issue/TECH-278/free-space-on-mntdata-in-the-coreweave-cluster).

## What

Replace the static `CACHE_VERSION` with a UTC ISO week bucket (`2026W32`). Each Production job creates the current week's cache dirs and deletes older week dirs. The previous week is kept only on Monday so jobs that still hold last week's mounts can finish, then removed from Tuesday on.