### PR TITLE
[IGNORE] Control run: quadrants 1.2.0 on the warm CI cache

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,6 +20,7 @@ env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HF_HUB_DOWNLOAD_TIMEOUT: 60
   # Increment to switch new jobs to fresh caches before deleting the previous version.
+  # (Control run for test_align_mesh: this comment is the only diff from 8e70e94.)
   CACHE_VERSION: "1"
   GENESIS_IMAGE_VER: "1_25"
   TIMEOUT_MINUTES: 60


### PR DESCRIPTION
## Description

Control run for the `test_align_mesh` failure on
[#3201](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3201) /
[#3202](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3202). This is
base `8e70e94` with its original `quadrants==1.2.0` pin and `CACHE_VERSION` left
at `"1"`; a comment in `production.yml` is the only diff, so nothing here can
change the simulation. Not intended to merge.

## Motivation and Context

The claim under test is that the regression lies between quadrants 1.2.0 and
1.3.0b1, resting on `8e70e94` having gone green with 1.2.0 on 2026-08-07. That
run and the failing ones differ in the quadrants version but also in when they
ran, and everything now points at the runner cache rather than at quadrants:

- Bumping `CACHE_VERSION` to 2, changing nothing else, turns #3202 green
  ([#3204](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3204), 938
  passed).
- Rerunning #3202 fails again on `rtx-209-195`, with the residual
  `[5.527567e-02, 2.961722e-03, 1.065692e-01]` bit-identical to the runs on
  `rtx-209-113`, so the failure is deterministic and not node-specific.
- The source asset and its decomposition are the same in CI as on a clean
  machine: `orange_plastic_bowl.glb` at 117808 bytes, sha256 `da908562...`,
  decomposing into the same 22 geoms
  ([#3205](https://github.com/Genesis-Embodied-AI/genesis-world/pull/3205)).
- On the cluster, 20 runs from an empty asset cache put the residual between
  `8.2e-06` and `1.2e-04` against `tol=0.05`. CI's `1.07e-01` is ~900x above the
  worst of them, i.e. not a tail of that distribution but a state a fresh run
  does not reach.
- quadrants 1.2.0, 1.3.0b1, and source builds either side of quadrants#790 (the
  only commit in that window touching code the CUDA backend runs) give
  bit-identical residuals on a fixed decomposition.

The `cvx` cache key covers vertex count, face connectivity and generation
parameters, with no stamp for the code that produced the entry, and a lookup that
misses the exact key accepts the first entry in the bucket matching within
`MESH_CACHE_MATCH_RTOL`. An entry written under one revision can therefore be
served to every later run.

## How Has This Been / Can This Be Tested?

Read the Production `unit_tests-ndarray` job:

- **Red** -> quadrants is not involved at all. The 2026-08-07 pass simply
  predates the current cache contents, and the fix is on the caching side
  (version the `cvx` entries, and invalidate).
- **Green** -> 1.2.0 and 1.3.0b1 really do differ on whatever geometry the
  version-1 cache holds, and the quadrants bump is at least the trigger even if
  the cached artifact is the underlying cause.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.

Made with [Cursor](https://cursor.com)