### PR TITLE
[IGNORE] Control run: quadrants 1.3.0b1 on the #3201 base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==1.2.0",
+    "quadrants==1.3.0b1",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",


### PR DESCRIPTION
## Description

Control run for the `test_align_mesh` failure on
[#3201](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3201). Same
base commit (`8e70e94`), same test code; the only difference from #3201 is
`quadrants==1.3.0b1` instead of `1.3.0b2`. Not intended to merge.

## Motivation and Context

On #3201, `tests/rigid/test_asset_loading.py::test_align_mesh` fails
deterministically: both CI attempts produced bit-identical residual angular
velocity `[5.53e-02, 2.96e-03, 1.07e-01]` against `tol=0.05`, as the only
failure out of 938 tests.

The base commit is already known good. genesis-world main at `8e70e94` went
green on all four Production jobs with `quadrants==1.2.0`, so the regression is
in quadrants somewhere between 1.2.0 and 1.3.0b2 rather than in genesis-world.

[#3190](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3190) already
tried 1.3.0b1 and was green, but it is not a clean control: it branches seven
commits earlier, before three rigid-body fixes that bear on this test (#3196
degenerate contacts, #3194 consistency across scales — the mango is
`scale=0.045`, #3184 authored inertia), and `tests/rigid/test_asset_loading.py`
itself changed by +87/-19 in that window, so it ran a different
`test_align_mesh`.

This PR holds all of that fixed and varies only the quadrants version.

## How Has This Been / Can This Be Tested?

Read the Production `unit_tests-ndarray` job:

- **Green** &rarr; the regression is in `1.3.0b1..1.3.0b2`. On CUDA that delta
  contains nothing reachable (the #841 partial-write fix is Metal/Vulkan-only,
  Metal atomics are Metal-only, the rest is docs, tests and a nanobind pin), so
  this outcome would be surprising and would need a closer look.
- **Red** &rarr; the regression is in `1.2.0..1.3.0b1`, where
  [quadrants#790](https://github.com/Genesis-Embodied-AI/quadrants/pull/790)
  (CSE per offload rather than whole kernel) is the only backend-neutral
  functional change, and #3190 was green only because it ran the older test.
  This also clears everything in the b1&rarr;b2 delta.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
