### PR TITLE
[BUG FIX] Prevent scikit-image import failures with NumPy 2.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     # Use to display camera images and export images
     "opencv-python",
     # Use by `RigidGeom.visualize_sdf` to render SDF as level 0 marching cubes
-    "scikit-image",
+    "scikit-image>=0.23.1",
     # Convex decomposition library
     "coacd",
     # Ray casting used in mesh to height field conversion


### PR DESCRIPTION
## Description

Require scikit-image 0.23.1 or newer. Version 0.23.1 is the first published scikit-image release built against
`NumPy >=2.0.0rc1`, so Genesis dependency resolution excludes 0.22 wheels built against the NumPy 1 ABI when NumPy 2 is
installed.

## Related Issue

Resolves #3182.

## Motivation and Context

scikit-image 0.22 raises `ValueError: numpy.dtype size changed` during import with NumPy 2, which prevents Genesis from
importing.

## How Has This Been / Can This Be Tested?

- Python 3.12.13 with NumPy 2.0.2 and scikit-image 0.22.0: `python -c "import skimage"` reproduces the reported error.
- Python 3.12.13 with NumPy 2.0.2 and scikit-image 0.23.1: the same command passes.
- `skimage.measure.marching_cubes` returns byte-identical outputs with scikit-image 0.23.1 under NumPy 1.26.4 and 2.0.2.
- The NumPy and scikit-image pair resolves across Python 3.10 through 3.13 on x86_64 Linux.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
