### PR TITLE
[MISC] Enable cross-platform window-less offscreen rendering.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,8 @@ cocoapy.NSOpenGLPFAAllRenderers = 70  # NSOpenGLPFARendererID
 cocoapy.NSOpenGLPFAMaximumPolicy = 0x00020400  # kCGLRendererGenericFloatID
 ```
 
-- Run with the same flags as macOS CI: `PYTHONPATH=<dir-with-force_sw.py> GS_TORCH_FORCE_CPU_DEVICE=1 pytest -p force_sw --dev --logical --backend cpu --forked <tests>` (CI additionally selects `-m 'required and not slow'`).
+- This reaches pyglet-created contexts only, so offscreen rendering must be routed back through the pyglet platform with `PYOPENGL_PLATFORM=pyglet`; its own default on macOS is CGL, which pyglet knows nothing about.
+- Run with the same flags as macOS CI: `PYTHONPATH=<dir-with-force_sw.py> PYOPENGL_PLATFORM=pyglet GS_TORCH_FORCE_CPU_DEVICE=1 pytest -p force_sw --dev --logical --backend cpu --forked <tests>` (CI additionally selects `-m 'required and not slow'`).
 - Verify it took effect: Genesis logs "Software rendering context detected" and `scene.visualizer.is_software` is True.
 - Known failure mode: any geometry with vertices outside the camera frustum is misrasterized, breaking pixel comparisons. In practice this bites through ground planes, whose default `plane_size` is effectively infinite (1 km x 1 km): give them a finite size and a position that puts every vertex inside the view.
 - Known failure mode: shadow mapping is forcibly disabled on software rendering backends for performance reasons, so snapshot scenes must disable shadows explicitly (`shadow=False` for the rasterizer); a snapshot generated on hardware GL with shadows enabled can never match.

--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -258,6 +258,10 @@ class OffscreenRenderer(object):
             from .platforms.osmesa import OSMesaPlatform
 
             self._platform = OSMesaPlatform(self.viewport_width, self.viewport_height)
+        elif platform == "cgl":
+            from .platforms.cgl import CGLPlatform
+
+            self._platform = CGLPlatform(self.viewport_width, self.viewport_height)
         else:
             raise ValueError("Unsupported PyOpenGL platform: {}".format(platform))
         self._platform.init_context()

--- a/genesis/ext/pyrender/platforms/cgl.py
+++ b/genesis/ext/pyrender/platforms/cgl.py
@@ -1,0 +1,134 @@
+import ctypes
+import functools
+
+import OpenGL.contextdata
+import OpenGL.platform
+import pyglet
+
+import genesis as gs
+
+from .base import Platform
+
+
+# CGL pixel format attributes and values, transliterated from the OpenGL framework headers, as PyOpenGL ships no CGL
+# bindings.
+CGL_PFA_DEPTH_SIZE = 12
+CGL_PFA_ACCELERATED = 73
+CGL_PFA_OPENGL_PROFILE = 99
+CGL_OPENGL_PROFILE_VERSION_3_2_CORE = 0x3200
+
+# A private handle to the OpenGL framework, opened from the path PyOpenGL already resolved. The entry points below need
+# explicit ctypes signatures, and annotating PyOpenGL's own handle in place would change process-wide behavior, since
+# 'CGLGetCurrentContext' is what backs its context bookkeeping.
+_framework = ctypes.CDLL(OpenGL.platform.PLATFORM.CGL._name)
+
+_CGLChoosePixelFormat = _framework.CGLChoosePixelFormat
+_CGLChoosePixelFormat.argtypes = (
+    ctypes.POINTER(ctypes.c_int),
+    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.POINTER(ctypes.c_int),
+)
+_CGLChoosePixelFormat.restype = ctypes.c_int
+
+_CGLDestroyPixelFormat = _framework.CGLDestroyPixelFormat
+_CGLDestroyPixelFormat.argtypes = (ctypes.c_void_p,)
+_CGLDestroyPixelFormat.restype = ctypes.c_int
+
+_CGLCreateContext = _framework.CGLCreateContext
+_CGLCreateContext.argtypes = (ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p))
+_CGLCreateContext.restype = ctypes.c_int
+
+_CGLDestroyContext = _framework.CGLDestroyContext
+_CGLDestroyContext.argtypes = (ctypes.c_void_p,)
+_CGLDestroyContext.restype = ctypes.c_int
+
+_CGLSetCurrentContext = _framework.CGLSetCurrentContext
+_CGLSetCurrentContext.argtypes = (ctypes.c_void_p,)
+_CGLSetCurrentContext.restype = ctypes.c_int
+
+_CGLGetCurrentContext = _framework.CGLGetCurrentContext
+_CGLGetCurrentContext.argtypes = ()
+_CGLGetCurrentContext.restype = ctypes.c_void_p
+
+
+class CGLPlatform(Platform):
+    """Renders offscreen using CGL, the window-system-independent OpenGL interface of MacOS.
+
+    The context requires neither a window nor an active display, rendering exclusively into framebuffer objects it
+    allocates itself. This is what sets it apart from the pyglet platform, whose context comes attached to an invisible
+    window and therefore to a screen: rendering here survives a locked screen, where every display is asleep, as well as
+    a virtual machine exposing no screen at all.
+    """
+
+    def __init__(self, viewport_width, viewport_height):
+        super().__init__(viewport_width, viewport_height)
+        self._pixel_format = None
+        self._context = None
+
+    def init_context(self):
+        # A core profile is mandatory: the compatibility profile caps the software renderer at OpenGL 2.1 / GLSL 1.20,
+        # which cannot compile the shaders. Hardware acceleration in contrast is only a preference, so it is requested
+        # first and dropped on retry, letting a machine with no usable GPU fall back to the software renderer. The
+        # sample count is left out because rendering targets framebuffer objects that carry their own.
+        attributes = [CGL_PFA_OPENGL_PROFILE, CGL_OPENGL_PROFILE_VERSION_3_2_CORE, CGL_PFA_DEPTH_SIZE, 24]
+        pixel_format, num_pixel_formats = ctypes.c_void_p(), ctypes.c_int()
+        for candidate in ([*attributes, CGL_PFA_ACCELERATED], attributes):
+            attributes_array = (ctypes.c_int * (len(candidate) + 1))(*candidate, 0)
+            error = _CGLChoosePixelFormat(attributes_array, ctypes.byref(pixel_format), ctypes.byref(num_pixel_formats))
+            if not error and num_pixel_formats.value:
+                break
+        else:
+            gs.raise_exception(
+                "Failed to find an OpenGL 3.2+ core profile pixel format. No OpenGL renderer is available on this "
+                "machine."
+            )
+
+        context = ctypes.c_void_p()
+        error = _CGLCreateContext(pixel_format, None, ctypes.byref(context))
+        if error:
+            _CGLDestroyPixelFormat(pixel_format)
+            gs.raise_exception(f"Failed to create an offscreen CGL context (error {error}).")
+
+        self._pixel_format = pixel_format
+        self._context = context
+
+    def make_current(self):
+        _CGLSetCurrentContext(self._context)
+        # pyglet tracks process-wide which of its contexts is current and short-circuits 'Context.set_current' when it
+        # matches, so taking the current context over behind its back would leave that belief stale and a later viewer
+        # rebind would be skipped, sending its GL calls here. Clear it in lockstep with 'gl_info', exactly as pyglet's
+        # own 'Context.set_current' and 'Context.destroy' do, so the next rebind actually happens.
+        pyglet.gl.current_context = None
+        pyglet.gl.gl_info.remove_active_context()
+
+    def make_uncurrent(self):
+        _CGLSetCurrentContext(None)
+
+    def save_current_context(self):
+        # 'make_uncurrent' clears the current context and every render path ends there, so this platform's own context
+        # is never the one captured here, only an external one (e.g. another renderer mid-render) or none. Restoring a
+        # context this platform is about to destroy would otherwise leave the caller with a dangling one.
+        context = _CGLGetCurrentContext()
+        if not context:
+            return None
+        return functools.partial(_CGLSetCurrentContext, ctypes.c_void_p(context))
+
+    def delete_context(self):
+        if self._context is not None:
+            # The current context is per-thread and shared across renderers, so release it only when it is ours:
+            # binding this one here would strand a renderer that is mid-render, and CGL destroys a context that is
+            # not current all the same.
+            if _CGLGetCurrentContext() == self._context.value:
+                OpenGL.contextdata.cleanupContext(OpenGL.contextdata.getContext())
+                _CGLSetCurrentContext(None)
+            _CGLDestroyContext(self._context)
+            self._context = None
+        if self._pixel_format is not None:
+            _CGLDestroyPixelFormat(self._pixel_format)
+            self._pixel_format = None
+
+    def supports_framebuffers(self):
+        return True
+
+
+__all__ = ["CGLPlatform"]

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -11,27 +11,13 @@ from threading import Event, RLock, Semaphore, Thread
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
+
 import OpenGL
 from OpenGL.GL import *
+import pyglet
 
 import genesis as gs
 from genesis.vis.keybindings import Key, KeyAction, Keybind, Keybindings, KeyMod
-
-# Importing tkinter and creating a first context before importing pyglet is necessary to avoid later segfault on MacOS.
-# Note that destroying the window will cause segfault at exit.
-root = None
-if sys.platform.startswith("darwin"):
-    try:
-        from tkinter import Tk
-
-        root = Tk()
-        root.withdraw()
-    except Exception:
-        # Some minimal Python install may not provide a working tkinter interface even if it is a standard library
-        pass
-
-import pyglet
-
 from genesis.vis.viewer_plugins import EVENT_HANDLE_STATE, EVENT_HANDLED, ViewerPlugin
 
 from .camera import IntrinsicsCamera, OrthographicCamera, PerspectiveCamera
@@ -65,6 +51,10 @@ HELP_TEXT_KEYBIND_NAME = "toggle_instructions"
 pyglet.options["shadow_window"] = False
 if pyglet.options.get("dpi_scaling") != "real":
     pyglet.options["dpi_scaling"] = "real"
+
+# Keeps the screen free of any window. pyglet's own option is EGL-backed and also selects its window and display
+# classes, so it cannot be requested off Linux, whereas 'GS_HEADLESS' applies everywhere.
+IS_HEADLESS = pyglet.options["headless"] or bool(os.environ.get("GS_HEADLESS"))
 
 
 class Viewer(pyglet.window.Window):
@@ -1009,8 +999,6 @@ class Viewer(pyglet.window.Window):
         self._trackball = Trackball(self._default_camera_pose, self.viewport_size, scale, centroid)
 
     def _get_save_filename(self, file_exts):
-        global root
-
         file_types = {
             "mp4": ("video files", "*.mp4"),
             "png": ("png files", "*.png"),
@@ -1018,29 +1006,28 @@ class Viewer(pyglet.window.Window):
             "gif": ("gif files", "*.gif"),
             "all": ("all files", "*"),
         }
-        filetypes = [file_types[x] for x in file_exts]
         save_dir = self.viewer_flags["save_directory"]
         if save_dir is None:
             save_dir = os.getcwd()
 
         try:
-            # Importing tkinter is very slow and not used very often. Let's delay import.
-            from tkinter import filedialog
+            # Imported on demand because 'imgui-bundle' is an optional dependency, unavailable on some platforms.
+            from imgui_bundle import portable_file_dialogs
 
-            dialog = filedialog.SaveAs(
-                parent=None,
-                initialdir=save_dir,
-                title="Select file save location",
-                filetypes=filetypes,
-                defaultextension=".png",
-            )
-            filename = dialog.show()
+            # The dialog is the native one of the platform and runs out of process, leaving pyglet sole owner of the
+            # windowing system. Filters are a flat sequence alternating label and patterns.
+            filters = [field for file_ext in file_exts for field in file_types[file_ext]]
+            filename = portable_file_dialogs.save_file("Select file save location", save_dir, filters).result()
         except Exception as e:
             gs.logger.warning(f"Failed to open file save location dialog: {e}")
             return None
 
         if not filename:
             return None
+        # The dialog hands the name back as typed, and a missing extension would leave the writer downstream with
+        # no format to select, so fall back on the first one offered.
+        if not os.path.splitext(filename)[1]:
+            filename = f"{filename}.{file_exts[0]}"
         return os.path.normpath(filename)
 
     def _save_image(self):
@@ -1284,7 +1271,8 @@ class Viewer(pyglet.window.Window):
                 self.refresh()
 
                 # At this point, we are all set to display the graphical window
-                self.set_visible(True)
+                if not IS_HEADLESS:
+                    self.set_visible(True)
 
                 # Run the entire rendering pipeline once again, as a final validation that everything is fine
                 self.refresh()

--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -28,13 +28,15 @@ class Rasterizer(RBC):
         if self._offscreen:
             # Select PyOpenGL backend for `pyrender.OffscreenRenderer`.
             # If env variable is set, use specified platform if supported, otherwise some platform-specific default.
-            platform = os.environ.get("PYOPENGL_PLATFORM", "egl" if sys.platform == "linux" else "pyglet")
-            if platform not in ("osmesa", "pyglet", "egl"):
+            default_platform = {"linux": "egl", "darwin": "cgl"}.get(sys.platform, "pyglet")
+            platform = os.environ.get("PYOPENGL_PLATFORM", default_platform)
+            if platform not in ("osmesa", "pyglet", "egl", "cgl"):
                 gs.logger.warning(f"PYOPENGL_PLATFORM='{platform}' not supported. Falling back to 'pyglet'.")
                 platform = "pyglet"
             if sys.platform == "win32" and platform == "osmesa":
-                gs.raise_exception("PYOPENGL_PLATFORM='osmesa' not supported on Windows OS. Falling back to 'pyglet'.")
-                platform = "pyglet"
+                gs.raise_exception("PYOPENGL_PLATFORM='osmesa' not supported on Windows OS.")
+            if sys.platform != "darwin" and platform == "cgl":
+                gs.raise_exception("PYOPENGL_PLATFORM='cgl' is only supported on MacOS.")
 
             # Start the viewer
             self._renderer = pyrender.OffscreenRenderer(

--- a/genesis/vis/viewer_plugins/plugins/default_controls.py
+++ b/genesis/vis/viewer_plugins/plugins/default_controls.py
@@ -22,9 +22,22 @@ class DefaultControlsPlugin(ViewerPlugin):
     def build(self, viewer, camera: "Node", scene: "Scene"):
         super().build(viewer, camera, scene)
 
+        keybinds = []
+
+        # Both shortcuts prompt for a destination through 'imgui-bundle', an optional dependency, and come first to
+        # keep the on-screen help order.
+        try:
+            import imgui_bundle  # noqa: F401
+
+            keybinds += [
+                Keybind("record_video", Key.R, callback=self._toggle_record_video, allow_overload=True),
+                Keybind("save_image", Key.S, callback=self._save_image, allow_overload=True),
+            ]
+        except ImportError:
+            pass
+
         self.viewer.register_keybinds(
-            Keybind("record_video", Key.R, callback=self._toggle_record_video, allow_overload=True),
-            Keybind("save_image", Key.S, callback=self._save_image, allow_overload=True),
+            *keybinds,
             Keybind("reset_camera", Key.Z, callback=self._reset_camera, allow_overload=True),
             Keybind("camera_rotation", Key.A, callback=self._toggle_cam_rotation, allow_overload=True),
             Keybind("shadow", Key.H, callback=self._toggle_shadow, allow_overload=True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,44 +21,31 @@ from syrupy.extensions.image import PNGImageSnapshotExtension
 
 from tests.gpu_info import detect_gpu_backend
 
-# Mock tkinter module for backward compatibility because it is a hard dependency for old Genesis versions
-has_tkinter = False
-try:
-    import tkinter
-
-    has_tkinter = True
-except ImportError:
-    tkinter = type(sys)("tkinter")
-    tkinter.filedialog = lambda *arg, **kwargs: None
-    tkinter.mainloop = type(sys)("mainloop")
-    tkinter.mainloop.__code__ = ""
-    tkinter.Tk = type(sys)("Tk")
-    tkinter.Misc = type(sys)("Misc")
-    tkinter.Misc.mainloop = tkinter.mainloop
-    sys.modules["tkinter"] = tkinter
-
-# Determine whether a screen is available
-if has_tkinter:
-    has_display = True
-    try:
-        root = tkinter.Tk()
-        root.withdraw()
-        root.destroy()
-    except tkinter.TclError:
-        has_display = False
-else:
-    # Assuming headless server if tkinter is not installed unless DISPLAY env var is available on Linux
-    if sys.platform.startswith("linux"):
-        has_display = bool(os.environ.get("DISPLAY"))
-    else:
-        has_display = False
-
-# Determine whether EGL driver is available
-has_egl = True
+# Determine whether rendering without a screen is possible, which pyglet implements through its EGL backend.
+is_headless_supported = True
 try:
     pyglet.lib.load_library("EGL")
 except ImportError:
-    has_egl = False
+    is_headless_supported = False
+
+# Determine whether a screen is available, which only the interactive viewer needs. Resolving a display binds pyglet's
+# windowing backend and would rule out its headless one, so the environment answers where headless exists, and pyglet
+# elsewhere, which is what detects a Mac whose displays are all asleep.
+if is_headless_supported:
+    has_display = bool(os.environ.get("DISPLAY")) if sys.platform.startswith("linux") else False
+else:
+    try:
+        has_display = bool(pyglet.display.get_display().get_screens())
+    except Exception:
+        has_display = False
+
+# Determine whether the optional 'imgui-bundle' dependency is available
+try:
+    import imgui_bundle  # noqa: F401
+
+    is_imgui_bundle_supported = True
+except ImportError:
+    is_imgui_bundle_supported = False
 
 # Forcibly disable Mujoco OpenGL to avoid conflicts with Genesis
 os.environ["MUJOCO_GL"] = "0"
@@ -68,11 +55,11 @@ os.environ["TQDM_DISABLE"] = "1"
 
 # pyglet must be configured in headless mode before importing Genesis if necessary.
 # Note that environment variables are used instead of global options to ease option propagation to subprocesses.
-if not has_display and has_egl:
+if not has_display and is_headless_supported:
     pyglet.options["headless"] = True
     os.environ["PYGLET_HEADLESS"] = "1"
 
-IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or has_egl
+IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or is_headless_supported
 
 TOL_SINGLE = 5e-5
 TOL_DOUBLE = 1e-9
@@ -100,6 +87,7 @@ SKIP_NO_MADRONA = _skip_reason("BatchRenderer is not supported because 'gs_madro
 SKIP_NO_LUISA = _skip_reason("RayTracer is not supported because 'LuisaRenderPy' is not available.")
 SKIP_NO_VIEWER = _skip_reason("Interactive viewer not supported on this platform.")
 SKIP_NO_OMNIVERSE_KIT = _skip_reason("omniverse-kit support not available")
+SKIP_NO_IMGUI_BUNDLE = _skip_reason("'imgui-bundle' is not available.")
 
 
 def is_mem_monitoring_supported():
@@ -196,10 +184,13 @@ def pytest_cmdline_main(config: pytest.Config) -> None:
     if is_pdb_enabled:
         config.option.reruns = 0
 
-    # Force headless rendering if available and the interactive viewer is disabled.
-    # FIXME: It breaks rendering on some platform...
-    # if not show_viewer and has_egl:
-    #     pyglet.options["headless"] = True
+    # Force headless mode when the viewer is not wanted, so a local run stays off the developer's desktop. Exporting
+    # the variable carries the request to the xdist workers; pyglet's own option only applies where EGL backs it.
+    if not show_viewer:
+        os.environ["GS_HEADLESS"] = "1"
+        if is_headless_supported:
+            pyglet.options["headless"] = True
+            os.environ["PYGLET_HEADLESS"] = "1"
 
     # Make sure that the number of workers is not too large if specified
     if isinstance(config.option.numprocesses, int):
@@ -466,7 +457,7 @@ def pytest_runtest_setup(item):
         cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
         if cuda_visible_devices is not None:
             gpu_index = int(cuda_visible_devices)
-            if has_egl:
+            if is_headless_supported:
                 try:
                     os.environ["EGL_DEVICE_ID"] = str(_get_egl_index(gpu_index))
                 except (AttributeError, KeyError):

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -1,7 +1,9 @@
 import os
 import pathlib
+import signal
 import subprocess
 import sys
+import time
 
 import numpy as np
 import pytest
@@ -118,6 +120,34 @@ def test_basic_sim_subprocess(test_backend: str, use_ndarray: bool):
         print("-" * 100)
         print(proc.stderr)
     assert proc.returncode == RET_SUCCESS
+
+
+def _termination_signal_child(args: list[str]):
+    """Child process: build a scene, then ask the operating system to terminate itself."""
+    gs.init(backend=gs.constants.backend.cpu, precision="32")
+
+    scene = gs.Scene(show_viewer=False)
+    scene.add_entity(gs.morphs.Plane())
+    scene.build()
+
+    os.kill(os.getpid(), signal.SIGTERM)
+
+    # Getting here means something intercepted the signal instead of letting it through.
+    time.sleep(10.0)
+    sys.exit(RET_SUCCESS)
+
+
+@pytest.mark.parametrize("backend", [None])
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows has no signal-based process termination status.")
+def test_process_terminates_on_signal():
+    cmd_line = [sys.executable, "-m", MODULE, _termination_signal_child.__name__]
+
+    proc = subprocess.run(cmd_line, capture_output=True, text=True, encoding="utf-8", cwd=MODULE_ROOT_DIR)
+    if proc.returncode != -signal.SIGTERM:
+        print(proc.stdout)
+        print("-" * 100)
+        print(proc.stderr)
+    assert proc.returncode == -signal.SIGTERM
 
 
 if __name__ == "__main__":

--- a/tests/rendering/test_imgui_overlay.py
+++ b/tests/rendering/test_imgui_overlay.py
@@ -9,15 +9,8 @@ import pytest
 import genesis as gs
 from genesis.ext.pyrender.overlay import ImGuiOverlayPlugin
 
-from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE
+from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE, SKIP_NO_IMGUI_BUNDLE, is_imgui_bundle_supported
 from ..utils.assertions import assert_allclose, assert_pixel_match, rgb_array_to_png_bytes
-
-try:
-    import imgui_bundle  # noqa: F401
-
-    _IMGUI_BUNDLE_AVAILABLE = True
-except ImportError:
-    _IMGUI_BUNDLE_AVAILABLE = False
 
 
 def _apply_deterministic_imgui_overrides(monkeypatch):
@@ -158,7 +151,7 @@ def _build_default_scene(*, enable_gui, run_in_thread=False):
 @pytest.mark.slow  # ~250s
 @pytest.mark.required
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason="Interactive viewer not supported on this platform.")
-@pytest.mark.skipif(not _IMGUI_BUNDLE_AVAILABLE, reason="imgui-bundle not installed (no Python 3.10 wheels).")
+@pytest.mark.skipif(not is_imgui_bundle_supported, reason=SKIP_NO_IMGUI_BUNDLE)
 def test_control_panel(png_snapshot, monkeypatch):
     scene = _build_default_scene(enable_gui=False)
 
@@ -184,7 +177,7 @@ def test_control_panel(png_snapshot, monkeypatch):
 @pytest.mark.slow  # ~250s
 @pytest.mark.required
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason="Interactive viewer not supported on this platform.")
-@pytest.mark.skipif(not _IMGUI_BUNDLE_AVAILABLE, reason="imgui-bundle not installed (no Python 3.10 wheels).")
+@pytest.mark.skipif(not is_imgui_bundle_supported, reason=SKIP_NO_IMGUI_BUNDLE)
 @pytest.mark.parametrize("performance_mode", [False, True])
 def test_editing_controls(png_snapshot, monkeypatch):
     # The scene-editing controls (Rebuild Scene, Add Entity, per-entity scale & remove) render enabled in normal
@@ -210,7 +203,7 @@ def test_editing_controls(png_snapshot, monkeypatch):
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason="Interactive viewer not supported on this platform.")
-@pytest.mark.skipif(not _IMGUI_BUNDLE_AVAILABLE, reason="imgui-bundle not installed (no Python 3.10 wheels).")
+@pytest.mark.skipif(not is_imgui_bundle_supported, reason=SKIP_NO_IMGUI_BUNDLE)
 def test_runtime_plugin_toggle_and_pause():
     from genesis.ext.pyrender.overlay.plugin import TOGGLEABLE_PLUGINS
     from genesis.vis.viewer_plugins import MouseInteractionPlugin, ViewerPlugin
@@ -295,7 +288,7 @@ def test_runtime_plugin_toggle_and_pause():
 
 @pytest.mark.required
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason="Interactive viewer not supported on this platform.")
-@pytest.mark.skipif(not _IMGUI_BUNDLE_AVAILABLE, reason="imgui-bundle not installed (no Python 3.10 wheels).")
+@pytest.mark.skipif(not is_imgui_bundle_supported, reason=SKIP_NO_IMGUI_BUNDLE)
 @pytest.mark.parametrize("performance_mode", [False])
 def test_scene_rebuild():
     # enable_gui makes the overlay own an InteractiveScene and rebuild the scene in place: the same Scene

--- a/tests/rendering/test_interactive_viewer.py
+++ b/tests/rendering/test_interactive_viewer.py
@@ -12,7 +12,7 @@ from genesis.options.sensors import RasterizerCameraOptions
 from genesis.utils.misc import tensor_to_array
 from genesis.vis.keybindings import Key, KeyAction, Keybind, KeyMod, MouseButton
 
-from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE, SKIP_NO_VIEWER
+from ..conftest import IS_INTERACTIVE_VIEWER_AVAILABLE, SKIP_NO_IMGUI_BUNDLE, SKIP_NO_VIEWER, is_imgui_bundle_supported
 from ..utils.assertions import assert_allclose
 from .conftest import RENDERER_TYPE
 
@@ -192,6 +192,7 @@ def test_default_plugin(n_envs):
 @pytest.mark.required
 @pytest.mark.parametrize("renderer_type", [RENDERER_TYPE.RASTERIZER])
 @pytest.mark.skipif(not IS_INTERACTIVE_VIEWER_AVAILABLE, reason=SKIP_NO_VIEWER)
+@pytest.mark.skipif(not is_imgui_bundle_supported, reason=SKIP_NO_IMGUI_BUNDLE)
 def test_key_press(renderer_type, tmp_path, monkeypatch, renderer, png_snapshot):
     IMAGE_FILENAME = tmp_path / "screenshot.png"
 


### PR DESCRIPTION
## Description

Offscreen rendering on MacOS goes through a new CGL platform instead of a hidden pyglet window, so it needs neither a window nor an active display.

Genesis no longer depends on tkinter, the viewer's save dialog using the native one of `imgui-bundle`. Setting `GS_HEADLESS` keeps the viewer window unmapped, which the test suite does unless `--vis` is passed.

## Motivation and Context

Locking the screen aborted every scene build on MacOS: all displays go to sleep, pyglet enumerates no screen, and creating the hidden window raised `IndexError: list index out of range`.

Importing the viewer also created a Tk root on MacOS, installing a Tk signal handler process-wide. Any signal was then swallowed, `Tcl_Exit` running the C++ static destructors from Tk's notifier thread and crashing the interpreter in `at::mps::MPSAllocator::~MPSAllocator`. That root only existed to initialize Tk before pyglet, the reverse order aborting with an uncaught `NSException`.

pyglet's own headless option cannot replace `GS_HEADLESS`, being EGL-backed and also selecting the window and display classes.

## How Has This Been / Can This Be Tested?

`tests/core/test_backend.py::test_process_terminates_on_signal` builds a scene in a child process and requires `SIGTERM` to terminate it. It fails on `main`, where the child survives it.

Checked by hand on MacOS: CGL and the pyglet platform render bit-identical RGB, depth and segmentation; forcing pyglet to enumerate no screen reproduces the original `IndexError` while CGL still renders; the Apple Software Renderer of the CI runners is reachable through CGL at OpenGL 4.1 core.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
