### PR TITLE
#3199 [BUG FIX] Isolate CoACD in a subprocess on HIP to avoid dual-OpenMP SIGSEGV

### DIFF
--- a/genesis/utils/_coacd_worker.py
+++ b/genesis/utils/_coacd_worker.py
@@ -1,0 +1,51 @@
+"""Isolated CoACD entrypoint.
+
+Must not import ``torch`` or ``genesis``: ROCm/HIP torch loads system ``libgomp`` into the
+parent process while the CoACD wheel vendors its own ``libgomp``. Two OpenMP runtimes in one
+process SIGSEGV inside CoACD's parallel regions (see SarahWeiii/CoACD#104). This module is
+executed in a fresh interpreter via ``subprocess`` so only CoACD's OpenMP is mapped.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 3:
+        print("usage: _coacd_worker.py IN.npz OUT.npz KWARGS.json", file=sys.stderr)
+        return 2
+
+    in_path, out_path, kwargs_path = argv
+
+    # Local imports keep module import side-effect free for discovery tools.
+    import coacd
+    import numpy as np
+
+    data = np.load(in_path)
+    vertices = np.ascontiguousarray(data["vertices"], dtype=np.float64)
+    faces = np.ascontiguousarray(data["faces"], dtype=np.int32)
+    with open(kwargs_path, "r", encoding="utf-8") as f:
+        kwargs = json.load(f)
+
+    result = coacd.run_coacd(coacd.Mesh(vertices, faces), **kwargs)
+
+    # Variable-length hull list → save as object arrays of contiguous buffers.
+    parts_v = []
+    parts_f = []
+    for vs, fs in result:
+        parts_v.append(np.ascontiguousarray(vs, dtype=np.float64))
+        parts_f.append(np.ascontiguousarray(fs, dtype=np.int32))
+    np.savez_compressed(
+        out_path,
+        n_parts=np.asarray([len(parts_v)], dtype=np.int32),
+        **{f"v{i}": parts_v[i] for i in range(len(parts_v))},
+        **{f"f{i}": parts_f[i] for i in range(len(parts_f))},
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -1,8 +1,12 @@
 import hashlib
+import json
 import marshal
 import math
 import os
 import pickle as pkl
+import subprocess
+import sys
+import tempfile
 from functools import lru_cache
 from pathlib import Path
 
@@ -410,6 +414,112 @@ def surface_uvs_to_trimesh_visual(surface, uvs=None, n_verts=None):
     return visual
 
 
+def _mapped_openmp_runtimes() -> set[str]:
+    """Return absolute paths of OpenMP runtimes mapped into this process (Linux ``/proc``)."""
+    paths: set[str] = set()
+    try:
+        with open("/proc/self/maps", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                # libgomp (GCC), libomp (LLVM), libiomp5 (Intel)
+                if "libgomp" in line or "libomp.so" in line or "libiomp" in line or "libomp.dylib" in line:
+                    paths.add(line.rsplit(None, 1)[-1])
+    except OSError:
+        pass
+    return paths
+
+
+def _coacd_must_isolate() -> bool:
+    """True when in-process ``coacd.run_coacd`` is unsafe.
+
+    CoACD wheels vendor ``libgomp``. ROCm/HIP torch also loads the system ``libgomp`` into the same
+    process. Two OpenMP runtimes then SIGSEGV inside CoACD's parallel regions (SarahWeiii/CoACD#104).
+    Isolate in a fresh interpreter when HIP is present or more than one OpenMP runtime is already mapped.
+    """
+    try:
+        import torch
+
+        if getattr(torch.version, "hip", None):
+            return True
+    except ImportError:
+        pass
+    return len(_mapped_openmp_runtimes()) > 1
+
+
+def _coacd_options_to_kwargs(coacd_options) -> dict:
+    args = coacd_options
+    return dict(
+        threshold=args.threshold,
+        max_convex_hull=args.max_convex_hull,
+        preprocess_mode=args.preprocess_mode,
+        preprocess_resolution=args.preprocess_resolution,
+        resolution=args.resolution,
+        mcts_nodes=args.mcts_nodes,
+        mcts_iterations=args.mcts_iterations,
+        mcts_max_depth=args.mcts_max_depth,
+        pca=args.pca,
+        merge=args.merge,
+        decimate=args.decimate,
+        max_ch_vertex=args.max_ch_vertex,
+        extrude=args.extrude,
+        extrude_margin=args.extrude_margin,
+        apx_mode=args.apx_mode,
+        seed=args.seed,
+    )
+
+
+def _run_coacd_inprocess(vertices, faces, kwargs: dict):
+    return coacd.run_coacd(coacd.Mesh(vertices, faces), **kwargs)
+
+
+def _run_coacd_subprocess(vertices, faces, kwargs: dict):
+    """Run CoACD in a clean interpreter so only CoACD's OpenMP runtime is loaded."""
+    worker = Path(__file__).resolve().parent / "_coacd_worker.py"
+    with tempfile.TemporaryDirectory(prefix="gs_coacd_") as tmp:
+        tmp_path = Path(tmp)
+        in_path = tmp_path / "in.npz"
+        out_path = tmp_path / "out.npz"
+        kwargs_path = tmp_path / "kwargs.json"
+        np.savez_compressed(
+            in_path,
+            vertices=np.ascontiguousarray(vertices, dtype=np.float64),
+            faces=np.ascontiguousarray(faces, dtype=np.int32),
+        )
+        with open(kwargs_path, "w", encoding="utf-8") as f:
+            json.dump(kwargs, f)
+
+        # Prefer a minimal env: keep PATH/PYTHONPATH so site-packages resolve, but do not inherit a
+        # ROCm-polluted LD_LIBRARY_PATH that could pull a second OpenMP into the child.
+        env = os.environ.copy()
+        env.pop("LD_LIBRARY_PATH", None)
+        env.pop("ROCM_PATH", None)
+
+        proc = subprocess.run(
+            [sys.executable, str(worker), str(in_path), str(out_path), str(kwargs_path)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            gs.raise_exception(
+                f"Isolated CoACD subprocess failed with exit code {proc.returncode}"
+                + (f":\n{detail}" if detail else ".")
+            )
+        data = np.load(out_path)
+        n_parts = int(data["n_parts"][0])
+        return [(data[f"v{i}"], data[f"f{i}"]) for i in range(n_parts)]
+
+
+def run_coacd(vertices, faces, coacd_options):
+    """Run CoACD, isolating into a subprocess when dual OpenMP runtimes would SIGSEGV."""
+    kwargs = _coacd_options_to_kwargs(coacd_options)
+    if _coacd_must_isolate():
+        gs.logger.debug("Running CoACD in an isolated subprocess (OpenMP runtime conflict avoidance).")
+        return _run_coacd_subprocess(vertices, faces, kwargs)
+    return _run_coacd_inprocess(vertices, faces, kwargs)
+
+
 def convex_decompose(mesh, coacd_options):
     # The decomposition of a scaled mesh is the decomposition of the mesh scaled, so the cache is keyed on vertices
     # normalized by the mesh scale and the hulls are rescaled on the way out: every scaled copy of an asset shares a
@@ -435,27 +545,7 @@ def convex_decompose(mesh, coacd_options):
 
     if not is_cached_loaded:
         with gs.logger.timer("Running convex decomposition."):
-            mesh = coacd.Mesh(mesh.vertices, mesh.faces)
-            args = coacd_options
-            result = coacd.run_coacd(
-                mesh,
-                threshold=args.threshold,
-                max_convex_hull=args.max_convex_hull,
-                preprocess_mode=args.preprocess_mode,
-                preprocess_resolution=args.preprocess_resolution,
-                resolution=args.resolution,
-                mcts_nodes=args.mcts_nodes,
-                mcts_iterations=args.mcts_iterations,
-                mcts_max_depth=args.mcts_max_depth,
-                pca=args.pca,
-                merge=args.merge,
-                decimate=args.decimate,
-                max_ch_vertex=args.max_ch_vertex,
-                extrude=args.extrude,
-                extrude_margin=args.extrude_margin,
-                apx_mode=args.apx_mode,
-                seed=args.seed,
-            )
+            result = run_coacd(mesh.vertices, mesh.faces, coacd_options)
             mesh_parts = []
             for vs, fs in result:
                 mesh_parts.append(trimesh.Trimesh(vs, fs))

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -8,8 +8,6 @@ import pytest
 import trimesh
 from PIL import Image
 
-import coacd
-
 import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.gltf as gltf_utils
@@ -851,14 +849,16 @@ def test_convex_decompose_cache(monkeypatch, asset_tmp_path):
     # A single decomposition must serve every mesh describing the same shape, whatever its placement: rescaled copies,
     # and re-exports of the model whose coordinates differ only in their last significant digits.
     n_coacd_runs = 0
-    real_run_coacd = coacd.run_coacd
+    real_run_coacd = mu.run_coacd
 
     def counted_run_coacd(*args, **kwargs):
         nonlocal n_coacd_runs
         n_coacd_runs += 1
         return real_run_coacd(*args, **kwargs)
 
-    monkeypatch.setattr(coacd, "run_coacd", counted_run_coacd)
+    # Patch Genesis' CoACD entry (not coacd.run_coacd): on HIP/ROCm, run_coacd isolates into a subprocess
+    # so monkeypatching the upstream symbol in the parent process would never see the call.
+    monkeypatch.setattr(mu, "run_coacd", counted_run_coacd)
 
     # Monkeypatch the convex_decompose function to track the convex decomposition result
     seen_results = []
@@ -912,3 +912,67 @@ def test_convex_decompose_cache(monkeypatch, asset_tmp_path):
         for part, cached_part in zip(parts, cached_parts):
             assert_allclose(part.vertices, cached_part.vertices * (scale / SCALES[0]), rtol=1e-6)
             assert_equal(part.faces, cached_part.faces)
+
+
+@pytest.mark.required
+@pytest.mark.cache(False)
+@pytest.mark.parametrize("backend", [None])  # init ourselves: conftest GPU-index check needs amdsmi
+def test_coacd_survives_amdgpu_openmp_isolation(tmp_path, monkeypatch):
+    """CoACD must not SIGSEGV after HIP/ROCm torch has loaded system libgomp.
+
+    Root cause: CoACD vendors libgomp; ROCm torch also loads system libgomp. Dual OpenMP → crash
+    during ``run_coacd`` (SarahWeiii/CoACD#104). Genesis isolates CoACD in a subprocess on HIP.
+    """
+    import torch
+
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("HIP/ROCm torch required for amdgpu CoACD isolation test")
+    try:
+        gs.utils.get_device(gs.amdgpu)
+    except gs.GenesisException:
+        pytest.skip("gs.amdgpu not available on this machine")
+
+    # ``backend=None`` skips autouse ``initialize_genesis`` before it honors ``@pytest.mark.cache(False)``.
+    # Point Genesis at a fresh cache so a warm ``.cvx`` from the default cache cannot skip CoACD.
+    monkeypatch.setenv("QD_OFFLINE_CACHE", "0")
+    monkeypatch.setenv("QD_OFFLINE_CACHE_FILE_PATH", str(tmp_path / ".cache" / "quadrants"))
+    monkeypatch.setenv("GS_CACHE_FILE_PATH", str(tmp_path / ".cache" / "genesis"))
+
+    n_isolated = 0
+    real_isolated = mu._run_coacd_subprocess
+
+    def counted_isolated(*args, **kwargs):
+        nonlocal n_isolated
+        n_isolated += 1
+        return real_isolated(*args, **kwargs)
+
+    monkeypatch.setattr(mu, "_run_coacd_subprocess", counted_isolated)
+
+    gs.init(backend=gs.amdgpu, precision="32", seed=0, logging_level="warning")
+    try:
+        assert mu._coacd_must_isolate()
+
+        # Non-convex duck forces CoACD when decompose_object_error_threshold=0.0 (hull volume error > 0).
+        scene = gs.Scene(show_viewer=False)
+        scene.add_entity(
+            morph=gs.morphs.Mesh(
+                file="meshes/duck.obj",
+                scale=0.1,
+                convexify=True,
+                decompose_object_error_threshold=0.0,
+                coacd_options=gs.options.CoacdOptions(
+                    threshold=0.1,
+                    max_convex_hull=8,
+                    preprocess_mode="auto",
+                    mcts_iterations=50,
+                    seed=0,
+                ),
+            ),
+        )
+        scene.build()
+        assert scene.sim.rigid_solver.dyn_info.geoms.is_convex.to_numpy().all()
+        # At least one geom should be marked as CoACD-decomposed.
+        assert any("decomposed" in geom.metadata for entity in scene.entities for geom in entity.geoms)
+        assert n_isolated >= 1, "expected isolated CoACD subprocess; cache may have skipped the crash path"
+    finally:
+        gs.destroy()


### PR DESCRIPTION
## Summary

- Fixes #3199: CoACD convex decomposition SIGSEGVs after `gs.init(backend=gs.amdgpu)` because ROCm/HIP torch loads system `libgomp` while the CoACD wheel vendors another — dual OpenMP in one process ([SarahWeiii/CoACD#104](https://github.com/SarahWeiii/CoACD/pull/104)).
- When HIP is present (or more than one OpenMP runtime is already mapped), run `coacd.run_coacd` in a fresh interpreter via `genesis/utils/_coacd_worker.py` (no torch/Genesis imports). CPU/CUDA keep the in-process path unless a conflict is detected.
- Existing `.cvx` cache still applies; warm loads do not pay for the subprocess.

## Test plan

- [x] Minimal: HIP torch alloc then `mu.convex_decompose(duck)` → OK (was SIGSEGV)
- [x] `pytest tests/parsers/test_mesh.py::test_coacd_survives_amdgpu_openmp_isolation -n0` → PASSED
- [x] ArmForge SO-101 replay with `convexify=True` / `decompose_robot_error_threshold=0.0` on `gs.amdgpu` → CoACD completes (no segfault)
- [ ] CI: mesh/CoACD tests on CPU (in-process path unchanged)
- [ ] Confirm CUDA hosts still use in-process CoACD when only one OpenMP is mapped


Made with [Cursor](https://cursor.com)