### PR TITLE
[BREAKING][MISC] Remove deprecated 'compile_kernels' build arg.

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -76,7 +76,7 @@ def launch(filename=None, collision=False, rotate=False, scale=1.0, show_link_fr
                 f"{morphs.MJCF_FORMAT}, {morphs.MESH_FORMATS}, or {morphs.USD_FORMATS}."
             )
 
-    scene.build(compile_kernels=False)
+    scene.build()
 
     # 'enable_gui=True' auto-attaches the ImGui overlay, which owns the simulation through an InteractiveScene:
     # play/pause/step/reset and per-joint sliders (editable while paused) live in the overlay. Start paused so the

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -868,7 +868,6 @@ class Scene(RBC):
         env_spacing=(0.0, 0.0),
         n_envs_per_row: int | None = None,
         center_envs_at_origin=True,
-        compile_kernels=None,
     ):
         """
         Builds the scene once all entities have been added. This operation is required before running the simulation.
@@ -886,12 +885,7 @@ class Scene(RBC):
             The number of environments per row for visualization. If None, it will be set to `sqrt(n_envs)`.
         center_envs_at_origin : bool
             Whether to put the center of all the environments at the origin (for visualization only).
-        compile_kernels : bool, optional
-            This parameter is deprecated and will be removed in future release.
         """
-        if compile_kernels is not None:
-            warn_once("`compile_kernels` is deprecated and will be removed in future release.")
-            compile_kernels = True
 
         # Start tracking the scene right away, so that destroy is called even if some error fires during build
         def _destroy_callback(scene_ref: weakref.ReferenceType["Scene"]):


### PR DESCRIPTION
## Description

`scene.build(compile_kernels=...)` has been a no-op emitting a deprecation warning for a while now. This PR removes the argument.

## Related Issue
Resolves https://github.com/Genesis-Embodied-AI/genesis-world/discussions/2517

## Motivation and Context
Confusing warning.

## How Has This Been / Can This Be Tested?

## Screenshots (if appropriate):

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.