### PR TITLE
[BUG FIX] Differential propeller thrust now rolls and pitches drone entities, enabling horizontal flight.

### DIFF
--- a/genesis/engine/entities/drone_entity.py
+++ b/genesis/engine/entities/drone_entity.py
@@ -1,6 +1,7 @@
 import os
 import xml.etree.ElementTree as ET
 
+import numpy as np
 import torch
 
 import genesis as gs
@@ -27,6 +28,9 @@ class DroneEntity(RigidEntity):
         try:
             self._propellers_vgeom_idxs = torch.tensor(
                 [link.vgeoms[0].idx for link in propellers_link], dtype=gs.tc_int, device=gs.device
+            )
+            self._propellers_pos = torch.tensor(
+                np.array([link.vgeoms[0].init_pos for link in propellers_link]), dtype=gs.tc_float, device=gs.device
             )
             self._animate_propellers = True
         except Exception:
@@ -76,7 +80,8 @@ class DroneEntity(RigidEntity):
         self._propellers_revs = (self._propellers_revs + propellers_rpm.T) % (60 / self.solver.dt)
 
         self.solver.set_drone_rpm(
-            self._propellers_link_idx,
+            self.base_link.idx,
+            self._propellers_pos,
             propellers_rpm,
             self._propellers_spin,
             self.KF,

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1128,7 +1128,8 @@ def kernel_get_dofs_control_force(
 
 @qd.kernel(fastcache=True)
 def kernel_set_drone_rpm(
-    propellers_link_idx: qd.types.ndarray(),
+    base_link_idx: qd.i32,
+    propellers_pos: qd.types.ndarray(),
     propellers_rpm: qd.types.ndarray(),
     propellers_spin: qd.types.ndarray(),
     KF: qd.float32,
@@ -1142,14 +1143,14 @@ def kernel_set_drone_rpm(
 
     This method should only be called by drone entities.
     """
-    n_propellers = propellers_link_idx.shape[0]
+    n_propellers = propellers_pos.shape[0]
     _B = propellers_rpm.shape[0]
 
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_b in range(_B):
+        force_total = qd.Vector.zero(gs.qd_float, 3)
+        torque_total = qd.Vector.zero(gs.qd_float, 3)
         for i_prop in range(n_propellers):
-            i_l = propellers_link_idx[i_prop]
-
             force = qd.Vector([0.0, 0.0, propellers_rpm[i_b, i_prop] ** 2 * KF], dt=gs.qd_float)
             torque = qd.Vector(
                 [0.0, 0.0, propellers_rpm[i_b, i_prop] ** 2 * KM * propellers_spin[i_prop]], dt=gs.qd_float
@@ -1157,8 +1158,22 @@ def kernel_set_drone_rpm(
             if invert:
                 torque = -torque
 
-            func_apply_link_external_force(i_l, i_b, force, dyn_state, 1, 1)
-            func_apply_link_external_torque(i_l, i_b, torque, dyn_state, 1, 1)
+            # The thrust acts at the propeller position, offset from the drone's center of mass.
+            pos = qd.Vector(
+                [propellers_pos[i_prop, 0], propellers_pos[i_prop, 1], propellers_pos[i_prop, 2]], dt=gs.qd_float
+            )
+            torque += pos.cross(force)
+            # The thrust and rotor torque follow the drone's attitude.
+            force = gu.qd_transform_by_quat(force, dyn_state.links.quat[base_link_idx, i_b])
+            torque = gu.qd_transform_by_quat(torque, dyn_state.links.quat[base_link_idx, i_b])
+            force_total += force
+            torque_total += torque
+
+        # The propellers are rigidly welded to the base link, so the whole wrench goes on the base link: external
+        # forces and torques applied to the massless propeller links do not carry the thrust moment into the
+        # composite body.
+        func_apply_link_external_force(base_link_idx, i_b, force_total, dyn_state, ref=1, local=0)
+        func_apply_link_external_torque(base_link_idx, i_b, torque_total, dyn_state, ref=1, local=0)
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -3308,9 +3308,17 @@ class RigidSolver(KinematicSolver):
             propellers_vgeom_idxs, propellers_revs, propellers_spin, self.dyn_state, self.rigid_info, self.rigid_config
         )
 
-    def set_drone_rpm(self, propellers_link_idx, propellers_rpm, propellers_spin, KF, KM, invert):
+    def set_drone_rpm(self, base_link_idx, propellers_pos, propellers_rpm, propellers_spin, KF, KM, invert):
         kernel_set_drone_rpm(
-            propellers_link_idx, propellers_rpm, propellers_spin, KF, KM, self.dyn_state, self.rigid_config, invert
+            base_link_idx,
+            propellers_pos,
+            propellers_rpm,
+            propellers_spin,
+            KF,
+            KM,
+            self.dyn_state,
+            self.rigid_config,
+            invert,
         )
 
     def update_verts_for_geoms(self, geoms_idx):

--- a/tests/rigid/test_control.py
+++ b/tests/rigid/test_control.py
@@ -275,6 +275,38 @@ def test_drone_propellers_force_substep_consistency(show_viewer, tol):
 
 
 @pytest.mark.required
+def test_drone_differential_thrust_rolls_body(show_viewer):
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=0.01,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.5, 0.0, 1.5),
+            camera_lookat=(0.0, 0.0, 0.5),
+        ),
+        show_viewer=show_viewer,
+    )
+    plane = scene.add_entity(gs.morphs.Plane())
+    drone = scene.add_entity(
+        morph=gs.morphs.Drone(
+            file="urdf/drones/cf2x.urdf",
+            pos=(0, 0, 0.5),
+        ),
+    )
+    scene.build()
+
+    # A differential RPM pattern with zero net yaw must roll the body: the propeller thrust acts at the propeller
+    # positions, offset from the drone's center of mass.
+    base_rpm = 14468.0
+    for _ in range(40):
+        drone.set_propellers_rpm([1.05 * base_rpm, 1.025 * base_rpm, base_rpm, 1.025 * base_rpm])
+        scene.step()
+
+    ang_vel = drone.get_dofs_velocity()
+    assert ang_vel[3].abs() > 1.0
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_drone_advanced(show_viewer):
     scene = gs.Scene(


### PR DESCRIPTION
## Problem

Differential propeller RPM never produces roll or pitch on a `Drone` entity. The propeller forces are applied at
each propeller link's center of mass, and the propeller links in the shipped drone URDFs are massless, so their
inertial offset (`i_pos`) degenerates to zero and the thrust moment `i_pos x F` vanishes. The drone can only climb
and yaw - it can never tilt or translate horizontally: `fly_route.py` never reaches its waypoints, and the random
x/y targets of the `hover_train.py` environment are unreachable.

Evidence: with a zero-yaw differential RPM pattern, the roll angular velocity stays exactly `0.0` over 100 steps,
while the same pattern produces a net roll torque of ~1e-3 N.m by the kernel's own arithmetic (`i_pos x F`, with
`i_pos` the +/-0.028 m arm authored in the URDF inertial origin - which the parser drops for zero-mass links).

## Fix

`kernel_set_drone_rpm` now accumulates each propeller thrust and its moment about the drone's center of mass,
using the propeller body-frame position passed from `DroneEntity` (taken from the propeller visual geometry, the
only place the arm survives in the loaded model). The net wrench is rotated by the base link's world orientation
so the thrust follows the drone's attitude, and applied to the base link: external forces and torques applied to
the massless propeller links do not carry the thrust moment into the composite body.

Behavior change: propeller thrust and rotor torque now follow the drone's attitude (previously always world-vertical).
This is required for horizontal translation once the body tilts, and leaves uniform-RPM vertical flight unchanged.

## Verification

- New regression test `test_drone_differential_thrust_rolls_body` fails on `main` (roll angular velocity exactly 0)
  and passes with the fix.
- Existing `test_drone_propellers_force_substep_consistency` still passes (uniform RPM: zero net moment).
- `fly_route.py` now flies toward its waypoints (previously the x/y position never changed).