### PR TITLE
[BUG FIX] Make successive trajectories bit-identical from the reset onwards.

### DIFF
--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1884,6 +1884,12 @@ class RigidSolver(KinematicSolver):
 
             state = RigidSolverState(self._scene, s_global)
 
+            # A captured state must be self-consistent: links_pos / links_quat have to be the Cartesian pose implied by
+            # the qpos captured alongside them, otherwise restoring it does not reproduce the configuration it was taken
+            # from. The step loop leaves that pose one integration behind qpos whenever it defers the post-integrate
+            # refresh, so catch up here - a no-op when the pose is already current, which is the common case.
+            self.update_forward_pos()
+
             kernel_get_state(
                 state.i_pos_shift,
                 state.qpos,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -3485,12 +3485,6 @@ def kernel_step_2(
 
     func_integrate(dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
 
-    if qd.static(rigid_config.use_hibernation):
-        func_hibernate__for_all_awake_islands_either_hiberanate_or_update_aabb_sort_buffer(
-            dyn_state, collider_state, constraint_state, dyn_info, rigid_info, rigid_config, errno
-        )
-        func_aggregate_awake_entities(dyn_state, dyn_info, rigid_info, rigid_config)
-
     if qd.static(not is_backward):
         func_copy_next_to_curr(dyn_state, rigid_info, rigid_config, errno)
 
@@ -3499,3 +3493,12 @@ def kernel_step_2(
                 dyn_state, dyn_info, rigid_info, rigid_config, force_update_fixed_geoms=False, is_backward=is_backward
             )
             func_forward_velocity(dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
+
+    # Hibernating comes last, after the post-integrate refresh above: both only visit awake entities, so deciding to
+    # sleep first would drop the newly-hibernated island from that refresh and freeze its Cartesian pose one
+    # integration behind the qpos this step just advanced, for as long as it sleeps.
+    if qd.static(rigid_config.use_hibernation):
+        func_hibernate__for_all_awake_islands_either_hiberanate_or_update_aabb_sort_buffer(
+            dyn_state, collider_state, constraint_state, dyn_info, rigid_info, rigid_config, errno
+        )
+        func_aggregate_awake_entities(dyn_state, dyn_info, rigid_info, rigid_config)

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -900,10 +900,32 @@ def test_axis_aligned_bounding_boxes(n_envs):
 
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
-def test_reset(show_viewer):
+@pytest.mark.parametrize(
+    "friction_cone, sparse_solve, use_hibernation, enable_mujoco_compatibility",
+    [
+        (gs.friction_cone.pyramidal, None, False, False),
+        # Every feature holding or reusing a buffer across steps at once: the elliptic cone keeps a cone-free Hessian
+        # mirror, the sparse solve zeroes each Jacobian row through the pattern the previous step left, hibernation
+        # sleeps both boxes before the state is captured so the reset has to wake them, and MuJoCo compatibility reads
+        # the warm-start acceleration unconditionally.
+        (gs.friction_cone.elliptic, True, True, True),
+    ],
+    ids=["default", "extreme"],
+)
+def test_reset(show_viewer, friction_cone, sparse_solve, use_hibernation, enable_mujoco_compatibility):
     BOOL_MASK = torch.tensor([True, False, True, False], dtype=torch.bool, device=gs.device)
 
     scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            friction_cone=friction_cone,
+            sparse_solve=sparse_solve,
+            use_hibernation=use_hibernation,
+            enable_mujoco_compatibility=enable_mujoco_compatibility,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.0, -2.5, 1.2),
+            camera_lookat=(1.0, 0.0, 0.05),
+        ),
         show_viewer=show_viewer,
     )
     scene.add_entity(
@@ -912,54 +934,80 @@ def test_reset(show_viewer):
             fixed=True,
         )
     )
-    scene.add_entity(
+    box = scene.add_entity(
         gs.morphs.Box(
             size=(0.1, 0.1, 0.1),
             pos=(0, 0, 0.5),
         )
     )
+    # Far enough from the first box to never interact, so each lands in its own island - the structure hibernation
+    # needs to engage.
+    scene.add_entity(
+        gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+            pos=(2.0, 0, 0.5),
+        )
+    )
     scene.build(n_envs=4)
+
+    # Every position- and velocity-level accessor must read the same in a restored state as it did at capture, starting
+    # before the first step that follows the reset. Acceleration only matches from the first step onwards: a restored
+    # state derives it from the restored velocity, while the capture reflects the refresh the setter left pending.
+    GETTERS = (
+        box.get_pos,
+        box.get_quat,
+        box.get_vel,
+        box.get_ang,
+        box.get_links_pos,
+        box.get_links_quat,
+        box.get_links_vel,
+        box.get_links_ang,
+        box.get_dofs_position,
+        box.get_dofs_velocity,
+    )
+    ACC_GETTERS = (
+        box.get_links_acc,
+        box.get_links_acc_ang,
+    )
 
     init_state = scene.get_state()
     init_rigid_state = next(s for s in init_state.solvers_state if isinstance(s, RigidSolverState))
-    for _ in range(50):
+    init_getters = tuple(getter() for getter in GETTERS)
+    # The horizon reaches past the point where both boxes come to rest, so the captured state is taken with them
+    # already hibernated whenever hibernation is enabled.
+    for _ in range(60):
         scene.step()
     fallen_state = scene.get_state()
     fallen_rigid_state = next(s for s in fallen_state.solvers_state if isinstance(s, RigidSolverState))
+    fallen_getters = tuple(getter() for getter in GETTERS)
+    fallen_acc_getters = tuple(getter() for getter in ACC_GETTERS)
 
     for envs_idx in (BOOL_MASK, torch.where(BOOL_MASK)[0]):
         scene.reset(state=fallen_state)
         scene.reset(state=init_state, envs_idx=envs_idx)
+        restored_rigid_state = next(s for s in scene.get_state().solvers_state if isinstance(s, RigidSolverState))
+        restored_getters = tuple(getter() for getter in GETTERS)
         for actual, init_ref, fallen_ref in (
-            (
-                qd_to_torch(scene.rigid_solver.rigid_info.qpos, transpose=True, copy=True),
-                init_rigid_state.qpos,
-                fallen_rigid_state.qpos,
-            ),
-            (
-                qd_to_torch(scene.rigid_solver.dyn_state.dofs.vel, transpose=True, copy=True),
-                init_rigid_state.dofs_vel,
-                fallen_rigid_state.dofs_vel,
-            ),
-            (
-                qd_to_torch(scene.rigid_solver.dyn_state.links.pos, transpose=True, copy=True),
-                init_rigid_state.links_pos,
-                fallen_rigid_state.links_pos,
-            ),
+            (restored_rigid_state.qpos, init_rigid_state.qpos, fallen_rigid_state.qpos),
+            (restored_rigid_state.dofs_vel, init_rigid_state.dofs_vel, fallen_rigid_state.dofs_vel),
+            (restored_rigid_state.links_pos, init_rigid_state.links_pos, fallen_rigid_state.links_pos),
+            *zip(restored_getters, init_getters, fallen_getters),
         ):
             assert_allclose(actual[BOOL_MASK], init_ref[BOOL_MASK], tol=gs.EPS)
             assert_allclose(actual[~BOOL_MASK], fallen_ref[~BOOL_MASK], tol=gs.EPS)
 
     # After reset, simulation from init_state should reproduce the original fallen_state trajectory
-    for _ in range(50):
+    for _ in range(60):
         scene.step()
+    replayed_rigid_state = next(s for s in scene.get_state().solvers_state if isinstance(s, RigidSolverState))
+    replayed_getters = tuple(getter() for getter in GETTERS)
+    replayed_acc_getters = tuple(getter() for getter in ACC_GETTERS)
     for actual, fallen_ref in (
-        (qd_to_torch(scene.rigid_solver.rigid_info.qpos, transpose=True, copy=True), fallen_rigid_state.qpos),
-        (qd_to_torch(scene.rigid_solver.dyn_state.dofs.vel, transpose=True, copy=True), fallen_rigid_state.dofs_vel),
-        (
-            qd_to_torch(scene.rigid_solver.dyn_state.links.pos, transpose=True, copy=True),
-            fallen_rigid_state.links_pos,
-        ),
+        (replayed_rigid_state.qpos, fallen_rigid_state.qpos),
+        (replayed_rigid_state.dofs_vel, fallen_rigid_state.dofs_vel),
+        (replayed_rigid_state.links_pos, fallen_rigid_state.links_pos),
+        *zip(replayed_getters, fallen_getters),
+        *zip(replayed_acc_getters, fallen_acc_getters),
     ):
         assert_allclose(actual[BOOL_MASK], fallen_ref[BOOL_MASK], tol=gs.EPS)
 

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -8,9 +8,9 @@ import torch
 import genesis as gs
 import genesis.utils.geom as gu
 from genesis.engine.states.solvers import RigidSolverState
-from genesis.utils.misc import qd_to_torch
+from genesis.utils.misc import qd_to_numpy, qd_to_torch
 
-from ..utils.assertions import assert_allclose
+from ..utils.assertions import assert_allclose, assert_equal
 
 
 @pytest.mark.slow  # ~200s
@@ -904,15 +904,18 @@ def test_axis_aligned_bounding_boxes(n_envs):
     "friction_cone, sparse_solve, use_hibernation, enable_mujoco_compatibility",
     [
         (gs.friction_cone.pyramidal, None, False, False),
-        # Every feature holding or reusing a buffer across steps at once: the elliptic cone keeps a cone-free Hessian
-        # mirror, the sparse solve zeroes each Jacobian row through the pattern the previous step left, hibernation
-        # sleeps both boxes before the state is captured so the reset has to wake them, and MuJoCo compatibility reads
-        # the warm-start acceleration unconditionally.
-        (gs.friction_cone.elliptic, True, True, True),
+        # Hibernation sleeps both boxes before the state is captured, so the reset has to wake them. It needs its own
+        # cell because MuJoCo compatibility lowers the rest threshold to a velocity this scene never reaches, which
+        # would leave the sleeping path unexercised.
+        (gs.friction_cone.pyramidal, None, True, False),
+        # The buffers a step leaves behind: the elliptic cone keeps a cone-free Hessian mirror, the sparse solve zeroes
+        # each Jacobian row through the pattern the previous step left, and MuJoCo compatibility reads the warm-start
+        # acceleration unconditionally.
+        (gs.friction_cone.elliptic, True, False, True),
     ],
-    ids=["default", "extreme"],
 )
 def test_reset(show_viewer, friction_cone, sparse_solve, use_hibernation, enable_mujoco_compatibility):
+    N_STEPS = 60
     BOOL_MASK = torch.tensor([True, False, True, False], dtype=torch.bool, device=gs.device)
 
     scene = gs.Scene(
@@ -940,9 +943,9 @@ def test_reset(show_viewer, friction_cone, sparse_solve, use_hibernation, enable
             pos=(0, 0, 0.5),
         )
     )
-    # Far enough from the first box to never interact, so each lands in its own island - the structure hibernation
-    # needs to engage.
-    scene.add_entity(
+    # Far enough from the first box to never interact, so the scene splits into one island each - the structure
+    # hibernation needs to engage.
+    box_far = scene.add_entity(
         gs.morphs.Box(
             size=(0.1, 0.1, 0.1),
             pos=(2.0, 0, 0.5),
@@ -973,10 +976,13 @@ def test_reset(show_viewer, friction_cone, sparse_solve, use_hibernation, enable
     init_state = scene.get_state()
     init_rigid_state = next(s for s in init_state.solvers_state if isinstance(s, RigidSolverState))
     init_getters = tuple(getter() for getter in GETTERS)
-    # The horizon reaches past the point where both boxes come to rest, so the captured state is taken with them
-    # already hibernated whenever hibernation is enabled.
-    for _ in range(60):
+    # The horizon reaches past the point where both boxes come to rest, so the state is captured with them asleep
+    # whenever hibernation is enabled, and the reset has to wake them.
+    for _ in range(N_STEPS):
         scene.step()
+    if use_hibernation:
+        for entity in (box, box_far):
+            assert qd_to_numpy(scene.rigid_solver.dyn_state.links.is_hibernated, entity.base_link_idx).all()
     fallen_state = scene.get_state()
     fallen_rigid_state = next(s for s in fallen_state.solvers_state if isinstance(s, RigidSolverState))
     fallen_getters = tuple(getter() for getter in GETTERS)
@@ -993,11 +999,11 @@ def test_reset(show_viewer, friction_cone, sparse_solve, use_hibernation, enable
             (restored_rigid_state.links_pos, init_rigid_state.links_pos, fallen_rigid_state.links_pos),
             *zip(restored_getters, init_getters, fallen_getters),
         ):
-            assert_allclose(actual[BOOL_MASK], init_ref[BOOL_MASK], tol=gs.EPS)
-            assert_allclose(actual[~BOOL_MASK], fallen_ref[~BOOL_MASK], tol=gs.EPS)
+            assert_equal(actual[BOOL_MASK], init_ref[BOOL_MASK])
+            assert_equal(actual[~BOOL_MASK], fallen_ref[~BOOL_MASK])
 
     # After reset, simulation from init_state should reproduce the original fallen_state trajectory
-    for _ in range(60):
+    for _ in range(N_STEPS):
         scene.step()
     replayed_rigid_state = next(s for s in scene.get_state().solvers_state if isinstance(s, RigidSolverState))
     replayed_getters = tuple(getter() for getter in GETTERS)
@@ -1009,7 +1015,7 @@ def test_reset(show_viewer, friction_cone, sparse_solve, use_hibernation, enable
         *zip(replayed_getters, fallen_getters),
         *zip(replayed_acc_getters, fallen_acc_getters),
     ):
-        assert_allclose(actual[BOOL_MASK], fallen_ref[BOOL_MASK], tol=gs.EPS)
+        assert_equal(actual[BOOL_MASK], fallen_ref[BOOL_MASK])
 
 
 @pytest.mark.slow  # ~350s


### PR DESCRIPTION
## Description

Two fixes making a restored state reproduce the configuration it was captured from, so successive trajectories are bit-identical from the reset onwards, including before the first step that follows it.

`RigidSolver.get_state` brings forward kinematics up to date before capturing, so a captured state's `links_pos` / `links_quat` are the Cartesian pose implied by the `qpos` captured alongside them.

`kernel_step_2` now decides who hibernates *after* the post-integrate Cartesian refresh instead of before it. Both only visit awake entities, so sleeping first dropped the newly-hibernated island from that refresh and froze its pose one integration behind the `qpos` the step had just advanced - for as long as it slept. Every reader saw it: `get_pos`, `get_links_pos` and `get_state` all reported a pose the body's own `qpos` contradicted.

`tests/rigid/test_api.py::test_reset` grows the coverage that pins this down: two extra parametrization cells, a second box far enough away to never interact, public-getter assertions on top of the existing state comparison, and exact comparisons instead of a near-zero tolerance.

## Related Issue

Follow-up to Genesis-Embodied-AI/genesis-world#3229, which reported that `Scene.reset()` leaves `ConstraintSolver.constraint_state` and `island_state` untouched and claimed this makes the outcome depend on pre-reset scene activity. It does not: those fields are per-step scratch rewritten before they are read, and everything genuinely carried across steps was already cleared. That issue was closed as not planned, but auditing it surfaced the two defects fixed here.

## Motivation and Context

The reset path was only covered at default solver options, leaving the features whose buffers survive a step unverified. The added cells cover them: the elliptic cone keeps a cone-free Hessian mirror in `nt_H`, the sparse solve zeroes each Jacobian row through the pattern the previous step left in `jac_n_dofs` / `jac_dofs_idx`, MuJoCo compatibility reads `qacc_ws` on every step with no warm-start gate, and hibernation sleeps a settled body that the reset then has to wake.

Hibernation gets its own cell rather than joining the others: MuJoCo compatibility lowers the rest threshold to a velocity this scene never reaches, so combining them leaves the sleeping path unexercised. The cell asserts both boxes are actually asleep before the state is captured, which is what caught the pose-freezing bug - and the boxes need a second, well-separated body to land in separate islands at all, since a single box on a plane is one island and never sleeps.

The horizon is 60 steps because both boxes come to rest around step 51 on cpu and on Metal, so the capture happens with them asleep.

The pose refresh in `get_state` costs nothing on the default path: the step loop already leaves the derived state current, so the catch-up returns immediately. Counting forward-kinematics passes over 20 steps, calling `get_state` on every step adds none of them. Under MuJoCo compatibility, where the step loop defers that refresh, the pass moves out of `kernel_step_1` instead of adding to it, since both are gated on the same flag.

Acceleration is compared from the first step onwards rather than at the pre-first-step point: a restored state derives it from the restored velocity, while the capture still reflects the refresh left pending by the setter that established that velocity.

## How Has This Been / Can This Be Tested?

`pytest tests/rigid/test_api.py -k test_reset` on the `cpu` and `gpu` backends, plus `tests/rigid/test_islands.py` (which exercises hibernation directly), `tests/rigid/test_kinematics.py`, `tests/sensors/test_raycaster.py` and the full `tests/rigid/test_mujoco_parity.py`.

The pose-freezing fix is checked directly by stepping a body through its sleep transition and comparing `links.pos` against `qpos` for a free-joint box, where the two must be equal: the gap appeared exactly on the step the body fell asleep and stayed frozen at `1.16e-6` (`v*dt` at the rest threshold) for every later step, and is `0` throughout afterwards, awake and asleep, on both backends.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
