### PR TITLE
[BUG FIX] Support FEM vertex constraints and topology queries in multi-entity scenes.

### DIFF
--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -994,7 +994,7 @@ class FEMEntity(Entity):
         target_poss = self._sanitize_verts_tensor(target_poss, gs.tc_float, verts_idx, envs_idx, (3,))
 
         if use_current_poss:
-            self._kernel_get_verts_pos(self._sim.cur_substep_local, target_poss, verts_idx)
+            self._kernel_get_verts_pos(self._sim.cur_substep_local, verts_idx, target_poss)
 
         if link is None:
             link_idx = -1
@@ -1053,10 +1053,9 @@ class FEMEntity(Entity):
         self._solver._kernel_remove_specific_constraints(verts_idx, envs_idx)
 
     @qd.kernel
-    def _kernel_get_verts_pos(self, f: qd.i32, pos: qd.types.ndarray(), verts_idx: qd.types.ndarray()):
-        # get current position of vertices
+    def _kernel_get_verts_pos(self, f: qd.i32, verts_idx: qd.types.ndarray(), pos: qd.types.ndarray()):
         for i_b, i_v_ in qd.ndrange(verts_idx.shape[0], verts_idx.shape[1]):
-            i_v = verts_idx[i_b, i_v_] + self.v_start
+            i_v = verts_idx[i_b, i_v_]
             for j in qd.static(range(3)):
                 pos[i_b, i_v_, j] = self._solver.elements_v[f, i_v, i_b].pos[j]
 
@@ -1067,10 +1066,15 @@ class FEMEntity(Entity):
         Returns
         -------
         el2v : gs.Tensor
-            Tensor of shape (n_elements, 4) mapping each element to its vertex indices.
+            Tensor of shape (n_elements, 4) mapping each element to its local vertex indices.
         """
         el2v = gs.zeros((self.n_elements, 4), dtype=int, requires_grad=False, scene=self.scene)
-        self._solver._kernel_get_el2v(element_el_start=self._el_start, n_elements=self.n_elements, el2v=el2v)
+        self._solver._kernel_get_el2v(
+            element_el_start=self._el_start,
+            element_v_start=self._v_start,
+            el2v=el2v,
+            n_elements=self.n_elements,
+        )
         return el2v
 
     @qd.kernel

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -1070,10 +1070,7 @@ class FEMEntity(Entity):
         """
         el2v = gs.zeros((self.n_elements, 4), dtype=int, requires_grad=False, scene=self.scene)
         self._solver._kernel_get_el2v(
-            element_el_start=self._el_start,
-            element_v_start=self._v_start,
-            el2v=el2v,
-            n_elements=self.n_elements,
+            element_el_start=self._el_start, element_v_start=self._v_start, el2v=el2v, n_elements=self.n_elements
         )
         return el2v
 

--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -1371,13 +1371,14 @@ class FEMSolver(Solver):
     def _kernel_get_el2v(
         self,
         element_el_start: qd.i32,
-        n_elements: qd.i32,
+        element_v_start: qd.i32,
         el2v: qd.types.ndarray(),
+        n_elements: qd.i32,
     ):
-        for i_e in range(n_elements):
-            i_global = i_e + element_el_start
+        for i_e_ in range(n_elements):
+            i_e = i_e_ + element_el_start
             for j in qd.static(range(4)):
-                el2v[i_global, j] = self.elements_i[i_global].el2v[j]
+                el2v[i_e_, j] = self.elements_i[i_e].el2v[j] - element_v_start
 
     @qd.kernel
     def _kernel_get_state(

--- a/tests/deformable/test_fem.py
+++ b/tests/deformable/test_fem.py
@@ -316,6 +316,7 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
         show_viewer=show_viewer,
         show_FPS=False,
     )
+    # Place the tested entity after another FEM entity so its local and solver indices differ.
     scene.add_entity(
         morph=gs.morphs.Box(
             pos=(-0.5, 0.0, HEIGHT + BOX_SIZE / 2),
@@ -344,7 +345,7 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
 
     assert_equal(box.get_el2v(), box.elems)
 
-    target_poss = box.get_state().pos[..., VERTICES_IDX, :].clone()
+    target_poss = box.get_state().pos[..., VERTICES_IDX, :]
     box.set_vertex_constraints(VERTICES_IDX)
     scene.step(update_visualizer=False)
     assert_allclose(box.get_state().pos[..., VERTICES_IDX, :], target_poss, tol=1e-8)

--- a/tests/deformable/test_fem.py
+++ b/tests/deformable/test_fem.py
@@ -8,7 +8,7 @@ import torch
 import genesis as gs
 from genesis.utils.misc import tensor_to_array
 
-from ..utils.assertions import assert_allclose
+from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.assets import get_hf_dataset
 
 
@@ -316,6 +316,18 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
         show_viewer=show_viewer,
         show_FPS=False,
     )
+    scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(-0.5, 0.0, HEIGHT + BOX_SIZE / 2),
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+        ),
+        material=gs.materials.FEM.Elastic(
+            E=1e5,
+            nu=0.45,
+            rho=1000.0,
+            model="linear_corotated" if use_implicit_solver else "stable_neohookean",
+        ),
+    )
     box = scene.add_entity(
         morph=gs.morphs.Box(
             pos=(-BOX_SIZE / 2, BOX_SIZE / 2 + MOTION_RADIUS, HEIGHT + BOX_SIZE / 2),
@@ -329,6 +341,13 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
         ),
     )
     scene.build(n_envs=2)
+
+    assert_equal(box.get_el2v(), box.elems)
+
+    target_poss = box.get_state().pos[..., VERTICES_IDX, :].clone()
+    box.set_vertex_constraints(VERTICES_IDX)
+    scene.step(update_visualizer=False)
+    assert_allclose(box.get_state().pos[..., VERTICES_IDX, :], target_poss, tol=1e-8)
 
     # Simulate
     n_steps = int(0.5 * math.pi / MOTION_SPEED)


### PR DESCRIPTION
## Description

Fixes FEM entity-offset handling in default vertex constraints and element-to-vertex mappings. Default constraint
targets now use the already-global vertex indices once, and `get_el2v()` reads global solver connectivity into an
entity-local output with local vertex indices.

## Related Issue

Resolves #3236

## Motivation and Context

For FEM entities after the first one, `set_vertex_constraints(..., target_poss=None)` applied the vertex offset twice,
while `get_el2v()` wrote a compact entity output using global element rows. This could access data outside the entity
and return an incorrect element-to-vertex mapping.

## How Has This Been / Can This Be Tested?

The existing hard-constraint test now adds a preceding FEM entity, checks the local topology mapping, and verifies that
omitting `target_poss` preserves the selected vertices for both explicit and implicit FEM solvers.

```bash
pytest tests/deformable/test_fem.py::test_hard_constraint -n 0 --backend cpu -q
```

Result: `2 passed` on macOS 15.7.3 with an Apple M4 and Python 3.11.14. The same two-entity scenario also passed a
standalone Metal smoke check. The full test matrix was not run locally and is left to CI.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
