### PR TITLE
[MISC] Support Inverse Kinematics and Jacobians for any entity unconditionally.

### DIFF
--- a/examples/rigid/ik_duck.py
+++ b/examples/rigid/ik_duck.py
@@ -32,7 +32,6 @@ def main():
             file="meshes/duck.obj",
             scale=0.06,
             pos=(3.5, -1.5, 0.7),
-            requires_jac_and_IK=True,
         ),
     )
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2705,7 +2705,6 @@ class RigidEntity(KinematicEntity):
 
     def _load_model(self):
         self._equalities = gs.List()
-        self._requires_jac_and_IK = self._morph.requires_jac_and_IK
         # MJCF and USD express in-model collision filtering (MJCF '<contact><exclude>', USD CollisionGroup /
         # FilteredPairsAPI) through synthesized contype/conaffinity bitmasks. Those masks are only consistent within
         # the entity: applied across entities, they would spuriously disable collision against geoms whose default
@@ -2770,9 +2769,6 @@ class RigidEntity(KinematicEntity):
         # (a small NumPy array, also read by path planning) and the IK error dimensions. The Jacobian / IK scratch
         # `qd.field`s are allocated lazily on first use (in `get_jacobian` / `inverse_kinematics_multilink`) so that
         # entities which never query the Jacobian or run IK do not each add a per-entity field bundle to the SNode tree.
-        if not self._requires_jac_and_IK:
-            return
-
         if self.n_dofs == 0:
             return
 
@@ -2955,11 +2951,6 @@ class RigidEntity(KinematicEntity):
         jacobian : torch.Tensor
             The Jacobian matrix of shape (n_envs, 6, entity.n_dofs) or (6, entity.n_dofs) if n_envs == 0.
         """
-        if not self._requires_jac_and_IK:
-            gs.raise_exception(
-                "Inverse kinematics and jacobian are disabled for this entity. Set `morph.requires_jac_and_IK` to True if you need them."
-            )
-
         if self.n_dofs == 0:
             gs.raise_exception("Entity has zero dofs.")
 
@@ -3263,11 +3254,6 @@ class RigidEntity(KinematicEntity):
         from genesis.engine.solvers.rigid.abd.inverse_kinematics import kernel_rigid_entity_inverse_kinematics
 
         envs_idx = self._scene._sanitize_envs_idx(envs_idx)
-
-        if not self._requires_jac_and_IK:
-            gs.raise_exception(
-                "Inverse kinematics and jacobian are disabled for this entity. Set `morph.requires_jac_and_IK` to True if you need them."
-            )
 
         if self.n_dofs == 0:
             gs.raise_exception("Entity has zero dofs.")

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -5,7 +5,6 @@ from itertools import chain
 from typing import TYPE_CHECKING, Literal, Any, Hashable
 from functools import wraps
 
-import quadrants as qd
 import numpy as np
 import torch
 import trimesh
@@ -15,7 +14,6 @@ from genesis.engine.materials.base import Material
 from genesis.engine.mesh import InertialProperties
 from genesis.options.morphs import Morph
 from genesis.options.surfaces import Surface
-from genesis.utils import array_class
 from genesis.utils import geom as gu
 from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
@@ -83,7 +81,6 @@ def tracked(fun):
     return wrapper
 
 
-@qd.data_oriented
 class KinematicEntity(Entity):
     """
     Base entity class for articulated rigid-body systems (morphology, FK, Jacobian, IK).
@@ -2532,6 +2529,367 @@ class KinematicEntity(Entity):
         """The base joint of the entity"""
         return self._joints[0][0]
 
+    def _init_q_limit(self):
+        if self.n_dofs == 0:
+            return
+
+        # Joint limits in q space, also read by path planning.
+        q_limit_lower = []
+        q_limit_upper = []
+        for joint in self.joints:
+            if joint.type == gs.JOINT_TYPE.FREE:
+                q_limit_lower.append(joint.dofs_limit[:3, 0])
+                q_limit_lower.append(-np.ones(4))  # quaternion lower bound
+                q_limit_upper.append(joint.dofs_limit[:3, 1])
+                q_limit_upper.append(np.ones(4))  # quaternion upper bound
+            elif joint.type == gs.JOINT_TYPE.FIXED:
+                pass
+            else:
+                q_limit_lower.append(joint.dofs_limit[:, 0])
+                q_limit_upper.append(joint.dofs_limit[:, 1])
+        self.q_limit = np.stack(
+            (np.concatenate(q_limit_lower), np.concatenate(q_limit_upper)), axis=0, dtype=gs.np_float
+        )
+
+    # ------------------------------------------------------------------------------------
+    # --------------------------------- Jacobian & IK ------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    @gs.assert_built
+    def get_jacobian(self, link, local_point=None):
+        """
+        Get the spatial Jacobian for a point on a target link.
+
+        Parameters
+        ----------
+        link : RigidLink
+            The target link.
+        local_point : torch.Tensor or None, shape (3,)
+            Coordinates of the point in the link's *local* frame.
+            If None, the link origin is used (back-compat).
+
+        Returns
+        -------
+        jacobian : torch.Tensor
+            The Jacobian matrix of shape (n_envs, 6, entity.n_dofs) or (6, entity.n_dofs) if n_envs == 0.
+        """
+        if self.n_dofs == 0:
+            gs.raise_exception("Entity has zero dofs.")
+
+        if local_point is not None:
+            local_point = torch.as_tensor(local_point, dtype=gs.tc_float, device=gs.device)
+            if local_point.shape != (3,):
+                gs.raise_exception("Must be a vector of length 3")
+
+        jacobian = self._solver.get_links_jacobian(link.idx, self._dof_start, self.n_dofs, local_point)
+        if self._solver.n_envs == 0:
+            jacobian = jacobian[0]
+
+        return jacobian
+
+    @gs.assert_built
+    def inverse_kinematics(
+        self,
+        link,
+        pos=None,
+        quat=None,
+        local_point=None,
+        init_qpos=None,
+        respect_joint_limit=True,
+        max_samples=50,
+        max_solver_iters=20,
+        damping=0.01,
+        pos_tol=5e-4,  # 0.5 mm
+        rot_tol=5e-3,  # 0.28 degree
+        pos_mask=[True, True, True],
+        rot_mask=[True, True, True],
+        max_step_size=0.5,
+        seed=None,
+        dofs_idx_local=None,
+        return_error=False,
+        envs_idx=None,
+    ):
+        """
+        Compute inverse kinematics for a single target link.
+
+        The target `pos`/`quat` are interpreted in the world frame (the morph pose offset is not applied), matching the
+        world-frame link poses reported by `get_links_pos` and `get_links_quat` with `relative=False`.
+
+        Parameters
+        ----------
+        link : RigidLink
+            The link to be used as the end-effector.
+        pos : None | array_like, shape (3,), optional
+            The target position. If None, position error will not be considered. Defaults to None.
+        quat : None | array_like, shape (4,), optional
+            The target orientation. If None, orientation error will not be considered. Defaults to None.
+        local_point : None | array_like, shape (3,), optional
+            A point in the link's local frame to be positioned at `pos`. If None, the link origin is used. This is
+            useful for positioning a tool center point (TCP) or fingertip that is offset from the link origin. Defaults
+            to None (equivalent to [0, 0, 0]).
+        init_qpos : None | array_like, shape (n_dofs,), optional
+            Initial qpos used for solving IK. If None, the current qpos will be used. Defaults to None.
+        respect_joint_limit : bool, optional
+            Whether to respect joint limits. Defaults to True.
+        max_samples : int, optional
+            Number of resample attempts. Defaults to 50.
+        max_solver_iters : int, optional
+            Maximum number of solver iterations per sample. Defaults to 20.
+        damping : float, optional
+            Damping for damped least squares. Defaults to 0.01.
+        pos_tol : float, optional
+            Position tolerance for normalized position error (in meter). Defaults to 1e-4.
+        rot_tol : float, optional
+            Rotation tolerance for normalized rotation vector error (in radian). Defaults to 1e-4.
+        pos_mask : list, shape (3,), optional
+            Mask for position error. Defaults to [True, True, True]. E.g.: If you only care about position along x and
+            y, you can set it to [True, True, False].
+        rot_mask : list, shape (3,), optional
+            Mask for rotation axis alignment. Defaults to [True, True, True]. E.g.: If you only want the link's Z-axis
+            to be aligned with the Z-axis in the given quat, you can set it to [False, False, True].
+        max_step_size : float, optional
+            Maximum step size in q space for each IK solver step. Defaults to 0.5.
+        seed : None | int, optional
+            Seed of the joint-limit resampling that escapes unreachable local branches. Repeated calls with the same
+            seed and inputs return the same solution; vary it to explore different branches. Defaults to None (a fixed
+            internal seed).
+        dofs_idx_local : None | array_like, optional
+            The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`,
+            not the scene-level one. Defaults to None. This is used to specify which dofs the IK is applied to.
+        return_error : bool, optional
+            Whether to return the final errorqpos. Defaults to False.
+        envs_idx: None | array_like, optional
+            The indices of the environments to set. If None, all environments will be set. Defaults to None.
+
+        Returns
+        -------
+        qpos : array_like, shape (n_dofs,) or (n_envs, n_dofs) or (len(envs_idx), n_dofs)
+            Solver qpos (joint positions).
+        (optional) error_pose : array_like, shape (6,) or (n_envs, 6) or (len(envs_idx), 6)
+            Pose error for each target. The 6-vector is [err_pos_x, err_pos_y, err_pos_z, err_rot_x, err_rot_y,
+            err_rot_z]. Only returned if `return_error` is True.
+        """
+        if self._solver.n_envs > 0:
+            envs_idx = self._scene._sanitize_envs_idx(envs_idx)
+
+            if pos is not None:
+                if len(pos) != len(envs_idx):
+                    gs.raise_exception("First dimension of `pos` must be equal to `scene.n_envs`.")
+            if quat is not None:
+                if len(quat) != len(envs_idx):
+                    gs.raise_exception("First dimension of `quat` must be equal to `scene.n_envs`.")
+
+        ret = self.inverse_kinematics_multilink(
+            links=[link],
+            poss=[pos] if pos is not None else [],
+            quats=[quat] if quat is not None else [],
+            local_points=[local_point] if local_point is not None else [],
+            init_qpos=init_qpos,
+            respect_joint_limit=respect_joint_limit,
+            max_samples=max_samples,
+            max_solver_iters=max_solver_iters,
+            damping=damping,
+            pos_tol=pos_tol,
+            rot_tol=rot_tol,
+            pos_mask=pos_mask,
+            rot_mask=rot_mask,
+            max_step_size=max_step_size,
+            seed=seed,
+            dofs_idx_local=dofs_idx_local,
+            return_error=return_error,
+            envs_idx=envs_idx,
+        )
+
+        if return_error:
+            qpos, error_pose = ret
+            return qpos, error_pose[..., 0, :]
+        return ret
+
+    @gs.assert_built
+    def inverse_kinematics_multilink(
+        self,
+        links,
+        poss=None,
+        quats=None,
+        local_points=None,
+        init_qpos=None,
+        respect_joint_limit=True,
+        max_samples=50,
+        max_solver_iters=20,
+        damping=0.01,
+        pos_tol=5e-4,  # 0.5 mm
+        rot_tol=5e-3,  # 0.28 degree
+        pos_mask=[True, True, True],
+        rot_mask=[True, True, True],
+        max_step_size=0.5,
+        seed=None,
+        dofs_idx_local=None,
+        return_error=False,
+        envs_idx=None,
+    ):
+        """
+        Compute inverse kinematics for multiple target links.
+
+        Parameters
+        ----------
+        links : list of RigidLink
+            List of links to be used as the end-effectors.
+        poss : list, optional
+            List of target positions. If empty, position error will not be considered. Defaults to None.
+        quats : list, optional
+            List of target orientations. If empty, orientation error will not be considered. Defaults to None.
+        local_points : list, optional
+            List of local points (one per link) in each link's local frame to be positioned at the corresponding target
+            position. If empty or None, link origins are used. Each element should be array_like of shape (3,) or None.
+            This is useful for positioning tool center points (TCP) or fingertips that are offset from the link origin.
+            Defaults to None.
+        init_qpos : array_like, shape (n_dofs,), optional
+            Initial qpos used for solving IK. If None, the current qpos will be used. Defaults to None.
+        respect_joint_limit : bool, optional
+            Whether to respect joint limits. Defaults to True.
+        max_samples : int, optional
+            Number of resample attempts. Defaults to 50.
+        max_solver_iters : int, optional
+            Maximum number of solver iterations per sample. Defaults to 20.
+        damping : float, optional
+            Damping for damped least squares. Defaults to 0.01.
+        pos_tol : float, optional
+            Position tolerance for normalized position error (in meter). Defaults to 1e-4.
+        rot_tol : float, optional
+            Rotation tolerance for normalized rotation vector error (in radian). Defaults to 1e-4.
+        pos_mask : list, shape (3,), optional
+            Mask for position error. Defaults to [True, True, True]. E.g.: If you only care about position along x and
+            y, you can set it to [True, True, False].
+        rot_mask : list, shape (3,), optional
+            Mask for rotation axis alignment. Defaults to [True, True, True]. E.g.: If you only want the link's Z-axis
+            to be aligned with the Z-axis in the given quat, you can set it to [False, False, True].
+        max_step_size : float, optional
+            Maximum step size in q space for each IK solver step. Defaults to 0.5.
+        seed : None | int, optional
+            Seed of the joint-limit resampling that escapes unreachable local branches. Repeated calls with the same
+            seed and inputs return the same solution; vary it to explore different branches. Defaults to None (a fixed
+            internal seed).
+        dofs_idx_local : None | array_like, optional
+            The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`,
+            not the scene-level one. Defaults to None. This is used to specify which dofs the IK is applied to.
+        return_error : bool, optional
+            Whether to return the final errorqpos. Defaults to False.
+        envs_idx : None | array_like, optional
+            The indices of the environments to set. If None, all environments will be set. Defaults to None.
+
+        Returns
+        -------
+        qpos : array_like, shape (n_dofs,) or (n_envs, n_dofs) or (len(envs_idx), n_dofs)
+            Solver qpos (joint positions).
+        (optional) error_pose : array_like, shape (6,) or (n_envs, 6) or (len(envs_idx), 6)
+            Pose error for each target. The 6-vector is [err_pos_x, err_pos_y, err_pos_z, err_rot_x, err_rot_y,
+            err_rot_z]. Only returned if `return_error` is True.
+        """
+        envs_idx = self._scene._sanitize_envs_idx(envs_idx)
+
+        if self.n_dofs == 0:
+            gs.raise_exception("Entity has zero dofs.")
+
+        n_links = len(links)
+        if n_links == 0:
+            gs.raise_exception("Target link not provided.")
+
+        poss = list(poss) if poss is not None else []
+        if not poss:
+            poss = [None for _ in range(n_links)]
+            pos_mask = [False, False, False]
+        elif len(poss) != n_links:
+            gs.raise_exception("Accepting only `poss` with length equal to `links` or empty list.")
+
+        quats = list(quats) if quats is not None else []
+        if not quats:
+            quats = [None for _ in range(n_links)]
+            rot_mask = [False, False, False]
+        elif len(quats) != n_links:
+            gs.raise_exception("Accepting only `quats` with length equal to `links` or empty list.")
+
+        # Process local_points - default to origin [0, 0, 0] for each link
+        local_points = list(local_points) if local_points is not None else []
+        if not local_points:
+            local_points = [None for _ in range(n_links)]
+        elif len(local_points) != n_links:
+            gs.raise_exception("Accepting only `local_points` with length equal to `links` or empty list.")
+        for i, lp in enumerate(local_points):
+            if lp is None:
+                lp = [0.0, 0.0, 0.0]
+            local_points[i] = torch.as_tensor(lp, dtype=gs.tc_float, device=gs.device)
+        local_points = torch.stack(local_points, dim=0)  # (n_links, 3)
+
+        link_pos_mask, link_rot_mask = [], []
+        for i, (pos, quat) in enumerate(zip(poss, quats)):
+            if pos is None and quat is None:
+                gs.raise_exception("At least one of `poss` or `quats` must be provided.")
+            link_pos_mask.append(pos is not None)
+            poss[i] = broadcast_tensor(pos, gs.tc_float, (len(envs_idx), 3), ("envs_idx", "")).contiguous()
+            link_rot_mask.append(quat is not None)
+            if quat is None:
+                quat = gu.identity_quat()
+            quats[i] = broadcast_tensor(quat, gs.tc_float, (len(envs_idx), 4), ("envs_idx", "")).contiguous()
+        link_pos_mask = torch.tensor(link_pos_mask, dtype=gs.tc_int, device=gs.device)
+        link_rot_mask = torch.tensor(link_rot_mask, dtype=gs.tc_int, device=gs.device)
+        poss = torch.stack(poss, dim=0)
+        quats = torch.stack(quats, dim=0)
+
+        custom_init_qpos = init_qpos is not None
+        init_qpos = broadcast_tensor(
+            init_qpos, gs.tc_float, (len(envs_idx), self.n_qs), ("envs_idx", "qs_idx")
+        ).contiguous()
+
+        # pos and rot mask
+        pos_mask = broadcast_tensor(pos_mask, gs.tc_bool, (3,)).contiguous()
+        rot_mask = broadcast_tensor(rot_mask, gs.tc_bool, (3,)).contiguous()
+        if (num_axis := rot_mask.sum()) == 1:
+            rot_mask = ~rot_mask if gs.tc_bool == torch.bool else 1 - rot_mask
+        elif num_axis == 2:
+            gs.raise_exception("You can only align 0, 1 axis or all 3 axes.")
+
+        dofs_idx = self._get_global_idx(dofs_idx_local, self.n_dofs)
+        n_dofs = len(dofs_idx)
+        if n_dofs == 0:
+            gs.raise_exception("Target dofs not provided.")
+
+        links_idx = torch.tensor([link.idx for link in links], dtype=gs.tc_int, device=gs.device)
+
+        qpos, err_pose = self._solver.inverse_kinematics(
+            self._idx_in_solver,
+            self._q_start,
+            self._link_start,
+            self._joint_start,
+            links_idx,
+            dofs_idx,
+            envs_idx,
+            poss,
+            quats,
+            local_points,
+            init_qpos,
+            pos_mask,
+            rot_mask,
+            link_pos_mask,
+            link_rot_mask,
+            self.n_qs,
+            self.n_dofs,
+            custom_init_qpos,
+            max_samples,
+            max_solver_iters,
+            damping,
+            pos_tol,
+            rot_tol,
+            max_step_size,
+            seed if seed is not None else 0,
+            respect_joint_limit,
+        )
+
+        qpos = qpos[0] if self._solver.n_envs == 0 else qpos[envs_idx]
+        if return_error:
+            error_pose = err_pose[0] if self._solver.n_envs == 0 else err_pose[envs_idx]
+            return qpos, error_pose
+        return qpos
+
 
 class RigidEntity(KinematicEntity):
     """
@@ -2762,40 +3120,7 @@ class RigidEntity(KinematicEntity):
         self._n_free_verts = len(self._free_verts_idx_local)
         self._n_fixed_verts = len(self._fixed_verts_idx_local)
 
-        self._init_jac_and_IK()
-
-    def _init_jac_and_IK(self):
-        # Build-time IK setup. Only the cheap, SNode-free metadata is computed here: the per-DOF joint limits in q-space
-        # (a small NumPy array, also read by path planning) and the IK error dimensions. The Jacobian / IK scratch
-        # `qd.field`s are allocated lazily on first use (in `get_jacobian` / `inverse_kinematics_multilink`) so that
-        # entities which never query the Jacobian or run IK do not each add a per-entity field bundle to the SNode tree.
-        if self.n_dofs == 0:
-            return
-
-        # compute joint limit in q space
-        q_limit_lower = []
-        q_limit_upper = []
-        for joint in self.joints:
-            if joint.type == gs.JOINT_TYPE.FREE:
-                q_limit_lower.append(joint.dofs_limit[:3, 0])
-                q_limit_lower.append(-np.ones(4))  # quaternion lower bound
-                q_limit_upper.append(joint.dofs_limit[:3, 1])
-                q_limit_upper.append(np.ones(4))  # quaternion upper bound
-            elif joint.type == gs.JOINT_TYPE.FIXED:
-                pass
-            else:
-                q_limit_lower.append(joint.dofs_limit[:, 0])
-                q_limit_upper.append(joint.dofs_limit[:, 1])
-        self.q_limit = np.stack(
-            (np.concatenate(q_limit_lower), np.concatenate(q_limit_upper)), axis=0, dtype=gs.np_float
-        )
-
-        self._IK_n_tgts = self._solver._options.IK_max_targets
-        self._IK_error_dim = self._IK_n_tgts * 6
-
-        # The Jacobian and IK scratch fields are allocated lazily on first use; None marks them as not yet created.
-        self._jacobian = None
-        self._IK_mat = None
+        self._init_q_limit()
 
     def _add_by_info(self, l_info, j_infos, g_infos, morph, surface):
         if len(j_infos) > 1 and any(j_info["type"] in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_info in j_infos):
@@ -2928,560 +3253,6 @@ class RigidEntity(KinematicEntity):
         )
         self._equalities.append(equality)
         return equality
-
-    # ------------------------------------------------------------------------------------
-    # --------------------------------- Jacobian & IK ------------------------------------
-    # ------------------------------------------------------------------------------------
-
-    @gs.assert_built
-    def get_jacobian(self, link, local_point=None):
-        """
-        Get the spatial Jacobian for a point on a target link.
-
-        Parameters
-        ----------
-        link : RigidLink
-            The target link.
-        local_point : torch.Tensor or None, shape (3,)
-            Coordinates of the point in the link's *local* frame.
-            If None, the link origin is used (back-compat).
-
-        Returns
-        -------
-        jacobian : torch.Tensor
-            The Jacobian matrix of shape (n_envs, 6, entity.n_dofs) or (6, entity.n_dofs) if n_envs == 0.
-        """
-        if self.n_dofs == 0:
-            gs.raise_exception("Entity has zero dofs.")
-
-        # Lazily allocate the Jacobian field on first use.
-        if self._jacobian is None:
-            self._jacobian = qd.field(dtype=gs.qd_float, shape=(6, self.n_dofs, self._solver._B))
-
-        if local_point is None:
-            sol = self._solver
-            self._kernel_get_jacobian_zero(link.idx, sol.dyn_state, sol.dyn_info)
-        else:
-            p_local = torch.as_tensor(local_point, dtype=gs.tc_float, device=gs.device)
-            if p_local.shape != (3,):
-                gs.raise_exception("Must be a vector of length 3")
-            sol = self._solver
-            self._kernel_get_jacobian(link.idx, p_local, sol.dyn_state, sol.dyn_info)
-
-        jacobian = qd_to_torch(self._jacobian, transpose=True, copy=True)
-        if self._solver.n_envs == 0:
-            jacobian = jacobian[0]
-
-        return jacobian
-
-    @qd.func
-    def _impl_get_jacobian(
-        self, tgt_link_idx, i_b, p_vec, dyn_state: array_class.DynState, dyn_info: array_class.DynInfo
-    ):
-        self._func_get_jacobian(
-            tgt_link_idx, i_b, p_vec, qd.Vector.one(gs.qd_int, 3), qd.Vector.one(gs.qd_int, 3), dyn_state, dyn_info
-        )
-
-    @qd.kernel
-    def _kernel_get_jacobian(
-        self,
-        tgt_link_idx: qd.i32,
-        p_local: qd.types.ndarray(),
-        dyn_state: array_class.DynState,
-        dyn_info: array_class.DynInfo,
-    ):
-        p_vec = qd.Vector([p_local[0], p_local[1], p_local[2]], dt=gs.qd_float)
-        for i_b in range(self._solver._B):
-            self._impl_get_jacobian(tgt_link_idx, i_b, p_vec, dyn_state, dyn_info)
-
-    @qd.kernel
-    def _kernel_get_jacobian_zero(
-        self, tgt_link_idx: qd.i32, dyn_state: array_class.DynState, dyn_info: array_class.DynInfo
-    ):
-        for i_b in range(self._solver._B):
-            self._impl_get_jacobian(tgt_link_idx, i_b, qd.Vector.zero(gs.qd_float, 3), dyn_state, dyn_info)
-
-    @qd.func
-    def _func_get_jacobian(
-        self,
-        tgt_link_idx,
-        i_b,
-        p_local,
-        pos_mask,
-        rot_mask,
-        dyn_state: array_class.DynState,
-        dyn_info: array_class.DynInfo,
-    ):
-        for i_row, i_d in qd.ndrange(6, self.n_dofs):
-            self._jacobian[i_row, i_d, i_b] = 0.0
-
-        tgt_link_pos = dyn_state.links.pos[tgt_link_idx, i_b] + gu.qd_transform_by_quat(
-            p_local, dyn_state.links.quat[tgt_link_idx, i_b]
-        )
-        i_l = tgt_link_idx
-        while i_l > -1:
-            I_l = [i_l, i_b] if qd.static(self.solver._options.batch_links_info) else i_l
-
-            for i_j in range(dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l]):
-                I_j = [i_j, i_b] if qd.static(self.solver._options.batch_joints_info) else i_j
-
-                if dyn_info.joints.type[I_j] == gs.JOINT_TYPE.FIXED:
-                    pass
-
-                elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.REVOLUTE:
-                    i_d_jac = dyn_info.joints.dof_start[I_j] - self._dof_start
-                    rotation = dyn_state.joints.xaxis[i_j, i_b]
-                    translation = rotation.cross(tgt_link_pos - dyn_state.joints.xanchor[i_j, i_b])
-
-                    self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
-                    self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
-                    self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
-                    self._jacobian[3, i_d_jac, i_b] = rotation[0] * rot_mask[0]
-                    self._jacobian[4, i_d_jac, i_b] = rotation[1] * rot_mask[1]
-                    self._jacobian[5, i_d_jac, i_b] = rotation[2] * rot_mask[2]
-
-                elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.PRISMATIC:
-                    i_d_jac = dyn_info.joints.dof_start[I_j] - self._dof_start
-                    translation = dyn_state.joints.xaxis[i_j, i_b]
-
-                    self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
-                    self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
-                    self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
-
-                elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.FREE:
-                    # translation
-                    for i_d_ in qd.static(range(3)):
-                        i_d_jac = dyn_info.joints.dof_start[I_j] + i_d_ - self._dof_start
-
-                        self._jacobian[i_d_, i_d_jac, i_b] = 1.0 * pos_mask[i_d_]
-
-                    # rotation
-                    for i_d_ in qd.static(range(3)):
-                        i_d = dyn_info.joints.dof_start[I_j] + i_d_ + 3
-                        i_d_jac = i_d - self._dof_start
-                        I_d = [i_d, i_b] if qd.static(self.solver._options.batch_dofs_info) else i_d
-                        rotation = dyn_info.dofs.motion_ang[I_d]
-                        translation = rotation.cross(tgt_link_pos - dyn_state.links.pos[i_l, i_b])
-
-                        self._jacobian[0, i_d_jac, i_b] = translation[0] * pos_mask[0]
-                        self._jacobian[1, i_d_jac, i_b] = translation[1] * pos_mask[1]
-                        self._jacobian[2, i_d_jac, i_b] = translation[2] * pos_mask[2]
-                        self._jacobian[3, i_d_jac, i_b] = rotation[0] * rot_mask[0]
-                        self._jacobian[4, i_d_jac, i_b] = rotation[1] * rot_mask[1]
-                        self._jacobian[5, i_d_jac, i_b] = rotation[2] * rot_mask[2]
-
-            i_l = dyn_info.links.parent_idx[I_l]
-
-    @gs.assert_built
-    def inverse_kinematics(
-        self,
-        link,
-        pos=None,
-        quat=None,
-        local_point=None,
-        init_qpos=None,
-        respect_joint_limit=True,
-        max_samples=50,
-        max_solver_iters=20,
-        damping=0.01,
-        pos_tol=5e-4,  # 0.5 mm
-        rot_tol=5e-3,  # 0.28 degree
-        pos_mask=[True, True, True],
-        rot_mask=[True, True, True],
-        max_step_size=0.5,
-        dofs_idx_local=None,
-        return_error=False,
-        envs_idx=None,
-    ):
-        """
-        Compute inverse kinematics for a single target link.
-
-        The target `pos`/`quat` are interpreted in the world frame (the morph pose offset is not applied), matching
-        the world-frame link poses returned by `forward_kinematics`.
-
-        Parameters
-        ----------
-        link : RigidLink
-            The link to be used as the end-effector.
-        pos : None | array_like, shape (3,), optional
-            The target position. If None, position error will not be considered. Defaults to None.
-        quat : None | array_like, shape (4,), optional
-            The target orientation. If None, orientation error will not be considered. Defaults to None.
-        local_point : None | array_like, shape (3,), optional
-            A point in the link's local frame to be positioned at `pos`. If None, the link origin is used.
-            This is useful for positioning a tool center point (TCP) or fingertip that is offset from the link origin.
-            Defaults to None (equivalent to [0, 0, 0]).
-        init_qpos : None | array_like, shape (n_dofs,), optional
-            Initial qpos used for solving IK. If None, the current qpos will be used. Defaults to None.
-        respect_joint_limit : bool, optional
-            Whether to respect joint limits. Defaults to True.
-        max_samples : int, optional
-            Number of resample attempts. Defaults to 50.
-        max_solver_iters : int, optional
-            Maximum number of solver iterations per sample. Defaults to 20.
-        damping : float, optional
-            Damping for damped least squares. Defaults to 0.01.
-        pos_tol : float, optional
-            Position tolerance for normalized position error (in meter). Defaults to 1e-4.
-        rot_tol : float, optional
-            Rotation tolerance for normalized rotation vector error (in radian). Defaults to 1e-4.
-        pos_mask : list, shape (3,), optional
-            Mask for position error. Defaults to [True, True, True]. E.g.: If you only care about position along x and y, you can set it to [True, True, False].
-        rot_mask : list, shape (3,), optional
-            Mask for rotation axis alignment. Defaults to [True, True, True]. E.g.: If you only want the link's Z-axis to be aligned with the Z-axis in the given quat, you can set it to [False, False, True].
-        max_step_size : float, optional
-            Maximum step size in q space for each IK solver step. Defaults to 0.5.
-        dofs_idx_local : None | array_like, optional
-            The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None. This is used to specify which dofs the IK is applied to.
-        return_error : bool, optional
-            Whether to return the final errorqpos. Defaults to False.
-        envs_idx: None | array_like, optional
-            The indices of the environments to set. If None, all environments will be set. Defaults to None.
-
-        Returns
-        -------
-        qpos : array_like, shape (n_dofs,) or (n_envs, n_dofs) or (len(envs_idx), n_dofs)
-            Solver qpos (joint positions).
-        (optional) error_pose : array_like, shape (6,) or (n_envs, 6) or (len(envs_idx), 6)
-            Pose error for each target. The 6-vector is [err_pos_x, err_pos_y, err_pos_z, err_rot_x, err_rot_y, err_rot_z]. Only returned if `return_error` is True.
-        """
-        if self._solver.n_envs > 0:
-            envs_idx = self._scene._sanitize_envs_idx(envs_idx)
-
-            if pos is not None:
-                if pos.shape[0] != len(envs_idx):
-                    gs.raise_exception("First dimension of `pos` must be equal to `scene.n_envs`.")
-            if quat is not None:
-                if quat.shape[0] != len(envs_idx):
-                    gs.raise_exception("First dimension of `quat` must be equal to `scene.n_envs`.")
-
-        ret = self.inverse_kinematics_multilink(
-            links=[link],
-            poss=[pos] if pos is not None else [],
-            quats=[quat] if quat is not None else [],
-            local_points=[local_point] if local_point is not None else [],
-            init_qpos=init_qpos,
-            respect_joint_limit=respect_joint_limit,
-            max_samples=max_samples,
-            max_solver_iters=max_solver_iters,
-            damping=damping,
-            pos_tol=pos_tol,
-            rot_tol=rot_tol,
-            pos_mask=pos_mask,
-            rot_mask=rot_mask,
-            max_step_size=max_step_size,
-            dofs_idx_local=dofs_idx_local,
-            return_error=return_error,
-            envs_idx=envs_idx,
-        )
-
-        if return_error:
-            qpos, error_pose = ret
-            return qpos, error_pose[..., 0, :]
-        return ret
-
-    @gs.assert_built
-    def inverse_kinematics_multilink(
-        self,
-        links,
-        poss=None,
-        quats=None,
-        local_points=None,
-        init_qpos=None,
-        respect_joint_limit=True,
-        max_samples=50,
-        max_solver_iters=20,
-        damping=0.01,
-        pos_tol=5e-4,  # 0.5 mm
-        rot_tol=5e-3,  # 0.28 degree
-        pos_mask=[True, True, True],
-        rot_mask=[True, True, True],
-        max_step_size=0.5,
-        dofs_idx_local=None,
-        return_error=False,
-        envs_idx=None,
-    ):
-        """
-        Compute inverse kinematics for multiple target links.
-
-        Parameters
-        ----------
-        links : list of RigidLink
-            List of links to be used as the end-effectors.
-        poss : list, optional
-            List of target positions. If empty, position error will not be considered. Defaults to None.
-        quats : list, optional
-            List of target orientations. If empty, orientation error will not be considered. Defaults to None.
-        local_points : list, optional
-            List of local points (one per link) in each link's local frame to be positioned at the corresponding target position.
-            If empty or None, link origins are used. Each element should be array_like of shape (3,) or None.
-            This is useful for positioning tool center points (TCP) or fingertips that are offset from the link origin.
-            Defaults to None.
-        init_qpos : array_like, shape (n_dofs,), optional
-            Initial qpos used for solving IK. If None, the current qpos will be used. Defaults to None.
-        respect_joint_limit : bool, optional
-            Whether to respect joint limits. Defaults to True.
-        max_samples : int, optional
-            Number of resample attempts. Defaults to 50.
-        max_solver_iters : int, optional
-            Maximum number of solver iterations per sample. Defaults to 20.
-        damping : float, optional
-            Damping for damped least squares. Defaults to 0.01.
-        pos_tol : float, optional
-            Position tolerance for normalized position error (in meter). Defaults to 1e-4.
-        rot_tol : float, optional
-            Rotation tolerance for normalized rotation vector error (in radian). Defaults to 1e-4.
-        pos_mask : list, shape (3,), optional
-            Mask for position error. Defaults to [True, True, True]. E.g.: If you only care about position along x and y, you can set it to [True, True, False].
-        rot_mask : list, shape (3,), optional
-            Mask for rotation axis alignment. Defaults to [True, True, True]. E.g.: If you only want the link's Z-axis to be aligned with the Z-axis in the given quat, you can set it to [False, False, True].
-        max_step_size : float, optional
-            Maximum step size in q space for each IK solver step. Defaults to 0.5.
-        dofs_idx_local : None | array_like, optional
-            The indices of the dofs to set. If None, all dofs will be set. Note that here this uses the local `q_idx`, not the scene-level one. Defaults to None. This is used to specify which dofs the IK is applied to.
-        return_error : bool, optional
-            Whether to return the final errorqpos. Defaults to False.
-        envs_idx : None | array_like, optional
-            The indices of the environments to set. If None, all environments will be set. Defaults to None.
-
-        Returns
-        -------
-        qpos : array_like, shape (n_dofs,) or (n_envs, n_dofs) or (len(envs_idx), n_dofs)
-            Solver qpos (joint positions).
-        (optional) error_pose : array_like, shape (6,) or (n_envs, 6) or (len(envs_idx), 6)
-            Pose error for each target. The 6-vector is [err_pos_x, err_pos_y, err_pos_z, err_rot_x, err_rot_y, err_rot_z]. Only returned if `return_error` is True.
-        """
-        from genesis.engine.solvers.rigid.abd.inverse_kinematics import kernel_rigid_entity_inverse_kinematics
-
-        envs_idx = self._scene._sanitize_envs_idx(envs_idx)
-
-        if self.n_dofs == 0:
-            gs.raise_exception("Entity has zero dofs.")
-
-        # Lazily allocate the Jacobian and IK scratch fields on first use.
-        if self._jacobian is None:
-            self._jacobian = qd.field(dtype=gs.qd_float, shape=(6, self.n_dofs, self._solver._B))
-        if self._IK_mat is None:
-            # for storing intermediate results
-            self._IK_mat = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._IK_error_dim, self._solver._B))
-            self._IK_inv = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._IK_error_dim, self._solver._B))
-            self._IK_L = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._IK_error_dim, self._solver._B))
-            self._IK_U = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._IK_error_dim, self._solver._B))
-            self._IK_y = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._IK_error_dim, self._solver._B))
-            self._IK_qpos_orig = qd.field(dtype=gs.qd_float, shape=(self.n_qs, self._solver._B))
-            self._IK_qpos_best = qd.field(dtype=gs.qd_float, shape=(self.n_qs, self._solver._B))
-            self._IK_delta_qpos = qd.field(dtype=gs.qd_float, shape=(self.n_dofs, self._solver._B))
-            self._IK_vec = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._solver._B))
-            self._IK_err_pose = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._solver._B))
-            self._IK_err_pose_best = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self._solver._B))
-            self._IK_jacobian = qd.field(dtype=gs.qd_float, shape=(self._IK_error_dim, self.n_dofs, self._solver._B))
-            self._IK_jacobian_T = qd.field(dtype=gs.qd_float, shape=(self.n_dofs, self._IK_error_dim, self._solver._B))
-
-        n_links = len(links)
-        if n_links == 0:
-            gs.raise_exception("Target link not provided.")
-
-        poss = list(poss) if poss is not None else []
-        if not poss:
-            poss = [None for _ in range(n_links)]
-            pos_mask = [False, False, False]
-        elif len(poss) != n_links:
-            gs.raise_exception("Accepting only `poss` with length equal to `links` or empty list.")
-
-        quats = list(quats) if quats is not None else []
-        if not quats:
-            quats = [None for _ in range(n_links)]
-            rot_mask = [False, False, False]
-        elif len(quats) != n_links:
-            gs.raise_exception("Accepting only `quats` with length equal to `links` or empty list.")
-
-        # Process local_points - default to origin [0, 0, 0] for each link
-        local_points = list(local_points) if local_points is not None else []
-        if not local_points:
-            local_points = [None for _ in range(n_links)]
-        elif len(local_points) != n_links:
-            gs.raise_exception("Accepting only `local_points` with length equal to `links` or empty list.")
-        for i, lp in enumerate(local_points):
-            if lp is None:
-                lp = [0.0, 0.0, 0.0]
-            local_points[i] = torch.as_tensor(lp, dtype=gs.tc_float, device=gs.device)
-        local_points = torch.stack(local_points, dim=0)  # (n_links, 3)
-
-        link_pos_mask, link_rot_mask = [], []
-        for i, (pos, quat) in enumerate(zip(poss, quats)):
-            if pos is None and quat is None:
-                gs.raise_exception("At least one of `poss` or `quats` must be provided.")
-            link_pos_mask.append(pos is not None)
-            poss[i] = broadcast_tensor(pos, gs.tc_float, (len(envs_idx), 3), ("envs_idx", "")).contiguous()
-            link_rot_mask.append(quat is not None)
-            if quat is None:
-                quat = gu.identity_quat()
-            quats[i] = broadcast_tensor(quat, gs.tc_float, (len(envs_idx), 4), ("envs_idx", "")).contiguous()
-        link_pos_mask = torch.tensor(link_pos_mask, dtype=gs.tc_int, device=gs.device)
-        link_rot_mask = torch.tensor(link_rot_mask, dtype=gs.tc_int, device=gs.device)
-        poss = torch.stack(poss, dim=0)
-        quats = torch.stack(quats, dim=0)
-
-        custom_init_qpos = init_qpos is not None
-        init_qpos = broadcast_tensor(
-            init_qpos, gs.tc_float, (len(envs_idx), self.n_qs), ("envs_idx", "qs_idx")
-        ).contiguous()
-
-        # pos and rot mask
-        pos_mask = broadcast_tensor(pos_mask, gs.tc_bool, (3,)).contiguous()
-        rot_mask = broadcast_tensor(rot_mask, gs.tc_bool, (3,)).contiguous()
-        if (num_axis := rot_mask.sum()) == 1:
-            rot_mask = ~rot_mask if gs.tc_bool == torch.bool else 1 - rot_mask
-        elif num_axis == 2:
-            gs.raise_exception("You can only align 0, 1 axis or all 3 axes.")
-
-        dofs_idx = self._get_global_idx(dofs_idx_local, self.n_dofs)
-        n_dofs = len(dofs_idx)
-        if n_dofs == 0:
-            gs.raise_exception("Target dofs not provided.")
-
-        links_idx = torch.tensor([link.idx for link in links], dtype=gs.tc_int, device=gs.device)
-
-        kernel_rigid_entity_inverse_kinematics(
-            links_idx,
-            dofs_idx,
-            envs_idx,
-            self,
-            poss,
-            quats,
-            local_points,
-            init_qpos,
-            pos_mask,
-            rot_mask,
-            link_pos_mask,
-            link_rot_mask,
-            self._solver.dyn_state,
-            self._solver.dyn_info,
-            self._solver.rigid_info,
-            self._solver.rigid_config,
-            custom_init_qpos,
-            max_samples,
-            max_solver_iters,
-            damping,
-            pos_tol,
-            rot_tol,
-            max_step_size,
-            respect_joint_limit,
-        )
-
-        qpos = qd_to_torch(self._IK_qpos_best, transpose=True, copy=True)
-        qpos = qpos[0] if self._solver.n_envs == 0 else qpos[envs_idx]
-
-        if return_error:
-            error_pose = qd_to_torch(self._IK_err_pose_best, transpose=True, copy=True).reshape(
-                (-1, self._IK_n_tgts, 6)
-            )[:, :n_links]
-            error_pose = error_pose[0] if self._solver.n_envs == 0 else error_pose[envs_idx]
-            return qpos, error_pose
-        return qpos
-
-    @gs.assert_built
-    def forward_kinematics(self, qpos, qs_idx_local=None, links_idx_local=None, envs_idx=None):
-        """
-        Compute forward kinematics for a single target link.
-
-        The returned link poses are in the world frame (the morph pose offset is not stripped), consistent with the
-        world-frame `qpos` input.
-
-        Parameters
-        ----------
-        qpos : array_like, shape (n_qs,) or (n_envs, n_qs) or (len(envs_idx), n_qs)
-            The joint positions.
-        qs_idx_local : None | array_like, optional
-            The indices of the qpos to set. If None, all qpos will be set. Defaults to None.
-        links_idx_local : None | array_like, optional
-            The indices of the links to get. If None, all links will be returned. Defaults to None.
-        envs_idx : None | array_like, optional
-            The indices of the environments to set. If None, all environments will be set. Defaults to None.
-
-        Returns
-        -------
-        links_pos : array_like, shape (n_links, 3) or (n_envs, n_links, 3) or (len(envs_idx), n_links, 3)
-            The positions of the links (link frame origins).
-        links_quat : array_like, shape (n_links, 4) or (n_envs, n_links, 4) or (len(envs_idx), n_links, 4)
-            The orientations of the links.
-        """
-
-        if self._solver.n_envs == 0:
-            qpos = qpos[None]
-            envs_idx = torch.zeros(1, dtype=gs.tc_int)
-        else:
-            envs_idx = self._scene._sanitize_envs_idx(envs_idx)
-
-        links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start)
-        links_pos = torch.empty((len(envs_idx), len(links_idx), 3), dtype=gs.tc_float, device=gs.device)
-        links_quat = torch.empty((len(envs_idx), len(links_idx), 4), dtype=gs.tc_float, device=gs.device)
-
-        self._kernel_forward_kinematics(
-            self._get_global_idx(qs_idx_local, self.n_qs, self._q_start),
-            links_idx,
-            envs_idx,
-            links_pos,
-            links_quat,
-            qpos,
-            self._solver.dyn_state,
-            self._solver.dyn_info,
-            self._solver.rigid_info,
-            self._solver.rigid_config,
-        )
-
-        if self._solver.n_envs == 0:
-            links_pos = links_pos[0]
-            links_quat = links_quat[0]
-        return links_pos, links_quat
-
-    @qd.kernel
-    def _kernel_forward_kinematics(
-        self,
-        qs_idx: qd.types.ndarray(),
-        links_idx: qd.types.ndarray(),
-        envs_idx: qd.types.ndarray(),
-        links_pos: qd.types.ndarray(),
-        links_quat: qd.types.ndarray(),
-        qpos: qd.types.ndarray(),
-        dyn_state: array_class.DynState,
-        dyn_info: array_class.DynInfo,
-        rigid_info: array_class.RigidInfo,
-        rigid_config: qd.template(),
-    ):
-        qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
-        for i_q_, i_b_ in qd.ndrange(qs_idx.shape[0], envs_idx.shape[0]):
-            # save original qpos
-            # NOTE: reusing the IK_qpos_orig as cache (should not be a problem)
-            self._IK_qpos_orig[qs_idx[i_q_], envs_idx[i_b_]] = rigid_info.qpos[qs_idx[i_q_], envs_idx[i_b_]]
-            # set new qpos
-            rigid_info.qpos[qs_idx[i_q_], envs_idx[i_b_]] = qpos[i_b_, i_q_]
-
-        # run FK
-        qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
-        for i_b_ in range(envs_idx.shape[0]):
-            gs.engine.solvers.rigid.rigid_solver.func_forward_kinematics_entity(
-                self._idx_in_solver, envs_idx[i_b_], dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
-            )
-
-        qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
-        for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
-            for i in qd.static(range(3)):
-                links_pos[i_b_, i_l_, i] = dyn_state.links.pos[links_idx[i_l_], envs_idx[i_b_]][i]
-            for i in qd.static(range(4)):
-                links_quat[i_b_, i_l_, i] = dyn_state.links.quat[links_idx[i_l_], envs_idx[i_b_]][i]
-
-        # restore original qpos
-        qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
-        for i_q_, i_b_ in qd.ndrange(qs_idx.shape[0], envs_idx.shape[0]):
-            rigid_info.qpos[qs_idx[i_q_], envs_idx[i_b_]] = self._IK_qpos_orig[qs_idx[i_q_], envs_idx[i_b_]]
-
-        # run FK
-        qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
-        for i_b_ in range(envs_idx.shape[0]):
-            gs.engine.solvers.rigid.rigid_solver.func_forward_kinematics_entity(
-                self._idx_in_solver, envs_idx[i_b_], dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
-            )
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- motion planing -----------------------------------

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1421,7 +1421,7 @@ class Scene(RBC):
 
             Ts = np.zeros((N_new, 4, 4))
             for i in range(N_new):
-                pos, quat = entity.forward_kinematics(qposs[indices[i]])
+                pos, quat = self.rigid_solver.forward_kinematics_query(entity, qposs[indices[i]])
                 Ts[i] = tensor_to_array(gu.trans_quat_to_T(pos[link_idx], quat[link_idx]))
 
             return self._visualizer.context.draw_debug_frames(

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -7,6 +7,13 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 from genesis.engine.entities.rigid_entity import KinematicEntity
+from genesis.engine.solvers.rigid.abd.inverse_kinematics import (
+    kernel_forward_kinematics_query,
+    kernel_get_jacobian,
+    kernel_get_jacobian_zero,
+    kernel_inverse_kinematics_entity,
+    kernel_set_ik_targets,
+)
 from genesis.engine.states.solvers import KinematicSolverState
 from genesis.options.solvers import KinematicOptions, RigidOptions
 from genesis.utils.misc import (
@@ -377,6 +384,7 @@ class KinematicSolver(Solver):
         self._rigid_adjoint_cache = self.data_manager.rigid_adjoint_cache
         self.dyn_info = self.data_manager.dyn_info
         self.dyn_state = self.data_manager.dyn_state
+        self.kinematics_scratch = self.data_manager.kinematics_scratch
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- hook methods -------------------------------------
@@ -1251,6 +1259,180 @@ class KinematicSolver(Solver):
             self.dyn_state.vverts.pos, envs_idx, slice(custom_vvert_start, custom_vvert_end), transpose=True, copy=True
         )
         return tensor[0] if self.n_envs == 0 else tensor
+
+    # ------------------------------------------------------------------------------------
+    # --------------------------------- Jacobian & IK ------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    def get_links_jacobian(self, link_idx, dof_start, n_dofs, local_point=None):
+        """Spatial Jacobian of a link-local point, as (n_envs, 6, n_dofs), for the entity owning that link.
+
+        dof_start offsets the entity degrees of freedom into the solver and n_dofs narrows the shared buffer down to
+        that entity. local_point defaults to the link origin.
+        """
+        jacobian = self.kinematics_scratch.jacobian
+        if local_point is None:
+            kernel_get_jacobian_zero(
+                link_idx, dof_start, jacobian, self.dyn_state, self.dyn_info, self.rigid_config, self._B
+            )
+        else:
+            kernel_get_jacobian(
+                link_idx, dof_start, local_point, jacobian, self.dyn_state, self.dyn_info, self.rigid_config, self._B
+            )
+        return qd_to_torch(jacobian, transpose=True, copy=True)[..., :n_dofs]
+
+    def forward_kinematics_query(self, entity, qpos, envs_idx=None):
+        """Link poses one entity would have at the given configuration, leaving the live configuration as it was.
+
+        Distinct from the forward kinematics the step propagates: this evaluates a configuration the solver does not
+        hold, and restores the one it does. Returns positions (n_envs, n_links, 3) and orientations
+        (n_envs, n_links, 4), without the batch dimension when the scene is not batched.
+        """
+        if self.n_envs == 0:
+            envs_idx = torch.zeros(1, dtype=gs.tc_int)
+        else:
+            envs_idx = self._scene._sanitize_envs_idx(envs_idx)
+        qpos = broadcast_tensor(qpos, gs.tc_float, (len(envs_idx), entity.n_qs), ("envs_idx", "qs_idx")).contiguous()
+
+        qs_idx = torch.arange(entity._q_start, entity._q_start + entity.n_qs, dtype=gs.tc_int, device=gs.device)
+        links_idx = torch.arange(
+            entity._link_start, entity._link_start + entity.n_links, dtype=gs.tc_int, device=gs.device
+        )
+        links_pos = torch.empty((len(envs_idx), entity.n_links, 3), dtype=gs.tc_float, device=gs.device)
+        links_quat = torch.empty((len(envs_idx), entity.n_links, 4), dtype=gs.tc_float, device=gs.device)
+        kernel_forward_kinematics_query(
+            entity._idx_in_solver,
+            qs_idx,
+            links_idx,
+            envs_idx,
+            links_pos,
+            links_quat,
+            qpos,
+            self.kinematics_scratch.qpos_cache,
+            self.dyn_state,
+            self.dyn_info,
+            self.rigid_info,
+            self.rigid_config,
+        )
+
+        if self.n_envs == 0:
+            links_pos = links_pos[0]
+            links_quat = links_quat[0]
+        return links_pos, links_quat
+
+    def inverse_kinematics(
+        self,
+        entity_idx,
+        q_start,
+        link_start,
+        joint_start,
+        links_idx,
+        dofs_idx,
+        envs_idx,
+        poss,
+        quats,
+        local_points,
+        init_qpos,
+        pos_mask,
+        rot_mask,
+        link_pos_mask,
+        link_rot_mask,
+        n_qs,
+        n_dofs,
+        custom_init_qpos,
+        max_samples,
+        max_solver_iters,
+        damping,
+        pos_tol,
+        rot_tol,
+        max_step_size,
+        seed,
+        respect_joint_limit,
+    ):
+        """Damped-least-squares inverse kinematics of one entity for the given link targets.
+
+        Returns the best configuration per environment, spanning the entity, and the stacked pose residual of every
+        target it carries. Callers narrow both to the environments and targets they asked for.
+        """
+        n_links = len(links_idx)
+        n_tgts = self._options.IK_max_targets
+        if n_links > n_tgts:
+            gs.raise_exception(f"Cannot solve for {n_links} targets. Raise 'IK_max_targets' above {n_tgts}.")
+
+        ik_state, ik_fk, targets = self.data_manager.ik_scratch
+
+        # Only the leading rows each buffer holds for this solve are written, and the kernel reads no further.
+        if gs.use_zerocopy:
+            for member, data in (
+                (targets.links_idx, links_idx),
+                (targets.local_point, local_points),
+                (targets.link_pos_mask, link_pos_mask),
+                (targets.link_rot_mask, link_rot_mask),
+            ):
+                member_t = qd_to_torch(member, copy=False)
+                member_t[:n_links] = data
+            dofs_idx_t = qd_to_torch(targets.dofs_idx, copy=False)
+            dofs_idx_t[: len(dofs_idx)] = dofs_idx
+            envs_idx_t = qd_to_torch(targets.envs_idx, copy=False)
+            envs_idx_t[: len(envs_idx)] = envs_idx
+            pos_mask_t = qd_to_torch(targets.pos_mask, copy=False)
+            pos_mask_t[:] = pos_mask
+            rot_mask_t = qd_to_torch(targets.rot_mask, copy=False)
+            rot_mask_t[:] = rot_mask
+            for member, data in ((targets.pos, poss), (targets.quat, quats)):
+                member_t = qd_to_torch(member, copy=False)
+                member_t[:n_links, envs_idx] = data
+            init_qpos_t = qd_to_torch(targets.init_qpos, copy=False)
+            init_qpos_t[envs_idx, :n_qs] = init_qpos
+            if gs.backend == gs.metal:
+                torch.mps.synchronize()
+        else:
+            kernel_set_ik_targets(
+                links_idx,
+                dofs_idx,
+                envs_idx,
+                poss,
+                quats,
+                local_points,
+                init_qpos,
+                pos_mask,
+                rot_mask,
+                link_pos_mask,
+                link_rot_mask,
+                targets,
+            )
+
+        kernel_inverse_kinematics_entity(
+            entity_idx,
+            q_start,
+            link_start,
+            joint_start,
+            self.dyn_state,
+            ik_state,
+            ik_fk,
+            targets,
+            self.dyn_info,
+            self.rigid_info,
+            self.rigid_config,
+            n_qs,
+            n_dofs,
+            n_links,
+            len(dofs_idx),
+            len(envs_idx),
+            custom_init_qpos,
+            max_samples,
+            max_solver_iters,
+            damping,
+            pos_tol,
+            rot_tol,
+            max_step_size,
+            seed,
+            respect_joint_limit,
+        )
+
+        qpos = qd_to_torch(ik_state.qpos_best, transpose=True, copy=True)[..., :n_qs]
+        err_pose = qd_to_torch(ik_state.err_pose_best, transpose=True, copy=True).reshape((-1, n_tgts, 6))
+        return qpos, err_pose[:, :n_links]
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/solvers/rigid/abd/inverse_kinematics.py
+++ b/genesis/engine/solvers/rigid/abd/inverse_kinematics.py
@@ -11,167 +11,531 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.linalg as lu
 import genesis.utils.array_class as array_class
+from genesis.engine.solvers.rigid.abd.forward_kinematics import func_forward_kinematics_entity
 
 
-# FIXME: RigidEntity is not compatible with fast cache
-@qd.kernel(fastcache=False)
-def kernel_rigid_entity_inverse_kinematics(
-    links_idx: qd.types.ndarray(),
-    dofs_idx: qd.types.ndarray(),
-    envs_idx: qd.types.ndarray(),
-    rigid_entity: qd.template(),
-    poss: qd.types.ndarray(),
-    quats: qd.types.ndarray(),
-    local_points: qd.types.ndarray(),
-    init_qpos: qd.types.ndarray(),
-    pos_mask_: qd.types.ndarray(),
-    rot_mask_: qd.types.ndarray(),
-    link_pos_mask: qd.types.ndarray(),
-    link_rot_mask: qd.types.ndarray(),
+@qd.func
+def func_forward_kinematics_scratch(
+    i_col_out,
+    i_col_q,
+    i_b,
+    entity_idx,
+    link_offset,
+    joint_offset,
+    q_offset,
+    qpos: qd.Tensor,
+    links_pos: qd.Tensor,
+    links_quat: qd.Tensor,
+    joints_xanchor: qd.Tensor,
+    joints_xaxis: qd.Tensor,
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
-    custom_init_qpos: qd.i32,
-    max_samples: qd.i32,
-    max_solver_iters: qd.i32,
-    damping: qd.f32,
-    pos_tol: qd.f32,
-    rot_tol: qd.f32,
-    max_step_size: qd.f32,
-    respect_joint_limit: qd.i32,
 ):
+    """Forward kinematics of one entity on caller-owned scratch buffers.
+
+    Reads the configuration from qpos[:, i_col_q] (entity-local q coordinates keyed by q_offset) and writes link
+    poses and joint frames at column i_col_out of the given tensors; the live solver state is only read (model
+    info and the fixed root pose). Handles every joint type, so callers get correct kinematics without mutating
+    solver state.
+    """
+    for i_l_ in range(dyn_info.entities.link_start[entity_idx], dyn_info.entities.link_end[entity_idx]):
+        i_l = gs.qd_int(i_l_)
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+
+        pos = dyn_info.links.pos[I_l]
+        quat = dyn_info.links.quat[I_l]
+        if dyn_info.links.parent_idx[I_l] != -1:
+            parent_pos = links_pos[dyn_info.links.parent_idx[I_l] - link_offset, i_col_out]
+            parent_quat = links_quat[dyn_info.links.parent_idx[I_l] - link_offset, i_col_out]
+            pos = parent_pos + gu.qd_transform_by_quat(dyn_info.links.pos[I_l], parent_quat)
+            quat = gu.qd_transform_quat_by_quat(dyn_info.links.quat[I_l], parent_quat)
+
+        for i_j_ in range(dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l]):
+            i_j = gs.qd_int(i_j_)
+            I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+            joint_type = dyn_info.joints.type[I_j]
+            q_start = dyn_info.joints.q_start[I_j]
+            dof_start = dyn_info.joints.dof_start[I_j]
+            I_d = [dof_start, i_b] if qd.static(rigid_config.batch_dofs_info) else dof_start
+
+            q_loc = q_start - q_offset
+            if joint_type == gs.JOINT_TYPE.FREE:
+                # Six-DOF root: the configuration carries the base position (3) then orientation quaternion (4).
+                base_pos = qd.Vector(
+                    [qpos[q_loc, i_col_q], qpos[q_loc + 1, i_col_q], qpos[q_loc + 2, i_col_q]], dt=gs.qd_float
+                )
+                joints_xanchor[i_j - joint_offset, i_col_out] = base_pos
+                joints_xaxis[i_j - joint_offset, i_col_out] = qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float)
+                base_quat = qd.Vector(
+                    [
+                        qpos[q_loc + 3, i_col_q],
+                        qpos[q_loc + 4, i_col_q],
+                        qpos[q_loc + 5, i_col_q],
+                        qpos[q_loc + 6, i_col_q],
+                    ],
+                    dt=gs.qd_float,
+                )
+                pos = base_pos
+                quat = base_quat / base_quat.norm()
+            elif joint_type == gs.JOINT_TYPE.SPHERICAL:
+                # Three-DOF ball joint: the configuration carries a local orientation quaternion (4).
+                q_loc_quat = qd.Vector(
+                    [
+                        qpos[q_loc, i_col_q],
+                        qpos[q_loc + 1, i_col_q],
+                        qpos[q_loc + 2, i_col_q],
+                        qpos[q_loc + 3, i_col_q],
+                    ],
+                    dt=gs.qd_float,
+                )
+                joints_xanchor[i_j - joint_offset, i_col_out] = (
+                    gu.qd_transform_by_quat(dyn_info.joints.pos[I_j], quat) + pos
+                )
+                joints_xaxis[i_j - joint_offset, i_col_out] = gu.qd_transform_by_quat(
+                    qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float), quat
+                )
+                quat = gu.qd_transform_quat_by_quat(q_loc_quat, quat)
+                pos = joints_xanchor[i_j - joint_offset, i_col_out] - gu.qd_transform_by_quat(
+                    dyn_info.joints.pos[I_j], quat
+                )
+            elif joint_type != gs.JOINT_TYPE.FIXED:
+                axis = qd.Vector([0.0, 0.0, 1.0], dt=gs.qd_float)
+                if joint_type == gs.JOINT_TYPE.REVOLUTE:
+                    axis = dyn_info.dofs.motion_ang[I_d]
+                else:
+                    axis = dyn_info.dofs.motion_vel[I_d]
+                joints_xanchor[i_j - joint_offset, i_col_out] = (
+                    gu.qd_transform_by_quat(dyn_info.joints.pos[I_j], quat) + pos
+                )
+                joints_xaxis[i_j - joint_offset, i_col_out] = gu.qd_transform_by_quat(axis, quat)
+
+                q_delta = qpos[q_loc, i_col_q] - rigid_info.qpos0[q_start, i_b]
+                if joint_type == gs.JOINT_TYPE.REVOLUTE:
+                    qloc = gu.qd_rotvec_to_quat(axis * q_delta, rigid_info.EPS[None])
+                    quat = gu.qd_transform_quat_by_quat(qloc, quat)
+                    pos = joints_xanchor[i_j - joint_offset, i_col_out] - gu.qd_transform_by_quat(
+                        dyn_info.joints.pos[I_j], quat
+                    )
+                else:
+                    pos = pos + joints_xaxis[i_j - joint_offset, i_col_out] * q_delta
+
+        # Fixed root links keep their live pose, exactly like the solver FK (users may overwrite them manually).
+        if dyn_info.links.parent_idx[I_l] == -1 and dyn_info.links.is_fixed[I_l]:
+            pos = dyn_state.links.pos[i_l, i_b]
+            quat = dyn_state.links.quat[i_l, i_b]
+        links_pos[i_l - link_offset, i_col_out] = pos
+        links_quat[i_l - link_offset, i_col_out] = quat
+
+
+@qd.func
+def func_jacobian_scratch(
+    i_col,
+    i_b,
+    entity_idx,
+    joint_offset,
+    ee_link,
+    ee_pos,
+    jacobian: qd.Tensor,
+    joints_xanchor: qd.Tensor,
+    joints_xaxis: qd.Tensor,
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    """Spatial Jacobian (6 x n_dofs) of the goal point at column i_col.
+
+    Reads the joint frames that func_forward_kinematics_scratch placed in the per-column scratch.
+
+    Walks the kinematic path from the target link to the entity root, filling each joint's columns from its world
+    axis and anchor (already placed by func_forward_kinematics_scratch into joints_xaxis / joints_xanchor). A
+    SPHERICAL joint contributes nothing, matching the solver-state Jacobian. Unmasked.
+    """
+    dof_offset = dyn_info.entities.dof_start[entity_idx]
+    for i_row, i_d in qd.ndrange(6, jacobian.shape[1]):
+        jacobian[i_row, i_d, i_col] = 0.0
+
+    i_l = ee_link
+    while i_l != -1:
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        for i_j_ in range(dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l]):
+            i_j = gs.qd_int(i_j_)
+            I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+            i_d_jac = dyn_info.joints.dof_start[I_j] - dof_offset
+            if dyn_info.joints.type[I_j] == gs.JOINT_TYPE.REVOLUTE:
+                rotation = joints_xaxis[i_j - joint_offset, i_col]
+                translation = rotation.cross(ee_pos - joints_xanchor[i_j - joint_offset, i_col])
+                for i in qd.static(range(3)):
+                    jacobian[i, i_d_jac, i_col] = translation[i]
+                    jacobian[i + 3, i_d_jac, i_col] = rotation[i]
+            elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.PRISMATIC:
+                translation = joints_xaxis[i_j - joint_offset, i_col]
+                for i in qd.static(range(3)):
+                    jacobian[i, i_d_jac, i_col] = translation[i]
+            elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.FREE:
+                # Base translation moves the goal point directly; base rotation contributes a lever-arm term about
+                # the root position (the FREE joint's scratch anchor, placed by func_forward_kinematics_scratch).
+                base_pos = joints_xanchor[i_j - joint_offset, i_col]
+                for i_d_ in qd.static(range(3)):
+                    jacobian[i_d_, dyn_info.joints.dof_start[I_j] + i_d_ - dof_offset, i_col] = 1.0
+                for i_d_ in qd.static(range(3)):
+                    i_d = dyn_info.joints.dof_start[I_j] + i_d_ + 3
+                    I_d = [i_d, i_b] if qd.static(rigid_config.batch_dofs_info) else i_d
+                    rotation = dyn_info.dofs.motion_ang[I_d]
+                    translation = rotation.cross(ee_pos - base_pos)
+                    for i in qd.static(range(3)):
+                        jacobian[i, i_d - dof_offset, i_col] = translation[i]
+                        jacobian[i + 3, i_d - dof_offset, i_col] = rotation[i]
+        i_l = dyn_info.links.parent_idx[I_l]
+
+
+@qd.func
+def func_get_jacobian(
+    i_b,
+    tgt_link_idx,
+    dof_start,
+    p_local,
+    jacobian: qd.Tensor,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    """Full spatial Jacobian (6 x n_dofs) of a target link's local point.
+
+    Written into column i_b of the buffer.
+
+    Sums the velocity contribution of each joint on the path to the root; dof_start offsets global joint DOFs into
+    the buffer rows. Axis masking is left to the caller (the inverse-kinematics solver masks the stacked copy).
+    """
+    n_dofs = jacobian.shape[1]
+    for i_row, i_d in qd.ndrange(6, n_dofs):
+        jacobian[i_row, i_d, i_b] = 0.0
+
+    tgt_link_pos = dyn_state.links.pos[tgt_link_idx, i_b] + gu.qd_transform_by_quat(
+        p_local, dyn_state.links.quat[tgt_link_idx, i_b]
+    )
+    i_l = tgt_link_idx
+    while i_l > -1:
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+
+        for i_j in range(dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l]):
+            I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+
+            if dyn_info.joints.type[I_j] == gs.JOINT_TYPE.FIXED:
+                pass
+
+            elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.REVOLUTE:
+                i_d_jac = dyn_info.joints.dof_start[I_j] - dof_start
+                rotation = dyn_state.joints.xaxis[i_j, i_b]
+                translation = rotation.cross(tgt_link_pos - dyn_state.joints.xanchor[i_j, i_b])
+
+                for i in qd.static(range(3)):
+                    jacobian[i, i_d_jac, i_b] = translation[i]
+                    jacobian[i + 3, i_d_jac, i_b] = rotation[i]
+
+            elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.PRISMATIC:
+                i_d_jac = dyn_info.joints.dof_start[I_j] - dof_start
+                translation = dyn_state.joints.xaxis[i_j, i_b]
+
+                for i in qd.static(range(3)):
+                    jacobian[i, i_d_jac, i_b] = translation[i]
+
+            elif dyn_info.joints.type[I_j] == gs.JOINT_TYPE.FREE:
+                for i_d_ in qd.static(range(3)):
+                    i_d_jac = dyn_info.joints.dof_start[I_j] + i_d_ - dof_start
+                    jacobian[i_d_, i_d_jac, i_b] = 1.0
+
+                for i_d_ in qd.static(range(3)):
+                    i_d = dyn_info.joints.dof_start[I_j] + i_d_ + 3
+                    i_d_jac = i_d - dof_start
+                    I_d = [i_d, i_b] if qd.static(rigid_config.batch_dofs_info) else i_d
+                    rotation = dyn_info.dofs.motion_ang[I_d]
+                    translation = rotation.cross(tgt_link_pos - dyn_state.links.pos[i_l, i_b])
+
+                    for i in qd.static(range(3)):
+                        jacobian[i, i_d_jac, i_b] = translation[i]
+                        jacobian[i + 3, i_d_jac, i_b] = rotation[i]
+
+        i_l = dyn_info.links.parent_idx[I_l]
+
+
+@qd.kernel
+def kernel_get_jacobian(
+    tgt_link_idx: int,
+    dof_start: int,
+    p_local: qd.types.ndarray(),
+    jacobian: qd.Tensor,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+    n_batch: int,
+):
+    """Full spatial Jacobian of a link-local point, for every environment column."""
+    p_vec = qd.Vector([p_local[0], p_local[1], p_local[2]], dt=gs.qd_float)
+    for i_b in range(n_batch):
+        func_get_jacobian(i_b, tgt_link_idx, dof_start, p_vec, jacobian, dyn_state, dyn_info, rigid_config)
+
+
+@qd.kernel
+def kernel_get_jacobian_zero(
+    tgt_link_idx: int,
+    dof_start: int,
+    jacobian: qd.Tensor,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+    n_batch: int,
+):
+    """Full spatial Jacobian of a link origin, for every environment column."""
+    for i_b in range(n_batch):
+        func_get_jacobian(
+            i_b, tgt_link_idx, dof_start, qd.Vector.zero(gs.qd_float, 3), jacobian, dyn_state, dyn_info, rigid_config
+        )
+
+
+@qd.func
+def func_integrate_dq_scratch(
+    i_col,
+    i_b,
+    entity_idx,
+    q_offset,
+    dq: qd.Tensor,
+    qpos: qd.Tensor,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+    respect_joint_limit,
+):
+    """Integrate a joint-space step into the scratch configuration column.
+
+    Mirrors the solver-state integrator on caller-owned qpos, leaving the live state untouched. dq is indexed by
+    entity-local DOF; a FREE root advances its position additively and its orientation by a world-frame delta
+    rotation, and a REVOLUTE / PRISMATIC DOF advances additively with optional limit clamping.
+    """
     EPS = rigid_info.EPS[None]
 
-    # convert to qd Vector
-    pos_mask = qd.Vector([pos_mask_[0], pos_mask_[1], pos_mask_[2]], dt=gs.qd_float)
-    rot_mask = qd.Vector([rot_mask_[0], rot_mask_[1], rot_mask_[2]], dt=gs.qd_float)
-    n_dofs = dofs_idx.shape[0]
-    n_links = links_idx.shape[0]
+    for i_l in range(dyn_info.entities.link_start[entity_idx], dyn_info.entities.link_end[entity_idx]):
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.n_dofs[I_l] == 0:
+            continue
+
+        i_j = dyn_info.links.joint_start[I_l]
+        I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+        joint_type = dyn_info.joints.type[I_j]
+
+        q_loc = dyn_info.links.q_start[I_l] - q_offset
+        dof_start = dyn_info.links.dof_start[I_l]
+        dq_start = dof_start - dyn_info.entities.dof_start[entity_idx]
+
+        if joint_type == gs.JOINT_TYPE.FREE:
+            pos = qd.Vector([qpos[q_loc, i_col], qpos[q_loc + 1, i_col], qpos[q_loc + 2, i_col]])
+            pos = pos + qd.Vector([dq[dq_start, i_col], dq[dq_start + 1, i_col], dq[dq_start + 2, i_col]])
+            quat = qd.Vector(
+                [qpos[q_loc + 3, i_col], qpos[q_loc + 4, i_col], qpos[q_loc + 5, i_col], qpos[q_loc + 6, i_col]]
+            )
+            dquat = gu.qd_rotvec_to_quat(
+                qd.Vector([dq[dq_start + 3, i_col], dq[dq_start + 4, i_col], dq[dq_start + 5, i_col]], dt=gs.qd_float),
+                EPS,
+            )
+            # The delta rotation is expressed in the world frame, so it composes on the left of the orientation.
+            quat = gu.qd_transform_quat_by_quat(quat, dquat)
+            for j in qd.static(range(3)):
+                qpos[q_loc + j, i_col] = pos[j]
+            for j in qd.static(range(4)):
+                qpos[q_loc + j + 3, i_col] = quat[j]
+
+        elif joint_type == gs.JOINT_TYPE.FIXED:
+            pass
+
+        else:
+            for i_d_ in range(dyn_info.links.n_dofs[I_l]):
+                qpos[q_loc + i_d_, i_col] = qpos[q_loc + i_d_, i_col] + dq[dq_start + i_d_, i_col]
+                if respect_joint_limit:
+                    I_d = [dof_start + i_d_, i_b] if qd.static(rigid_config.batch_dofs_info) else dof_start + i_d_
+                    qpos[q_loc + i_d_, i_col] = qd.math.clamp(
+                        qpos[q_loc + i_d_, i_col], dyn_info.dofs.limit[I_d][0], dyn_info.dofs.limit[I_d][1]
+                    )
+
+
+@qd.func
+def func_inverse_kinematics(
+    entity_idx,
+    q_offset,
+    link_offset,
+    joint_offset,
+    dyn_state: array_class.DynState,
+    ik_state: array_class.IKState,
+    fk: array_class.IKScratchFK,
+    targets: array_class.IKTargets,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+    n_qs,
+    entity_n_dofs,
+    n_links,
+    n_dofs,
+    n_envs,
+    custom_init_qpos,
+    max_samples,
+    max_solver_iters,
+    damping,
+    pos_tol,
+    rot_tol,
+    max_step_size,
+    seed,
+    respect_joint_limit,
+):
+    """Damped-least-squares inverse kinematics for the target links.
+
+    Writes the best configuration found per column into ik_state.qpos_best.
+
+    Runs up to max_samples restarts of at most max_solver_iters Gauss-Newton steps against the stacked multi-target
+    pose error, keeping the least-error configuration. Every evaluation and integration happens on the caller-owned
+    forward-kinematics scratch (fk), so the live solver state is only read; unconverged restarts resample
+    joint-limited DOFs with a counter-based draw so the result is deterministic across parallel schedules.
+    """
+    EPS = rigid_info.EPS[None]
+
     n_error_dims = 6 * n_links
 
-    for i_b_ in range(envs_idx.shape[0]):
-        i_b = envs_idx[i_b_]
+    for i_b_ in range(n_envs):
+        i_b = targets.envs_idx[i_b_]
 
-        # save original qpos
-        for i_q in range(rigid_entity.n_qs):
-            rigid_entity._IK_qpos_orig[i_q, i_b] = rigid_info.qpos[i_q + rigid_entity._q_start, i_b]
-
-        if custom_init_qpos:
-            for i_q in range(rigid_entity.n_qs):
-                rigid_info.qpos[i_q + rigid_entity._q_start, i_b] = init_qpos[i_b_, i_q]
+        # Seed the working configuration from the requested initial guess or the live solver configuration.
+        for i_q in range(n_qs):
+            if custom_init_qpos:
+                fk.qpos[i_q, i_b] = targets.init_qpos[i_b, i_q]
+            else:
+                fk.qpos[i_q, i_b] = rigid_info.qpos[i_q + q_offset, i_b]
 
         for i_error in range(n_error_dims):
-            rigid_entity._IK_err_pose_best[i_error, i_b] = 1e4
+            ik_state.err_pose_best[i_error, i_b] = 1e4
 
         solved = False
         for i_sample in range(max_samples):
             for _ in range(max_solver_iters):
-                # run FK to update link states using current q
-                gs.engine.solvers.rigid.rigid_solver.func_forward_kinematics_entity(
-                    rigid_entity._idx_in_solver, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
+                func_forward_kinematics_scratch(
+                    i_b,
+                    i_b,
+                    i_b,
+                    entity_idx,
+                    link_offset,
+                    joint_offset,
+                    q_offset,
+                    fk.qpos,
+                    fk.links_pos,
+                    fk.links_quat,
+                    fk.joints_xanchor,
+                    fk.joints_xaxis,
+                    dyn_state,
+                    dyn_info,
+                    rigid_info,
+                    rigid_config,
                 )
-                # compute error
+
                 solved = True
                 for i_ee in range(n_links):
-                    i_l_ee = links_idx[i_ee]
-
-                    tgt_pos_i = qd.Vector([poss[i_ee, i_b_, 0], poss[i_ee, i_b_, 1], poss[i_ee, i_b_, 2]])
-                    local_point_i = qd.Vector([local_points[i_ee, 0], local_points[i_ee, 1], local_points[i_ee, 2]])
-                    pos_curr_i = dyn_state.links.pos[i_l_ee, i_b] + gu.qd_transform_by_quat(
-                        local_point_i, dyn_state.links.quat[i_l_ee, i_b]
+                    i_l_ee = targets.links_idx[i_ee]
+                    ee_quat = fk.links_quat[i_l_ee - link_offset, i_b]
+                    ee_pos = fk.links_pos[i_l_ee - link_offset, i_b] + gu.qd_transform_by_quat(
+                        targets.local_point[i_ee], ee_quat
                     )
-                    err_pos_i = tgt_pos_i - pos_curr_i
+
+                    err_pos_i = targets.pos[i_ee, i_b] - ee_pos
                     for k in range(3):
-                        err_pos_i[k] *= pos_mask[k] * link_pos_mask[i_ee]
+                        err_pos_i[k] = err_pos_i[k] * (targets.pos_mask[k] * targets.link_pos_mask[i_ee])
                     if err_pos_i.norm() > pos_tol:
                         solved = False
 
-                    tgt_quat_i = qd.Vector(
-                        [quats[i_ee, i_b_, 0], quats[i_ee, i_b_, 1], quats[i_ee, i_b_, 2], quats[i_ee, i_b_, 3]]
-                    )
                     err_rot_i = gu.qd_quat_to_rotvec(
-                        gu.qd_transform_quat_by_quat(gu.qd_inv_quat(dyn_state.links.quat[i_l_ee, i_b]), tgt_quat_i), EPS
+                        gu.qd_transform_quat_by_quat(gu.qd_inv_quat(ee_quat), targets.quat[i_ee, i_b]), EPS
                     )
                     for k in range(3):
-                        err_rot_i[k] *= rot_mask[k] * link_rot_mask[i_ee]
+                        err_rot_i[k] = err_rot_i[k] * (targets.rot_mask[k] * targets.link_rot_mask[i_ee])
                     if err_rot_i.norm() > rot_tol:
                         solved = False
 
-                    # put into multi-link error array
                     for k in range(3):
-                        rigid_entity._IK_err_pose[i_ee * 6 + k, i_b] = err_pos_i[k]
-                        rigid_entity._IK_err_pose[i_ee * 6 + k + 3, i_b] = err_rot_i[k]
+                        ik_state.err_pose[i_ee * 6 + k, i_b] = err_pos_i[k]
+                        ik_state.err_pose[i_ee * 6 + k + 3, i_b] = err_rot_i[k]
 
                 if solved:
                     break
 
-                # compute multi-link jacobian
                 for i_ee in range(n_links):
-                    # update jacobian for ee link
-                    i_l_ee = links_idx[i_ee]
-                    local_point_i = qd.Vector([local_points[i_ee, 0], local_points[i_ee, 1], local_points[i_ee, 2]])
-                    rigid_entity._func_get_jacobian(
-                        i_l_ee, i_b, local_point_i, pos_mask, rot_mask, dyn_state, dyn_info
-                    )  # NOTE: we still compute jacobian for all dofs as we haven't found a clean way to implement this
+                    i_l_ee = targets.links_idx[i_ee]
+                    ee_quat = fk.links_quat[i_l_ee - link_offset, i_b]
+                    ee_pos = fk.links_pos[i_l_ee - link_offset, i_b] + gu.qd_transform_by_quat(
+                        targets.local_point[i_ee], ee_quat
+                    )
+                    # Full single-link Jacobian over the entity DOFs; axis masking is applied while stacking below.
+                    func_jacobian_scratch(
+                        i_b,
+                        i_b,
+                        entity_idx,
+                        joint_offset,
+                        i_l_ee,
+                        ee_pos,
+                        ik_state.jacobian,
+                        fk.joints_xanchor,
+                        fk.joints_xaxis,
+                        dyn_info,
+                        rigid_config,
+                    )
 
-                    # copy to multi-link jacobian (only for the effective n_dofs instead of self.n_dofs)
                     for i_d_ in range(n_dofs):
-                        i_d = dofs_idx[i_d_]
-                        for i_error in qd.static(range(6)):
-                            i_row = i_ee * 6 + i_error
-                            rigid_entity._IK_jacobian[i_row, i_d_, i_b] = rigid_entity._jacobian[i_error, i_d, i_b]
+                        i_d = targets.dofs_idx[i_d_]
+                        for i_error in qd.static(range(3)):
+                            ik_state.jacobian_stacked[i_ee * 6 + i_error, i_d_, i_b] = (
+                                ik_state.jacobian[i_error, i_d, i_b] * targets.pos_mask[i_error]
+                            )
+                            ik_state.jacobian_stacked[i_ee * 6 + i_error + 3, i_d_, i_b] = (
+                                ik_state.jacobian[i_error + 3, i_d, i_b] * targets.rot_mask[i_error]
+                            )
 
-                # compute dq = jac.T @ inverse(jac @ jac.T + diag) @ error (only for the effective n_dofs instead of self.n_dofs)
-                lu.mat_transpose(rigid_entity._IK_jacobian, rigid_entity._IK_jacobian_T, n_error_dims, n_dofs, i_b)
+                lu.mat_transpose(ik_state.jacobian_stacked, ik_state.jacobian_stacked_t, n_error_dims, n_dofs, i_b)
                 lu.mat_mul(
-                    rigid_entity._IK_jacobian,
-                    rigid_entity._IK_jacobian_T,
-                    rigid_entity._IK_mat,
+                    ik_state.jacobian_stacked,
+                    ik_state.jacobian_stacked_t,
+                    ik_state.mat,
                     n_error_dims,
                     n_dofs,
                     n_error_dims,
                     i_b,
                 )
-                lu.mat_add_eye(rigid_entity._IK_mat, damping**2, n_error_dims, i_b)
+                lu.mat_add_eye(ik_state.mat, damping**2, n_error_dims, i_b)
                 lu.mat_inverse(
-                    rigid_entity._IK_mat,
-                    rigid_entity._IK_L,
-                    rigid_entity._IK_U,
-                    rigid_entity._IK_y,
-                    rigid_entity._IK_inv,
+                    ik_state.mat,
+                    ik_state.lu_lower,
+                    ik_state.lu_upper,
+                    ik_state.lu_y,
+                    ik_state.inv,
                     n_error_dims,
                     i_b,
                 )
-                lu.mat_mul_vec(
-                    rigid_entity._IK_inv,
-                    rigid_entity._IK_err_pose,
-                    rigid_entity._IK_vec,
-                    n_error_dims,
-                    n_error_dims,
-                    i_b,
-                )
+                lu.mat_mul_vec(ik_state.inv, ik_state.err_pose, ik_state.vec, n_error_dims, n_error_dims, i_b)
 
-                for i_d_ in range(rigid_entity.n_dofs):  # IK_delta_qpos = IK_jacobian_T @ IK_vec
-                    rigid_entity._IK_delta_qpos[i_d_, i_b] = 0
+                for i_d_ in range(entity_n_dofs):
+                    ik_state.delta_qpos[i_d_, i_b] = 0
                 for i_d_ in range(n_dofs):
-                    i_d = dofs_idx[i_d_]
+                    i_d = targets.dofs_idx[i_d_]
                     for j in range(n_error_dims):
-                        # NOTE: IK_delta_qpos uses the original indexing instead of the effective n_dofs
-                        rigid_entity._IK_delta_qpos[i_d, i_b] += (
-                            rigid_entity._IK_jacobian_T[i_d_, j, i_b] * rigid_entity._IK_vec[j, i_b]
+                        ik_state.delta_qpos[i_d, i_b] = ik_state.delta_qpos[i_d, i_b] + (
+                            ik_state.jacobian_stacked_t[i_d_, j, i_b] * ik_state.vec[j, i_b]
                         )
 
-                for i_d_ in range(rigid_entity.n_dofs):
-                    rigid_entity._IK_delta_qpos[i_d_, i_b] = qd.math.clamp(
-                        rigid_entity._IK_delta_qpos[i_d_, i_b], -max_step_size, max_step_size
+                for i_d_ in range(entity_n_dofs):
+                    ik_state.delta_qpos[i_d_, i_b] = qd.math.clamp(
+                        ik_state.delta_qpos[i_d_, i_b], -max_step_size, max_step_size
                     )
 
-                # update q
-                gs.engine.solvers.rigid.rigid_solver.func_integrate_dq_entity(
-                    rigid_entity._idx_in_solver,
+                func_integrate_dq_scratch(
                     i_b,
-                    rigid_entity._IK_delta_qpos,
+                    i_b,
+                    entity_idx,
+                    q_offset,
+                    ik_state.delta_qpos,
+                    fk.qpos,
                     dyn_info,
                     rigid_info,
                     rigid_config,
@@ -179,84 +543,86 @@ def kernel_rigid_entity_inverse_kinematics(
                 )
 
             if not solved:
-                # re-compute final error if exited not due to solved
-                gs.engine.solvers.rigid.rigid_solver.func_forward_kinematics_entity(
-                    rigid_entity._idx_in_solver, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
+                # Recompute the residual for the final configuration when the iteration budget ran out.
+                func_forward_kinematics_scratch(
+                    i_b,
+                    i_b,
+                    i_b,
+                    entity_idx,
+                    link_offset,
+                    joint_offset,
+                    q_offset,
+                    fk.qpos,
+                    fk.links_pos,
+                    fk.links_quat,
+                    fk.joints_xanchor,
+                    fk.joints_xaxis,
+                    dyn_state,
+                    dyn_info,
+                    rigid_info,
+                    rigid_config,
                 )
                 solved = True
                 for i_ee in range(n_links):
-                    i_l_ee = links_idx[i_ee]
-
-                    tgt_pos_i = qd.Vector([poss[i_ee, i_b_, 0], poss[i_ee, i_b_, 1], poss[i_ee, i_b_, 2]])
-                    local_point_i = qd.Vector([local_points[i_ee, 0], local_points[i_ee, 1], local_points[i_ee, 2]])
-                    pos_curr_i = dyn_state.links.pos[i_l_ee, i_b] + gu.qd_transform_by_quat(
-                        local_point_i, dyn_state.links.quat[i_l_ee, i_b]
+                    i_l_ee = targets.links_idx[i_ee]
+                    ee_quat = fk.links_quat[i_l_ee - link_offset, i_b]
+                    ee_pos = fk.links_pos[i_l_ee - link_offset, i_b] + gu.qd_transform_by_quat(
+                        targets.local_point[i_ee], ee_quat
                     )
-                    err_pos_i = tgt_pos_i - pos_curr_i
+                    err_pos_i = targets.pos[i_ee, i_b] - ee_pos
                     for k in range(3):
-                        err_pos_i[k] *= pos_mask[k] * link_pos_mask[i_ee]
+                        err_pos_i[k] = err_pos_i[k] * (targets.pos_mask[k] * targets.link_pos_mask[i_ee])
                     if err_pos_i.norm() > pos_tol:
                         solved = False
 
-                    tgt_quat_i = qd.Vector(
-                        [quats[i_ee, i_b_, 0], quats[i_ee, i_b_, 1], quats[i_ee, i_b_, 2], quats[i_ee, i_b_, 3]]
-                    )
                     err_rot_i = gu.qd_quat_to_rotvec(
-                        gu.qd_transform_quat_by_quat(gu.qd_inv_quat(dyn_state.links.quat[i_l_ee, i_b]), tgt_quat_i), EPS
+                        gu.qd_transform_quat_by_quat(gu.qd_inv_quat(ee_quat), targets.quat[i_ee, i_b]), EPS
                     )
                     for k in range(3):
-                        err_rot_i[k] *= rot_mask[k] * link_rot_mask[i_ee]
+                        err_rot_i[k] = err_rot_i[k] * (targets.rot_mask[k] * targets.link_rot_mask[i_ee])
                     if err_rot_i.norm() > rot_tol:
                         solved = False
 
-                    # put into multi-link error array
                     for k in range(3):
-                        rigid_entity._IK_err_pose[i_ee * 6 + k, i_b] = err_pos_i[k]
-                        rigid_entity._IK_err_pose[i_ee * 6 + k + 3, i_b] = err_rot_i[k]
+                        ik_state.err_pose[i_ee * 6 + k, i_b] = err_pos_i[k]
+                        ik_state.err_pose[i_ee * 6 + k + 3, i_b] = err_rot_i[k]
 
             if solved:
-                for i_q in range(rigid_entity.n_qs):
-                    rigid_entity._IK_qpos_best[i_q, i_b] = rigid_info.qpos[i_q + rigid_entity._q_start, i_b]
+                for i_q in range(n_qs):
+                    ik_state.qpos_best[i_q, i_b] = fk.qpos[i_q, i_b]
                 for i_error in range(n_error_dims):
-                    rigid_entity._IK_err_pose_best[i_error, i_b] = rigid_entity._IK_err_pose[i_error, i_b]
+                    ik_state.err_pose_best[i_error, i_b] = ik_state.err_pose[i_error, i_b]
                 break
 
             else:
-                # copy to _IK_qpos if this sample is better
                 improved = True
                 for i_ee in range(n_links):
-                    error_pos_i = qd.Vector(
-                        [rigid_entity._IK_err_pose[i_ee * 6 + i_error, i_b] for i_error in range(3)]
-                    )
-                    error_rot_i = qd.Vector(
-                        [rigid_entity._IK_err_pose[i_ee * 6 + i_error, i_b] for i_error in range(3, 6)]
-                    )
+                    error_pos_i = qd.Vector([ik_state.err_pose[i_ee * 6 + i_error, i_b] for i_error in range(3)])
+                    error_rot_i = qd.Vector([ik_state.err_pose[i_ee * 6 + i_error, i_b] for i_error in range(3, 6)])
                     error_pos_best = qd.Vector(
-                        [rigid_entity._IK_err_pose_best[i_ee * 6 + i_error, i_b] for i_error in range(3)]
+                        [ik_state.err_pose_best[i_ee * 6 + i_error, i_b] for i_error in range(3)]
                     )
                     error_rot_best = qd.Vector(
-                        [rigid_entity._IK_err_pose_best[i_ee * 6 + i_error, i_b] for i_error in range(3, 6)]
+                        [ik_state.err_pose_best[i_ee * 6 + i_error, i_b] for i_error in range(3, 6)]
                     )
                     if error_pos_i.norm() > error_pos_best.norm() or error_rot_i.norm() > error_rot_best.norm():
                         improved = False
                         break
 
                 if improved:
-                    for i_q in range(rigid_entity.n_qs):
-                        rigid_entity._IK_qpos_best[i_q, i_b] = rigid_info.qpos[i_q + rigid_entity._q_start, i_b]
+                    for i_q in range(n_qs):
+                        ik_state.qpos_best[i_q, i_b] = fk.qpos[i_q, i_b]
                     for i_error in range(n_error_dims):
-                        rigid_entity._IK_err_pose_best[i_error, i_b] = rigid_entity._IK_err_pose[i_error, i_b]
+                        ik_state.err_pose_best[i_error, i_b] = ik_state.err_pose[i_error, i_b]
 
-                # Resample init q
                 if respect_joint_limit and i_sample < max_samples - 1:
-                    i_e = rigid_entity._idx_in_solver
-                    entity_dof_start = dyn_info.entities.dof_start[i_e]
-                    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
+                    entity_dof_start = dyn_info.entities.dof_start[entity_idx]
+                    for i_l in range(dyn_info.entities.link_start[entity_idx], dyn_info.entities.link_end[entity_idx]):
                         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
 
                         must_resample = False
                         for i_d_ in range(n_dofs):
-                            i_d = dofs_idx[i_d_]
+                            i_d = targets.dofs_idx[i_d_]
                             link_dof_start_local = dyn_info.links.dof_start[I_l] - entity_dof_start
                             link_dof_end_local = dyn_info.links.dof_end[I_l] - entity_dof_start
                             if link_dof_start_local <= i_d and i_d < link_dof_end_local:
@@ -276,15 +642,155 @@ def kernel_rigid_entity_inverse_kinematics(
                                 or dyn_info.joints.type[I_j] == gs.JOINT_TYPE.PRISMATIC
                             ) and not (qd.math.isinf(dof_limit[0]) or qd.math.isinf(dof_limit[1])):
                                 q_start = dyn_info.joints.q_start[I_j]
-                                rigid_info.qpos[q_start, i_b] = dof_limit[0] + qd.random() * (
-                                    dof_limit[1] - dof_limit[0]
-                                )
-                else:
-                    pass  # When respect_joint_limit=False, we can simply continue from the last solution
+                                # Counter-based draw keyed on (env, restart, DOF): a qd.random() per-thread stream
+                                # would order by the parallel schedule, making the resampled - and returned -
+                                # configuration nondeterministic across runs.
+                                fk.qpos[q_start - q_offset, i_b] = dof_limit[0] + gu.qd_hash01(
+                                    seed, i_b, i_sample, q_start
+                                ) * (dof_limit[1] - dof_limit[0])
 
-        # restore original qpos and link state
-        for i_q in range(rigid_entity.n_qs):
-            rigid_info.qpos[i_q + rigid_entity._q_start, i_b] = rigid_entity._IK_qpos_orig[i_q, i_b]
-        gs.engine.solvers.rigid.rigid_solver.func_forward_kinematics_entity(
-            rigid_entity._idx_in_solver, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
+
+@qd.kernel(fastcache=True)
+def kernel_inverse_kinematics_entity(
+    entity_idx: int,
+    q_offset: int,
+    link_offset: int,
+    joint_offset: int,
+    dyn_state: array_class.DynState,
+    ik_state: array_class.IKState,
+    fk: array_class.IKScratchFK,
+    targets: array_class.IKTargets,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+    n_qs: int,
+    entity_n_dofs: int,
+    n_links: int,
+    n_dofs: int,
+    n_envs: int,
+    custom_init_qpos: int,
+    max_samples: int,
+    max_solver_iters: int,
+    damping: float,
+    pos_tol: float,
+    rot_tol: float,
+    max_step_size: float,
+    seed: int,
+    respect_joint_limit: int,
+):
+    """Entity-facing launch wrapper forwarding the IK scratch and model scalars to func_inverse_kinematics."""
+    func_inverse_kinematics(
+        entity_idx,
+        q_offset,
+        link_offset,
+        joint_offset,
+        dyn_state,
+        ik_state,
+        fk,
+        targets,
+        dyn_info,
+        rigid_info,
+        rigid_config,
+        n_qs,
+        entity_n_dofs,
+        n_links,
+        n_dofs,
+        n_envs,
+        custom_init_qpos,
+        max_samples,
+        max_solver_iters,
+        damping,
+        pos_tol,
+        rot_tol,
+        max_step_size,
+        seed,
+        respect_joint_limit,
+    )
+
+
+@qd.kernel(fastcache=True)
+def kernel_set_ik_targets(
+    links_idx: qd.types.ndarray(),
+    dofs_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    poss: qd.types.ndarray(),
+    quats: qd.types.ndarray(),
+    local_points: qd.types.ndarray(),
+    init_qpos: qd.types.ndarray(),
+    pos_mask: qd.types.ndarray(),
+    rot_mask: qd.types.ndarray(),
+    link_pos_mask: qd.types.ndarray(),
+    link_rot_mask: qd.types.ndarray(),
+    targets: array_class.IKTargets,
+):
+    """Copy externally supplied inverse-kinematics targets into the solver-side struct (non-zero-copy fallback)."""
+    for i_ee in range(links_idx.shape[0]):
+        targets.links_idx[i_ee] = links_idx[i_ee]
+        targets.link_pos_mask[i_ee] = link_pos_mask[i_ee]
+        targets.link_rot_mask[i_ee] = link_rot_mask[i_ee]
+        targets.local_point[i_ee] = qd.Vector([local_points[i_ee, 0], local_points[i_ee, 1], local_points[i_ee, 2]])
+        for i_c in range(envs_idx.shape[0]):
+            i_b = envs_idx[i_c]
+            targets.pos[i_ee, i_b] = qd.Vector([poss[i_ee, i_c, 0], poss[i_ee, i_c, 1], poss[i_ee, i_c, 2]])
+            targets.quat[i_ee, i_b] = qd.Vector(
+                [quats[i_ee, i_c, 0], quats[i_ee, i_c, 1], quats[i_ee, i_c, 2], quats[i_ee, i_c, 3]]
+            )
+    for i_d in range(dofs_idx.shape[0]):
+        targets.dofs_idx[i_d] = dofs_idx[i_d]
+    for i_c in range(envs_idx.shape[0]):
+        targets.envs_idx[i_c] = envs_idx[i_c]
+        for i_q in range(init_qpos.shape[1]):
+            targets.init_qpos[envs_idx[i_c], i_q] = init_qpos[i_c, i_q]
+    for k in qd.static(range(3)):
+        targets.pos_mask[k] = pos_mask[k]
+        targets.rot_mask[k] = rot_mask[k]
+
+
+@qd.kernel
+def kernel_forward_kinematics_query(
+    entity_idx: int,
+    qs_idx: qd.types.ndarray(),
+    links_idx: qd.types.ndarray(),
+    envs_idx: qd.types.ndarray(),
+    links_pos: qd.types.ndarray(),
+    links_quat: qd.types.ndarray(),
+    qpos: qd.types.ndarray(),
+    qpos_cache: qd.Tensor,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+):
+    """Link poses of one entity at a queried configuration, leaving the live configuration as it was.
+
+    The queried configuration is written into the solver, forward kinematics runs, the poses are read out, and the
+    saved configuration is restored and re-propagated. qpos_cache spans the solver configuration, so the global q
+    indices index it directly.
+    """
+    qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_q_, i_b_ in qd.ndrange(qs_idx.shape[0], envs_idx.shape[0]):
+        qpos_cache[qs_idx[i_q_], envs_idx[i_b_]] = rigid_info.qpos[qs_idx[i_q_], envs_idx[i_b_]]
+        rigid_info.qpos[qs_idx[i_q_], envs_idx[i_b_]] = qpos[i_b_, i_q_]
+
+    qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_b_ in range(envs_idx.shape[0]):
+        func_forward_kinematics_entity(
+            entity_idx, envs_idx[i_b_], dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
+        )
+
+    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
+        for i in qd.static(range(3)):
+            links_pos[i_b_, i_l_, i] = dyn_state.links.pos[links_idx[i_l_], envs_idx[i_b_]][i]
+        for i in qd.static(range(4)):
+            links_quat[i_b_, i_l_, i] = dyn_state.links.quat[links_idx[i_l_], envs_idx[i_b_]][i]
+
+    qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_q_, i_b_ in qd.ndrange(qs_idx.shape[0], envs_idx.shape[0]):
+        rigid_info.qpos[qs_idx[i_q_], envs_idx[i_b_]] = qpos_cache[qs_idx[i_q_], envs_idx[i_b_]]
+
+    qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
+    for i_b_ in range(envs_idx.shape[0]):
+        func_forward_kinematics_entity(
+            entity_idx, envs_idx[i_b_], dyn_state, dyn_info, rigid_info, rigid_config, is_backward=False
         )

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -803,6 +803,7 @@ class RigidSolver(KinematicSolver):
         self._rigid_adjoint_cache = self.data_manager.rigid_adjoint_cache
         self.dyn_info = self.data_manager.dyn_info
         self.dyn_state = self.data_manager.dyn_state
+        self.kinematics_scratch = self.data_manager.kinematics_scratch
         if self._use_hibernation:
             self.n_awake_dofs = self.rigid_info.n_awake_dofs
             self.awake_dofs = self.rigid_info.awake_dofs

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -110,8 +110,7 @@ class Morph(Options):
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
     requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
+        This parameter is deprecated.
     is_free : bool, optional
         This parameter is deprecated.
     """
@@ -125,7 +124,6 @@ class Morph(Options):
     offset_quat: UnitVec4FType | None = None
     visualization: StrictBool = True
     collision: StrictBool = True
-    requires_jac_and_IK: StrictBool = False
     enable_custom_vverts: StrictBool = False
 
     @model_validator(mode="before")
@@ -134,6 +132,8 @@ class Morph(Options):
         is_free = data.pop("is_free", None)
         if is_free is not None:
             gs.logger.warning("'is_free' is deprecated and will be removed in the future.")
+        if data.pop("requires_jac_and_IK", None) is not None:
+            gs.logger.warning("'requires_jac_and_IK' is deprecated and has no effect.")
         euler = data.get("euler")
         quat = data.get("quat")
         if euler is not None and quat is not None:
@@ -201,9 +201,6 @@ class Primitive(Morph):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics.
-        Defaults to False. **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the primitive should be fixed. Defaults to False. **This is only used for RigidEntity.**
     batch_fixed_verts : bool, optional
@@ -254,9 +251,6 @@ class Box(Primitive, TetGenMixin):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the primitive should be fixed. Defaults to False. **This is only used for RigidEntity.**
     batch_fixed_verts : bool, optional
@@ -346,9 +340,6 @@ class Cylinder(Primitive, TetGenMixin):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the primitive should be fixed. Defaults to False. **This is only used for RigidEntity.**
     batch_fixed_verts : bool, optional
@@ -411,9 +402,6 @@ class Sphere(Primitive, TetGenMixin):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
     fixed : bool, optional
         Whether the primitive should be fixed. Defaults to False. **This is only used for RigidEntity.**
     batch_fixed_verts : bool, optional
@@ -508,8 +496,6 @@ class Plane(Primitive):
             gs.raise_exception("Plane `fixed` must be True.")
         super().__init__(fixed=True, **data)
 
-        if self.requires_jac_and_IK:
-            gs.raise_exception("`requires_jac_and_IK` must be False for `Plane`.")
         if self.enable_custom_vverts:
             gs.raise_exception("`enable_custom_vverts` must be False for `Plane`.")
 
@@ -597,9 +583,6 @@ class FileMorph(Morph):
     batch_fixed_verts : bool, optional
         Whether to batch fixed vertices. This will allow setting env-specific poses to fixed geometries, at the cost of
         significantly increasing memory usage. Default to true. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
     """
 
     # Shown in the repr header via __repr_name__ (a bounded identifier for in-memory descriptions), so it is kept out
@@ -780,9 +763,6 @@ class Mesh(FileMorph, TetGenMixin):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
     parse_glb_with_zup : bool, optional
         This parameter is deprecated, see file_meshes_are_zup.
     file_meshes_are_zup : bool, optional
@@ -979,8 +959,6 @@ class MJCF(FileMorph):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False.
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to True.
     batch_fixed_verts : bool, optional
         Whether to batch fixed vertices. This will allow setting env-specific poses to fixed geometries, at the cost of
         significantly increasing memory usage. Default to true. **This is only used for RigidEntity.**
@@ -998,7 +976,6 @@ class MJCF(FileMorph):
 
     pos: Vec3FType | None = None
     quat: UnitVec4FType | None = None
-    requires_jac_and_IK: StrictBool = True
     default_armature: float | None = Field(default=0.1, ge=0)
     exclude_ground_plane: StrictBool = False
 
@@ -1111,8 +1088,6 @@ class URDF(FileMorph):
     collision : bool, optional
         Whether the entity needs to be considered for collision checking. Defaults to True.
         `visualization` and `collision` cannot both be False.
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to True.
     fixed : bool, optional
         Whether the baselink of the entity should be fixed. Defaults to False.
     batch_fixed_verts : bool, optional
@@ -1141,7 +1116,6 @@ class URDF(FileMorph):
 
     fixed: StrictBool = False
     prioritize_urdf_material: StrictBool = False
-    requires_jac_and_IK: StrictBool = True
     merge_fixed_links: StrictBool = True
     links_to_keep: StrArrayType = ()
     default_armature: float | None = Field(default=0.1, ge=0)
@@ -1610,9 +1584,6 @@ class USD(FileMorph):
     batch_fixed_verts : bool, optional
         Whether to batch fixed vertices. This will allow setting env-specific poses to fixed geometries, at the cost of
         significantly increasing memory usage. Default to true. **This is only used for RigidEntity.**
-    requires_jac_and_IK : bool, optional
-        Whether this morph, if created as `RigidEntity`, requires jacobian and inverse kinematics. Defaults to False.
-        **This is only used for RigidEntity.**
     default_armature : float, optional
         Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
         file, regardless of whether it is actuated. None to disable. Default to 0.1.

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -365,12 +365,16 @@ class KinematicOptions(Options):
         Whether to batch link info. Automatically enabled for heterogeneous simulation. Defaults to False.
     batch_dofs_info : bool, optional
         Whether to batch DOF info. Defaults to False.
+    IK_max_targets : int, optional
+        Maximum number of IK targets. Increasing this doesn't affect IK solving speed, but will increase memory usage.
+        Defaults to 6.
     """
 
     dt: PositiveFloat | None = None
     batch_links_info: StrictBool = False
     batch_joints_info: StrictBool = False
     batch_dofs_info: StrictBool = False
+    IK_max_targets: PositiveInt = 6
 
 
 class ToolOptions(Options):

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1,6 +1,7 @@
 import dataclasses
 import math
 from enum import IntEnum
+from typing import NamedTuple
 
 import quadrants as qd
 from typing_extensions import dataclass_transform  # Made it into standard lib from Python 3.12
@@ -406,6 +407,173 @@ def get_island_state(solver, collider):
         rcm_tree_degree=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), rcm_active)),
         rcm_tree_is_ordered=V(dtype=gs.qd_bool, shape=maybe_shape((n_links, _B), rcm_active)),
         rcm_tree_order=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), rcm_active)),
+    )
+
+
+# =========================================== IKState ===========================================
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class IKState:
+    """Damped-least-squares inverse-kinematics scratch, one column per parallel solve.
+
+    A column is an environment for the entity API or a candidate restart for the planner; error_dim = 6 * n_targets
+    stacks the per-target pose residuals.
+    """
+
+    # Single-target spatial Jacobian (6 x n_dofs), rebuilt per target link and copied into the stacked block.
+    jacobian: qd.Tensor
+    # Stacked multi-target Jacobian and its transpose, feeding the damped normal-equations solve.
+    jacobian_stacked: qd.Tensor
+    jacobian_stacked_t: qd.Tensor
+    # Damped normal matrix J J^T + damping^2 I, its lower / upper LU factors and forward-substitution scratch, and
+    # its inverse.
+    mat: qd.Tensor
+    lu_lower: qd.Tensor
+    lu_upper: qd.Tensor
+    lu_y: qd.Tensor
+    inv: qd.Tensor
+    # Stacked pose residual, the best residual seen across restarts, and inv @ residual.
+    err_pose: qd.Tensor
+    err_pose_best: qd.Tensor
+    vec: qd.Tensor
+    # Joint-space step and the best configuration found across restarts.
+    delta_qpos: qd.Tensor
+    qpos_best: qd.Tensor
+
+
+def get_ik_state(n_qs, n_dofs, error_dim, n_cols):
+    return IKState(
+        jacobian=V(dtype=gs.qd_float, shape=(6, n_dofs, n_cols)),
+        jacobian_stacked=V(dtype=gs.qd_float, shape=(error_dim, n_dofs, n_cols)),
+        jacobian_stacked_t=V(dtype=gs.qd_float, shape=(n_dofs, error_dim, n_cols)),
+        mat=V(dtype=gs.qd_float, shape=(error_dim, error_dim, n_cols)),
+        lu_lower=V(dtype=gs.qd_float, shape=(error_dim, error_dim, n_cols)),
+        lu_upper=V(dtype=gs.qd_float, shape=(error_dim, error_dim, n_cols)),
+        lu_y=V(dtype=gs.qd_float, shape=(error_dim, error_dim, n_cols)),
+        inv=V(dtype=gs.qd_float, shape=(error_dim, error_dim, n_cols)),
+        err_pose=V(dtype=gs.qd_float, shape=(error_dim, n_cols)),
+        err_pose_best=V(dtype=gs.qd_float, shape=(error_dim, n_cols)),
+        vec=V(dtype=gs.qd_float, shape=(error_dim, n_cols)),
+        delta_qpos=V(dtype=gs.qd_float, shape=(n_dofs, n_cols)),
+        qpos_best=V(dtype=gs.qd_float, shape=(n_qs, n_cols)),
+    )
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class IKScratchFK:
+    """Per-column forward-kinematics scratch for the entity inverse-kinematics solve.
+
+    Holds the working configuration and the link / joint frames it produces, so each Gauss-Newton step evaluates
+    and integrates poses on caller-owned buffers without mutating live solver state. A column is an environment.
+    """
+
+    # Entity-local working configuration iterated by the solve.
+    qpos: qd.Tensor
+    # Link poses and joint frames placed by func_forward_kinematics_scratch, feeding the error and the Jacobian.
+    links_pos: qd.Tensor
+    links_quat: qd.Tensor
+    joints_xanchor: qd.Tensor
+    joints_xaxis: qd.Tensor
+
+
+def get_ik_scratch_fk(n_qs, n_links, n_joints, n_cols):
+    return IKScratchFK(
+        qpos=V(dtype=gs.qd_float, shape=(n_qs, n_cols)),
+        links_pos=V(dtype=gs.qd_vec3, shape=(n_links, n_cols)),
+        links_quat=V(dtype=gs.qd_vec4, shape=(n_links, n_cols)),
+        joints_xanchor=V(dtype=gs.qd_vec3, shape=(n_joints, n_cols)),
+        joints_xaxis=V(dtype=gs.qd_vec3, shape=(n_joints, n_cols)),
+    )
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class IKTargets:
+    """Inverse-kinematics targets and DOF selection for one solve batch, one column per parallel solve.
+
+    A column is an environment for the entity API or a candidate restart for the planner. Positions and
+    orientations are vec-typed so the solver reads a target pose per (link, column) directly; the host populates
+    every field before the solve.
+    """
+
+    # Global indices of the target links, the effective DOFs to move, and the columns (solver envs) to solve.
+    links_idx: qd.Tensor
+    dofs_idx: qd.Tensor
+    envs_idx: qd.Tensor
+    # Target pose per (link, column) and the link-local point whose pose is driven, in the world frame.
+    pos: qd.Tensor
+    quat: qd.Tensor
+    local_point: qd.Tensor
+    # Optional custom initial configuration per (column, q); used only when custom_init_qpos is set.
+    init_qpos: qd.Tensor
+    # Which position / rotation axes to solve (shared across links), and per-link position / rotation enables.
+    pos_mask: qd.Tensor
+    rot_mask: qd.Tensor
+    link_pos_mask: qd.Tensor
+    link_rot_mask: qd.Tensor
+
+
+def get_ik_targets(n_links, n_dofs, n_qs, n_cols):
+    return IKTargets(
+        links_idx=V(dtype=gs.qd_int, shape=(n_links,)),
+        dofs_idx=V(dtype=gs.qd_int, shape=(n_dofs,)),
+        envs_idx=V(dtype=gs.qd_int, shape=(n_cols,)),
+        pos=V_VEC(3, dtype=gs.qd_float, shape=(n_links, n_cols)),
+        quat=V_VEC(4, dtype=gs.qd_float, shape=(n_links, n_cols)),
+        local_point=V_VEC(3, dtype=gs.qd_float, shape=(n_links,)),
+        init_qpos=V(dtype=gs.qd_float, shape=(n_cols, n_qs)),
+        pos_mask=V(dtype=gs.qd_float, shape=(3,)),
+        rot_mask=V(dtype=gs.qd_float, shape=(3,)),
+        link_pos_mask=V(dtype=gs.qd_int, shape=(n_links,)),
+        link_rot_mask=V(dtype=gs.qd_int, shape=(n_links,)),
+    )
+
+
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class KinematicsScratch:
+    """Buffers backing the kinematics queries of every entity of one solver.
+
+    A column is an environment. The Jacobian spans the widest entity, and the configuration cache spans the solver
+    configuration so the global q indices callers already work in index it directly.
+    """
+
+    jacobian: qd.Tensor
+    qpos_cache: qd.Tensor
+
+
+def get_kinematics_scratch(solver):
+    n_dofs = max((entity.n_dofs for entity in solver.entities), default=0)
+    is_active = n_dofs > 0
+
+    return KinematicsScratch(
+        jacobian=V(dtype=gs.qd_float, shape=maybe_shape((6, n_dofs, solver._B), is_active)),
+        qpos_cache=V(dtype=gs.qd_float, shape=maybe_shape((solver.n_qs, solver._B), is_active)),
+    )
+
+
+class IKScratch(NamedTuple):
+    """The three solve-time buffers an inverse-kinematics call needs, shared by every entity of one solver.
+
+    Sized by the largest entity the solver holds and by the target cap, so each solve writes the leading rows its own
+    entity spans; a column is an environment.
+    """
+
+    state: IKState
+    fk: IKScratchFK
+    targets: IKTargets
+
+
+def get_ik_scratch(solver):
+    n_qs = max(entity.n_qs for entity in solver.entities)
+    n_dofs = max(entity.n_dofs for entity in solver.entities)
+    n_links = max(entity.n_links for entity in solver.entities)
+    n_joints = max(entity.n_joints for entity in solver.entities)
+    n_tgts = solver._options.IK_max_targets
+
+    return IKScratch(
+        state=get_ik_state(n_qs, n_dofs, 6 * n_tgts, solver._B),
+        fk=get_ik_scratch_fk(n_qs, n_links, n_joints, solver._B),
+        targets=get_ik_targets(n_tgts, n_dofs, n_qs, solver._B),
     )
 
 
@@ -2554,6 +2722,8 @@ class DataManager:
 
         equalities_info = get_equalities_info(solver, is_dynamic)
 
+        self.kinematics_scratch = get_kinematics_scratch(solver)
+
         self.dyn_info = DynInfo(
             entities=entities_info,
             links=links_info,
@@ -2586,6 +2756,20 @@ class DataManager:
 
         self.rigid_adjoint_cache = get_rigid_adjoint_cache(solver)
         self.errno = V(dtype=gs.qd_int, shape=(solver._B,))
+
+        self._solver = solver
+        self._ik_scratch = None
+
+    @property
+    def ik_scratch(self) -> IKScratch:
+        """Inverse-kinematics scratch, allocated the first time a solve asks for it.
+
+        The damped normal matrix it holds is quadratic in RigidOptions.IK_max_targets, so a scene that never solves
+        inverse kinematics carries none of it.
+        """
+        if self._ik_scratch is None:
+            self._ik_scratch = get_ik_scratch(self._solver)
+        return self._ik_scratch
 
 
 # =========================================== RaycastResult ===========================================

--- a/genesis/utils/geom.py
+++ b/genesis/utils/geom.py
@@ -2657,3 +2657,17 @@ def orthogonals(a) -> tuple[np.ndarray, np.ndarray]:
     b_1d /= np.sqrt(np.sum(np.square(b_1d), -1)).reshape((-1, 1))
 
     return np.cross(b_1d, a_1d).reshape((*B, 3)), b_1d.reshape((*B, 3))
+
+
+@qd.func
+def qd_hash01(k0, k1, k2, k3):
+    """Counter-based hash to [0, 1): value depends only on the four keys, never on thread scheduling, so kernels
+    drawing from it stay bitwise deterministic under any parallel execution."""
+    h = qd.cast(k0, qd.u32) * qd.u32(0x9E3779B1)
+    h = (h ^ qd.cast(k1, qd.u32)) * qd.u32(0x85EBCA77)
+    h = (h ^ qd.cast(k2, qd.u32)) * qd.u32(0xC2B2AE3D)
+    h = (h ^ qd.cast(k3, qd.u32)) * qd.u32(0x27D4EB2F)
+    h = h ^ (h >> qd.u32(15))
+    h = h * qd.u32(0x2C1B3C6D)
+    h = h ^ (h >> qd.u32(12))
+    return qd.cast(h >> qd.u32(8), gs.qd_float) * (1.0 / 16777216.0)

--- a/genesis/utils/linalg.py
+++ b/genesis/utils/linalg.py
@@ -4,7 +4,7 @@ import genesis as gs
 
 
 @qd.func
-def mat_mul(A, B, res, n, m, l, i_b):
+def mat_mul(A: qd.Tensor, B: qd.Tensor, res: qd.Tensor, n, m, l, i_b):
     """
     Performs matrix multiplication between matrices A and B and stores the result in res.
 
@@ -25,7 +25,7 @@ def mat_mul(A, B, res, n, m, l, i_b):
 
 
 @qd.func
-def mat_mul_vec(mat, vec, res, n, m, i_b):
+def mat_mul_vec(mat: qd.Tensor, vec: qd.Tensor, res: qd.Tensor, n, m, i_b):
     for i in range(n):
         res[i, i_b] = 0
         for j in range(m):
@@ -34,7 +34,7 @@ def mat_mul_vec(mat, vec, res, n, m, i_b):
 
 
 @qd.func
-def mat_inverse(mat, L, U, y, res, n, i_b):
+def mat_inverse(mat: qd.Tensor, L: qd.Tensor, U: qd.Tensor, y: qd.Tensor, res: qd.Tensor, n, i_b):
     """
     Inverse via LU decomposition
     """
@@ -82,14 +82,14 @@ def mat_add(A, B, n, m, i_b):
 
 
 @qd.func
-def mat_transpose(A, B, n, m, i_b):
+def mat_transpose(A: qd.Tensor, B: qd.Tensor, n, m, i_b):
     for i in range(n):
         for k in range(m):
             B[k, i, i_b] = A[i, k, i_b]
 
 
 @qd.func
-def mat_add_eye(A, x, n, i_b):
+def mat_add_eye(A: qd.Tensor, x, n, i_b):
     for i in range(n):
         A[i, i, i_b] += x
 

--- a/tests/rigid/test_kinematics.py
+++ b/tests/rigid/test_kinematics.py
@@ -355,7 +355,8 @@ def test_inverse_kinematics_multilink(show_viewer, tol):
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_inverse_kinematics_local_point(n_envs, show_viewer, tol):
-    # local_point positions an offset point of the link at the target instead of the link origin.
+    # local_point positions an offset point of the link at the target. The floating-base go2 also exercises the
+    # FREE root joint (base translation and orientation degrees of freedom) at a non-zero entity offset.
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(2.5, 0.0, 1.5),
@@ -365,6 +366,12 @@ def test_inverse_kinematics_local_point(n_envs, show_viewer, tol):
     )
     robot = scene.add_entity(
         morph=gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"),
+    )
+    floating = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file="urdf/go2/urdf/go2.urdf",
+            pos=(0.0, 1.5, 0.42),
+        ),
     )
     scene.build(n_envs=n_envs)
 
@@ -419,8 +426,44 @@ def test_inverse_kinematics_local_point(n_envs, show_viewer, tol):
     # Check that the offset point reached the target
     assert_allclose(actual_point_pos, target_pos, tol=tol)
 
+    # Floating-base IK: place an offset point of the go2 trunk (its FREE root link) at a target pose, reached purely
+    # through the FREE joint's translation and orientation degrees of freedom.
+    base = floating.base_link
+    base_offset = torch.tensor([0.1, 0.05, 0.0], dtype=gs.tc_float, device=gs.device)
+    base_pos_all = [[0.1, 1.5, 0.6], [0.05, 1.45, 0.55]][:num_envs]
+    base_quat_all = torch.tensor(
+        [[0.9239, 0.0, 0.0, 0.3827], [1.0, 0.0, 0.0, 0.0]], dtype=gs.tc_float, device=gs.device
+    )[:num_envs]
+
+    base_qpos_live = floating.get_qpos().clone()
+    base_links_pos_live = floating.get_links_pos(relative=False).clone()
+    base_vgeoms_idx = [vgeom.idx for link in floating.links for vgeom in link.vgeoms]
+    base_vgeoms_pos_live = scene.rigid_solver.get_vgeoms_pos(base_vgeoms_idx).clone()
+
+    base_qpos, base_err = floating.inverse_kinematics(
+        link=base,
+        pos=base_pos_all,
+        quat=base_quat_all,
+        local_point=base_offset,
+        max_solver_iters=100,
+        pos_tol=tol,
+        rot_tol=tol,
+        return_error=True,
+    )
+    assert_allclose(base_err, 0.0, atol=tol)
+
+    # The solve reports a configuration without moving the entity to it, so the live state is what it was.
+    assert_allclose(floating.get_qpos(), base_qpos_live, tol=gs.EPS)
+    assert_allclose(floating.get_links_pos(relative=False), base_links_pos_live, tol=gs.EPS)
+    assert_allclose(scene.rigid_solver.get_vgeoms_pos(base_vgeoms_idx), base_vgeoms_pos_live, tol=gs.EPS)
+
+    floating.set_qpos(base_qpos)
+    assert_allclose(base.get_pos() + gu.transform_by_quat(base_offset, base.get_quat()), base_pos_all, tol=tol)
+    base_rpy = gu.quat_to_xyz(gu.transform_quat_by_quat(gu.inv_quat(base_quat_all), base.get_quat()), rpy=True)
+    assert_allclose(base_rpy, 0.0, atol=tol)
+
     # Also verify via forward kinematics
-    links_pos, links_quat = robot.forward_kinematics(qpos)
+    links_pos, links_quat = scene.rigid_solver.forward_kinematics_query(robot, qpos)
 
     # Handle indexing based on n_envs
     if n_envs > 0:
@@ -819,3 +862,91 @@ def test_track_rigid(show_viewer, tol):
     assert_allclose(ghost.get_vAABB(), frozen_ghost_vaabb, tol=gs.EPS)
     with pytest.raises(AssertionError):
         assert_allclose(robot.get_vAABB(), frozen_robot_vaabb, atol=0.1)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_kinematics_queries_span_entities_and_solvers(n_envs, show_viewer, tol):
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, 1.0, 1.2),
+            camera_lookat=(0.2, 0.6, 0.3),
+        ),
+        show_viewer=show_viewer,
+    )
+    franka = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file="xml/franka_emika_panda/panda.xml",
+        ),
+    )
+    go2 = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file="urdf/go2/urdf/go2.urdf",
+            pos=(0.0, 1.5, 0.42),
+        ),
+    )
+    fixed_box = scene.add_entity(
+        morph=gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+            pos=(1.0, 0.0, 0.05),
+            fixed=True,
+        ),
+    )
+    ghost = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file="xml/franka_emika_panda/panda.xml",
+        ),
+        material=gs.materials.Kinematic(),
+    )
+    scene.build(n_envs=n_envs)
+
+    # Queried at the configuration it already holds, every entity must report its live link poses: whatever its offset
+    # in the solver configuration, with or without a degree of freedom, and whichever solver backs it.
+    for entity in (franka, go2, fixed_box, ghost):
+        links_pos, links_quat = entity.solver.forward_kinematics_query(entity, entity.get_qpos())
+        assert_allclose(links_pos, entity.get_links_pos(relative=False), tol=gs.EPS)
+        assert_allclose(links_quat, entity.get_links_quat(relative=False), tol=gs.EPS)
+
+    # Callers hand the query whatever array-like configuration they hold, a NumPy trajectory included.
+    links_pos, links_quat = franka.solver.forward_kinematics_query(franka, tensor_to_array(franka.get_qpos()))
+    assert_allclose(links_pos, franka.get_links_pos(relative=False), tol=gs.EPS)
+    assert_allclose(links_quat, franka.get_links_quat(relative=False), tol=gs.EPS)
+
+    # Inverse kinematics reaches its target for an entity of either solver.
+    target_pos = [[0.45, 0.1, 0.5], [0.4, 0.0, 0.55]][: max(n_envs, 1)]
+    if n_envs == 0:
+        target_pos = target_pos[0]
+    for entity in (franka, ghost):
+        end_effector = entity.get_link("hand")
+        qpos_live = entity.get_qpos().clone()
+        links_pos_live = entity.get_links_pos(relative=False).clone()
+        vgeoms_idx = [vgeom.idx for link in entity.links for vgeom in link.vgeoms]
+        vgeoms_pos_live = entity.solver.get_vgeoms_pos(vgeoms_idx).clone()
+
+        qpos, err_pose = entity.inverse_kinematics(
+            link=end_effector,
+            pos=target_pos,
+            max_solver_iters=100,
+            pos_tol=tol,
+            rot_tol=tol,
+            return_error=True,
+        )
+        assert_allclose(err_pose, 0.0, atol=tol)
+
+        # The solve reports a configuration without moving the entity to it, so the live state is what it was.
+        assert_allclose(entity.get_qpos(), qpos_live, tol=gs.EPS)
+        assert_allclose(entity.get_links_pos(relative=False), links_pos_live, tol=gs.EPS)
+        assert_allclose(entity.solver.get_vgeoms_pos(vgeoms_idx), vgeoms_pos_live, tol=gs.EPS)
+        with pytest.raises(AssertionError):
+            assert_allclose(end_effector.get_pos(), target_pos, tol=tol)
+
+        entity.set_qpos(qpos)
+        assert_allclose(end_effector.get_pos(), target_pos, tol=tol)
+
+    # Carrying more targets than the error buffer is sized for is refused, rather than written past.
+    n_tgts = franka.solver._options.IK_max_targets
+    with pytest.raises(gs.GenesisException):
+        franka.inverse_kinematics_multilink(
+            links=franka.links[: n_tgts + 1],
+            poss=[target_pos] * (n_tgts + 1),
+        )


### PR DESCRIPTION
## Description

Inverse kinematics and the Jacobian now work on any entity, with no opt-in flag: `requires_jac_and_IK` reserved nothing and only forbade calls that would otherwise work. It is still accepted and now warns.

Kinematics also becomes a capability of the kinematic layer, which is what makes it work for entities backed by `KinematicSolver`. The public methods move to `KinematicEntity`; `KinematicSolver` launches every kernel and owns the buffers, declared in `array_class.py` and shared by every entity of that solver. They are sized by the widest entity, so the footprint follows the biggest entity rather than how many entities run kinematics, and an entity holds no kinematics state. The solve works on that scratch instead of walking through live state, so the entity no longer saves and restores `qpos` around a call, configurations solve concurrently, and the restart loop is one launch.

Three fixes ride along, all reachable once the flag stops hiding the paths:

- **Forward kinematics on an entity that is not the first of its solver**: the configuration cache was sized per entity yet indexed with solver-global `q` indices, so later entities read and wrote past it - silently, since the restore read back the same address.
- **Forward kinematics on a zero-DOF entity** raised, reusing a buffer only the IK path allocated. It now reports that entity's fixed link poses.
- **More IK targets than `IK_max_targets`** wrote past the error buffer; it now raises. The cap is also added to `KinematicOptions`, without which IK on a kinematic entity raised `AttributeError`.

Two API changes:

- **`RigidEntity.forward_kinematics` is removed** - undocumented, one in-engine caller, and not an operation to encourage at entity level. `KinematicSolver.forward_kinematics_query(entity, qpos)` replaces it, named apart from the forward kinematics the step propagates.
- **Convergence at default tolerances lands closer to the requested tolerance**, since the solve stops once `pos_tol` / `rot_tol` are met. Over 200 poses of the `ik_franka` target (cpu, fp32) position error worsens from a median 8.4e-5 to 1.1e-4 and rotation from 4.5e-5 to 3.2e-4, with zero solves outside tolerance either side; given tight tolerances both reach ~1e-7.

## Motivation and Context

The kinematics core of #3109 landed on its own so the two can be reviewed separately; #3109 then rebases onto it and drops its copy. Allocating the scratch per entity on first use also made an entity's footprint a function of call history and left solver-owned buffers on the entity, which is the shape both indexing bugs came from.

## How Has This Been / Can This Be Tested?

`test_inverse_kinematics_local_point` now solves for an offset point of a floating-base go2 trunk, exercising IK through a FREE root joint. `test_kinematics_queries_span_entities_and_solvers` builds one scene with a Franka, a go2 at a non-zero configuration offset, a fixed box and a kinematic-material Franka, checking forward kinematics against live poses for all four, IK reaching its target on both solvers, and an over-cap solve raising. Each fix above was reintroduced on purpose to confirm that test fails - the per-entity cache only under `--dev`, which is how CI runs.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
