### PR TITLE
[BUG FIX] Always give recorded videos a valid default filename.

### DIFF
--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -235,6 +235,19 @@ def fits_in_gpu_shared_memory(*dims: int) -> bool:
     return math.prod(dims) * itemsize <= qd.lang.impl.get_max_shared_memory_bytes(is_lowerbound_ok=True)
 
 
+def get_entry_point_name():
+    """
+    Name of the script the process was launched from, without directory nor extension.
+
+    Falls back to 'genesis' whenever the process has no script to be named after, as when running interactively or
+    through 'python -c', so that a name derived from it is always a valid filename.
+    """
+    entry_point = sys.argv[0]
+    if not os.path.isfile(entry_point):
+        return "genesis"
+    return os.path.splitext(os.path.basename(entry_point))[0]
+
+
 def get_src_dir():
     return os.path.dirname(gs.__file__)
 

--- a/genesis/utils/tools.py
+++ b/genesis/utils/tools.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import time
 
@@ -7,6 +6,7 @@ import quadrants as qd
 from PIL import Image
 
 import genesis as gs
+from genesis.utils.misc import get_entry_point_name
 
 
 def animate(imgs, filename=None, fps=60):
@@ -15,7 +15,8 @@ def animate(imgs, filename=None, fps=60):
 
     Args:
         imgs (list): List of input images.
-        filename (str, optional): Name of the output video file. If not provided, the name will be default to the name of the caller file, with a timestamp and '.mp4' extension.
+        filename (str, optional): Name of the output video file. If not provided, the name will default to the name
+            of the script the process was launched from, with a timestamp and '.mp4' extension.
     """
     assert isinstance(imgs, list)
     if len(imgs) == 0:
@@ -23,9 +24,7 @@ def animate(imgs, filename=None, fps=60):
         return
 
     if filename is None:
-        caller_file = inspect.stack()[-1].filename
-        # caller file + timestamp + .mp4
-        filename = os.path.splitext(os.path.basename(caller_file))[0] + f"_{time.strftime('%Y%m%d_%H%M%S')}.mp4"
+        filename = f"{get_entry_point_name()}_{time.strftime('%Y%m%d_%H%M%S')}.mp4"
     os.makedirs(os.path.abspath(os.path.dirname(filename)), exist_ok=True)
 
     gs.logger.info(f'Saving video to ~<"{filename}">~...')

--- a/genesis/vis/camera.py
+++ b/genesis/vis/camera.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import time
 from functools import cached_property
@@ -11,7 +10,7 @@ import genesis.utils.geom as gu
 from genesis.constants import IMAGE_TYPE
 from genesis.repr_base import RBC
 from genesis.utils.image_exporter import as_grayscale_image
-from genesis.utils.misc import tensor_to_array
+from genesis.utils.misc import get_entry_point_name, tensor_to_array
 from genesis.utils.video_encoder import VideoEncoder
 
 RECORDING_DEFAULT_FPS = 60
@@ -738,8 +737,8 @@ class Camera(RBC):
         Parameters
         ----------
         save_to_filename : str, optional
-            Name of the output video file, ending in '.mp4'. Defaults to the name of the caller file, with camera
-            idx, a timestamp and '.mp4' extension.
+            Name of the output video file, ending in '.mp4'. Defaults to the name of the script the process was
+            launched from, with camera idx, a timestamp and '.mp4' extension.
         fps : float, optional
             Framerate of the recorded video. A low framerate keeps the file small and spares the renderer, at the
             cost of temporal resolution; a high one resolves fast motion. One second of video always covers one
@@ -762,11 +761,7 @@ class Camera(RBC):
         if fps <= 0.0:
             gs.raise_exception("Framerate of a recording must be positive.")
         if save_to_filename is None:
-            caller_file = inspect.stack()[-1].filename
-            save_to_filename = (
-                os.path.splitext(os.path.basename(caller_file))[0]
-                + f"_cam_{self.idx}_{time.strftime('%Y%m%d_%H%M%S')}.mp4"
-            )
+            save_to_filename = f"{get_entry_point_name()}_cam_{self.idx}_{time.strftime('%Y%m%d_%H%M%S')}.mp4"
 
         # A realtime factor left unset means running as fast as possible, which carries no time scale to honor.
         viewer = self._visualizer.viewer


### PR DESCRIPTION
## Description

The default filename of a recorded video is now derived from the entry-point script rather than from the bottom frame of the call stack, which is a pseudo-filename whenever the process was not launched from a script.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3178

## Motivation and Context

`inspect.stack()[-1].filename` is `<frozen runpy>` under `python -m`, `<string>` under `python -c` and `<stdin>` on piped input, so `camera.start_recording()` and `gs.tools.animate()` used to write `<frozen runpy>_cam_0_20260813_163150.mp4`, a name containing characters Windows reserves. `sys.argv[0]` names the script in both the `python -m` and the plain script case, and falls back to `genesis` when there is no script at all.

## How Has This Been / Can This Be Tested?

Record a video without passing a filename and launch the script with `python -m`: the video is now named after the script instead of `<frozen runpy>`.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
