### PR TITLE
[MISC] Enable cross-platform window-less offscreen rendering (cont'd).

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -17,6 +17,7 @@ from OpenGL.GL import *
 import pyglet
 
 import genesis as gs
+from genesis.utils.misc import get_default_screen
 from genesis.vis.keybindings import Key, KeyAction, Keybind, Keybindings, KeyMod
 from genesis.vis.viewer_plugins import EVENT_HANDLE_STATE, EVENT_HANDLED, ViewerPlugin
 
@@ -51,10 +52,6 @@ HELP_TEXT_KEYBIND_NAME = "toggle_instructions"
 pyglet.options["shadow_window"] = False
 if pyglet.options.get("dpi_scaling") != "real":
     pyglet.options["dpi_scaling"] = "real"
-
-# Keeps the screen free of any window. pyglet's own option is EGL-backed and also selects its window and display
-# classes, so it cannot be requested off Linux, whereas 'GS_HEADLESS' applies everywhere.
-IS_HEADLESS = pyglet.options["headless"] or bool(os.environ.get("GS_HEADLESS"))
 
 
 class Viewer(pyglet.window.Window):
@@ -1242,12 +1239,18 @@ class Viewer(pyglet.window.Window):
                 # This approach avoids "flickering" when creating and closing an invalid context. Besides, it avoids
                 # "frozen" graphical window during compilation that would be interpreted as as bug by the end-user.
                 try:
+                    # Resolving the screen rather than letting pyglet do it keeps the viewer available while every
+                    # display is asleep, which pyglet reports as no screen at all. See 'get_default_screen'. It
+                    # belongs inside this block, whose failures are reported to the thread waiting on startup.
+                    screen = get_default_screen()
+
                     super().__init__(
                         config=conf,
                         visible=False,
                         resizable=True,
                         width=self._viewport_size[0],
                         height=self._viewport_size[1],
+                        screen=screen,
                         # Enable vsync only when the viewer owns a render thread. In main-thread mode (e.g. macOS),
                         # a vsync-locked flip() would block the simulation loop for up to a display frame on every
                         # redraw, periodically overrunning the step budget and stuttering; redraws are already
@@ -1270,8 +1273,10 @@ class Viewer(pyglet.window.Window):
                 # Run the entire rendering pipeline first without window, to make sure that all kernels are compiled
                 self.refresh()
 
-                # At this point, we are all set to display the graphical window
-                if not IS_HEADLESS:
+                # At this point, we are all set to display the graphical window, unless asked to keep the screen
+                # free of any. The request is read here rather than at import, this module being imported before
+                # the caller gets a chance to make it. pyglet's own option only covers its EGL-backed backend.
+                if not (pyglet.options["headless"] or os.environ.get("GS_HEADLESS")):
                     self.set_visible(True)
 
                 # Run the entire rendering pipeline once again, as a final validation that everything is fine
@@ -1316,7 +1321,11 @@ class Viewer(pyglet.window.Window):
 
         # Update window title
         self.set_caption(self.viewer_flags["window_title"])
-        self.activate()
+
+        # Bringing the window to the front pulls the whole application forward on MacOS, which puts it on screen even
+        # though it was never mapped, so it is skipped whenever the screen must be left alone.
+        if not (pyglet.options["headless"] or os.environ.get("GS_HEADLESS")):
+            self.activate()
 
         # The viewer can be considered as fully initialized at this point
         if not self._initialized_event.is_set():

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -518,6 +518,42 @@ def make_tensor_field(shape: tuple[int, ...] = (), dtype_factory: Callable[[], t
     return field(default_factory=_default_factory)
 
 
+def get_default_screen(display=None):
+    """Return the screen a window should be created on, for the given pyglet display or the default one.
+
+    Leaving the display out selects whichever pyglet itself would use, headless included, which is what creating a
+    window must go through. Passing one explicitly is for callers that need a specific backend, such as the native
+    display backing a physical screen size.
+
+    MacOS enumerates only the displays that are awake, so every one of them being asleep, as happens while the screen
+    is locked, leaves pyglet with no screen at all and no way to open a window. Such a display is still online and
+    accepts a window all the same, hence the fallback, which keeps the interactive viewer available on a locked
+    machine. The main display is preferred throughout.
+    """
+    # The display namespace moved from 'pyglet.canvas' to 'pyglet.display' in pyglet 2.0.
+    displays = pyglet.canvas if pyglet.version < "2.0" else pyglet.display
+    if display is None:
+        display = displays.get_display()
+
+    try:
+        return display.get_default_screen()
+    except IndexError:
+        if pyglet.compat_platform != "darwin":
+            raise
+
+        from pyglet.libs.darwin.cocoapy import CGDirectDisplayID, quartz
+
+        CocoaScreen = import_module(f"{displays.__name__}.cocoa").CocoaScreen
+        display_ids = (CGDirectDisplayID * 256)()
+        num_displays = ctypes.c_uint32()
+        quartz.CGGetOnlineDisplayList(len(display_ids), display_ids, ctypes.byref(num_displays))
+        if not num_displays.value:
+            raise
+        online_ids = [display_ids[i] for i in range(num_displays.value)]
+        main_id = quartz.CGMainDisplayID()
+        return CocoaScreen(display, main_id if main_id in online_ids else online_ids[0])
+
+
 def try_get_display_size() -> tuple[int | None, int | None, float | None]:
     """
     Try to connect to display if it exists and get the screen size.
@@ -533,10 +569,10 @@ def try_get_display_size() -> tuple[int | None, int | None, float | None]:
     screen_scale : float | None
         The scale of the screen.
     """
-    # Resolve pyglet's native display backend directly (under 'pyglet.canvas' before 2.0, 'pyglet.display' from 2.0 on),
-    # never the placeholder headless one whose finalizer calls eglTerminate on the EGL display the offscreen renderers
-    # share. A headless process then raises here, reported as no display - the fallback to a default size is the
-    # viewer's concern. Reuse a display pyglet already has open if any (the isinstance check skips a headless one).
+    # Resolve pyglet's native display backend directly, never the placeholder headless one whose finalizer calls
+    # eglTerminate on the EGL display the offscreen renderers share. A headless process then raises here, reported as
+    # no display - the fallback to a default size is the viewer's concern. Reuse a display pyglet already has open if
+    # any (the isinstance check skips a headless one).
     native = {
         "darwin": ("cocoa", "CocoaDisplay"),
         "win32": ("win32", "Win32Display"),
@@ -548,16 +584,13 @@ def try_get_display_size() -> tuple[int | None, int | None, float | None]:
     # The backend submodule depends on the platform and pyglet version, and a foreign-platform one fails to import
     # (e.g. 'win32' off Windows needs Windows-only ctypes), so it cannot be a top-level import; resolving it by
     # computed name avoids a platform-by-version tree of local imports.
-    if pyglet.version < "2.0":
-        Display = getattr(import_module(f"pyglet.canvas.{native[0]}"), native[1])
-        display = next((d for d in pyglet.canvas._displays if isinstance(d, Display)), None)
-    else:
-        Display = getattr(import_module(f"pyglet.display.{native[0]}"), native[1])
-        display = next((d for d in pyglet.display._displays if isinstance(d, Display)), None)
+    displays = pyglet.canvas if pyglet.version < "2.0" else pyglet.display
+    Display = getattr(import_module(f"{displays.__name__}.{native[0]}"), native[1])
+    display = next((d for d in displays._displays if isinstance(d, Display)), None)
     if display is None:
         display = Display()
 
-    screen = display.get_default_screen()
+    screen = get_default_screen(display)
     if pyglet.version < "2.0":
         screen_scale = 1.0
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,23 +21,30 @@ from syrupy.extensions.image import PNGImageSnapshotExtension
 
 from tests.gpu_info import detect_gpu_backend
 
-# Determine whether rendering without a screen is possible, which pyglet implements through its EGL backend.
-is_headless_supported = True
+# Determine whether EGL driver is available, which is what backs pyglet's own headless mode
+has_egl = True
 try:
     pyglet.lib.load_library("EGL")
 except ImportError:
-    is_headless_supported = False
+    has_egl = False
 
-# Determine whether a screen is available, which only the interactive viewer needs. Resolving a display binds pyglet's
-# windowing backend and would rule out its headless one, so the environment answers where headless exists, and pyglet
-# elsewhere, which is what detects a Mac whose displays are all asleep.
-if is_headless_supported:
+# Determine whether a screen is available, which only the interactive viewer needs. Resolving a display binds
+# pyglet's windowing backend and would rule out its headless one, so the environment answers where headless exists.
+if has_egl:
     has_display = bool(os.environ.get("DISPLAY")) if sys.platform.startswith("linux") else False
 else:
     try:
         has_display = bool(pyglet.display.get_display().get_screens())
     except Exception:
         has_display = False
+    if not has_display and sys.platform == "darwin":
+        # A display asleep, as while the screen is locked, stops being active but stays online, and Genesis opens
+        # the viewer window on it all the same, which 'genesis.utils.misc.get_default_screen' takes care of.
+        from pyglet.libs.darwin.cocoapy import quartz
+
+        num_displays = ctypes.c_uint32()
+        quartz.CGGetOnlineDisplayList(0, None, ctypes.byref(num_displays))
+        has_display = bool(num_displays.value)
 
 # Determine whether the optional 'imgui-bundle' dependency is available
 try:
@@ -55,11 +62,11 @@ os.environ["TQDM_DISABLE"] = "1"
 
 # pyglet must be configured in headless mode before importing Genesis if necessary.
 # Note that environment variables are used instead of global options to ease option propagation to subprocesses.
-if not has_display and is_headless_supported:
+if not has_display and has_egl:
     pyglet.options["headless"] = True
     os.environ["PYGLET_HEADLESS"] = "1"
 
-IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or is_headless_supported
+IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or has_egl
 
 TOL_SINGLE = 5e-5
 TOL_DOUBLE = 1e-9
@@ -184,13 +191,10 @@ def pytest_cmdline_main(config: pytest.Config) -> None:
     if is_pdb_enabled:
         config.option.reruns = 0
 
-    # Force headless mode when the viewer is not wanted, so a local run stays off the developer's desktop. Exporting
-    # the variable carries the request to the xdist workers; pyglet's own option only applies where EGL backs it.
+    # Keep the viewer off the developer's desktop when it is not wanted, the variable carrying the request to the
+    # xdist workers.
     if not show_viewer:
         os.environ["GS_HEADLESS"] = "1"
-        if is_headless_supported:
-            pyglet.options["headless"] = True
-            os.environ["PYGLET_HEADLESS"] = "1"
 
     # Make sure that the number of workers is not too large if specified
     if isinstance(config.option.numprocesses, int):
@@ -457,7 +461,7 @@ def pytest_runtest_setup(item):
         cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
         if cuda_visible_devices is not None:
             gpu_index = int(cuda_visible_devices)
-            if is_headless_supported:
+            if has_egl:
                 try:
                     os.environ["EGL_DEVICE_ID"] = str(_get_egl_index(gpu_index))
                 except (AttributeError, KeyError):


### PR DESCRIPTION
## Description

The interactive viewer now opens while every display is asleep on MacOS, as happens when the screen is locked.

## Motivation and Context

pyglet enumerates screens through `CGGetActiveDisplayList`, and a sleeping display stops being active, leaving it with no screen and `get_default_screen` raising `IndexError: list index out of range`. Such a display is still online and accepts a window all the same, so the screen is resolved from the online list instead and passed to the window explicitly.

Offscreen rendering has no drawable to fall back on there: a CGL context without one cannot render to the default framebuffer, and CGL pbuffers are rejected on modern MacOS whatever their target, format and size.

## How Has This Been / Can This Be Tested?

`pytest tests/rendering tests/sensors/test_camera.py` on a MacOS machine whose screen is locked and whose display has gone to sleep, checking `CGGetActiveDisplayList` reports no display before and after the run. It gives the same 68 passed as with the screen awake, the viewer tests running rather than being skipped.

`test_key_press` now counts key releases instead of rejecting a second one, dispatching pending events also delivering whatever the window system has queued.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
