### PR TITLE
[IGNORE] Control run: quadrants 1.3.0b1 on cold CI caches

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,9 +20,9 @@ env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HF_HUB_DOWNLOAD_TIMEOUT: 60
   # Increment to switch new jobs to fresh caches before deleting the previous version.
-  CACHE_VERSION: "1"
+  CACHE_VERSION: "2"
   GENESIS_IMAGE_VER: "1_25"
-  TIMEOUT_MINUTES: 60
+  TIMEOUT_MINUTES: 120
   FORCE_COLOR: 1
   PY_COLORS: 1
   MADRONA_DISABLE_CUDA_HEAP_SIZE: "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==1.2.0",
+    "quadrants==1.3.0b1",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",


### PR DESCRIPTION
## Description

Control run for the `test_align_mesh` failure on
[#3201](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3201) and
[#3202](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3202). Same
tree as #3202 (base `8e70e94`, `quadrants==1.3.0b1`); the only difference is
`CACHE_VERSION: "1"` -> `"2"`, so every job starts from empty uv / genesis /
quadrants / huggingface caches. `TIMEOUT_MINUTES` goes to 120 because a cold run
re-downloads the assets, re-runs mesh processing and recompiles every kernel.
Not intended to merge.

## Motivation and Context

The failure does not reproduce outside CI. On the cluster, at base `8e70e94`
with `quadrants==1.3.0b1`, on `rtx-209-113` (the same node both CI failures ran
on), with a `/venv` that matches CI's in 198 of 200 packages and the identical
`pytest -v -ra --backend gpu --dev --forked ./tests` invocation,
`test_align_mesh` passes -- both standalone and in a full-suite run where it
landed on `gw53`, the same xdist worker as CI.

An instrumented copy of the test says the margin is not close. Residual angular
velocity after the 600 steps is `2.32e-05` against `tol=0.05`, and it is
bit-identical across `quadrants` 1.2.0 and 1.3.0b1, so on this geometry the
version bump changes nothing at all.

The interesting part is which environment diverges. The scene is built with
`n_envs=2`, and CI's failing tensor is:

```
[[ 5.527567e-02,  2.961722e-03,  1.065692e-01],
 [ 1.627962e-06, -4.872959e-09,  4.313075e-06]]
```

The env-1 row is bit-identical to what I measure locally; only env 0 differs,
and by four orders of magnitude. Env 0 is the environment holding the bowl
variant of the heterogeneous entity, env 1 the mango variant. That points at the
processed collision geometry of `orange_plastic_bowl.glb` -- i.e. at the cached
asset, which lives in the runner's persistent `~/.cache/N/genesis` and differs
between CI and any fresh machine -- rather than at anything quadrants compiles.

## How Has This Been / Can This Be Tested?

Read the Production `unit_tests-ndarray` job:

- **Green** -> the failure is an artifact of stale cached assets on the runner,
  not a quadrants regression, and the fix is to invalidate the cache (and to
  make the cache key cover whatever changed) rather than to revert anything in
  quadrants.
- **Red** -> the caches are not involved, and the difference between CI and a
  clean cluster run is something else still unaccounted for.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.

Made with [Cursor](https://cursor.com)