### PR TITLE
[BUG FIX] Support envs_idx mask in FEM vertex constraints.

### DIFF
--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -994,7 +994,7 @@ class FEMEntity(Entity):
         target_poss = self._sanitize_verts_tensor(target_poss, gs.tc_float, verts_idx, envs_idx, (3,))
 
         if use_current_poss:
-            self._kernel_get_verts_pos(self._sim.cur_substep_local, verts_idx, target_poss)
+            self._kernel_get_verts_pos(self._sim.cur_substep_local, verts_idx, envs_idx, target_poss)
 
         if link is None:
             link_idx = -1
@@ -1003,22 +1003,23 @@ class FEMEntity(Entity):
         else:
             assert isinstance(link, RigidLink), "Only RigidLink is supported for vertex constraints."
             link_idx = link.idx
-            link_init_pos = link.get_pos(relative=False)
-            link_init_quat = link.get_quat(relative=False)
             if self._scene.n_envs == 0:
-                link_init_pos = link_init_pos[None]
-                link_init_quat = link_init_quat[None]
+                link_init_pos = link.get_pos(relative=False)[None]
+                link_init_quat = link.get_quat(relative=False)[None]
+            else:
+                link_init_pos = link.get_pos(envs_idx=envs_idx, relative=False)
+                link_init_quat = link.get_quat(envs_idx=envs_idx, relative=False)
 
         self._solver._kernel_set_vertex_constraints(
             self._sim.cur_substep_local,
             verts_idx,
-            target_poss,
+            envs_idx,
+            link_idx,
             is_soft_constraint,
             stiffness,
-            link_idx,
+            target_poss,
             link_init_pos,
             link_init_quat,
-            envs_idx,
         )
 
     def update_constraint_targets(self, verts_idx_local, target_poss, envs_idx=None):
@@ -1033,16 +1034,16 @@ class FEMEntity(Entity):
         verts_idx = verts_idx_local + self._v_start
         target_poss = self._sanitize_verts_tensor(target_poss, gs.tc_float, verts_idx, envs_idx, (3,))
 
-        self._solver._kernel_update_constraint_targets(verts_idx, target_poss, envs_idx)
+        self._solver._kernel_update_constraint_targets(verts_idx, envs_idx, target_poss)
 
     def remove_vertex_constraints(self, verts_idx_local=None, envs_idx=None):
-        """Remove constraints from specified vertices, or all if None."""
+        """Remove constraints from the specified vertices and environments, or from all of them if None."""
         if not self._solver._constraints_initialized:
             gs.logger.warning("Ignoring remove_vertex_constraints; constraints have not been initialized.")
             return
 
         # FIXME: Quadrants 'fill' method is very inefficient. Try using zero-copy if possible.
-        if verts_idx_local is None:
+        if verts_idx_local is None and envs_idx is None:
             self._solver.vertex_constraints.is_constrained.fill(0)
             return
 
@@ -1053,11 +1054,14 @@ class FEMEntity(Entity):
         self._solver._kernel_remove_specific_constraints(verts_idx, envs_idx)
 
     @qd.kernel
-    def _kernel_get_verts_pos(self, f: qd.i32, verts_idx: qd.types.ndarray(), pos: qd.types.ndarray()):
-        for i_b, i_v_ in qd.ndrange(verts_idx.shape[0], verts_idx.shape[1]):
-            i_v = verts_idx[i_b, i_v_]
+    def _kernel_get_verts_pos(
+        self, f: qd.i32, verts_idx: qd.types.ndarray(), envs_idx: qd.types.ndarray(), pos: qd.types.ndarray()
+    ):
+        for i_b_, i_v_ in qd.ndrange(verts_idx.shape[0], verts_idx.shape[1]):
+            i_b = envs_idx[i_b_]
+            i_v = verts_idx[i_b_, i_v_]
             for j in qd.static(range(3)):
-                pos[i_b, i_v_, j] = self._solver.elements_v[f, i_v, i_b].pos[j]
+                pos[i_b_, i_v_, j] = self._solver.elements_v[f, i_v, i_b].pos[j]
 
     def get_el2v(self):
         """

--- a/genesis/engine/entities/fem_entity.py
+++ b/genesis/engine/entities/fem_entity.py
@@ -998,8 +998,8 @@ class FEMEntity(Entity):
 
         if link is None:
             link_idx = -1
-            link_init_pos = torch.zeros((self._sim._B, 3), dtype=gs.tc_float, device=gs.device)
-            link_init_quat = torch.zeros((self._sim._B, 4), dtype=gs.tc_float, device=gs.device)
+            link_init_pos = torch.zeros((len(envs_idx), 3), dtype=gs.tc_float, device=gs.device)
+            link_init_quat = torch.zeros((len(envs_idx), 4), dtype=gs.tc_float, device=gs.device)
         else:
             assert isinstance(link, RigidLink), "Only RigidLink is supported for vertex constraints."
             link_idx = link.idx

--- a/genesis/engine/solvers/fem_solver.py
+++ b/genesis/engine/solvers/fem_solver.py
@@ -1553,18 +1553,18 @@ class FEMSolver(Solver):
     def _kernel_set_vertex_constraints(
         self,
         f: qd.i32,
-        verts_idx: qd.types.ndarray(),  # shape [B, V]
-        target_poss: qd.types.ndarray(),  # shape [B, V, 3]
+        verts_idx: qd.types.ndarray(),  # shape [n_selected_envs, n_verts]
+        envs_idx: qd.types.ndarray(),  # shape [n_selected_envs]
+        link_idx: qd.i32,
         is_soft_constraint: qd.i32,
         stiffness: qd.f32,
-        link_idx: qd.i32,
-        link_init_pos: qd.types.ndarray(),  # shape [B, 3]
-        link_init_quat: qd.types.ndarray(),  # shape [B, 4]
-        envs_idx: qd.types.ndarray(),  # shape [B]
+        target_poss: qd.types.ndarray(),  # shape [n_selected_envs, n_verts, 3]
+        link_init_pos: qd.types.ndarray(),  # shape [n_selected_envs, 3]
+        link_init_quat: qd.types.ndarray(),  # shape [n_selected_envs, 4]
     ):
         for i_v_, i_b_ in qd.ndrange(verts_idx.shape[1], envs_idx.shape[0]):
             i_b = envs_idx[i_b_]
-            i_v = verts_idx[i_b, i_v_]
+            i_v = verts_idx[i_b_, i_v_]
             self.vertex_constraints[i_v, i_b].is_constrained = True
             self.vertex_constraints[i_v, i_b].is_soft_constraint = qd.cast(is_soft_constraint, gs.qd_bool)
             self.vertex_constraints[i_v, i_b].stiffness = stiffness
@@ -1579,11 +1579,11 @@ class FEMSolver(Solver):
 
     @qd.kernel
     def _kernel_update_constraint_targets(
-        self, verts_idx: qd.types.ndarray(), new_target_poss: qd.types.ndarray(), envs_idx: qd.types.ndarray()
+        self, verts_idx: qd.types.ndarray(), envs_idx: qd.types.ndarray(), new_target_poss: qd.types.ndarray()
     ):
         for i_v_, i_b_ in qd.ndrange(verts_idx.shape[1], envs_idx.shape[0]):
             i_b = envs_idx[i_b_]
-            i_v = verts_idx[i_b, i_v_]
+            i_v = verts_idx[i_b_, i_v_]
             for j in qd.static(range(3)):
                 self.vertex_constraints[i_v, i_b].target_pos[j] = new_target_poss[i_b_, i_v_, j]
 
@@ -1591,5 +1591,5 @@ class FEMSolver(Solver):
     def _kernel_remove_specific_constraints(self, verts_idx: qd.types.ndarray(), envs_idx: qd.types.ndarray()):
         for i_v_, i_b_ in qd.ndrange(verts_idx.shape[1], envs_idx.shape[0]):
             i_b = envs_idx[i_b_]
-            i_v = verts_idx[i_b, i_v_]
+            i_v = verts_idx[i_b_, i_v_]
             self.vertex_constraints[i_v, i_b].is_constrained = False

--- a/tests/deformable/test_fem.py
+++ b/tests/deformable/test_fem.py
@@ -341,6 +341,14 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
             model="linear_corotated" if use_implicit_solver else "stable_neohookean",
         ),
     )
+    anchor = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(10.0, 0.0, HEIGHT),
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+            fixed=True,
+        ),
+        material=gs.materials.Rigid(),
+    )
     scene.build(n_envs=2)
 
     assert_equal(box.get_el2v(), box.elems)
@@ -400,6 +408,40 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
     com_pos_z_f = box.get_state().pos[..., 8, 2]
     com_pos_delta = -0.5 * 9.81 * (n_steps * DT) ** 2
     assert_allclose(com_pos_z_f - com_pos_z_0, com_pos_delta, tol=0.05)
+
+    # Distinct positions and link poses per environment make cross-environment index mixups observable.
+    box.set_position(((0.0, 0.0, 0.0), (0.0, 0.0, 0.2)))
+    box.set_velocity((0.0, 0.0, 0.0))
+    anchor.set_pos(((10.0, 0.0, HEIGHT), (20.0, 0.0, HEIGHT)), relative=False)
+    target_poss = box.get_state().pos[..., VERTICES_IDX, :]
+    box.set_vertex_constraints(VERTICES_IDX, envs_idx=[1])
+    scene.step(update_visualizer=False)
+    assert_allclose(box.get_state().pos[1, VERTICES_IDX, :], target_poss[1], tol=1e-8)
+
+    box.remove_vertex_constraints(envs_idx=[1])
+    box.set_vertex_constraints(VERTICES_IDX, link=anchor.base_link, envs_idx=[1])
+    scene.step(update_visualizer=False)
+    assert_allclose(box.get_state().pos[1, VERTICES_IDX, :], target_poss[1], tol=1e-8)
+
+    box.remove_vertex_constraints(envs_idx=[1])
+    box.set_position((0.0, 0.0, 0.0))
+    box.set_velocity((0.0, 0.0, 0.0))
+    target_poss = box.get_state().pos[..., VERTICES_IDX, :]
+    box.set_vertex_constraints(VERTICES_IDX)
+    target_poss = target_poss + torch.tensor(
+        (((0.0, 0.0, 0.0),), ((0.0, 0.0, 0.02),)), dtype=gs.tc_float, device=gs.device
+    )
+    box.update_constraint_targets(VERTICES_IDX, target_poss[1], envs_idx=[1])
+    scene.step(update_visualizer=False)
+    assert_allclose(box.get_state().pos[..., VERTICES_IDX, :], target_poss, tol=1e-6)
+
+    box.remove_vertex_constraints(envs_idx=[1])
+    target_poss = target_poss + torch.tensor((0.0, 0.0, 0.05), dtype=gs.tc_float, device=gs.device)
+    box.update_constraint_targets(VERTICES_IDX, target_poss)
+    scene.step(update_visualizer=False)
+    constrained_poss = box.get_state().pos[..., VERTICES_IDX, :]
+    assert_allclose(constrained_poss[0], target_poss[0], tol=1e-6)
+    assert (torch.linalg.norm(constrained_poss[1] - target_poss[1], dim=-1) > 0.01).all()
 
 
 @pytest.mark.required

--- a/tests/deformable/test_fem.py
+++ b/tests/deformable/test_fem.py
@@ -413,6 +413,7 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
     box.set_position(((0.0, 0.0, 0.0), (0.0, 0.0, 0.2)))
     box.set_velocity((0.0, 0.0, 0.0))
     anchor.set_pos(((10.0, 0.0, HEIGHT), (20.0, 0.0, HEIGHT)), relative=False)
+    anchor.set_quat(((1.0, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0)), relative=False)
     target_poss = box.get_state().pos[..., VERTICES_IDX, :]
     box.set_vertex_constraints(VERTICES_IDX, envs_idx=[1])
     scene.step(update_visualizer=False)

--- a/tests/deformable/test_fem.py
+++ b/tests/deformable/test_fem.py
@@ -355,7 +355,7 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
 
     target_poss = box.get_state().pos[..., VERTICES_IDX, :]
     box.set_vertex_constraints(VERTICES_IDX)
-    scene.step(update_visualizer=False)
+    scene.step()
     assert_allclose(box.get_state().pos[..., VERTICES_IDX, :], target_poss, tol=1e-8)
 
     # Simulate
@@ -416,12 +416,12 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
     anchor.set_quat(((1.0, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0)), relative=False)
     target_poss = box.get_state().pos[..., VERTICES_IDX, :]
     box.set_vertex_constraints(VERTICES_IDX, envs_idx=[1])
-    scene.step(update_visualizer=False)
+    scene.step()
     assert_allclose(box.get_state().pos[1, VERTICES_IDX, :], target_poss[1], tol=1e-8)
 
     box.remove_vertex_constraints(envs_idx=[1])
     box.set_vertex_constraints(VERTICES_IDX, link=anchor.base_link, envs_idx=[1])
-    scene.step(update_visualizer=False)
+    scene.step()
     assert_allclose(box.get_state().pos[1, VERTICES_IDX, :], target_poss[1], tol=1e-8)
 
     box.remove_vertex_constraints(envs_idx=[1])
@@ -433,13 +433,13 @@ def test_hard_constraint(use_implicit_solver, show_viewer):
         (((0.0, 0.0, 0.0),), ((0.0, 0.0, 0.02),)), dtype=gs.tc_float, device=gs.device
     )
     box.update_constraint_targets(VERTICES_IDX, target_poss[1], envs_idx=[1])
-    scene.step(update_visualizer=False)
+    scene.step()
     assert_allclose(box.get_state().pos[..., VERTICES_IDX, :], target_poss, tol=1e-6)
 
     box.remove_vertex_constraints(envs_idx=[1])
     target_poss = target_poss + torch.tensor((0.0, 0.0, 0.05), dtype=gs.tc_float, device=gs.device)
     box.update_constraint_targets(VERTICES_IDX, target_poss)
-    scene.step(update_visualizer=False)
+    scene.step()
     constrained_poss = box.get_state().pos[..., VERTICES_IDX, :]
     assert_allclose(constrained_poss[0], target_poss[0], tol=1e-6)
     assert (torch.linalg.norm(constrained_poss[1] - target_poss[1], dim=-1) > 0.01).all()


### PR DESCRIPTION
## Description

Fixes environment indexing in the FEM vertex-constraint API for `envs_idx` subsets. The kernels now index the compacted per-call arrays (`verts_idx`, `target_poss`, link poses) by positional row and solver state by global environment id, link poses are queried for the selected environments only, and removing all constraints with `envs_idx` clears only the selected environments.

## Related Issue

Resolves #3240

## Motivation and Context

With a non-prefix `envs_idx` subset, setting, updating, or removing specific vertex constraints read the compacted index arrays out of bounds (segfault or silent corruption), default targets were captured from the wrong environments, linked constraints used another environment's link pose, and the remove-all path cleared every environment. All of it was masked by `envs_idx=None` and prefix subsets, where positional rows and global ids coincide.

## How Has This Been / Can This Be Tested?

The hard-constraint test now gives each environment distinct vertex positions and link poses, then exercises a non-prefix `envs_idx=[1]` through default targets, link-attached constraints, target updates, and subset removal. Each new phase was verified to fail when its corresponding fix is reverted.

```bash
pytest tests/deformable/test_fem.py::test_hard_constraint -n 0 --backend cpu -q
```

Result: `2 passed` on macOS 15.7.3 with an Apple M4 and Python 3.11.14. The full test matrix is left to CI.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
