### PR TITLE
[IGNORE] Diagnostic run: dump CI's processed collision geometry for test_align_mesh

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -108,7 +108,7 @@ jobs:
             # tmate -S /tmp/tmate.sock wait tmate-ready
             # tmate -S /tmp/tmate.sock display -p '#{tmate_ssh}'
 
-            pytest -v -ra --backend gpu --dev --forked ./tests
+            pytest -v -ra -s -n 0 --backend gpu --dev tests/rigid/test_align_probe3.py tests/rigid/test_asset_loading.py::test_align_mesh
 
             # tmate -S /tmp/tmate.sock wait tmate-exit
           EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
-    "quadrants==1.2.0",
+    "quadrants==1.3.0b1",
     "pydantic>=2.11.0",
     "numpy>=1.26.4",
     "frozendict",

--- a/tests/rigid/test_align_probe3.py
+++ b/tests/rigid/test_align_probe3.py
@@ -1,0 +1,87 @@
+"""Geometry diagnostics for the test_align_mesh scene.
+
+Env 0 and env 1 differ only in which variant of the heterogeneous entity they hold: env 0 the bowl, env 1 the
+mango. CI's failing run matches a local run bit-for-bit on env 1 and diverges by four orders of magnitude on
+env 0, so this dumps the processed collision geometry (convex-piece counts, vertex/face totals, AABBs) alongside
+the settling residuals of both the measured mango and the heterogeneous entity, to show whether the two
+environments are looking at the same bowl.
+"""
+
+import numpy as np
+import pytest
+
+import genesis as gs
+
+from ..utils import get_hf_dataset
+
+
+@pytest.mark.required
+def test_align_probe3(show_viewer, tol):
+    INIT_POS = (0.0, 0.0, 0.1)
+
+    mango_path = get_hf_dataset(pattern="glb/mango.glb")
+    bowl_path = get_hf_dataset(pattern="glb/orange_plastic_bowl.glb")
+
+    for name, path in (("mango.glb", f"{mango_path}/glb/mango.glb"), ("bowl.glb", f"{bowl_path}/glb/orange_plastic_bowl.glb")):
+        with open(path, "rb") as fd:
+            data = fd.read()
+        import hashlib
+
+        print(f"GEOM asset {name} bytes={len(data)} sha256={hashlib.sha256(data).hexdigest()}", flush=True)
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(dt=0.01),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    mango_morph = gs.morphs.Mesh(file=f"{mango_path}/glb/mango.glb", scale=0.045, pos=INIT_POS, align=True)
+    mango = scene.add_entity(
+        mango_morph,
+        material=gs.materials.Rigid(rho=1000.0),
+        vis_mode="collision",
+        visualize_contact=True,
+    )
+    ghost_mango = scene.add_entity(mango_morph, material=gs.materials.Kinematic())
+    HET_POS = (0.5, 0.0, 0.1)
+    het_obj = scene.add_entity(
+        morph=(
+            gs.morphs.Mesh(
+                file=f"{bowl_path}/glb/orange_plastic_bowl.glb",
+                scale=0.5,
+                pos=HET_POS,
+                offset_euler=(30.0, 0.0, 0.0),
+                align=True,
+            ),
+            gs.morphs.Mesh(file=f"{mango_path}/glb/mango.glb", scale=0.045, pos=HET_POS, align=True),
+        ),
+        material=gs.materials.Rigid(rho=1000.0),
+    )
+    scene.build(n_envs=2)
+
+    for label, entity in (("mango", mango), ("het_obj", het_obj)):
+        print(f"GEOM {label} n_geoms={len(entity.geoms)}", flush=True)
+        for i, g in enumerate(entity.geoms):
+            verts = np.asarray(g.init_verts)
+            faces = np.asarray(g.init_faces)
+            print(
+                f"GEOM {label}[{i}] verts={verts.shape} faces={faces.shape} "
+                f"vmin={np.round(verts.min(axis=0), 9).tolist()!r} vmax={np.round(verts.max(axis=0), 9).tolist()!r}",
+                flush=True,
+            )
+
+    qpos = (0.3, -0.2, 1.0, 0.6, 0.5, 0.3, 0.0)
+    mango.set_qpos(qpos)
+    ghost_mango.set_qpos(qpos)
+    scene.reset()
+
+    for i in range(600):
+        scene.step()
+        if (i + 1) % 200 == 0:
+            m = mango.get_dofs_velocity(dofs_idx_local=(3, 4, 5)).cpu().numpy()
+            h = het_obj.get_dofs_velocity().cpu().numpy()
+            print(f"PROBE3 step={i + 1:4d} mango_ang={m.tolist()!r} het_absmax={np.abs(h).max(axis=-1).tolist()!r}", flush=True)
+
+    m = mango.get_dofs_velocity(dofs_idx_local=(3, 4, 5)).cpu().numpy()
+    h = het_obj.get_dofs_velocity().cpu().numpy()
+    print(f"PROBE3 FINAL mango_ang={m.tolist()!r}", flush=True)
+    print(f"PROBE3 FINAL het_vel={h.tolist()!r}", flush=True)


### PR DESCRIPTION
## Description

Diagnostic run for the `test_align_mesh` failure on
[#3201](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3201) /
[#3202](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3202). Same
tree as #3202 (base `8e70e94`, `quadrants==1.3.0b1`, `CACHE_VERSION` left at
`"1"` so the runner caches stay warm), plus a probe that prints the source asset
hashes and the processed collision geometry. The production job is narrowed to
the probe plus `test_align_mesh` itself. Not intended to merge.

## Motivation and Context

CI's failing tensor is:

```
[[ 5.527567e-02,  2.961722e-03,  1.065692e-01],
 [ 1.627962e-06, -4.872959e-09,  4.313075e-06]]
```

Running the same test on the cluster at the same base commit with the same
quadrants wheel, the env-1 row comes out bit-identical and env 0 does not: I
measure `2.32e-05` where CI gets `1.07e-01`, against `tol=0.05`. The scene is
built with `n_envs=2` and the two environments differ only in which variant of
the heterogeneous entity they hold, the bowl in env 0 and the mango in env 1, so
the divergence is on the side that owns `orange_plastic_bowl.glb`.

On a clean machine that bowl decomposes into 21 convex pieces (`het_obj` has 22
geoms, the 22nd being the mango variant), from a `orange_plastic_bowl.glb` of
117808 bytes, sha256 `da908562...`. This run reports the same numbers from CI.

Worth noting that the quadrants version is not implicated by anything I can
measure. Between 1.2.0 and 1.3.0b1 the only commit touching code the CUDA
backend runs is quadrants#790 (CSE per offload), and source builds either side
of it produce bit-identical residuals on this scene, as do the 1.2.0 and
1.3.0b1 wheels themselves.

## How Has This Been / Can This Be Tested?

Read the `GEOM` lines in the Production `unit_tests-ndarray` job log:

- **Different asset hash or piece count from the numbers above** -> CI is
  simulating a different bowl, and the failure is about the cached asset rather
  than about quadrants.
- **Same geometry** -> the geometry is exonerated and the divergence is
  somewhere else in the runner environment.

Whether `test_align_mesh` still fails when it is the only test in the job also
says whether the failure needs the rest of the suite around it.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.

Made with [Cursor](https://cursor.com)