### PR TITLE
[BUG FIX] Fix minor physics discrepancy between generic and GPU-only constraint solver implementations.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -173,7 +173,7 @@ class ConstraintSolver:
 
         self.ls_alpha = cs.ls_alpha
         self.ls_improvement = cs.ls_improvement
-        self.ls_alpha_newton = cs.ls_alpha_newton
+        self.ls_p0_deriv = cs.ls_p0_deriv
         self.ls_gtol = cs.ls_gtol
         self.ls_it = cs.ls_it
         self.ls_result = cs.ls_result

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -133,9 +133,12 @@ def _func_decomp_linesearch_p0(
             grad_sqnorm = sh_grad_sqnorm[0]
 
             if snorm < rigid_info.EPS[None]:
-                # Converged — only thread 0 writes
+                # A search direction that has gone to zero leaves nothing to step along, so the refinement is bypassed
+                # and this env is done - status 1, as the monolith linesearch reports it.
                 if tid == 0:
                     constraint_state.ls_alpha[i_b] = 0.0
+                    constraint_state.ls_improvement[i_b] = 0.0
+                    constraint_state.ls_result[i_b] = 1
                     constraint_state.improved[i_b] = False
             else:
                 # Thread 0 writes quad_gauss to global memory
@@ -232,17 +235,17 @@ def _func_decomp_linesearch_p0(
                     constraint_state.eq_sum[0, i_b] = sh_qg_grad[0]
                     constraint_state.eq_sum[1, i_b] = sh_qg_hess[0]
                     constraint_state.ls_it[i_b] = 1
-                    # Initialize best alpha and improvement for parallel linesearch
-                    constraint_state.ls_alpha[i_b] = 0.0  # default: no step
-                    constraint_state.ls_improvement[i_b] = 0.0
 
-                    # Newton step estimate from the full DOF + constraint gradient/hessian
+                    # Newton step from the full DOF + constraint gradient/hessian, the trial point the refinement
+                    # starts from: -grad/hess, signed because a search direction that does not descend needs a step
+                    # backwards along it, with a non-positive curvature floored rather than skipped so a flat or
+                    # concave quadratic still yields a point to bracket from. Same trial point as the monolith
+                    # linesearch's first evaluation (func_ls_init_and_eval_p0 in solver.py).
                     total_hess = 2.0 * (constraint_state.quad_gauss[1, i_b] + sh_constraint_hess[0])
-                    if total_hess > 0.0:
-                        total_grad = constraint_state.quad_gauss[0, i_b] + sh_constraint_grad[0]
-                        constraint_state.ls_alpha_newton[i_b] = qd.abs(total_grad / total_hess)
-                    else:
-                        constraint_state.ls_alpha_newton[i_b] = 0.0
+                    if total_hess <= 0.0:
+                        total_hess = rigid_info.EPS[None]
+                    total_grad = constraint_state.quad_gauss[0, i_b] + sh_constraint_grad[0]
+                    constraint_state.ls_alpha_newton[i_b] = -total_grad / total_hess
                     # Store gtol for gradient-guided refinement. Same bound as the monolith linesearch, so the two
                     # arms refine to the same accuracy - see func_linesearch_batch in solver.py for why the gradient
                     # norm carries the scale and why the ratio is floored.
@@ -270,40 +273,46 @@ def _func_decomp_linesearch_refine_coop(
     ``_func_linesearch_eval_at_alpha`` / ``func_linesearch_refine`` (called with the Python literal ``True`` for the ``coop``
     template arg). Writes to ``ls_alpha`` / ``ls_improvement`` are tid==0-guarded since the result is per-env, not
     per-lane."""
-    # Gated: skip when the Newton step is zero (degenerate hessian).
-    if alpha_newton > 0.0:
-        if tid == 0:
-            constraint_state.ls_alpha[i_b] = 0.0
+    p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
+        i_b, tid, alpha_newton, constraint_state, rigid_info, rigid_config, coop=True
+    )
+    # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py): positive means no improvement
+    # FIXME: the monolith falls back on p0's stored derivative pair, whose curvature is floored at EPS, where this
+    # re-evaluation returns the raw one, so the two arms still part ways on a non-positive curvature. Closing it needs
+    # a state field to carry p0's derivatives across the P0 / refine kernel boundary.
+    if p1_cost > 0.0:
         p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
-            i_b, tid, alpha_newton, constraint_state, rigid_info, rigid_config, coop=True
+            i_b, tid, 0.0, constraint_state, rigid_info, rigid_config, coop=True
         )
-        # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py): positive means no improvement
-        if p1_cost > 0.0:
-            p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
-                i_b, tid, 0.0, constraint_state, rigid_info, rigid_config, coop=True
-            )
-        if p1_cost < 0.0 and tid == 0:
-            constraint_state.ls_alpha[i_b] = p1_alpha
-            constraint_state.ls_improvement[i_b] = -p1_cost
-        if qd.abs(p1_deriv_0) > gtol:
-            res_alpha, res_cost, ls_result = solver.func_linesearch_refine(
-                i_b,
-                tid,
-                p1_alpha,
-                p1_cost,
-                p1_deriv_0,
-                p1_deriv_1,
-                gtol,
-                constraint_state,
-                rigid_info,
-                rigid_config,
-                coop=True,
-            )
-            # Skip status 7 (brackets stalled, midpoint non-improving) to preserve the validated
-            # p1_alpha already written above.
-            if qd.abs(res_alpha) > rigid_info.EPS[None] and ls_result != 7 and tid == 0:
-                constraint_state.ls_alpha[i_b] = res_alpha
-                constraint_state.ls_improvement[i_b] = -res_cost
+    res_alpha = p1_alpha
+    improvement = -p1_cost
+    ls_result = 0
+    if qd.abs(p1_deriv_0) < gtol:
+        if qd.abs(p1_alpha) < rigid_info.EPS[None]:
+            ls_result = 2
+    else:
+        res_alpha, res_cost, ls_result = solver.func_linesearch_refine(
+            i_b,
+            tid,
+            p1_alpha,
+            p1_cost,
+            p1_deriv_0,
+            p1_deriv_1,
+            gtol,
+            constraint_state,
+            rigid_info,
+            rigid_config,
+            coop=True,
+        )
+        improvement = -res_cost
+        # Status 7: both brackets stalled and the midpoint does not improve on alpha=0. Reject the alpha.
+        if ls_result == 7:
+            res_alpha = 0.0
+            improvement = 0.0
+    if tid == 0:
+        constraint_state.ls_alpha[i_b] = res_alpha
+        constraint_state.ls_improvement[i_b] = improvement
+        constraint_state.ls_result[i_b] = ls_result
 
 
 @qd.func
@@ -316,23 +325,25 @@ def _func_decomp_linesearch_refine_serial(
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """1-thread-per-env variant of ``_func_decomp_linesearch_refine``: bit-identical to the pre-coop baseline.
-    Only ``tid == 0`` runs the work; the unified helpers are called with the Python literal ``False`` for ``coop``."""
-    # Gated: skip when the Newton step is zero (degenerate hessian).
-    if alpha_newton > 0.0 and tid == 0:
-        constraint_state.ls_alpha[i_b] = 0.0
+    """1-thread-per-env variant of ``_func_decomp_linesearch_refine``: only ``tid == 0`` runs the work, and the
+    unified helpers are called with the Python literal ``False`` for ``coop``."""
+    if tid == 0:
         p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
             i_b, tid, alpha_newton, constraint_state, rigid_info, rigid_config, coop=False
         )
-        # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py): positive means no improvement
+        # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py): positive means no improvement.
+        # Carries the same FIXME as _func_decomp_linesearch_refine_coop on p0's floored curvature.
         if p1_cost > 0.0:
             p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
                 i_b, tid, 0.0, constraint_state, rigid_info, rigid_config, coop=False
             )
-        if p1_cost < 0.0:
-            constraint_state.ls_alpha[i_b] = p1_alpha
-            constraint_state.ls_improvement[i_b] = -p1_cost
-        if qd.abs(p1_deriv_0) > gtol:
+        res_alpha = p1_alpha
+        improvement = -p1_cost
+        ls_result = 0
+        if qd.abs(p1_deriv_0) < gtol:
+            if qd.abs(p1_alpha) < rigid_info.EPS[None]:
+                ls_result = 2
+        else:
             res_alpha, res_cost, ls_result = solver.func_linesearch_refine(
                 i_b,
                 tid,
@@ -346,11 +357,14 @@ def _func_decomp_linesearch_refine_serial(
                 rigid_config,
                 coop=False,
             )
-            # Skip status 7 (brackets stalled, midpoint non-improving) to preserve the validated
-            # p1_alpha already written above.
-            if qd.abs(res_alpha) > rigid_info.EPS[None] and ls_result != 7:
-                constraint_state.ls_alpha[i_b] = res_alpha
-                constraint_state.ls_improvement[i_b] = -res_cost
+            improvement = -res_cost
+            # Status 7: both brackets stalled and the midpoint does not improve on alpha=0. Reject the alpha.
+            if ls_result == 7:
+                res_alpha = 0.0
+                improvement = 0.0
+        constraint_state.ls_alpha[i_b] = res_alpha
+        constraint_state.ls_improvement[i_b] = improvement
+        constraint_state.ls_result[i_b] = ls_result
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -134,7 +134,7 @@ def _func_decomp_linesearch_p0(
 
             if snorm < rigid_info.EPS[None]:
                 # A search direction that has gone to zero leaves nothing to step along, so the refinement is bypassed
-                # and this env is done - status 1, as the monolith linesearch reports it.
+                # and this env is done, reported as linesearch status 1
                 if tid == 0:
                     constraint_state.ls_alpha[i_b] = 0.0
                     constraint_state.ls_improvement[i_b] = 0.0
@@ -236,16 +236,15 @@ def _func_decomp_linesearch_p0(
                     constraint_state.eq_sum[1, i_b] = sh_qg_hess[0]
                     constraint_state.ls_it[i_b] = 1
 
-                    # Newton step from the full DOF + constraint gradient/hessian, the trial point the refinement
-                    # starts from: -grad/hess, signed because a search direction that does not descend needs a step
-                    # backwards along it, with a non-positive curvature floored rather than skipped so a flat or
-                    # concave quadratic still yields a point to bracket from. Same trial point as the monolith
-                    # linesearch's first evaluation (func_ls_init_and_eval_p0 in solver.py).
+                    # Cost derivative and curvature along the search direction at alpha = 0, over the DOFs and the
+                    # constraints together, the curvature floored so a flat or concave quadratic still yields a trial
+                    # step to bracket from. The refinement derives that step from the ratio and falls back on the pair
+                    # itself, the bound and the fallback both matching func_ls_init_and_eval_p0 in solver.py
                     total_hess = 2.0 * (constraint_state.quad_gauss[1, i_b] + sh_constraint_hess[0])
                     if total_hess <= 0.0:
                         total_hess = rigid_info.EPS[None]
-                    total_grad = constraint_state.quad_gauss[0, i_b] + sh_constraint_grad[0]
-                    constraint_state.ls_alpha_newton[i_b] = -total_grad / total_hess
+                    constraint_state.ls_p0_deriv[0, i_b] = constraint_state.quad_gauss[0, i_b] + sh_constraint_grad[0]
+                    constraint_state.ls_p0_deriv[1, i_b] = total_hess
                     # Store gtol for gradient-guided refinement. Same bound as the monolith linesearch, so the two
                     # arms refine to the same accuracy - see func_linesearch_batch in solver.py for why the gradient
                     # norm carries the scale and why the ratio is floored.
@@ -263,27 +262,29 @@ def _func_decomp_linesearch_p0(
 def _func_decomp_linesearch_refine_coop(
     i_b,
     tid,
-    alpha_newton,
+    p0_deriv_0,
+    p0_deriv_1,
     gtol,
     constraint_state: array_class.ConstraintState,
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """Warp-cooperative variant of ``_func_decomp_linesearch_refine``: all 32 lanes drive the unified
-    ``_func_linesearch_eval_at_alpha`` / ``func_linesearch_refine`` (called with the Python literal ``True`` for the ``coop``
-    template arg). Writes to ``ls_alpha`` / ``ls_improvement`` are tid==0-guarded since the result is per-env, not
-    per-lane."""
+    """Refine the linesearch step with all 32 lanes of the block evaluating it together, one lane writing the result.
+
+    The unified evaluators run with ``coop=True``, so every lane drives them and each cost reduction spans the warp.
+    The accepted step belongs to the env rather than to a lane, so the writes to ``ls_alpha`` / ``ls_improvement`` /
+    ``ls_result`` are guarded on ``tid == 0``.
+    """
     p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
-        i_b, tid, alpha_newton, constraint_state, rigid_info, rigid_config, coop=True
+        i_b, tid, -p0_deriv_0 / p0_deriv_1, constraint_state, rigid_info, rigid_config, coop=True
     )
-    # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py): positive means no improvement
-    # FIXME: the monolith falls back on p0's stored derivative pair, whose curvature is floored at EPS, where this
-    # re-evaluation returns the raw one, so the two arms still part ways on a non-positive curvature. Closing it needs
-    # a state field to carry p0's derivatives across the P0 / refine kernel boundary.
+    # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py), so a positive one means the trial step
+    # raises the cost and alpha = 0 takes its place, at cost identically 0 and the derivatives P0 stored
     if p1_cost > 0.0:
-        p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
-            i_b, tid, 0.0, constraint_state, rigid_info, rigid_config, coop=True
-        )
+        p1_alpha = gs.qd_float(0.0)
+        p1_cost = gs.qd_float(0.0)
+        p1_deriv_0 = p0_deriv_0
+        p1_deriv_1 = p0_deriv_1
     res_alpha = p1_alpha
     improvement = -p1_cost
     ls_result = 0
@@ -305,7 +306,7 @@ def _func_decomp_linesearch_refine_coop(
             coop=True,
         )
         improvement = -res_cost
-        # Status 7: both brackets stalled and the midpoint does not improve on alpha=0. Reject the alpha.
+        # Status 7 leaves both brackets stalled with the midpoint above alpha=0's cost, so the step is rejected
         if ls_result == 7:
             res_alpha = 0.0
             improvement = 0.0
@@ -319,24 +320,28 @@ def _func_decomp_linesearch_refine_coop(
 def _func_decomp_linesearch_refine_serial(
     i_b,
     tid,
-    alpha_newton,
+    p0_deriv_0,
+    p0_deriv_1,
     gtol,
     constraint_state: array_class.ConstraintState,
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """1-thread-per-env variant of ``_func_decomp_linesearch_refine``: only ``tid == 0`` runs the work, and the
-    unified helpers are called with the Python literal ``False`` for ``coop``."""
+    """Refine the linesearch step on one lane per env, the other 31 lanes of the block idle.
+
+    The unified evaluators run with ``coop=False``, so lane 0 alone drives them and the whole body sits under its
+    guard, leaving every write per-env by construction.
+    """
     if tid == 0:
         p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
-            i_b, tid, alpha_newton, constraint_state, rigid_info, rigid_config, coop=False
+            i_b, tid, -p0_deriv_0 / p0_deriv_1, constraint_state, rigid_info, rigid_config, coop=False
         )
-        # Costs are shifted deltas from alpha=0 (see quad_gauss in array_class.py): positive means no improvement.
-        # Carries the same FIXME as _func_decomp_linesearch_refine_coop on p0's floored curvature.
+        # A trial step that raises the cost gives way to alpha = 0, carrying the derivatives P0 stored for it
         if p1_cost > 0.0:
-            p1_alpha, p1_cost, p1_deriv_0, p1_deriv_1 = solver._func_linesearch_eval_at_alpha(
-                i_b, tid, 0.0, constraint_state, rigid_info, rigid_config, coop=False
-            )
+            p1_alpha = gs.qd_float(0.0)
+            p1_cost = gs.qd_float(0.0)
+            p1_deriv_0 = p0_deriv_0
+            p1_deriv_1 = p0_deriv_1
         res_alpha = p1_alpha
         improvement = -p1_cost
         ls_result = 0
@@ -358,7 +363,7 @@ def _func_decomp_linesearch_refine_serial(
                 coop=False,
             )
             improvement = -res_cost
-            # Status 7: both brackets stalled and the midpoint does not improve on alpha=0. Reject the alpha.
+            # Status 7 leaves both brackets stalled with the midpoint above alpha=0's cost, so the step is rejected
             if ls_result == 7:
                 res_alpha = 0.0
                 improvement = 0.0
@@ -371,36 +376,36 @@ def _func_decomp_linesearch_refine_serial(
 def _func_decomp_linesearch_refine(
     i_b,
     tid,
-    alpha_newton,
+    p0_deriv_0,
+    p0_deriv_1,
     gtol,
     constraint_state: array_class.ConstraintState,
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """Linesearch refinement body, called per-env from ``_func_decomp_linesearch_refine_and_apply``. Dispatches at
-    compile time on ``enable_cooperative_constraint_kernels`` to ``_func_decomp_linesearch_refine_coop``
-    (warp-cooperative, all 32 lanes) or ``_func_decomp_linesearch_refine_serial`` (1-thread-per-env, bit-identical
-    baseline).
+    """Refine the linesearch step through the cooperative or the single-lane variant, selected at compile time.
 
-    Each branch passes the literal Python ``True`` / ``False`` for the ``coop`` template arg of the unified
-    ``_func_linesearch_eval_at_alpha`` / ``func_linesearch_refine``: Quadrants' ``qd.template()`` machinery does not
-    auto-promote a struct member access to a compile-time value, so we cannot share a single call site here."""
+    The ``coop`` template argument of the shared evaluators cannot be read off the config struct, since quadrants does
+    not promote a struct member access to a compile-time value, so each branch passes it as a Python literal.
+    """
     if qd.static(rigid_config.enable_cooperative_constraint_kernels):
-        _func_decomp_linesearch_refine_coop(i_b, tid, alpha_newton, gtol, constraint_state, rigid_info, rigid_config)
+        _func_decomp_linesearch_refine_coop(
+            i_b, tid, p0_deriv_0, p0_deriv_1, gtol, constraint_state, rigid_info, rigid_config
+        )
     else:
-        _func_decomp_linesearch_refine_serial(i_b, tid, alpha_newton, gtol, constraint_state, rigid_info, rigid_config)
+        _func_decomp_linesearch_refine_serial(
+            i_b, tid, p0_deriv_0, p0_deriv_1, gtol, constraint_state, rigid_info, rigid_config
+        )
 
 
 @qd.func
 def _func_decomp_linesearch_refine_and_apply(
     constraint_state: array_class.ConstraintState, rigid_info: array_class.RigidInfo, rigid_config: qd.template()
 ):
-    """Decomposed solver eval kernel: linesearch refinement from Newton step + cooperative apply.
+    """Refine the linesearch step from the Newton estimate, then apply the accepted one cooperatively.
 
-    The P0 kernel precomputes a Newton step (ls_alpha_newton). This kernel refines it via the unified
-    ``func_linesearch_refine`` (templated on ``coop``: serial-on-tid-0 when False, cooperative across the 32-lane
-    warp when True), gated on ``enable_cooperative_constraint_kernels``. It then cooperatively applies the chosen alpha
-    to qacc, Ma, and Jaref.
+    The estimate is the ratio of the cost derivatives P0 left at alpha = 0 (see ls_p0_deriv in array_class.py), and the
+    accepted alpha lands in qacc, Ma and Jaref.
 
     The cooperative path is only safe when the layout-flippable constraint-state tensors are stored with
     ``layout=(1, 0)`` (so per-lane strided reads of ``Jaref[i_c, i_b]`` etc. are coalesced across constraints for a
@@ -423,9 +428,12 @@ def _func_decomp_linesearch_refine_and_apply(
 
         if active:
             gtol = constraint_state.ls_gtol[i_b]
-            alpha_newton = constraint_state.ls_alpha_newton[i_b]
+            p0_deriv_0 = constraint_state.ls_p0_deriv[0, i_b]
+            p0_deriv_1 = constraint_state.ls_p0_deriv[1, i_b]
 
-            _func_decomp_linesearch_refine(i_b, tid, alpha_newton, gtol, constraint_state, rigid_info, rigid_config)
+            _func_decomp_linesearch_refine(
+                i_b, tid, p0_deriv_0, p0_deriv_1, gtol, constraint_state, rigid_info, rigid_config
+            )
             qd.simt.block.sync()
         else:
             if tid == 0:

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -52,8 +52,9 @@ def _func_decomp_linesearch_p0(
         tid = i_flat % _T
         i_b = i_flat // _T
 
-        # 5 shared arrays for parallel reductions (reused across phases)
+        # 6 shared arrays for parallel reductions (reused across phases)
         sh_snorm_sq = qd.simt.block.SharedArray((_T,), gs.qd_float)
+        sh_grad_sqnorm = qd.simt.block.SharedArray((_T,), gs.qd_float)
         sh_qg_grad = qd.simt.block.SharedArray((_T,), gs.qd_float)
         sh_qg_hess = qd.simt.block.SharedArray((_T,), gs.qd_float)
         sh_constraint_grad = qd.simt.block.SharedArray((_T,), gs.qd_float)
@@ -92,37 +93,44 @@ def _func_decomp_linesearch_p0(
 
             qd.simt.block.sync()  # Ensure mv and jv are written before Phase 1 reads them
 
-            # === Phase 1: Fused snorm + quad_gauss, parallel over n_dofs ===
+            # === Phase 1: Fused snorm + grad norm + quad_gauss, parallel over n_dofs ===
             local_snorm_sq = gs.qd_float(0.0)
+            local_grad_sqnorm = gs.qd_float(0.0)
             local_qg_grad = gs.qd_float(0.0)
             local_qg_hess = gs.qd_float(0.0)
 
             i_d = tid
             while i_d < n_dofs:
                 s = constraint_state.search[i_d, i_b]
+                g = constraint_state.grad[i_d, i_b]
                 local_snorm_sq += s * s
+                local_grad_sqnorm += g * g
                 local_qg_grad += s * constraint_state.Ma[i_d, i_b] - s * dyn_state.dofs.force[i_d, i_b]
                 local_qg_hess += 0.5 * s * constraint_state.mv[i_d, i_b]
                 i_d += _T
 
             sh_snorm_sq[tid] = local_snorm_sq
+            sh_grad_sqnorm[tid] = local_grad_sqnorm
             sh_qg_grad[tid] = local_qg_grad
             sh_qg_hess[tid] = local_qg_hess
 
             qd.simt.block.sync()
 
-            # Tree reduction for 3 accumulators
+            # Tree reduction for 4 accumulators
             stride = _T // 2
             while stride > 0:
                 if tid < stride:
                     sh_snorm_sq[tid] += sh_snorm_sq[tid + stride]
+                    sh_grad_sqnorm[tid] += sh_grad_sqnorm[tid + stride]
                     sh_qg_grad[tid] += sh_qg_grad[tid + stride]
                     sh_qg_hess[tid] += sh_qg_hess[tid + stride]
                 qd.simt.block.sync()
                 stride //= 2
 
-            # All threads read the reduced snorm
+            # All threads read the reduced snorm; the gradient norm is kept in a register because Phase 2 overwrites
+            # the shared arrays before the threshold below is assembled.
             snorm = qd.sqrt(sh_snorm_sq[0])
+            grad_sqnorm = sh_grad_sqnorm[0]
 
             if snorm < rigid_info.EPS[None]:
                 # Converged — only thread 0 writes
@@ -235,12 +243,17 @@ def _func_decomp_linesearch_p0(
                         constraint_state.ls_alpha_newton[i_b] = qd.abs(total_grad / total_hess)
                     else:
                         constraint_state.ls_alpha_newton[i_b] = 0.0
-                    # Store gtol for gradient-guided refinement
+                    # Store gtol for gradient-guided refinement. Same bound as the monolith linesearch, so the two
+                    # arms refine to the same accuracy - see func_linesearch_batch in solver.py for why the gradient
+                    # norm carries the scale and why the ratio is floored.
                     n_dofs_val = constraint_state.search.shape[0]
                     scale = rigid_info.meaninertia[i_b] * qd.max(1, n_dofs_val)
-                    constraint_state.ls_gtol[i_b] = (
-                        rigid_info.tolerance[None] * rigid_info.ls_tolerance[None] * snorm * scale
-                    )
+                    ls_ratio = rigid_info.tolerance[None] * rigid_info.ls_tolerance[None]
+                    if qd.static(not rigid_config.enable_mujoco_compatibility):
+                        scale = qd.sqrt(grad_sqnorm)
+                        LS_NOISE_RATIO = qd.static(10.0)
+                        ls_ratio = qd.max(ls_ratio, LS_NOISE_RATIO * rigid_info.EPS[None])
+                    constraint_state.ls_gtol[i_b] = ls_ratio * snorm * scale
 
 
 @qd.func

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -461,7 +461,8 @@ class ConstraintState:
     quad_gauss: qd.Tensor
     ls_alpha: qd.Tensor
     ls_improvement: qd.Tensor
-    ls_alpha_newton: qd.Tensor
+    # Cost derivative and curvature along the search direction at alpha=0, [deriv, curvature], curvature floored at EPS
+    ls_p0_deriv: qd.Tensor
     ls_gtol: qd.Tensor
     eq_sum: qd.Tensor
     ls_it: qd.Tensor
@@ -610,7 +611,7 @@ def get_constraint_state(constraint_solver, solver, collider):
         quad_gauss=V(dtype=gs.qd_float, shape=(2, _B)),
         ls_alpha=V(dtype=gs.qd_float, shape=(_B,)),
         ls_improvement=V(dtype=gs.qd_float, shape=(_B,)),
-        ls_alpha_newton=V(dtype=gs.qd_float, shape=(_B,)),
+        ls_p0_deriv=V(dtype=gs.qd_float, shape=(2, _B)),
         ls_gtol=V(dtype=gs.qd_float, shape=(_B,)),
         eq_sum=V(dtype=gs.qd_float, shape=(2, _B)),
         Ma=V(dtype=gs.qd_float, shape=(solver.n_dofs_, _B), layout=dof_vec_layout),

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -3,9 +3,12 @@ import math
 import numpy as np
 import pytest
 import torch
+from quadrants.lang._perf_dispatch import PerformanceDispatcher
 
 import genesis as gs
 import genesis.utils.geom as gu
+from genesis.engine.solvers.rigid.constraint import solver as constraint_solver
+from genesis.engine.solvers.rigid.constraint.solver import ConstraintSolver
 from genesis.utils.array_class import RigidSimStaticConfig
 from genesis.utils.misc import qd_to_numpy, tensor_to_array
 
@@ -643,80 +646,108 @@ def test_cholesky_tiling(monkeypatch, tol):
 
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.gpu])
-def test_solve_arm_equivalence(monkeypatch, show_viewer):
+def test_solve_arm_equivalence(monkeypatch, show_viewer, tol):
     SIZE = 0.1
-    N_STEPS = 25
+    N_STEPS = 12
 
-    # Which implementations the dispatcher may pick is resolved once per built scene, so each arm needs its own build.
-    scenes = []
-    prefer_decomposed_solver = 0
+    # Dispatch dynamically whatever the suite or the caller pinned: eligibility is filtered on this field, so only its
+    # own default leaves both implementations in the running.
     init_orig = RigidSimStaticConfig.__init__
 
-    def init_forced(self, *args, **kwargs):
-        kwargs["prefer_decomposed_solver"] = prefer_decomposed_solver
+    def init_dynamic(self, *args, **kwargs):
+        kwargs["prefer_decomposed_solver"] = -1
         init_orig(self, *args, **kwargs)
 
-    monkeypatch.setattr(RigidSimStaticConfig, "__init__", init_forced)
+    monkeypatch.setattr(RigidSimStaticConfig, "__init__", init_dynamic)
 
-    for prefer_decomposed_solver in (0, 1):
-        scene = gs.Scene(
-            sim_options=gs.options.SimOptions(
-                dt=0.01,
-                gravity=(2.0, 0.0, -9.81),
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=0.01,
+            gravity=(0.0, 0.0, -9.81),
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.1, -1.1, 0.7),
+            camera_lookat=(1.1, 0.1, 0.05),
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    # Islands of one, three and nine bodies at once, each sunk a ten-thousandth of its height so contact has real depth
+    positions = [(0.0, 0.0, (1 - 1e-4) * SIZE / 2)]
+    positions += [(10 * SIZE, 0.0, (1 - 1e-4) * SIZE * (0.5 + i)) for i in range(3)]
+    positions += [(20 * SIZE + SIZE * (i % 3), SIZE * (i // 3), (1 - 1e-4) * SIZE / 2) for i in range(9)]
+    for pos in positions:
+        scene.add_entity(
+            morph=gs.morphs.Box(
+                size=(SIZE, SIZE, SIZE),
+                pos=pos,
             ),
-            rigid_options=gs.options.RigidOptions(
-                friction_cone=gs.friction_cone.elliptic,
-            ),
-            viewer_options=gs.options.ViewerOptions(
-                camera_pos=(0.9, -0.9, 0.6),
-                camera_lookat=(0.1, 0.1, 0.05),
-            ),
-            show_viewer=show_viewer,
+            vis_mode="collision",
         )
-        scene.add_entity(gs.morphs.Plane())
-        # A 3x3 base of boxes touching each other and the plane, plus a second layer seated on its seams, every body a
-        # ten-thousandth of its height into what carries it so the first solve resolves real depth, and gravity leaning
-        # sideways so the elliptic cones stay loaded in shear: one contact island spanning 78 DOFs and hundreds of
-        # constraint rows, enough for every cooperative reduction to stride over more than its 32 lanes.
-        for i in range(13):
-            offset, layer = (i % 3, i // 3) if i < 9 else (0.5 + (i - 9) % 2, 0.5 + (i - 9) // 2)
-            scene.add_entity(
-                morph=gs.morphs.Box(
-                    size=(SIZE, SIZE, SIZE),
-                    pos=(SIZE * offset, SIZE * layer, (1 - 1e-4) * SIZE * (0.5 if i < 9 else 1.5)),
-                ),
-                vis_mode="collision",
-            )
-        scene.build(n_envs=2)
-        # Eligibility is read off this field on every dispatch, so one value leaves exactly one implementation to run
-        # and a comparison cannot degenerate into the same one twice.
-        assert scene.rigid_solver.rigid_config.prefer_decomposed_solver == prefer_decomposed_solver
-        scenes.append(scene)
+    scene.build(n_envs=2)
+    solver = scene.rigid_solver
+    constraint_state = solver.constraint_solver.constraint_state
+    dofs = solver.dyn_state.dofs
 
-    reference, compared = (scene.rigid_solver for scene in scenes)
-    reference_state = reference.constraint_solver.constraint_state
-    compared_state = compared.constraint_solver.constraint_state
+    # Selecting by index into the candidates the dispatcher deems eligible replaces its whole decision, the timing it
+    # would do and any QD_PERFDISPATCH_FORCE in the environment alike, and demanding more than one candidate means a
+    # selection that stopped working fails here instead of quietly comparing one implementation against itself.
+    selected = 0
 
-    # Both scenes solve the same problem every step: the compared arm is handed the reference arm's state along with the
-    # warm start it left, which the state setter clears on its own and which decides how close to the optimum the solve
-    # starts - the regime the linesearch refinement lives in. Resynchronizing every step keeps each comparison a single
-    # solve from a common state, while the trajectory still walks the pile through settling under shear.
+    def call_selected(self, *args, **kwargs):
+        eligible = self._get_compatible_functions(*args, **kwargs)
+        # Registration order, so an index means the same implementation on every call and every run.
+        candidates = [impl for impl in self._dispatch_impls if impl in eligible]
+        assert len(candidates) > 1
+        return candidates[selected](*args, **kwargs)
+
+    monkeypatch.setattr(PerformanceDispatcher, "__call__", call_selected)
+
+    # A solve leaves its own inputs changed: the warm start it wrote, the factor and active set the incremental path
+    # maintains across calls, and the applied force it folded the constraint force into. The second implementation gets
+    # all of them back exactly as the first one received them, or it would be solving a different problem.
+    solve_inputs = (
+        constraint_state.qacc_ws,
+        constraint_state.is_warmstart,
+        constraint_state.active,
+        constraint_state.prev_active,
+        constraint_state.incr_changed_idx,
+        constraint_state.incr_n_changed,
+        constraint_state.nt_H,
+        constraint_state.nt_jacobi,
+        constraint_state.use_full_hessian,
+        constraint_state.solver_iter_counter,
+        constraint_state.improved,
+        dofs.force,
+    )
+
+    accelerations = []
+    resolve_orig = ConstraintSolver.resolve
+
+    def resolve_compared(self):
+        nonlocal selected
+        inputs = [qd_to_numpy(tensor, copy=True) for tensor in solve_inputs]
+        accelerations.clear()
+        # The candidate order is fixed, so solving with index 0 last leaves the trajectory to one implementation.
+        for selected in (1, 0):
+            for tensor, value in zip(solve_inputs, inputs):
+                tensor.from_numpy(value)
+            resolve_orig(self)
+            accelerations.append(qd_to_numpy(constraint_state.qacc, copy=True))
+
+    monkeypatch.setattr(ConstraintSolver, "resolve", resolve_compared)
+
     for i_step in range(N_STEPS):
-        compared.set_state(scenes[1].sim.cur_substep_local, reference.get_state())
-        compared_state.qacc_ws.from_numpy(qd_to_numpy(reference_state.qacc_ws, copy=True))
-        compared_state.is_warmstart.from_numpy(qd_to_numpy(reference_state.is_warmstart, copy=True))
+        scene.step()
+        assert not solver.get_error_envs_mask().any()
+        # Neither implementation may be compared on a solve that had nothing to resolve
+        assert (qd_to_numpy(constraint_state.n_constraints) > 32).all()
 
-        velocities = []
-        for scene, solver in zip(scenes, (reference, compared)):
-            scene.step()
-            assert not solver.get_error_envs_mask().any()
-            velocities.append(tensor_to_array(solver.get_dofs_velocity()))
-
-        # Neither arm may compare a solve that had nothing to resolve
-        assert (qd_to_numpy(compared_state.n_constraints) > 32).all()
-        # Velocities of a few hundredths, so the bound is absolute. It holds the arms to the rounding of their
-        # differently-ordered reductions, factors and solves, which a divergence in what the linesearch accepts exceeds.
-        assert_allclose(*velocities, atol=2e-5, err_msg=f"step {i_step}")
+        compared, reference = accelerations
+        # The two implementations spread every reduction, factor and solve differently, so their accelerations land
+        # within rounding of each other and never on the same value: a gap of exactly zero means one of them ran twice.
+        assert np.abs(compared.astype(np.float64) - reference.astype(np.float64)).max() > 0.0
+        assert_allclose(compared, reference, tol=tol, err_msg=f"step {i_step}")
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -6,6 +6,7 @@ import torch
 
 import genesis as gs
 import genesis.utils.geom as gu
+from genesis.utils.array_class import RigidSimStaticConfig
 from genesis.utils.misc import qd_to_numpy, tensor_to_array
 
 from ..utils import (
@@ -638,6 +639,84 @@ def test_cholesky_tiling(monkeypatch, tol):
 
     # analysis for choice tolerance: https://github.com/Genesis-Embodied-AI/Genesis/pull/2659#discussion_r3041684256
     assert_allclose(*values, tol=5e-4)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("backend", [gs.gpu])
+def test_solve_arm_equivalence(monkeypatch, show_viewer):
+    SIZE = 0.1
+    N_STEPS = 25
+
+    # Which implementations the dispatcher may pick is resolved once per built scene, so each arm needs its own build.
+    scenes = []
+    prefer_decomposed_solver = 0
+    init_orig = RigidSimStaticConfig.__init__
+
+    def init_forced(self, *args, **kwargs):
+        kwargs["prefer_decomposed_solver"] = prefer_decomposed_solver
+        init_orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(RigidSimStaticConfig, "__init__", init_forced)
+
+    for prefer_decomposed_solver in (0, 1):
+        scene = gs.Scene(
+            sim_options=gs.options.SimOptions(
+                dt=0.01,
+                gravity=(2.0, 0.0, -9.81),
+            ),
+            rigid_options=gs.options.RigidOptions(
+                friction_cone=gs.friction_cone.elliptic,
+            ),
+            viewer_options=gs.options.ViewerOptions(
+                camera_pos=(0.9, -0.9, 0.6),
+                camera_lookat=(0.1, 0.1, 0.05),
+            ),
+            show_viewer=show_viewer,
+        )
+        scene.add_entity(gs.morphs.Plane())
+        # A 3x3 base of boxes touching each other and the plane, plus a second layer seated on its seams, every body a
+        # ten-thousandth of its height into what carries it so the first solve resolves real depth, and gravity leaning
+        # sideways so the elliptic cones stay loaded in shear: one contact island spanning 78 DOFs and hundreds of
+        # constraint rows, enough for every cooperative reduction to stride over more than its 32 lanes.
+        for i in range(13):
+            offset, layer = (i % 3, i // 3) if i < 9 else (0.5 + (i - 9) % 2, 0.5 + (i - 9) // 2)
+            scene.add_entity(
+                morph=gs.morphs.Box(
+                    size=(SIZE, SIZE, SIZE),
+                    pos=(SIZE * offset, SIZE * layer, (1 - 1e-4) * SIZE * (0.5 if i < 9 else 1.5)),
+                ),
+                vis_mode="collision",
+            )
+        scene.build(n_envs=2)
+        # Eligibility is read off this field on every dispatch, so one value leaves exactly one implementation to run
+        # and a comparison cannot degenerate into the same one twice.
+        assert scene.rigid_solver.rigid_config.prefer_decomposed_solver == prefer_decomposed_solver
+        scenes.append(scene)
+
+    reference, compared = (scene.rigid_solver for scene in scenes)
+    reference_state = reference.constraint_solver.constraint_state
+    compared_state = compared.constraint_solver.constraint_state
+
+    # Both scenes solve the same problem every step: the compared arm is handed the reference arm's state along with the
+    # warm start it left, which the state setter clears on its own and which decides how close to the optimum the solve
+    # starts - the regime the linesearch refinement lives in. Resynchronizing every step keeps each comparison a single
+    # solve from a common state, while the trajectory still walks the pile through settling under shear.
+    for i_step in range(N_STEPS):
+        compared.set_state(scenes[1].sim.cur_substep_local, reference.get_state())
+        compared_state.qacc_ws.from_numpy(qd_to_numpy(reference_state.qacc_ws, copy=True))
+        compared_state.is_warmstart.from_numpy(qd_to_numpy(reference_state.is_warmstart, copy=True))
+
+        velocities = []
+        for scene, solver in zip(scenes, (reference, compared)):
+            scene.step()
+            assert not solver.get_error_envs_mask().any()
+            velocities.append(tensor_to_array(solver.get_dofs_velocity()))
+
+        # Neither arm may compare a solve that had nothing to resolve
+        assert (qd_to_numpy(compared_state.n_constraints) > 32).all()
+        # Velocities of a few hundredths, so the bound is absolute. It holds the arms to the rounding of their
+        # differently-ordered reductions, factors and solves, which a divergence in what the linesearch accepts exceeds.
+        assert_allclose(*velocities, atol=2e-5, err_msg=f"step {i_step}")
 
 
 @pytest.mark.slow  # ~200s


### PR DESCRIPTION
## Description

The two registered constraint-solve implementations must agree, since the dispatcher may pick either one on any step. Their linesearches did not, in three ways, all aligned here on the monolith:

- **Tolerance.** #3194 made the linesearch bound gradient-scaled and floored at the working precision, in `func_linesearch_batch` only, so the arm that runs on GPU kept the mass-scaled one - `4.456e-02` against `7.463e-07` on the same state. The gradient norm now rides the existing tree reduction.
- **Trial point.** `|grad/hess|`, abandoning the step on a non-positive curvature, becomes the signed `-grad/hess` with the curvature floored.
- **Accepted step.** The refinement's result is taken unconditionally, a stalled bracket rejects the step, and `ls_improvement` is written whatever its sign - the termination test reads a negative improvement as noise around the optimum and was being denied those values.

`ls_alpha_newton` becomes `ls_p0_deriv`, the derivative pair the refinement derives its trial step from and falls back on, which also drops a cooperative evaluation from that fallback.

## Motivation and Context

Quoted against the mean inertia, the bound tracks the model's mass rather than the gradient it bounds - the scale-dependence #3194 removed from the reference arm and not from the GPU one.

## How Has This Been / Can This Be Tested?

`test_dynamics.py::test_solve_arm_equivalence` (GPU only), on one scene carrying islands of one, three and nine bodies: the dispatcher's `__call__` is replaced to select by index among the candidates it deems eligible, and the inputs a solve mutates are restored between passes so both implementations solve the same problem. Per step the accelerations must agree within `tol` and differ by more than zero, since exactly zero means the selection stopped working.

Per solve from identical inputs, CUDA, 12 steps, 2 envs:

| | `qacc` | `ls_alpha` | `ls_it` mismatches |
|---|---|---|---|
| merge base, fp64 | 4.707e-14 | 6.550e-14 | 0 |
| this branch, fp64 | 4.707e-14 | 6.550e-14 | 0 |
| merge base, fp32 | 1.878e-06 | 7.838e-05 | 16 |
| this branch, fp32 | 1.878e-06 | 7.838e-05 | 8 |

fp64 agrees on the accepted step, the evaluation count and the acceleration before and after; in fp32 the acceleration and the step are identical between trees and only the evaluation count moves, so those count differences are rounding tipping refinement decisions rather than the threshold formula. A stack, a 3x3 pile, the elliptic cone at its Coulomb limit and scene scales from 0.02 to 100 agree to rounding on both trees too. The test passes on the merge base, so it locks the parity in rather than witnessing a regression: this change aligns the implementations in code, with no observable difference in the solve output on any scene tested.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
