### PR TITLE
[FEATURE] Add bit-exact deterministic simulation mode on a given hardware.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -49,6 +49,7 @@ device: torch.device | None = None
 backend: _gs_backend | None = None
 use_ndarray: bool | None = None
 use_zerocopy: bool | None = None
+use_deterministic_algorithms: bool | None = None
 EPS: float | None = None
 
 
@@ -64,6 +65,7 @@ def init(
     theme="dark",
     logger_verbose_time=False,
     performance_mode=False,
+    use_deterministic_algorithms=False,
 ):
     global _initialized
     if _initialized:
@@ -159,6 +161,10 @@ def init(
         if _use_zerocopy:
             raise_exception(f"Zero-copy not supported on {backend} backend.")
     use_zerocopy = bool(_use_zerocopy)
+
+    # Reproducing a rollout means settling the runtime-measured choices the simulation would otherwise keep revisiting
+    # (see prefer_decomposed_solver in rigid_solver.py), at the cost of the throughput they were buying, hence opt-in.
+    globals()["use_deterministic_algorithms"] = use_deterministic_algorithms
 
     # Define the right dtypes in accordance with selected backend and precision
     global qd_float, np_float, tc_float

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -747,8 +747,8 @@ class RigidSolver(KinematicSolver):
 
                 # The autotuner picks between two numerically distinct arms by timing them as the simulation runs, so
                 # which one runs at a given step follows the machine rather than the scene. Pinning the arm is what
-                # makes a trajectory reproducible, and the decomposed one is worth keeping wherever it engages at all,
-                # every case the monolith wins being pinned above already.
+                # makes a trajectory reproducible; the decomposed one takes whatever the static scene description
+                # leaves open, every case that description settles in the monolith's favor being pinned above already.
                 if gs.use_deterministic_algorithms and rigid_config.get("prefer_decomposed_solver", -1) == -1:
                     rigid_config["prefer_decomposed_solver"] = 1
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -745,6 +745,13 @@ class RigidSolver(KinematicSolver):
                     # arm has nothing to exploit, so the scalar one-thread-per-env monolith is the clear winner.
                     rigid_config["prefer_decomposed_solver"] = 0
 
+                # The autotuner picks between two numerically distinct arms by timing them as the simulation runs, so
+                # which one runs at a given step follows the machine rather than the scene. Pinning the arm is what
+                # makes a trajectory reproducible, and the decomposed one is worth keeping wherever it engages at all,
+                # every case the monolith wins being pinned above already.
+                if gs.use_deterministic_algorithms and rigid_config.get("prefer_decomposed_solver", -1) == -1:
+                    rigid_config["prefer_decomposed_solver"] = 1
+
             # Add terms for static inner loops, use -1 if not requires_grad to avoid re-compilation
             if self.sim.options.requires_grad:
                 rigid_config.update(

--- a/tests/benchmarks/test_rigid.py
+++ b/tests/benchmarks/test_rigid.py
@@ -28,6 +28,8 @@ pytestmark = [
     pytest.mark.benchmarks,
     pytest.mark.cache(False),
     pytest.mark.debug(False),
+    # Benchmarks measure the solve implementation the autotuner actually settles on, so the choice is left to it
+    pytest.mark.use_deterministic_algorithms(False),
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -743,8 +743,23 @@ def debug(request):
     return debug
 
 
+@pytest.fixture
+def use_deterministic_algorithms(request):
+    use_deterministic_algorithms = None
+    for mark in request.node.iter_markers("use_deterministic_algorithms"):
+        if mark.args:
+            if use_deterministic_algorithms is not None:
+                pytest.fail("'use_deterministic_algorithms' can only be specified once.")
+            (use_deterministic_algorithms,) = mark.args
+    if use_deterministic_algorithms is None:
+        use_deterministic_algorithms = True
+    return use_deterministic_algorithms
+
+
 @pytest.fixture(scope="function", autouse=True)
-def initialize_genesis(request, monkeypatch, tmp_path, backend, precision, performance_mode, debug, cache):
+def initialize_genesis(
+    request, monkeypatch, tmp_path, backend, precision, performance_mode, debug, cache, use_deterministic_algorithms
+):
     import genesis as gs
 
     # Early return if backend is None
@@ -801,23 +816,9 @@ def initialize_genesis(request, monkeypatch, tmp_path, backend, precision, perfo
             seed=0,
             logging_level=logging_level,
             performance_mode=performance_mode,
+            use_deterministic_algorithms=use_deterministic_algorithms,
         )
         gc.collect()
-
-        # Prefer the decomposed solver on GPU so both code paths (decomposed on GPU, monolith on CPU) are tested
-        # Skip for benchmarks - let auto-detection choose freely
-        expr = Expression.compile(request.config.option.markexpr)
-        is_benchmarks = expr.evaluate(MarkMatcher.from_markers((pytest.mark.benchmarks,)))
-        if not is_benchmarks:
-            from genesis.utils.array_class import RigidSimStaticConfig
-
-            _RigidSimStaticConfig_init_orig = RigidSimStaticConfig.__init__
-
-            def _RigidSimStaticConfig_init(self, *args, **kwargs):
-                kwargs.setdefault("prefer_decomposed_solver", int(gs.backend != gs.cpu))
-                _RigidSimStaticConfig_init_orig(self, *args, **kwargs)
-
-            monkeypatch.setattr(RigidSimStaticConfig, "__init__", _RigidSimStaticConfig_init)
 
         if gs.backend != gs.cpu and gs.device.index is not None:
             # The device torch selected must be one this worker is allowed to use. Anything else - including a

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -1233,9 +1233,9 @@ def test_gpu_simulation_determinism(prefer_decomposed_solver, contact_pruning_to
     #   - contact set    -> narrowphase / pruning
     #   - contact order  -> contact sort
     #   - dofs velocity  -> constraint solve
-    if prefer_decomposed_solver is not None:
-        from genesis.utils.array_class import RigidSimStaticConfig
+    from genesis.utils.array_class import RigidSimStaticConfig
 
+    if prefer_decomposed_solver is not None:
         init_orig = RigidSimStaticConfig.__init__
 
         def init_forced(self, *args, **kwargs):

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -1209,14 +1209,22 @@ def test_contype_conaffinity(show_viewer, tol):
 @pytest.mark.precision("32")
 @pytest.mark.parametrize("backend", [gs.gpu])
 @pytest.mark.parametrize("contact_pruning_tolerance", [0.02, None], ids=["prune", "noprune"])
-@pytest.mark.parametrize("prefer_decomposed_solver", [0, 1], ids=["monolith", "decomposed"])
+@pytest.mark.parametrize(
+    "prefer_decomposed_solver",
+    [
+        pytest.param(False, marks=pytest.mark.use_deterministic_algorithms(False)),
+        pytest.param(True, marks=pytest.mark.use_deterministic_algorithms(False)),
+        None,
+    ],
+    ids=["monolith", "decomposed", "deterministic"],
+)
 def test_gpu_simulation_determinism(prefer_decomposed_solver, contact_pruning_tolerance, monkeypatch, show_viewer):
     # Run-to-run reproducibility on GPU: from an identical initial state, every trial must reproduce a bit-identical
     # trajectory. CPU is serialized and deterministic by construction, so this targets GPU parallel races only
     # (atomic_add slot reservation, parallel reductions, scheduling). The two registered solve implementations are
-    # numerically distinct, so each is pinned via prefer_decomposed_solver (0 -> monolith, 1 -> decomposed) to bypass
-    # the perf-dispatch autotuner, whose timing-based choice between them is a separate nondeterminism source; this
-    # isolates physics-kernel determinism per variant.
+    # numerically distinct, so each is pinned via prefer_decomposed_solver to isolate physics-kernel determinism per
+    # variant. The third case asks for neither and runs under 'use_deterministic_algorithms', whose job is precisely
+    # to resolve that choice itself instead of leaving it to a timing measurement that varies with machine load.
     #
     # The authored-decomposition tower is the stress case: stacked rings pre-split into convex wedges produce many
     # multi-contact manifolds per geom pair, exercising the narrowphase, contact pruning, the contact sort, and the
@@ -1225,15 +1233,16 @@ def test_gpu_simulation_determinism(prefer_decomposed_solver, contact_pruning_to
     #   - contact set    -> narrowphase / pruning
     #   - contact order  -> contact sort
     #   - dofs velocity  -> constraint solve
-    from genesis.utils.array_class import RigidSimStaticConfig
+    if prefer_decomposed_solver is not None:
+        from genesis.utils.array_class import RigidSimStaticConfig
 
-    init_orig = RigidSimStaticConfig.__init__
+        init_orig = RigidSimStaticConfig.__init__
 
-    def init_forced(self, *args, **kwargs):
-        kwargs["prefer_decomposed_solver"] = prefer_decomposed_solver
-        init_orig(self, *args, **kwargs)
+        def init_forced(self, *args, **kwargs):
+            kwargs["prefer_decomposed_solver"] = int(prefer_decomposed_solver)
+            init_orig(self, *args, **kwargs)
 
-    monkeypatch.setattr(RigidSimStaticConfig, "__init__", init_forced)
+        monkeypatch.setattr(RigidSimStaticConfig, "__init__", init_forced)
 
     N_TRIALS = 8
     N_STEPS = 25

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -9,7 +9,6 @@ import genesis as gs
 import genesis.utils.geom as gu
 from genesis.engine.solvers.rigid.constraint import solver as constraint_solver
 from genesis.engine.solvers.rigid.constraint.solver import ConstraintSolver
-from genesis.utils.array_class import RigidSimStaticConfig
 from genesis.utils.misc import qd_to_numpy, tensor_to_array
 
 from ..utils.assertions import assert_allclose, assert_equal
@@ -641,20 +640,11 @@ def test_cholesky_tiling(monkeypatch, tol):
 
 
 @pytest.mark.required
+@pytest.mark.use_deterministic_algorithms(False)
 @pytest.mark.parametrize("backend", [gs.gpu])
 def test_solve_arm_equivalence(monkeypatch, show_viewer, tol):
     SIZE = 0.1
     N_STEPS = 12
-
-    # Dispatch dynamically whatever the suite or the caller pinned: eligibility is filtered on this field, so only its
-    # own default leaves both implementations in the running.
-    init_orig = RigidSimStaticConfig.__init__
-
-    def init_dynamic(self, *args, **kwargs):
-        kwargs["prefer_decomposed_solver"] = -1
-        init_orig(self, *args, **kwargs)
-
-    monkeypatch.setattr(RigidSimStaticConfig, "__init__", init_dynamic)
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(


### PR DESCRIPTION
## Description

Adds `use_deterministic_algorithms` to `gs.init`, off by default. When enabled, the implementation of every performance-dispatched computation is settled at build time rather than picked by timing candidates as the simulation runs, so a rollout replays bit-for-bit on a given machine.

The test suite runs deterministic by default, which replaces the `prefer_decomposed_solver` monkeypatch in `conftest.py`. Benchmarks and the two tests that drive dispatching themselves opt out with `@pytest.mark.use_deterministic_algorithms(False)`.

## Motivation and Context

Interchangeable implementations agree only to within floating-point noise, so which one ran at which step is part of the trajectory, and the timing that picks them follows machine load and everything the process ran before. Comparing two runs or tracking down a divergence is out of reach until that choice is settled.

It stays opt-in because settling it costs whatever throughput the measurement was buying, by an amount that depends on the scene and on how far its state travels.

## How Has This Been / Can This Be Tested?

`test_gpu_simulation_determinism` gains a case that pins no implementation and runs under the flag:

```
pytest tests/rigid/test_collision.py::test_gpu_simulation_determinism
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed. See Genesis-Embodied-AI/genesis-doc#143.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
