### PR TITLE
[BUG FIX] Support PyTorch prerelease builds.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -34,7 +34,7 @@ from .utils import redirect_libc_stderr, set_random_seed, get_device
 _IS_OLD_TORCH = tuple(map(int, torch.__version__.split(".")[:2])) < (2, 8)
 # FIXME: qd.Field does not support zero-copy on Metal for 'torch<=2.9.1'.
 # See: https://github.com/pytorch/pytorch/pull/168193
-_TORCH_MPS_SUPPORT_DLPACK_FIELD = tuple(map(int, torch.__version__.replace("+", ".").split(".")[:3])) > (2, 9, 1)
+_TORCH_MPS_SUPPORT_DLPACK_FIELD = torch.torch_version.TorchVersion(torch.__version__.split("+", 1)[0]) > (2, 9, 1)
 if _IS_OLD_TORCH:
     warn("'torch<2.8.0' is not supported. Please upgrade pytorch manually: https://pytorch.org/get-started/locally/")
 

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -17,32 +17,6 @@ MODULE_ROOT_DIR = FILE_PATH.parents[2]
 MODULE = ".".join((FILE_PATH.parents[1].name, FILE_PATH.parent.name, FILE_PATH.stem))
 
 
-@pytest.mark.parametrize("backend", [None])
-@pytest.mark.parametrize(
-    ("torch_version", "is_old_torch", "has_mps_dlpack_field"),
-    [
-        ("2.7.1", True, False),
-        ("2.8.0a0+cu128", False, False),
-        ("2.9.1+cu128", False, False),
-        ("2.9.2a0+cu128", False, True),
-        ("2.10.0", False, True),
-        ("2.12.0a0+rocm7.13.0a20260325", False, True),
-    ],
-)
-def test_torch_version_import(backend, torch_version, is_old_torch, has_mps_dlpack_field):
-    code = (
-        "import torch\n"
-        f"torch.__version__ = {torch_version!r}\n"
-        "import genesis as gs\n"
-        f"assert gs._IS_OLD_TORCH is {is_old_torch!r}\n"
-        f"assert gs._TORCH_MPS_SUPPORT_DLPACK_FIELD is {has_mps_dlpack_field!r}\n"
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, encoding="utf-8", cwd=MODULE_ROOT_DIR
-    )
-    assert proc.returncode == 0, proc.stderr
-
-
 @pytest.mark.parametrize("backend", [None])  # Disable genesis initialization at worker level
 @pytest.mark.parametrize(
     "order",

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -17,6 +17,32 @@ MODULE_ROOT_DIR = FILE_PATH.parents[2]
 MODULE = ".".join((FILE_PATH.parents[1].name, FILE_PATH.parent.name, FILE_PATH.stem))
 
 
+@pytest.mark.parametrize("backend", [None])
+@pytest.mark.parametrize(
+    ("torch_version", "is_old_torch", "has_mps_dlpack_field"),
+    [
+        ("2.7.1", True, False),
+        ("2.8.0a0+cu128", False, False),
+        ("2.9.1+cu128", False, False),
+        ("2.9.2a0+cu128", False, True),
+        ("2.10.0", False, True),
+        ("2.12.0a0+rocm7.13.0a20260325", False, True),
+    ],
+)
+def test_torch_version_import(backend, torch_version, is_old_torch, has_mps_dlpack_field):
+    code = (
+        "import torch\n"
+        f"torch.__version__ = {torch_version!r}\n"
+        "import genesis as gs\n"
+        f"assert gs._IS_OLD_TORCH is {is_old_torch!r}\n"
+        f"assert gs._TORCH_MPS_SUPPORT_DLPACK_FIELD is {has_mps_dlpack_field!r}\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, encoding="utf-8", cwd=MODULE_ROOT_DIR
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
 @pytest.mark.parametrize("backend", [None])  # Disable genesis initialization at worker level
 @pytest.mark.parametrize(
     "order",


### PR DESCRIPTION
## Description

`import genesis` parses the first three `torch.__version__` components with `int`, so valid alpha builds such as
`2.12.0a0+rocm7.13.0a20260325` raise before initialization. Use PyTorch's `TorchVersion` for the existing Metal DLPack
threshold after removing the local-build suffix. The `<2.8` warning predicate is untouched, and `2.9.1+local` remains
below the capability boundary.

## Related Issue

Addresses the prerelease import failure identified in #3059. The issue's primary AMD runtime-symbol failure remains
separate.

## Motivation and Context

Valid prerelease builds can reach backend initialization instead of failing while parsing their version string.

## How Has This Been / Can This Be Tested?

- Verified the reported `2.12.0a0+rocm7.13.0a20260325` version imports locally.
- `.venv/bin/pre-commit run -a` - passed.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
