### PR TITLE
[BREAKING][FEATURE] Apply morph pose offset to velocity/acceleration getters.

### DIFF
--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -468,7 +468,7 @@ class KinematicEntityDescription(EntityDescription):
                     cg_vg_infos.append((cg_infos, vg_infos))
 
                 # Extract variant's init_qpos from parsed joint infos, composing the morph offset into the free joint so
-                # relative getters report the variant's user frame.
+                # relative getters report the variant's authored frame.
                 variant_init_qpos_parts = []
                 for v_l_info, v_j_infos in zip(v_l_infos, v_links_j_infos):
                     is_root = v_l_info["parent_idx"] == -1
@@ -1175,7 +1175,7 @@ class KinematicEntityDescription(EntityDescription):
                             props = LinkInertial(gs.EPS, pos, quat, np.zeros((3, 3), dtype=gs.np_float))
                         desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia = props
 
-                # Fold the anchoring into the offset (relative getters keep reporting the user frame) and the root
+                # Fold the anchoring into the offset (relative getters keep reporting the authored frame) and the root
                 # free-joint init_qpos (the body frame moves to old_pose o (com_root, principal), keeping the
                 # re-expressed geoms in world).
                 if variants:
@@ -1403,7 +1403,7 @@ class KinematicEntityDescription(EntityDescription):
             return inertial_info
 
         # Compose the morph pose offset into the root link's world pose. The solver strips the matching offset in
-        # relative getters, so the user frame is unchanged.
+        # relative getters, so the authored frame is unchanged.
         offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
         offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
         l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -754,7 +754,7 @@ class KinematicEntity(Entity):
         return self._solver.get_links_quat(self.base_link_idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
-    def get_vel(self, envs_idx=None):
+    def get_vel(self, envs_idx=None, *, relative=True):
         """
         Returns linear velocity of the entity's base link.
 
@@ -762,13 +762,17 @@ class KinematicEntity(Entity):
         ----------
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            Whether to report the velocity of the user-frame origin, with the morph pose offset and inertial
+            alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
+            is rotating. Defaults to True.
 
         Returns
         -------
         vel : torch.Tensor, shape (3,) or (n_envs, 3)
             The linear velocity of the entity's base link.
         """
-        return self._solver.get_links_vel(self.base_link_idx, envs_idx)[..., 0, :]
+        return self._solver.get_links_vel(self.base_link_idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
     def get_ang(self, envs_idx=None):
@@ -870,7 +874,7 @@ class KinematicEntity(Entity):
         return torch.stack((aabbs[..., 0, :].min(dim=-2).values, aabbs[..., 1, :].max(dim=-2).values), dim=-2)
 
     @gs.assert_built
-    def get_links_vel(self, links_idx_local=None, envs_idx=None):
+    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, relative=True):
         """
         Returns linear velocity of all the entity's links expressed at a given reference position in world coordinates.
 
@@ -880,6 +884,10 @@ class KinematicEntity(Entity):
             The indices of the links. Defaults to None.
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            Whether to report the velocity of the user-frame origin, with the morph pose offset and inertial
+            alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
+            is rotating. Defaults to True.
 
         Returns
         -------
@@ -887,7 +895,7 @@ class KinematicEntity(Entity):
             The linear velocity of all the entity's links.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_vel(links_idx, envs_idx)
+        return self._solver.get_links_vel(links_idx, envs_idx, relative=relative)
 
     @gs.assert_built
     def get_links_ang(self, links_idx_local=None, envs_idx=None):
@@ -2187,7 +2195,9 @@ class RigidEntity(KinematicEntity):
         return self._solver.get_links_pos(links_idx, envs_idx, ref=ref, relative=relative)
 
     @gs.assert_built
-    def get_links_vel(self, links_idx_local=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin):
+    def get_links_vel(
+        self, links_idx_local=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin, relative=True
+    ):
         """
         Returns linear velocity of all the entity's links expressed at a given reference position in world coordinates.
 
@@ -2200,6 +2210,10 @@ class RigidEntity(KinematicEntity):
         ref: gs.link_ref_frame, optional
             The reference point used to express the velocity of each link: its origin ('link_origin') or its center of
             mass ('link_COM'). Defaults to 'link_origin'.
+        relative : bool, optional
+            If True, report the velocity of the user-frame origin, with the morph pose offset and inertial alignment
+            stripped; this only affects ref=gs.link_ref_frame.link_origin, since the offset is defined on the link
+            origin. The two frames differ whenever the link is rotating. Defaults to True.
 
         Returns
         -------
@@ -2207,12 +2221,32 @@ class RigidEntity(KinematicEntity):
             The linear velocity of all the entity's links.
         """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_vel(links_idx, envs_idx, ref=ref)
+        return self._solver.get_links_vel(links_idx, envs_idx, ref=ref, relative=relative)
 
     @gs.assert_built
-    def get_links_acc(self, links_idx_local=None, envs_idx=None):
+    def get_links_acc(self, links_idx_local=None, envs_idx=None, *, relative=True):
+        """
+        Returns classical linear acceleration of all the entity's links expressed at their origin in world
+        coordinates.
+
+        Parameters
+        ----------
+        links_idx_local : None | array_like
+            The indices of the links. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+        relative : bool, optional
+            Whether to report the acceleration of the user-frame origin, with the morph pose offset and inertial
+            alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
+            is rotating. Defaults to True.
+
+        Returns
+        -------
+        acc : torch.Tensor, shape (n_links, 3) or (n_envs, n_links, 3)
+            The classical linear acceleration of all the entity's links.
+        """
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
-        return self._solver.get_links_acc(links_idx, envs_idx)
+        return self._solver.get_links_acc(links_idx, envs_idx, relative=relative)
 
     @gs.assert_built
     def get_links_acc_ang(self, links_idx_local=None, envs_idx=None):

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -724,8 +724,8 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the position of the authored link origin rather than of the internal link origin used by
-            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            the solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat'
+            and, on a free root link with 'align=True', by the inertial alignment. Defaults to True.
 
         Returns
         -------
@@ -745,8 +745,8 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the orientation of the authored link origin rather than of the internal link origin used
-            by the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            by the solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat'
+            and, on a free root link with 'align=True', by the inertial alignment. Defaults to True.
 
         Returns
         -------
@@ -766,9 +766,10 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the velocity of the authored link origin rather than of the internal link origin used by
-            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
-            transport 'omega x d'. Defaults to True.
+            the solver. The internal link origin is the authored one moved by the world-frame vector 'd'. That
+            displacement composes the morph 'offset_pos' / 'offset_quat' and, on a free root link with 'align=True', the
+            inertial alignment. Both readings are expressed in world coordinates and differ by the transport 'omega x
+            d'. Defaults to True.
 
         Returns
         -------
@@ -807,8 +808,9 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the position of the authored link origin, which is where the morph 'pos' placed it, rather
-            than of the internal link origin used by the solver. The morph's 'offset_pos' / 'offset_quat' and the
-            inertial alignment of a free root link ('align=True') displace one from the other. Defaults to True.
+            than of the internal link origin used by the solver. The internal link origin is the authored one moved by
+            the morph 'offset_pos' / 'offset_quat' and, on a free root link with 'align=True', by the inertial
+            alignment. Defaults to True.
 
         Returns
         -------
@@ -831,9 +833,9 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the orientation of the authored link origin, which is where the morph 'quat' / 'euler'
-            placed it, rather than of the internal link origin used by the solver. The morph's 'offset_pos' /
-            'offset_quat' and the inertial alignment of a free root link ('align=True') displace one from the other.
-            Defaults to True.
+            placed it, rather than of the internal link origin used by the solver. The internal link origin is the
+            authored one moved by the morph 'offset_pos' / 'offset_quat' and, on a free root link with 'align=True', by
+            the inertial alignment. Defaults to True.
 
         Returns
         -------
@@ -892,9 +894,10 @@ class KinematicEntity(Entity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the velocity of the authored link origin rather than of the internal link origin used by
-            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
-            transport 'omega x d'. Defaults to True.
+            the solver. The internal link origin is the authored one moved by the world-frame vector 'd'. That
+            displacement composes the morph 'offset_pos' / 'offset_quat' and, on a free root link with 'align=True', the
+            inertial alignment. Both readings are expressed in world coordinates and differ by the transport 'omega x
+            d'. Defaults to True.
 
         Returns
         -------
@@ -940,8 +943,8 @@ class KinematicEntity(Entity):
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
             Whether 'pos' places the authored link origin rather than directly the internal link origin used by the
-            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat' and, on
+            a free root link with 'align=True', by the inertial alignment. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -972,8 +975,8 @@ class KinematicEntity(Entity):
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
             Whether 'quat' orients the authored link origin rather than directly the internal link origin used by the
-            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat' and, on
+            a free root link with 'align=True', by the inertial alignment. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """
@@ -2192,9 +2195,10 @@ class RigidEntity(KinematicEntity):
             joint at its root. Defaults to 'link_origin'.
         relative : bool, optional
             Whether to report the position of the authored link origin rather than of the internal link origin used by
-            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Only 'ref=gs.link_ref_frame.link_origin' is affected, since the
-            offset is defined on the link origin. Defaults to True.
+            the solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat'
+            and, on a free root link with 'align=True', by the inertial alignment. Only
+            'ref=gs.link_ref_frame.link_origin' is affected, since the offset is defined on the link origin. Defaults to
+            True.
 
         Returns
         -------
@@ -2222,9 +2226,10 @@ class RigidEntity(KinematicEntity):
             mass ('link_COM'). Defaults to 'link_origin'.
         relative : bool, optional
             Whether to report the velocity of the authored link origin rather than of the internal link origin used by
-            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
-            transport 'omega x d'. Only 'ref=gs.link_ref_frame.link_origin' is affected. Defaults to True.
+            the solver. The internal link origin is the authored one moved by the world-frame vector 'd'. That
+            displacement composes the morph 'offset_pos' / 'offset_quat' and, on a free root link with 'align=True', the
+            inertial alignment. Both readings are expressed in world coordinates and differ by the transport 'omega x
+            d'. Only 'ref=gs.link_ref_frame.link_origin' is affected. Defaults to True.
 
         Returns
         -------
@@ -2237,8 +2242,7 @@ class RigidEntity(KinematicEntity):
     @gs.assert_built
     def get_links_acc(self, links_idx_local=None, envs_idx=None, *, relative=True):
         """
-        Returns classical linear acceleration of all the entity's links expressed at their origin in world
-        coordinates.
+        Returns classical linear acceleration of all the entity's links expressed at their origin in world coordinates.
 
         Parameters
         ----------
@@ -2248,9 +2252,10 @@ class RigidEntity(KinematicEntity):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
             Whether to report the acceleration of the authored link origin rather than of the internal link origin used
-            by the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
-            transport 'alpha x d + omega x (omega x d)'. Defaults to True.
+            by the solver. The internal link origin is the authored one moved by the world-frame vector 'd'. That
+            displacement composes the morph 'offset_pos' / 'offset_quat' and, on a free root link with 'align=True', the
+            inertial alignment. Both readings are expressed in world coordinates and differ by the transport 'alpha x d
+            + omega x (omega x d)'. Defaults to True.
 
         Returns
         -------
@@ -2423,8 +2428,8 @@ class RigidEntity(KinematicEntity):
             sudden change in entity pose.
         relative : bool, optional
             Whether 'pos' places the authored link origin rather than directly the internal link origin used by the
-            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat' and, on
+            a free root link with 'align=True', by the inertial alignment. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -2457,8 +2462,8 @@ class RigidEntity(KinematicEntity):
             sudden change in entity pose.
         relative : bool, optional
             Whether 'quat' orients the authored link origin rather than directly the internal link origin used by the
-            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            solver. The internal link origin is the authored one moved by the morph 'offset_pos' / 'offset_quat' and, on
+            a free root link with 'align=True', by the inertial alignment. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -723,8 +723,9 @@ class KinematicEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            Whether to report the position in the user frame, with the morph pose offset and inertial alignment
-            stripped, rather than the world frame used by the solver. Defaults to True.
+            Whether to report the position of the authored link origin rather than of the internal link origin used by
+            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
 
         Returns
         -------
@@ -743,8 +744,9 @@ class KinematicEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            Whether to report the orientation in the user frame, with the morph pose offset and inertial alignment
-            stripped, rather than the world frame used by the solver. Defaults to True.
+            Whether to report the orientation of the authored link origin rather than of the internal link origin used
+            by the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
 
         Returns
         -------
@@ -763,9 +765,10 @@ class KinematicEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            Whether to report the velocity of the user-frame origin, with the morph pose offset and inertial
-            alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
-            is rotating. Defaults to True.
+            Whether to report the velocity of the authored link origin rather than of the internal link origin used by
+            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
+            transport 'omega x d'. Defaults to True.
 
         Returns
         -------
@@ -803,8 +806,9 @@ class KinematicEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            If True, return the user-frame position with the morph pose offset stripped (matching the morph 'pos'); if
-            False, return the world-frame position used by the solver. Defaults to True.
+            Whether to report the position of the authored link origin, which is where the morph 'pos' placed it, rather
+            than of the internal link origin used by the solver. The morph's 'offset_pos' / 'offset_quat' and the
+            inertial alignment of a free root link ('align=True') displace one from the other. Defaults to True.
 
         Returns
         -------
@@ -826,8 +830,10 @@ class KinematicEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            If True, return the user-frame orientation with the morph pose offset stripped (matching the morph
-            'quat'/'euler'); if False, return the world-frame orientation used by the solver. Defaults to True.
+            Whether to report the orientation of the authored link origin, which is where the morph 'quat' / 'euler'
+            placed it, rather than of the internal link origin used by the solver. The morph's 'offset_pos' /
+            'offset_quat' and the inertial alignment of a free root link ('align=True') displace one from the other.
+            Defaults to True.
 
         Returns
         -------
@@ -885,9 +891,10 @@ class KinematicEntity(Entity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            Whether to report the velocity of the user-frame origin, with the morph pose offset and inertial
-            alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
-            is rotating. Defaults to True.
+            Whether to report the velocity of the authored link origin rather than of the internal link origin used by
+            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
+            transport 'omega x d'. Defaults to True.
 
         Returns
         -------
@@ -932,8 +939,9 @@ class KinematicEntity(Entity):
         zero_velocity : bool, optional
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
-            Whether 'pos' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
-            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
+            Whether 'pos' places the authored link origin rather than directly the internal link origin used by the
+            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -963,8 +971,9 @@ class KinematicEntity(Entity):
         zero_velocity : bool, optional
             Whether to zero the velocity of all the entity's dofs. Defaults to False.
         relative : bool, optional
-            Whether 'quat' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
-            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
+            Whether 'quat' orients the authored link origin rather than directly the internal link origin used by the
+            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """
@@ -2182,9 +2191,10 @@ class RigidEntity(KinematicEntity):
             'RigidEntity' may comprise several physical sub-entities, each a kinematic sub-tree with at most one free
             joint at its root. Defaults to 'link_origin'.
         relative : bool, optional
-            If True, strip the morph pose offset to return the user-frame position; this only affects
-            ref=gs.link_ref_frame.link_origin, since the offset is defined on the link origin. If False, return the
-            world frame. Defaults to True.
+            Whether to report the position of the authored link origin rather than of the internal link origin used by
+            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Only 'ref=gs.link_ref_frame.link_origin' is affected, since the
+            offset is defined on the link origin. Defaults to True.
 
         Returns
         -------
@@ -2211,9 +2221,10 @@ class RigidEntity(KinematicEntity):
             The reference point used to express the velocity of each link: its origin ('link_origin') or its center of
             mass ('link_COM'). Defaults to 'link_origin'.
         relative : bool, optional
-            If True, report the velocity of the user-frame origin, with the morph pose offset and inertial alignment
-            stripped; this only affects ref=gs.link_ref_frame.link_origin, since the offset is defined on the link
-            origin. The two frames differ whenever the link is rotating. Defaults to True.
+            Whether to report the velocity of the authored link origin rather than of the internal link origin used by
+            the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
+            transport 'omega x d'. Only 'ref=gs.link_ref_frame.link_origin' is affected. Defaults to True.
 
         Returns
         -------
@@ -2236,10 +2247,10 @@ class RigidEntity(KinematicEntity):
         envs_idx : None | array_like, optional
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         relative : bool, optional
-            Whether to report the acceleration of the user-frame origin, with the morph pose offset and inertial
-            alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
-            is rotating or being angularly accelerated, so a link barely turning can still read far apart between the
-            frames. Defaults to True.
+            Whether to report the acceleration of the authored link origin rather than of the internal link origin used
+            by the solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
+            transport 'alpha x d + omega x (omega x d)'. Defaults to True.
 
         Returns
         -------
@@ -2411,8 +2422,9 @@ class RigidEntity(KinematicEntity):
             Whether to zero the velocity of all the entity's dofs. Defaults to True. This is a safety measure after a
             sudden change in entity pose.
         relative : bool, optional
-            Whether 'pos' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
-            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
+            Whether 'pos' places the authored link origin rather than directly the internal link origin used by the
+            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting position. Defaults to False.
         """
@@ -2444,8 +2456,9 @@ class RigidEntity(KinematicEntity):
             Whether to zero the velocity of all the entity's dofs. Defaults to True. This is a safety measure after a
             sudden change in entity pose.
         relative : bool, optional
-            Whether 'quat' is expressed in the user frame, with the morph pose offset and inertial alignment applied on
-            top to reach the world frame used by the solver, rather than directly in the world frame. Defaults to True.
+            Whether 'quat' orients the authored link origin rather than directly the internal link origin used by the
+            solver. The morph's 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
         skip_forward : bool, optional
             Whether to skip forward kinematics after setting quaternion. Defaults to False.
         """

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2238,7 +2238,8 @@ class RigidEntity(KinematicEntity):
         relative : bool, optional
             Whether to report the acceleration of the user-frame origin, with the morph pose offset and inertial
             alignment stripped, rather than of the link origin used by the solver. The two differ whenever the link
-            is rotating. Defaults to True.
+            is rotating or being angularly accelerated, so a link barely turning can still read far apart between the
+            frames. Defaults to True.
 
         Returns
         -------

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -401,8 +401,8 @@ class RigidGeom(RBC):
         """
         Get the position of the geom.
 
-        When 'relative' is True (default), the position reported is that of the authored geom origin, which the entity's
-        morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
+        When 'relative' is True (default), the position reported is that of the authored geom origin. The internal geom
+        origin used by the solver is the authored one moved by the entity's morph 'offset_pos' / 'offset_quat'.
         """
         return self._solver.get_geoms_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -411,8 +411,8 @@ class RigidGeom(RBC):
         """
         Get the quaternion of the geom.
 
-        When 'relative' is True (default), the orientation reported is that of the authored geom origin, which the
-        entity's morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
+        When 'relative' is True (default), the orientation reported is that of the authored geom origin. The internal
+        geom origin used by the solver is the authored one moved by the entity's morph 'offset_pos' / 'offset_quat'.
         """
         return self._solver.get_geoms_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -902,8 +902,8 @@ class RigidVisGeom(RBC):
         """
         Get the position of the visual geom.
 
-        When 'relative' is True (default), the position reported is that of the authored geom origin, which the entity's
-        morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
+        When 'relative' is True (default), the position reported is that of the authored geom origin. The internal geom
+        origin used by the solver is the authored one moved by the entity's morph 'offset_pos' / 'offset_quat'.
         """
         return self._solver.get_vgeoms_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -912,8 +912,8 @@ class RigidVisGeom(RBC):
         """
         Get the quaternion of the visual geom.
 
-        When 'relative' is True (default), the orientation reported is that of the authored geom origin, which the
-        entity's morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
+        When 'relative' is True (default), the orientation reported is that of the authored geom origin. The internal
+        geom origin used by the solver is the authored one moved by the entity's morph 'offset_pos' / 'offset_quat'.
         """
         return self._solver.get_vgeoms_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -401,8 +401,8 @@ class RigidGeom(RBC):
         """
         Get the position of the geom.
 
-        When 'relative' is True (default), the position is reported in the user frame, with the entity's morph pose
-        offset stripped, rather than the world frame used by the solver.
+        When 'relative' is True (default), the position reported is that of the authored geom origin, which the entity's
+        morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
         """
         return self._solver.get_geoms_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -411,8 +411,8 @@ class RigidGeom(RBC):
         """
         Get the quaternion of the geom.
 
-        When 'relative' is True (default), the orientation is reported in the user frame, with the entity's morph pose
-        offset stripped, rather than the world frame used by the solver.
+        When 'relative' is True (default), the orientation reported is that of the authored geom origin, which the
+        entity's morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
         """
         return self._solver.get_geoms_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -902,8 +902,8 @@ class RigidVisGeom(RBC):
         """
         Get the position of the visual geom.
 
-        When 'relative' is True (default), the position is reported in the user frame, with the entity's morph pose
-        offset stripped, rather than the world frame used by the solver.
+        When 'relative' is True (default), the position reported is that of the authored geom origin, which the entity's
+        morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
         """
         return self._solver.get_vgeoms_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -912,8 +912,8 @@ class RigidVisGeom(RBC):
         """
         Get the quaternion of the visual geom.
 
-        When 'relative' is True (default), the orientation is reported in the user frame, with the entity's morph pose
-        offset stripped, rather than the world frame used by the solver.
+        When 'relative' is True (default), the orientation reported is that of the authored geom origin, which the
+        entity's morph 'offset_pos' / 'offset_quat' displaces from the internal one used by the solver.
         """
         return self._solver.get_vgeoms_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -109,11 +109,12 @@ class KinematicLink(RBC):
         Parameters
         ----------
         envs_idx : int or array of int, optional
-            The indices of the environments to get the position. If None, get the position of all environments. Default is None.
+            The indices of the environments to get the position. If None, get the position of all environments. Default
+            is None.
         relative : bool, optional
             Whether to report the position of the authored link origin rather than of the internal link origin used by
-            the solver. The entity's morph 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other. Defaults to True.
+            the solver. The internal link origin is the authored one moved by the entity's morph 'offset_pos' /
+            'offset_quat' and, on a free root link with 'align=True', by the inertial alignment. Defaults to True.
         """
         return self._solver.get_links_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -125,11 +126,12 @@ class KinematicLink(RBC):
         Parameters
         ----------
         envs_idx : int or array of int, optional
-            The indices of the environments to get the quaternion. If None, get the quaternion of all environments. Default is None.
+            The indices of the environments to get the quaternion. If None, get the quaternion of all environments.
+            Default is None.
         relative : bool, optional
             Whether to report the orientation of the authored link origin rather than of the internal link origin used
-            by the solver. The entity's morph 'offset_pos' / 'offset_quat' and the inertial alignment of a free root
-            link ('align=True') displace one from the other. Defaults to True.
+            by the solver. The internal link origin is the authored one moved by the entity's morph 'offset_pos' /
+            'offset_quat' and, on a free root link with 'align=True', by the inertial alignment. Defaults to True.
         """
         return self._solver.get_links_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -141,11 +143,13 @@ class KinematicLink(RBC):
         Parameters
         ----------
         envs_idx : int or array of int, optional
-            The indices of the environments to get the linear velocity. If None, get the linear velocity of all environments. Default is None.
+            The indices of the environments to get the linear velocity. If None, get the linear velocity of all
+            environments. Default is None.
         relative : bool, optional
             Whether to report the velocity of the authored link origin rather than of the internal link origin used by
-            the solver. The entity's morph 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
-            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
+            the solver. The internal link origin is the authored one moved by the world-frame vector 'd'. That
+            displacement composes the entity's morph 'offset_pos' / 'offset_quat' and, on a free root link with
+            'align=True', the inertial alignment. Both readings are expressed in world coordinates and differ by the
             transport 'omega x d'. Defaults to True.
         """
         return self._solver.get_links_vel(self._idx, envs_idx, relative=relative)[..., 0, :]

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -132,7 +132,7 @@ class KinematicLink(RBC):
         return self._solver.get_links_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
-    def get_vel(self, envs_idx=None) -> torch.Tensor:
+    def get_vel(self, envs_idx=None, *, relative=True) -> torch.Tensor:
         """
         Get the linear velocity of the link in the world frame.
 
@@ -140,8 +140,12 @@ class KinematicLink(RBC):
         ----------
         envs_idx : int or array of int, optional
             The indices of the environments to get the linear velocity. If None, get the linear velocity of all environments. Default is None.
+        relative : bool, optional
+            Whether to report the velocity of the user-frame origin, with the entity's morph pose offset and
+            inertial alignment stripped, rather than of the link origin used by the solver. The two differ whenever
+            the link is rotating. Defaults to True.
         """
-        return self._solver.get_links_vel(self._idx, envs_idx)[..., 0, :]
+        return self._solver.get_links_vel(self._idx, envs_idx, relative=relative)[..., 0, :]
 
     @gs.assert_built
     def get_ang(self, envs_idx=None) -> torch.Tensor:

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -111,8 +111,9 @@ class KinematicLink(RBC):
         envs_idx : int or array of int, optional
             The indices of the environments to get the position. If None, get the position of all environments. Default is None.
         relative : bool, optional
-            Whether to report the position in the user frame, with the entity's morph pose offset and inertial
-            alignment stripped, rather than the world frame used by the solver. Defaults to True.
+            Whether to report the position of the authored link origin rather than of the internal link origin used by
+            the solver. The entity's morph 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other. Defaults to True.
         """
         return self._solver.get_links_pos(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -126,8 +127,9 @@ class KinematicLink(RBC):
         envs_idx : int or array of int, optional
             The indices of the environments to get the quaternion. If None, get the quaternion of all environments. Default is None.
         relative : bool, optional
-            Whether to report the orientation in the user frame, with the entity's morph pose offset and inertial
-            alignment stripped, rather than the world frame used by the solver. Defaults to True.
+            Whether to report the orientation of the authored link origin rather than of the internal link origin used
+            by the solver. The entity's morph 'offset_pos' / 'offset_quat' and the inertial alignment of a free root
+            link ('align=True') displace one from the other. Defaults to True.
         """
         return self._solver.get_links_quat(self._idx, envs_idx, relative=relative)[..., 0, :]
 
@@ -141,9 +143,10 @@ class KinematicLink(RBC):
         envs_idx : int or array of int, optional
             The indices of the environments to get the linear velocity. If None, get the linear velocity of all environments. Default is None.
         relative : bool, optional
-            Whether to report the velocity of the user-frame origin, with the entity's morph pose offset and
-            inertial alignment stripped, rather than of the link origin used by the solver. The two differ whenever
-            the link is rotating. Defaults to True.
+            Whether to report the velocity of the authored link origin rather than of the internal link origin used by
+            the solver. The entity's morph 'offset_pos' / 'offset_quat' and the inertial alignment of a free root link
+            ('align=True') displace one from the other by 'd'. Both are expressed in world coordinates and differ by the
+            transport 'omega x d'. Defaults to True.
         """
         return self._solver.get_links_vel(self._idx, envs_idx, relative=relative)[..., 0, :]
 

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1107,6 +1107,18 @@ class KinematicSolver(Solver):
             heights = heights[..., 0]
         return heights
 
+    def _links_offset_shift(self, links_idx, envs_idx):
+        """World-frame displacement from the user-facing link origin to the internal link origin.
+
+        Shaped to broadcast against a '[n_envs, n_sel, dim]' state query. The user frame is rigidly attached to the
+        link, so every relative link-origin getter is the world one transported by this displacement: the position
+        subtracts it, the velocity and acceleration apply the rigid-body transport law about it.
+        """
+        quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
+        offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+        offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+        return _offset_world_shift(offset_pos, offset_quat, quat)
+
     def get_links_pos(self, links_idx=None, envs_idx=None, *, relative=False):
         if not gs.use_zerocopy:
             _, links_idx, envs_idx = self._sanitize_io_variables(
@@ -1114,10 +1126,7 @@ class KinematicSolver(Solver):
             )
         tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
         if relative and self._links_offset_pos is not None:
-            quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
-            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
+            tensor -= self._links_offset_shift(links_idx, envs_idx)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_quat(self, links_idx=None, envs_idx=None, *, relative=False):
@@ -1151,25 +1160,29 @@ class KinematicSolver(Solver):
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_links_vel(self, links_idx=None, envs_idx=None):
+    def get_links_vel(self, links_idx=None, envs_idx=None, *, relative=False):
         if gs.use_zerocopy:
-            mask = (0, *indices_to_mask(links_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, links_idx)
+            mask = indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
             cd_ang = qd_to_torch(self.dyn_state.links.cd_ang, transpose=True)
             pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)
             root_COM = qd_to_torch(self.dyn_state.links.root_COM, transpose=True)
-            return cd_vel[mask] + cd_ang[mask].cross(pos[mask] - root_COM[mask], dim=-1)
+            tensor = cd_vel[mask] + cd_ang[mask].cross(pos[mask] - root_COM[mask], dim=-1)
+        else:
+            _tensor, links_idx, envs_idx = self._sanitize_io_variables(
+                None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
+            )
+            assert _tensor is not None
+            tensor = _tensor[None] if self.n_envs == 0 else _tensor
+            # The frame is passed as a plain int, see 'RigidSolver._sanitize_ref_frame'.
+            kernel_get_links_vel(
+                links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=int(gs.link_ref_frame.link_origin)
+            )
 
-        _tensor, links_idx, envs_idx = self._sanitize_io_variables(
-            None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
-        )
-        assert _tensor is not None
-        tensor = _tensor[None] if self.n_envs == 0 else _tensor
-        # The frame is passed as a plain int, see 'RigidSolver._sanitize_ref_frame'.
-        kernel_get_links_vel(
-            links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=int(gs.link_ref_frame.link_origin)
-        )
-        return _tensor
+        if relative and self._links_offset_pos is not None:
+            ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
+            tensor -= ang.cross(self._links_offset_shift(links_idx, envs_idx), dim=-1)
+        return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_ang(self, links_idx=None, envs_idx=None):
         tensor = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -87,24 +87,25 @@ def _balanced_variant_mapping(n_variants, B):
 def _select_links_offset(offset, links_idx, envs_idx):
     """Index a base-link forward offset for a transposed state query.
 
-    'offset' has shape '[n_offset_envs, n_links, dim]', where 'n_offset_envs' is 1 for an environment-uniform offset
-    (broadcast over the batch) or 'n_envs' when heterogeneous variants make it environment-specific. It is indexed
-    with the same combined mask as 'qd_to_torch' so the result broadcasts against the '[n_envs, n_sel, dim]' state
-    tensor, keeping the link dimension for integer indices. The environment axis is left unindexed (broadcast) when
-    the offset is environment-uniform.
+    'offset' has shape '[n_links, dim]' for an environment-uniform offset or '[n_envs, n_links, dim]' when
+    heterogeneous variants make it environment-specific. It is indexed with the same combined mask as 'qd_to_torch' so
+    the result broadcasts against the '[n_envs, n_sel, dim]' state tensor, keeping the link dimension for integer
+    indices.
     """
-    row_mask = None if offset.shape[0] == 1 else envs_idx
-    return offset[indices_to_mask(row_mask, links_idx)]
+    if offset.ndim == 2:
+        return offset[indices_to_mask(links_idx)]
+    return offset[indices_to_mask(envs_idx, links_idx)]
 
 
 def _offset_world_shift(offset_pos, offset_quat, world_quat):
     """World-frame displacement contributed by a body-frame offset position at a given world orientation.
 
-    The user orientation is 'world_quat' with the offset stripped, and 'offset_pos' rotates with it. Relative getters
-    subtract this from the world position to recover the user position; relative setters add it to do the reverse.
+    The authored orientation is 'world_quat' with the offset stripped, and 'offset_pos' rotates with it. Relative
+    getters subtract this from the world position to recover the authored position; relative setters add it to do the
+    reverse.
     """
-    user_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), world_quat)
-    return gu.transform_by_quat(offset_pos, user_quat)
+    authored_quat = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), world_quat)
+    return gu.transform_by_quat(offset_pos, authored_quat)
 
 
 def _fill_base_link_geom_offsets(offset_pos, offset_quat, entity, geoms, ranges):
@@ -261,12 +262,12 @@ class KinematicSolver(Solver):
                 base_links_idx.append(joint.link.idx)
         self._base_links_idx = torch.tensor(base_links_idx, dtype=gs.tc_int, device=gs.device)
 
-        # World<-user pose offset, applied by the relative get/set methods. Links carry the morph offset composed with
-        # the base-link inertial alignment (identity for non-base links); geoms and visual geoms carry only the morph
-        # offset, since alignment re-expresses them into the aligned frame. Heterogeneous entities vary the base-link
-        # offset per environment (one offset per variant), so the link offset is stored per-env when any such entity
-        # has divergent variant offsets, and as a single broadcast row otherwise. The relative getters recompute the
-        # inverse on the fly.
+        # World<-authored pose offset, applied by the relative get/set methods. Links carry the morph offset composed
+        # with the base-link inertial alignment (identity for non-base links); geoms and visual geoms carry only the
+        # morph offset, since alignment re-expresses them into the aligned frame. Heterogeneous entities vary the
+        # base-link offset per environment (one offset per variant), so the link offset is stored per-env when any such
+        # entity has divergent variant offsets, and without an environment axis otherwise. The relative getters
+        # recompute the inverse on the fly.
         links_offset_per_env = any(
             not all(
                 np.allclose(variant.offset_pos, entity._desc.variants[0].offset_pos)
@@ -275,9 +276,9 @@ class KinematicSolver(Solver):
             )
             for entity in self._entities
         )
-        n_offset_envs = self._B if links_offset_per_env else 1
-        links_offset_pos = np.zeros((n_offset_envs, self.n_links, 3), dtype=gs.np_float)
-        links_offset_quat = np.tile(gu.identity_quat(), (n_offset_envs, self.n_links, 1))
+        offset_shape = (self._B, self.n_links) if links_offset_per_env else (self.n_links,)
+        links_offset_pos = np.zeros((*offset_shape, 3), dtype=gs.np_float)
+        links_offset_quat = np.tile(gu.identity_quat(), (*offset_shape, 1))
         vgeoms_offset_pos = np.zeros((self.n_vgeoms, 3), dtype=gs.np_float)
         vgeoms_offset_quat = np.tile(gu.identity_quat(), (self.n_vgeoms, 1))
         for entity in self._entities:
@@ -294,23 +295,22 @@ class KinematicSolver(Solver):
                 # Each root link carries its own offset; children inherit it through the kinematic chain and stay
                 # identity. Visual geoms get the morph offset conjugated into their own frame.
                 for local_idx, link in enumerate(entity.links):
-                    links_offset_pos[:, entity._link_start + local_idx] = link.desc.offset_pos
-                    links_offset_quat[:, entity._link_start + local_idx] = link.desc.offset_quat
+                    links_offset_pos[..., entity._link_start + local_idx, :] = link.desc.offset_pos
+                    links_offset_quat[..., entity._link_start + local_idx, :] = link.desc.offset_quat
                 vgeoms_ranges = None
             _fill_base_link_geom_offsets(vgeoms_offset_pos, vgeoms_offset_quat, entity, entity.vgeoms, vgeoms_ranges)
-        # Per-link identity masks gate the relative set/backward paths: a relative set on a link whose offset is
+        # Per-link identity masks gate the relative get/set/backward paths: a relative set on a link whose offset is
         # identity is a plain passthrough, while a non-identity offset rewrites the world position or drops the
         # composition jacobian. Kept as host-side numpy (never used in kernels) so the gates avoid a GPU->host sync.
         self._links_offset_quat_is_identity = np.all(
-            np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0, atol=gs.EPS), axis=2
-        ).all(axis=0)
-        self._links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=2).all(axis=0)
-        # The link offset tensors are allocated even when every link is identity, so the getter kernels can take them
-        # unconditionally. '_has_links_offset' is what gates the relative paths, one broadcast row costing nothing.
-        self._has_links_offset = not (
-            self._links_offset_pos_is_identity.all() and self._links_offset_quat_is_identity.all()
+            np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0, atol=gs.EPS), axis=-1
         )
-        self._is_links_offset_per_env = links_offset_per_env
+        self._links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=-1)
+        if links_offset_per_env:
+            self._links_offset_quat_is_identity = self._links_offset_quat_is_identity.all(axis=0)
+            self._links_offset_pos_is_identity = self._links_offset_pos_is_identity.all(axis=0)
+        # The link offset tensors are allocated even when every link is identity, so the getter kernels can take them
+        # unconditionally.
         self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
         self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
         self._vgeoms_offset_pos = self._vgeoms_offset_quat = None
@@ -814,9 +814,10 @@ class KinematicSolver(Solver):
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
-        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
-        # absolute one.
-        if relative and not self._has_links_offset:
+        # Without any offset position on the targeted links, the authored and internal link origins coincide, so a
+        # relative set is just an absolute one.
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        if relative and self._links_offset_pos_is_identity[idx].all():
             relative = False
         pos, links_idx, envs_idx = self._sanitize_io_variables(
             pos, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
@@ -825,8 +826,8 @@ class KinematicSolver(Solver):
             pos = pos[None]
 
         if relative:
-            # Compose the body-frame offset onto the user position while keeping the current orientation, then set the
-            # resulting world position.
+            # Compose the body-frame offset onto the authored position while keeping the current orientation, then set
+            # the resulting world position.
             cur_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
             offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
@@ -848,9 +849,9 @@ class KinematicSolver(Solver):
     def set_base_links_pos_grad(self, links_idx, envs_idx, relative, pos_grad):
         if links_idx is None:
             links_idx = self._base_links_idx
-        # A relative 'set_pos' adds 'R(user_quat) @ offset_pos', which reads the current orientation; that dependency
-        # is not propagated, so with a non-zero offset position the backward pass is only supported on links without
-        # one. 'relative=False' sets the world position directly and is a plain passthrough.
+        # A relative 'set_pos' adds 'R(authored_quat) @ offset_pos', which reads the current orientation; that
+        # dependency is not propagated, so with a non-zero offset position the backward pass is only supported on links
+        # without one. 'relative=False' sets the world position directly and is a plain passthrough.
         idx = links_idx if isinstance(links_idx, int) else slice(None)
         if relative and not self._links_offset_pos_is_identity[idx].all():
             gs.raise_exception(
@@ -871,11 +872,13 @@ class KinematicSolver(Solver):
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
-        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
-        # absolute one.
-        if relative and not self._has_links_offset:
-            relative = False
+        # Without any pose offset on the targeted links, the authored and internal link origins coincide, so a relative
+        # set is just an absolute one.
         idx = links_idx if isinstance(links_idx, int) else slice(None)
+        if relative and (
+            self._links_offset_quat_is_identity[idx].all() and self._links_offset_pos_is_identity[idx].all()
+        ):
+            relative = False
         relative_pos_passthrough = relative and self._links_offset_pos_is_identity[idx].all()
         quat, links_idx, envs_idx = self._sanitize_io_variables(
             quat, links_idx, self.n_links, "links_idx", envs_idx, (4,), skip_allocation=True
@@ -886,17 +889,17 @@ class KinematicSolver(Solver):
         if relative:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
             if not relative_pos_passthrough:
-                # The offset position rotates with the orientation, so keep the user-frame position fixed by rewriting
-                # the world position from the current user position and the new user orientation.
+                # The offset position rotates with the orientation, so keep the authored-frame position fixed by
+                # rewriting the world position from the current authored position and the new authored orientation.
                 cur_pos = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
                 cur_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
                 offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-                user_pos = cur_pos - _offset_world_shift(offset_pos, offset_quat, cur_quat)
-                world_pos = user_pos + gu.transform_by_quat(offset_pos, quat)
+                authored_pos = cur_pos - _offset_world_shift(offset_pos, offset_quat, cur_quat)
+                world_pos = authored_pos + gu.transform_by_quat(offset_pos, quat)
                 kernel_set_links_pos(
                     links_idx, envs_idx, world_pos, self.dyn_state, self.dyn_info, self.rigid_info, self.rigid_config
                 )
-            # Compose the offset onto the user orientation, then set the resulting world orientation.
+            # Compose the offset onto the authored orientation, then set the resulting world orientation.
             quat = gu.transform_quat_by_quat(offset_quat, quat)
             relative = False
 
@@ -1113,31 +1116,24 @@ class KinematicSolver(Solver):
             heights = heights[..., 0]
         return heights
 
-    def _links_offset_shift(self, links_idx, envs_idx):
-        """World-frame displacement from the authored link origin to the internal link origin.
-
-        Shaped to broadcast against a '[n_envs, n_sel, dim]' state query. Both origins belong to the same rigid link,
-        so every relative link-origin getter is the internal one referenced at this displacement instead: the position
-        subtracts it, the velocity moves its reference point by it.
-        """
-        quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
-        offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-        offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-        return _offset_world_shift(offset_pos, offset_quat, quat)
-
     def get_links_pos(self, links_idx=None, envs_idx=None, *, relative=False):
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
         if not gs.use_zerocopy:
             _, links_idx, envs_idx = self._sanitize_io_variables(
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
             )
         tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
-        if relative and self._has_links_offset:
-            tensor -= self._links_offset_shift(links_idx, envs_idx)
+        if relative and not self._links_offset_pos_is_identity[idx].all():
+            quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
+            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_quat(self, links_idx=None, envs_idx=None, *, relative=False):
         tensor = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
-        if relative and self._has_links_offset:
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        if relative and not self._links_offset_quat_is_identity[idx].all():
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
@@ -1167,7 +1163,8 @@ class KinematicSolver(Solver):
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_vel(self, links_idx=None, envs_idx=None, *, relative=False):
-        is_relative = relative and self._has_links_offset
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        is_relative = relative and not self._links_offset_pos_is_identity[idx].all()
         if gs.use_zerocopy:
             mask = indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
@@ -1176,28 +1173,30 @@ class KinematicSolver(Solver):
             root_COM = qd_to_torch(self.dyn_state.links.root_COM, transpose=True)
             cpos = pos[mask] - root_COM[mask]
             if is_relative:
-                cpos = cpos - self._links_offset_shift(links_idx, envs_idx)
+                quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
+                offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+                offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+                cpos = cpos - _offset_world_shift(offset_pos, offset_quat, quat)
             tensor = cd_vel[mask] + cd_ang[mask].cross(cpos, dim=-1)
-        else:
-            _tensor, links_idx, envs_idx = self._sanitize_io_variables(
-                None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
-            )
-            assert _tensor is not None
-            tensor = _tensor[None] if self.n_envs == 0 else _tensor
-            # The frame is passed as a plain int, see 'RigidSolver._sanitize_ref_frame'.
-            kernel_get_links_vel(
-                links_idx,
-                envs_idx,
-                tensor,
-                self._links_offset_pos,
-                self._links_offset_quat,
-                self.dyn_state,
-                self.rigid_config,
-                ref=int(gs.link_ref_frame.link_origin),
-                is_relative=is_relative,
-                is_offset_per_env=self._is_links_offset_per_env,
-            )
-        return tensor[0] if self.n_envs == 0 else tensor
+            return tensor[0] if self.n_envs == 0 else tensor
+
+        _tensor, links_idx, envs_idx = self._sanitize_io_variables(
+            None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
+        )
+        tensor = _tensor[None] if self.n_envs == 0 else _tensor
+        # The frame is passed as a plain int, see 'RigidSolver._sanitize_ref_frame'.
+        kernel_get_links_vel(
+            links_idx,
+            envs_idx,
+            tensor,
+            self._links_offset_pos,
+            self._links_offset_quat,
+            self.dyn_state,
+            self.rigid_config,
+            ref=int(gs.link_ref_frame.link_origin),
+            is_relative=is_relative,
+        )
+        return _tensor
 
     def get_links_ang(self, links_idx=None, envs_idx=None):
         tensor = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -265,8 +265,8 @@ class KinematicSolver(Solver):
         # the base-link inertial alignment (identity for non-base links); geoms and visual geoms carry only the morph
         # offset, since alignment re-expresses them into the aligned frame. Heterogeneous entities vary the base-link
         # offset per environment (one offset per variant), so the link offset is stored per-env when any such entity
-        # has divergent variant offsets, and as a single broadcast row otherwise. Forward offset device tensors are
-        # None when everything is identity, and the relative getters recompute the inverse on the fly.
+        # has divergent variant offsets, and as a single broadcast row otherwise. The relative getters recompute the
+        # inverse on the fly.
         links_offset_per_env = any(
             not all(
                 np.allclose(variant.offset_pos, entity._desc.variants[0].offset_pos)
@@ -305,10 +305,14 @@ class KinematicSolver(Solver):
             np.isclose(gu.quat_to_xyz(links_offset_quat), 0.0, atol=gs.EPS), axis=2
         ).all(axis=0)
         self._links_offset_pos_is_identity = np.all(np.isclose(links_offset_pos, 0.0, atol=gs.EPS), axis=2).all(axis=0)
-        self._links_offset_pos = self._links_offset_quat = None
-        if not (self._links_offset_pos_is_identity.all() and self._links_offset_quat_is_identity.all()):
-            self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
-            self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
+        # The link offset tensors are allocated even when every link is identity, so the getter kernels can take them
+        # unconditionally. '_has_links_offset' is what gates the relative paths, one broadcast row costing nothing.
+        self._has_links_offset = not (
+            self._links_offset_pos_is_identity.all() and self._links_offset_quat_is_identity.all()
+        )
+        self._is_links_offset_per_env = links_offset_per_env
+        self._links_offset_pos = torch.from_numpy(links_offset_pos).to(device=gs.device, dtype=gs.tc_float)
+        self._links_offset_quat = torch.from_numpy(links_offset_quat).to(device=gs.device, dtype=gs.tc_float)
         self._vgeoms_offset_pos = self._vgeoms_offset_quat = None
         if not (
             np.allclose(vgeoms_offset_pos, 0.0, atol=gs.EPS)
@@ -810,8 +814,9 @@ class KinematicSolver(Solver):
     def set_base_links_pos(self, pos, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
-        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
-        if relative and self._links_offset_pos is None:
+        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
+        # absolute one.
+        if relative and not self._has_links_offset:
             relative = False
         pos, links_idx, envs_idx = self._sanitize_io_variables(
             pos, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
@@ -866,8 +871,9 @@ class KinematicSolver(Solver):
     def set_base_links_quat(self, quat, links_idx=None, envs_idx=None, *, relative=False, skip_forward=False):
         if links_idx is None:
             links_idx = self._base_links_idx
-        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
-        if relative and self._links_offset_quat is None:
+        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
+        # absolute one.
+        if relative and not self._has_links_offset:
             relative = False
         idx = links_idx if isinstance(links_idx, int) else slice(None)
         relative_pos_passthrough = relative and self._links_offset_pos_is_identity[idx].all()
@@ -1108,11 +1114,11 @@ class KinematicSolver(Solver):
         return heights
 
     def _links_offset_shift(self, links_idx, envs_idx):
-        """World-frame displacement from the user-facing link origin to the internal link origin.
+        """World-frame displacement from the authored link origin to the internal link origin.
 
-        Shaped to broadcast against a '[n_envs, n_sel, dim]' state query. The user frame is rigidly attached to the
-        link, so every relative link-origin getter is the world one transported by this displacement: the position
-        subtracts it, the velocity and acceleration apply the rigid-body transport law about it.
+        Shaped to broadcast against a '[n_envs, n_sel, dim]' state query. Both origins belong to the same rigid link,
+        so every relative link-origin getter is the internal one referenced at this displacement instead: the position
+        subtracts it, the velocity moves its reference point by it.
         """
         quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
         offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
@@ -1125,13 +1131,13 @@ class KinematicSolver(Solver):
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
             )
         tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
-        if relative and self._links_offset_pos is not None:
+        if relative and self._has_links_offset:
             tensor -= self._links_offset_shift(links_idx, envs_idx)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_quat(self, links_idx=None, envs_idx=None, *, relative=False):
         tensor = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
-        if relative and self._links_offset_quat is not None:
+        if relative and self._has_links_offset:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
         return tensor[0] if self.n_envs == 0 else tensor
@@ -1161,13 +1167,17 @@ class KinematicSolver(Solver):
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_vel(self, links_idx=None, envs_idx=None, *, relative=False):
+        is_relative = relative and self._has_links_offset
         if gs.use_zerocopy:
             mask = indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
             cd_ang = qd_to_torch(self.dyn_state.links.cd_ang, transpose=True)
             pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)
             root_COM = qd_to_torch(self.dyn_state.links.root_COM, transpose=True)
-            tensor = cd_vel[mask] + cd_ang[mask].cross(pos[mask] - root_COM[mask], dim=-1)
+            cpos = pos[mask] - root_COM[mask]
+            if is_relative:
+                cpos = cpos - self._links_offset_shift(links_idx, envs_idx)
+            tensor = cd_vel[mask] + cd_ang[mask].cross(cpos, dim=-1)
         else:
             _tensor, links_idx, envs_idx = self._sanitize_io_variables(
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
@@ -1176,12 +1186,17 @@ class KinematicSolver(Solver):
             tensor = _tensor[None] if self.n_envs == 0 else _tensor
             # The frame is passed as a plain int, see 'RigidSolver._sanitize_ref_frame'.
             kernel_get_links_vel(
-                links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref=int(gs.link_ref_frame.link_origin)
+                links_idx,
+                envs_idx,
+                tensor,
+                self._links_offset_pos,
+                self._links_offset_quat,
+                self.dyn_state,
+                self.rigid_config,
+                ref=int(gs.link_ref_frame.link_origin),
+                is_relative=is_relative,
+                is_offset_per_env=self._is_links_offset_per_env,
             )
-
-        if relative and self._links_offset_pos is not None:
-            ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
-            tensor -= ang.cross(self._links_offset_shift(links_idx, envs_idx), dim=-1)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_ang(self, links_idx=None, envs_idx=None):

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1097,21 +1097,18 @@ def func_link_offset_shift(
     links_offset_pos: qd.types.ndarray(),
     links_offset_quat: qd.types.ndarray(),
     dyn_state: array_class.DynState,
-    is_offset_per_env: qd.template(),
 ):
-    """World-frame displacement from the authored link origin to the internal one, as 'KinematicSolver' does in torch.
+    """World-frame displacement from the authored link origin to the internal one.
 
-    The morph pose offset is expressed in the authored body frame, so it must be rotated by the authored orientation,
-    ie the internal orientation with 'offset_quat' stripped. Both origins belong to the same rigid link, so a relative
-    link-origin getter is the internal one referenced at this displacement instead.
+    The offset tensors carry a leading environment axis only when the offset is environment-specific.
     """
-    i_o = i_b if qd.static(is_offset_per_env) else 0
+    I_l = [i_b, i_l] if qd.static(len(links_offset_pos.shape) == 3) else i_l
     offset_pos = qd.Vector.zero(gs.qd_float, 3)
     for j in qd.static(range(3)):
-        offset_pos[j] = links_offset_pos[i_o, i_l, j]
+        offset_pos[j] = links_offset_pos[I_l, j]
     offset_quat = qd.Vector.zero(gs.qd_float, 4)
     for j in qd.static(range(4)):
-        offset_quat[j] = links_offset_quat[i_o, i_l, j]
+        offset_quat[j] = links_offset_quat[I_l, j]
     authored_quat = gu.qd_transform_quat_by_quat(gu.qd_inv_quat(offset_quat), dyn_state.links.quat[i_l, i_b])
     return gu.qd_transform_by_quat(offset_pos, authored_quat)
 
@@ -1127,7 +1124,6 @@ def kernel_get_links_vel(
     rigid_config: qd.template(),
     ref: qd.template(),
     is_relative: qd.template(),
-    is_offset_per_env: qd.template(),
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
@@ -1143,9 +1139,7 @@ def kernel_get_links_vel(
         if qd.static(ref == gs.link_ref_frame.link_origin):
             cpos = dyn_state.links.pos[i_l, i_b] - dyn_state.links.root_COM[i_l, i_b]
             if qd.static(is_relative):
-                cpos = cpos - func_link_offset_shift(
-                    i_l, i_b, links_offset_pos, links_offset_quat, dyn_state, is_offset_per_env
-                )
+                cpos = cpos - func_link_offset_shift(i_l, i_b, links_offset_pos, links_offset_quat, dyn_state)
             vel = vel + dyn_state.links.cd_ang[i_l, i_b].cross(cpos)
 
         for j in qd.static(range(3)):
@@ -1162,7 +1156,6 @@ def kernel_get_links_acc(
     dyn_state: array_class.DynState,
     rigid_config: qd.template(),
     is_relative: qd.template(),
-    is_offset_per_env: qd.template(),
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
@@ -1172,9 +1165,7 @@ def kernel_get_links_acc(
         # Compute links spatial acceleration expressed at links origin in world coordinates
         cpos = dyn_state.links.pos[i_l, i_b] - dyn_state.links.root_COM[i_l, i_b]
         if qd.static(is_relative):
-            cpos = cpos - func_link_offset_shift(
-                i_l, i_b, links_offset_pos, links_offset_quat, dyn_state, is_offset_per_env
-            )
+            cpos = cpos - func_link_offset_shift(i_l, i_b, links_offset_pos, links_offset_quat, dyn_state)
         acc_ang = dyn_state.links.cacc_ang[i_l, i_b]
         acc_lin = dyn_state.links.cacc_lin[i_l, i_b] + acc_ang.cross(cpos)
 

--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -1090,30 +1090,63 @@ def kernel_control_dofs_position_velocity(
         dyn_state.dofs.ctrl_vel[i_d, i_b] = velocity[i_b_, i_d_]
 
 
+@qd.func
+def func_link_offset_shift(
+    i_l,
+    i_b,
+    links_offset_pos: qd.types.ndarray(),
+    links_offset_quat: qd.types.ndarray(),
+    dyn_state: array_class.DynState,
+    is_offset_per_env: qd.template(),
+):
+    """World-frame displacement from the authored link origin to the internal one, as 'KinematicSolver' does in torch.
+
+    The morph pose offset is expressed in the authored body frame, so it must be rotated by the authored orientation,
+    ie the internal orientation with 'offset_quat' stripped. Both origins belong to the same rigid link, so a relative
+    link-origin getter is the internal one referenced at this displacement instead.
+    """
+    i_o = i_b if qd.static(is_offset_per_env) else 0
+    offset_pos = qd.Vector.zero(gs.qd_float, 3)
+    for j in qd.static(range(3)):
+        offset_pos[j] = links_offset_pos[i_o, i_l, j]
+    offset_quat = qd.Vector.zero(gs.qd_float, 4)
+    for j in qd.static(range(4)):
+        offset_quat[j] = links_offset_quat[i_o, i_l, j]
+    authored_quat = gu.qd_transform_quat_by_quat(gu.qd_inv_quat(offset_quat), dyn_state.links.quat[i_l, i_b])
+    return gu.qd_transform_by_quat(offset_pos, authored_quat)
+
+
 @qd.kernel(fastcache=True)
 def kernel_get_links_vel(
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
     tensor: qd.types.ndarray(),
+    links_offset_pos: qd.types.ndarray(),
+    links_offset_quat: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     rigid_config: qd.template(),
     ref: qd.template(),
+    is_relative: qd.template(),
+    is_offset_per_env: qd.template(),
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
+        i_l = links_idx[i_l_]
+        i_b = envs_idx[i_b_]
+
         # This is the velocity in world coordinates expressed at global com-position
-        vel = dyn_state.links.cd_vel[links_idx[i_l_], envs_idx[i_b_]]  # entity's CoM
+        vel = dyn_state.links.cd_vel[i_l, i_b]  # entity's CoM
 
         # Translate to get the velocity expressed at a different position if necessary link-position
         if qd.static(ref == gs.link_ref_frame.link_COM):
-            vel = vel + dyn_state.links.cd_ang[links_idx[i_l_], envs_idx[i_b_]].cross(
-                dyn_state.links.i_pos[links_idx[i_l_], envs_idx[i_b_]]
-            )
+            vel = vel + dyn_state.links.cd_ang[i_l, i_b].cross(dyn_state.links.i_pos[i_l, i_b])
         if qd.static(ref == gs.link_ref_frame.link_origin):
-            vel = vel + dyn_state.links.cd_ang[links_idx[i_l_], envs_idx[i_b_]].cross(
-                dyn_state.links.pos[links_idx[i_l_], envs_idx[i_b_]]
-                - dyn_state.links.root_COM[links_idx[i_l_], envs_idx[i_b_]]
-            )
+            cpos = dyn_state.links.pos[i_l, i_b] - dyn_state.links.root_COM[i_l, i_b]
+            if qd.static(is_relative):
+                cpos = cpos - func_link_offset_shift(
+                    i_l, i_b, links_offset_pos, links_offset_quat, dyn_state, is_offset_per_env
+                )
+            vel = vel + dyn_state.links.cd_ang[i_l, i_b].cross(cpos)
 
         for j in qd.static(range(3)):
             tensor[i_b_, i_l_, j] = vel[j]
@@ -1124,8 +1157,12 @@ def kernel_get_links_acc(
     links_idx: qd.types.ndarray(),
     envs_idx: qd.types.ndarray(),
     tensor: qd.types.ndarray(),
+    links_offset_pos: qd.types.ndarray(),
+    links_offset_quat: qd.types.ndarray(),
     dyn_state: array_class.DynState,
     rigid_config: qd.template(),
+    is_relative: qd.template(),
+    is_offset_per_env: qd.template(),
 ):
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
     for i_l_, i_b_ in qd.ndrange(links_idx.shape[0], envs_idx.shape[0]):
@@ -1134,6 +1171,10 @@ def kernel_get_links_acc(
 
         # Compute links spatial acceleration expressed at links origin in world coordinates
         cpos = dyn_state.links.pos[i_l, i_b] - dyn_state.links.root_COM[i_l, i_b]
+        if qd.static(is_relative):
+            cpos = cpos - func_link_offset_shift(
+                i_l, i_b, links_offset_pos, links_offset_quat, dyn_state, is_offset_per_env
+            )
         acc_ang = dyn_state.links.cacc_ang[i_l, i_b]
         acc_lin = dyn_state.links.cacc_lin[i_l, i_b] + acc_ang.cross(cpos)
 

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1990,12 +1990,13 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         if links_idx is None:
             links_idx = self._base_links_idx
 
-        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
-        # absolute one.
-        if relative and not self._has_links_offset:
+        # Without any offset position on the targeted links, the authored and internal link origins coincide, so a
+        # relative set is just an absolute one.
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        if relative and self._links_offset_pos_is_identity[idx].all():
             relative = False
 
-        # Map a single base link's user position to world here (keeping the current orientation) so the zero-copy
+        # Map a single base link's authored position to world here (keeping the current orientation) so the zero-copy
         # in-place write below still applies, both for an environment-uniform and a per-environment offset. Multi-link
         # relative sets are composed in the kernel branch instead.
         if relative and isinstance(links_idx, int):
@@ -2054,8 +2055,8 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 pos = pos[None]
 
             if relative:
-                # Compose the body-frame offset onto the user position, keeping the current orientation, then set the
-                # resulting world position absolutely.
+                # Compose the body-frame offset onto the authored position, keeping the current orientation, then set
+                # the resulting world position absolutely.
                 cur_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
                 offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
                 offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
@@ -2113,17 +2114,19 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         if links_idx is None:
             links_idx = self._base_links_idx
 
-        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
-        # absolute one.
-        if relative and not self._has_links_offset:
+        # Without any pose offset on the targeted links, the authored and internal link origins coincide, so a relative
+        # set is just an absolute one.
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        if relative and (
+            self._links_offset_quat_is_identity[idx].all() and self._links_offset_pos_is_identity[idx].all()
+        ):
             relative = False
 
-        # Computed once and reused by the int fast path and the kernel branch below.
-        idx = links_idx if isinstance(links_idx, int) else slice(None)
+        # Reused by the int fast path and the kernel branch below.
         relative_pos_passthrough = relative and self._links_offset_pos_is_identity[idx].all()
 
-        # Compose a single base link's user orientation to world here so the zero-copy in-place write below still
-        # applies, both for an environment-uniform and a per-environment offset. This only preserves the user-frame
+        # Compose a single base link's authored orientation to world here so the zero-copy in-place write below still
+        # applies, both for an environment-uniform and a per-environment offset. This only preserves the authored-frame
         # position when the offset position is identity; a non-zero offset position rotates with the orientation and
         # is handled (together with multi-link relative sets) in the kernel branch instead.
         if isinstance(links_idx, int) and relative_pos_passthrough:
@@ -2179,13 +2182,13 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             if relative:
                 offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
                 if not relative_pos_passthrough:
-                    # The offset position rotates with the orientation, so keep the user-frame position fixed by
-                    # rewriting the world position from the current user position and the new user orientation.
+                    # The offset position rotates with the orientation, so keep the authored-frame position fixed by
+                    # rewriting the world position from the current authored position and the new authored orientation.
                     cur_pos = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
                     cur_quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
                     offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-                    user_pos = cur_pos - _offset_world_shift(offset_pos, offset_quat, cur_quat)
-                    world_pos = user_pos + gu.transform_by_quat(offset_pos, quat)
+                    authored_pos = cur_pos - _offset_world_shift(offset_pos, offset_quat, cur_quat)
+                    world_pos = authored_pos + gu.transform_by_quat(offset_pos, quat)
                     kernel_set_links_pos(
                         links_idx,
                         envs_idx,
@@ -2195,7 +2198,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                         self.rigid_info,
                         self.rigid_config,
                     )
-                # Compose the offset onto the user orientation, then set the resulting world orientation absolutely.
+                # Compose the offset onto the authored orientation, then set the resulting world orientation absolutely.
                 quat = gu.transform_quat_by_quat(offset_quat, quat)
                 relative = False
 
@@ -2821,6 +2824,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         ref: link_ref_frame = link_ref_frame.link_origin,
         relative=False,
     ):
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
         if not gs.use_zerocopy:
             _, links_idx, envs_idx = self._sanitize_io_variables(
                 None, links_idx, self.n_links, "links_idx", envs_idx, (3,), skip_allocation=True
@@ -2837,8 +2841,11 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
 
         # The pose offset is defined on the link origin, so it is only stripped for the 'link_origin' reference.
-        if relative and ref_frame == link_ref_frame.link_origin and self._has_links_offset:
-            tensor -= self._links_offset_shift(links_idx, envs_idx)
+        if relative and ref_frame == link_ref_frame.link_origin and not self._links_offset_pos_is_identity[idx].all():
+            quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
+            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
 
         return tensor[0] if self.n_envs == 0 else tensor
 
@@ -2846,8 +2853,11 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         self, links_idx=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin, relative=False
     ):
         ref_frame = self._sanitize_ref_frame(ref, has_root_COM=False)
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
         # Only the 'link_origin' reference carries the offset, as in 'get_links_pos'.
-        is_relative = relative and ref_frame == link_ref_frame.link_origin and self._has_links_offset
+        is_relative = (
+            relative and ref_frame == link_ref_frame.link_origin and not self._links_offset_pos_is_identity[idx].all()
+        )
         if gs.use_zerocopy:
             mask = indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
@@ -2860,30 +2870,32 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 root_COM = qd_to_torch(self.dyn_state.links.root_COM, transpose=True)
                 delta = pos[mask] - root_COM[mask]
                 if is_relative:
-                    delta = delta - self._links_offset_shift(links_idx, envs_idx)
+                    quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True)
+                    offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
+                    offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
+                    delta = delta - _offset_world_shift(offset_pos, offset_quat, quat)
             tensor = cd_vel[mask] + cd_ang[mask].cross(delta, dim=-1)
-        else:
-            _tensor, links_idx, envs_idx = self._sanitize_io_variables(
-                None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
-            )
-            assert _tensor is not None
-            tensor = _tensor[None] if self.n_envs == 0 else _tensor
-            kernel_get_links_vel(
-                links_idx,
-                envs_idx,
-                tensor,
-                self._links_offset_pos,
-                self._links_offset_quat,
-                self.dyn_state,
-                self.rigid_config,
-                ref_frame,
-                is_relative=is_relative,
-                is_offset_per_env=self._is_links_offset_per_env,
-            )
+            return tensor[0] if self.n_envs == 0 else tensor
 
-        return tensor[0] if self.n_envs == 0 else tensor
+        _tensor, links_idx, envs_idx = self._sanitize_io_variables(
+            None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
+        )
+        tensor = _tensor[None] if self.n_envs == 0 else _tensor
+        kernel_get_links_vel(
+            links_idx,
+            envs_idx,
+            tensor,
+            self._links_offset_pos,
+            self._links_offset_quat,
+            self.dyn_state,
+            self.rigid_config,
+            ref_frame,
+            is_relative=is_relative,
+        )
+        return _tensor
 
     def get_links_acc(self, links_idx=None, envs_idx=None, *, relative=False):
+        idx = links_idx if isinstance(links_idx, int) else slice(None)
         _tensor, links_idx, envs_idx = self._sanitize_io_variables(
             None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
         )
@@ -2896,10 +2908,9 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             self._links_offset_quat,
             self.dyn_state,
             self.rigid_config,
-            is_relative=relative and self._has_links_offset,
-            is_offset_per_env=self._is_links_offset_per_env,
+            is_relative=relative and not self._links_offset_pos_is_identity[idx].all(),
         )
-        return tensor[0] if self.n_envs == 0 else tensor
+        return _tensor
 
     def get_links_acc_ang(self, links_idx=None, envs_idx=None):
         tensor = qd_to_torch(self.dyn_state.links.cacc_ang, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2836,17 +2836,16 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
 
         # The pose offset is defined on the link origin, so it is only stripped for the 'link_origin' reference.
         if relative and ref_frame == link_ref_frame.link_origin and self._links_offset_pos is not None:
-            quat = qd_to_torch(self.dyn_state.links.quat, envs_idx, links_idx, transpose=True, copy=True)
-            offset_pos = _select_links_offset(self._links_offset_pos, links_idx, envs_idx)
-            offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
-            tensor -= _offset_world_shift(offset_pos, offset_quat, quat)
+            tensor -= self._links_offset_shift(links_idx, envs_idx)
 
         return tensor[0] if self.n_envs == 0 else tensor
 
-    def get_links_vel(self, links_idx=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin):
+    def get_links_vel(
+        self, links_idx=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin, relative=False
+    ):
         ref_frame = self._sanitize_ref_frame(ref, has_root_COM=False)
         if gs.use_zerocopy:
-            mask = (0, *indices_to_mask(links_idx)) if self.n_envs == 0 else indices_to_mask(envs_idx, links_idx)
+            mask = indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
             cd_ang = qd_to_torch(self.dyn_state.links.cd_ang, transpose=True)
             if ref_frame == link_ref_frame.link_COM:
@@ -2856,23 +2855,38 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)
                 root_COM = qd_to_torch(self.dyn_state.links.root_COM, transpose=True)
                 delta = pos[mask] - root_COM[mask]
-            return cd_vel[mask] + cd_ang[mask].cross(delta, dim=-1)
+            tensor = cd_vel[mask] + cd_ang[mask].cross(delta, dim=-1)
+        else:
+            _tensor, links_idx, envs_idx = self._sanitize_io_variables(
+                None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
+            )
+            assert _tensor is not None
+            tensor = _tensor[None] if self.n_envs == 0 else _tensor
+            kernel_get_links_vel(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref_frame)
 
-        _tensor, links_idx, envs_idx = self._sanitize_io_variables(
-            None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
-        )
-        assert _tensor is not None
-        tensor = _tensor[None] if self.n_envs == 0 else _tensor
-        kernel_get_links_vel(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref_frame)
-        return _tensor
+        # Only the 'link_origin' reference carries the offset, as in 'get_links_pos'.
+        if relative and ref_frame == link_ref_frame.link_origin and self._links_offset_pos is not None:
+            ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
+            tensor -= ang.cross(self._links_offset_shift(links_idx, envs_idx), dim=-1)
 
-    def get_links_acc(self, links_idx=None, envs_idx=None):
+        return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_links_acc(self, links_idx=None, envs_idx=None, *, relative=False):
         _tensor, links_idx, envs_idx = self._sanitize_io_variables(
             None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
         )
         tensor = _tensor[None] if self.n_envs == 0 else _tensor
         kernel_get_links_acc(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config)
-        return _tensor
+
+        # Classical acceleration transported over a displacement of '-shift', hence both signs:
+        # 'a - alpha x shift - omega x (omega x shift)'.
+        if relative and self._links_offset_pos is not None:
+            ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
+            acc_ang = qd_to_torch(self.dyn_state.links.cacc_ang, envs_idx, links_idx, transpose=True)
+            shift = self._links_offset_shift(links_idx, envs_idx)
+            tensor -= acc_ang.cross(shift, dim=-1) + ang.cross(ang.cross(shift, dim=-1), dim=-1)
+
+        return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_acc_ang(self, links_idx=None, envs_idx=None):
         tensor = qd_to_torch(self.dyn_state.links.cacc_ang, envs_idx, links_idx, transpose=True, copy=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1990,8 +1990,9 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         if links_idx is None:
             links_idx = self._base_links_idx
 
-        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
-        if relative and self._links_offset_pos is None:
+        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
+        # absolute one.
+        if relative and not self._has_links_offset:
             relative = False
 
         # Map a single base link's user position to world here (keeping the current orientation) so the zero-copy
@@ -2112,8 +2113,9 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         if links_idx is None:
             links_idx = self._base_links_idx
 
-        # Without any pose offset, the user and world frames coincide, so a relative set is just an absolute one.
-        if relative and self._links_offset_quat is None:
+        # Without any pose offset, the authored and internal link origins coincide, so a relative set is just an
+        # absolute one.
+        if relative and not self._has_links_offset:
             relative = False
 
         # Computed once and reused by the int fast path and the kernel branch below.
@@ -2835,7 +2837,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             tensor = qd_to_torch(self.dyn_state.links.pos, envs_idx, links_idx, transpose=True, copy=True)
 
         # The pose offset is defined on the link origin, so it is only stripped for the 'link_origin' reference.
-        if relative and ref_frame == link_ref_frame.link_origin and self._links_offset_pos is not None:
+        if relative and ref_frame == link_ref_frame.link_origin and self._has_links_offset:
             tensor -= self._links_offset_shift(links_idx, envs_idx)
 
         return tensor[0] if self.n_envs == 0 else tensor
@@ -2844,6 +2846,8 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         self, links_idx=None, envs_idx=None, *, ref: link_ref_frame = link_ref_frame.link_origin, relative=False
     ):
         ref_frame = self._sanitize_ref_frame(ref, has_root_COM=False)
+        # Only the 'link_origin' reference carries the offset, as in 'get_links_pos'.
+        is_relative = relative and ref_frame == link_ref_frame.link_origin and self._has_links_offset
         if gs.use_zerocopy:
             mask = indices_to_mask(envs_idx, links_idx)
             cd_vel = qd_to_torch(self.dyn_state.links.cd_vel, transpose=True)
@@ -2855,6 +2859,8 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 pos = qd_to_torch(self.dyn_state.links.pos, transpose=True)
                 root_COM = qd_to_torch(self.dyn_state.links.root_COM, transpose=True)
                 delta = pos[mask] - root_COM[mask]
+                if is_relative:
+                    delta = delta - self._links_offset_shift(links_idx, envs_idx)
             tensor = cd_vel[mask] + cd_ang[mask].cross(delta, dim=-1)
         else:
             _tensor, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2862,12 +2868,18 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             )
             assert _tensor is not None
             tensor = _tensor[None] if self.n_envs == 0 else _tensor
-            kernel_get_links_vel(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config, ref_frame)
-
-        # Only the 'link_origin' reference carries the offset, as in 'get_links_pos'.
-        if relative and ref_frame == link_ref_frame.link_origin and self._links_offset_pos is not None:
-            ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
-            tensor -= ang.cross(self._links_offset_shift(links_idx, envs_idx), dim=-1)
+            kernel_get_links_vel(
+                links_idx,
+                envs_idx,
+                tensor,
+                self._links_offset_pos,
+                self._links_offset_quat,
+                self.dyn_state,
+                self.rigid_config,
+                ref_frame,
+                is_relative=is_relative,
+                is_offset_per_env=self._is_links_offset_per_env,
+            )
 
         return tensor[0] if self.n_envs == 0 else tensor
 
@@ -2876,16 +2888,17 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             None, links_idx, self.n_links, "links_idx", envs_idx, (3,)
         )
         tensor = _tensor[None] if self.n_envs == 0 else _tensor
-        kernel_get_links_acc(links_idx, envs_idx, tensor, self.dyn_state, self.rigid_config)
-
-        # Classical acceleration transported over a displacement of '-shift', hence both signs:
-        # 'a - alpha x shift - omega x (omega x shift)'.
-        if relative and self._links_offset_pos is not None:
-            ang = qd_to_torch(self.dyn_state.links.cd_ang, envs_idx, links_idx, transpose=True)
-            acc_ang = qd_to_torch(self.dyn_state.links.cacc_ang, envs_idx, links_idx, transpose=True)
-            shift = self._links_offset_shift(links_idx, envs_idx)
-            tensor -= acc_ang.cross(shift, dim=-1) + ang.cross(ang.cross(shift, dim=-1), dim=-1)
-
+        kernel_get_links_acc(
+            links_idx,
+            envs_idx,
+            tensor,
+            self._links_offset_pos,
+            self._links_offset_quat,
+            self.dyn_state,
+            self.rigid_config,
+            is_relative=relative and self._has_links_offset,
+            is_offset_per_env=self._is_links_offset_per_env,
+        )
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_links_acc_ang(self, links_idx=None, envs_idx=None):

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -350,7 +350,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         # Current link state in env-local frame
         link_pos = tensor_to_array(self._held_link.get_pos(envs_idx=envs_idx, relative=False).squeeze(0))
         link_quat = tensor_to_array(self._held_link.get_quat(envs_idx=envs_idx, relative=False).squeeze(0))
-        lin_vel = tensor_to_array(self._held_link.get_vel(envs_idx=envs_idx).squeeze(0))
+        lin_vel = tensor_to_array(self._held_link.get_vel(envs_idx=envs_idx, relative=False).squeeze(0))
         ang_vel = tensor_to_array(self._held_link.get_ang(envs_idx=envs_idx).squeeze(0))
 
         # Held point in env-local frame; control point comes from a world-space plane raycast, so strip the offset.

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -729,9 +729,10 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
         - torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1),
         tol=tol,
     )
-    # Neither transported term is vacuous: the angular-acceleration contribution alone exceeds the tolerance, and
-    # both frames genuinely disagree while the box rotates.
+    # Neither transported term is vacuous: each contributes more than the tolerance on its own, and both frames
+    # genuinely disagree while the box rotates.
     assert (torch.cross(alpha, offset_shift, dim=-1).abs() > tol).any()
+    assert (torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1).abs() > tol).any()
     with pytest.raises(AssertionError):
         assert_allclose(posed_box.get_vel(relative=True), posed_box.get_vel(relative=False), tol=tol)
     with pytest.raises(AssertionError):

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -667,10 +667,12 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     )
     POSED_BOX_POS = (2.0, 0.5, 0.3)
     POSED_BOX_OFFSET_EULER = (0.0, 0.0, 45.0)
+    # Distinct principal moments, so a free spin precesses and the angular-acceleration term of the relative-frame
+    # acceleration transport below stays above the comparison tolerance.
     posed_box = scene.add_entity(
         gs.morphs.Box(
             pos=POSED_BOX_POS,
-            size=(0.04, 0.04, 0.04),
+            size=(0.04, 0.06, 0.10),
             offset_pos=(0.0, 0.0, 0.5),
             offset_euler=POSED_BOX_OFFSET_EULER,
         ),
@@ -702,6 +704,43 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
 
     robot_aabb_init, robot_base_aabb_init = robot.get_AABB(), robot.geoms[0].get_AABB()
     cube_aabb_init, cube_base_aabb_init = cube.get_AABB(), cube.geoms[0].get_AABB()
+
+    # Velocity and acceleration describe the same point as the position. Without rotation the user frame only
+    # translates with the link origin, so both frames report the same free fall.
+    scene.step()
+    assert_allclose(posed_box.get_vel(relative=True), posed_box.get_vel(relative=False), tol=tol)
+    assert_allclose(posed_box.get_links_acc(relative=True), posed_box.get_links_acc(relative=False), tol=tol)
+
+    # Spinning the box, the user-frame origin orbits the link origin, so it is transported by the rigid-body law about
+    # the very displacement the position getters strip: 'v - omega x d' and 'a - alpha x d - omega x (omega x d)'.
+    posed_box.set_dofs_velocity((0.0, 0.0, 0.0, 1.0, 2.0, -3.0))
+    scene.step()
+    offset_shift = posed_box.get_pos(relative=False) - posed_box.get_pos(relative=True)
+    omega, alpha = posed_box.get_ang(), posed_box.get_links_acc_ang()[..., 0, :]
+    assert_allclose(
+        posed_box.get_vel(relative=True),
+        posed_box.get_vel(relative=False) - torch.cross(omega, offset_shift, dim=-1),
+        tol=tol,
+    )
+    assert_allclose(
+        posed_box.get_links_acc(relative=True)[..., 0, :],
+        posed_box.get_links_acc(relative=False)[..., 0, :]
+        - torch.cross(alpha, offset_shift, dim=-1)
+        - torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1),
+        tol=tol,
+    )
+    # Neither transported term is vacuous: the angular-acceleration contribution alone exceeds the tolerance, and
+    # both frames genuinely disagree while the box rotates.
+    assert (torch.cross(alpha, offset_shift, dim=-1).abs() > tol).any()
+    with pytest.raises(AssertionError):
+        assert_allclose(posed_box.get_vel(relative=True), posed_box.get_vel(relative=False), tol=tol)
+    with pytest.raises(AssertionError):
+        assert_allclose(posed_box.get_links_acc(relative=True), posed_box.get_links_acc(relative=False), tol=tol)
+
+    # Masking rows and columns must strip the same offset as the unmasked query.
+    assert_allclose(
+        posed_box.get_links_vel(links_idx_local=0, envs_idx=[1])[..., 0, :], posed_box.get_vel()[[1]], tol=tol
+    )
 
     # Make sure that it is not possible to end up in an inconsistent state for fixed geometries. These place entities
     # at absolute world positions, so they bypass the pose offset (relative=False).

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -682,7 +682,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     assert_allclose(plain_box.get_pos(), (2.0, 0.0, 0.2), tol=tol)
 
     # With both a morph pose and an offset, the relative getter returns the morph pose while the world getter carries
-    # the offset composed onto it (the offset position adds in z since the user orientation is identity).
+    # the offset composed onto it (the offset position adds in z since the authored orientation is identity).
     assert_allclose(posed_box.get_pos(relative=True), POSED_BOX_POS, tol=tol)
     assert_allclose(posed_box.get_quat(relative=True), gu.identity_quat(), tol=tol)
     assert_allclose(posed_box.get_pos(relative=False), (2.0, 0.5, 0.8), tol=tol)
@@ -692,9 +692,9 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
         tol=tol,
     )
 
-    # Setting the orientation in the user frame keeps the user-frame position fixed: the offset position rotates with
-    # the orientation, so the world position is rewritten to preserve the reported relative position. Rotating about x
-    # while the offset position is along z makes that offset contribution change, exercising the rewrite.
+    # Setting the orientation in the authored frame keeps the authored-frame position fixed: the offset position rotates
+    # with the orientation, so the world position is rewritten to preserve the reported relative position. Rotating
+    # about x while the offset position is along z makes that offset contribution change, exercising the rewrite.
     new_quat = gu.xyz_to_quat(np.array((90.0, 0.0, 0.0)), rpy=True, degrees=True)
     posed_box.set_quat(new_quat, relative=True)
     assert_allclose(posed_box.get_pos(relative=True), POSED_BOX_POS, tol=tol)
@@ -710,15 +710,13 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
 
     # Spinning the box makes the authored origin orbit the internal one, so both are reported at the displacement 'd'
     # the position getters strip. The spin is about a principal body axis orthogonal to the offset position, so it is
-    # torque-free and stays orthogonal to 'd', which collapses the centripetal transport of the acceleration to
-    # '-SPIN**2 * d'.
+    # torque-free and stays orthogonal to 'd', which collapses the acceleration transport to the centripetal term
+    # 'SPIN**2 * d' toward the internal origin.
     SPIN = 5.0
     posed_box.set_dofs_velocity((0.0, 0.0, 0.0, SPIN, 0.0, 0.0))
     scene.step()
     omega = posed_box.get_ang()
     offset_shift = posed_box.get_pos(relative=False) - posed_box.get_pos(relative=True)
-    assert_allclose((omega * offset_shift).sum(dim=-1), 0.0, tol=tol)
-    assert_allclose(posed_box.get_links_acc_ang(), 0.0, tol=tol)
     assert_allclose(
         posed_box.get_vel(relative=True),
         posed_box.get_vel(relative=False) - torch.cross(omega, offset_shift, dim=-1),
@@ -786,7 +784,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
             pos_zero = torch.tensor(pos_zero, device=gs.device, dtype=gs.tc_float)
             euler_zero = torch.deg2rad(torch.tensor(euler_zero, dtype=gs.tc_float))
             quat_zero = gu.xyz_to_quat(euler_zero, rpy=True)
-            # The pose lives in the offset, so the world frame (relative=False) carries it; the user frame is identity.
+            # The pose lives in the offset, so relative=False reports it and the authored frame is identity.
             assert_allclose(entity.get_pos(relative=False), pos_zero, tol=tol)
             assert_allclose(entity.get_pos(relative=True), 0.0, tol=tol)
             # Use quaternion for comparison to avoid gymbal lock issue in euler angles

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -667,12 +667,10 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     )
     POSED_BOX_POS = (2.0, 0.5, 0.3)
     POSED_BOX_OFFSET_EULER = (0.0, 0.0, 45.0)
-    # Distinct principal moments, so a free spin precesses and the angular-acceleration term of the relative-frame
-    # acceleration transport below stays above the comparison tolerance.
     posed_box = scene.add_entity(
         gs.morphs.Box(
             pos=POSED_BOX_POS,
-            size=(0.04, 0.06, 0.10),
+            size=(0.04, 0.04, 0.04),
             offset_pos=(0.0, 0.0, 0.5),
             offset_euler=POSED_BOX_OFFSET_EULER,
         ),
@@ -705,17 +703,22 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     robot_aabb_init, robot_base_aabb_init = robot.get_AABB(), robot.geoms[0].get_AABB()
     cube_aabb_init, cube_base_aabb_init = cube.get_AABB(), cube.geoms[0].get_AABB()
 
-    # Without rotation the user frame only translates with the link origin, so both frames report the same free fall.
+    # A non-rotating link origin only translates, so both frames report the same free fall.
     scene.step()
     assert_allclose(posed_box.get_vel(relative=True), posed_box.get_vel(relative=False), tol=tol)
     assert_allclose(posed_box.get_links_acc(relative=True), posed_box.get_links_acc(relative=False), tol=tol)
 
-    # Spinning the box, the user-frame origin orbits the link origin, so it is transported by the rigid-body law about
-    # the very displacement the position getters strip: 'v - omega x d' and 'a - alpha x d - omega x (omega x d)'.
-    posed_box.set_dofs_velocity((0.0, 0.0, 0.0, 1.0, 2.0, -3.0))
+    # Spinning the box makes the authored origin orbit the internal one, so both are reported at the displacement 'd'
+    # the position getters strip. The spin is about a principal body axis orthogonal to the offset position, so it is
+    # torque-free and stays orthogonal to 'd', which collapses the centripetal transport of the acceleration to
+    # '-SPIN**2 * d'.
+    SPIN = 5.0
+    posed_box.set_dofs_velocity((0.0, 0.0, 0.0, SPIN, 0.0, 0.0))
     scene.step()
+    omega = posed_box.get_ang()
     offset_shift = posed_box.get_pos(relative=False) - posed_box.get_pos(relative=True)
-    omega, alpha = posed_box.get_ang(), posed_box.get_links_acc_ang()[..., 0, :]
+    assert_allclose((omega * offset_shift).sum(dim=-1), 0.0, tol=tol)
+    assert_allclose(posed_box.get_links_acc_ang(), 0.0, tol=tol)
     assert_allclose(
         posed_box.get_vel(relative=True),
         posed_box.get_vel(relative=False) - torch.cross(omega, offset_shift, dim=-1),
@@ -723,23 +726,12 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     )
     assert_allclose(
         posed_box.get_links_acc(relative=True)[..., 0, :],
-        posed_box.get_links_acc(relative=False)[..., 0, :]
-        - torch.cross(alpha, offset_shift, dim=-1)
-        - torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1),
+        posed_box.get_links_acc(relative=False)[..., 0, :] + SPIN**2 * offset_shift,
         tol=tol,
     )
-    # Neither transported term is vacuous: each exceeds the tolerance on its own.
-    assert (torch.cross(alpha, offset_shift, dim=-1).abs() > tol).any()
-    assert (torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1).abs() > tol).any()
-    with pytest.raises(AssertionError):
-        assert_allclose(posed_box.get_vel(relative=True), posed_box.get_vel(relative=False), tol=tol)
-    with pytest.raises(AssertionError):
-        assert_allclose(posed_box.get_links_acc(relative=True), posed_box.get_links_acc(relative=False), tol=tol)
 
     # Masking rows and columns must strip the same offset as the unmasked query.
-    assert_allclose(
-        posed_box.get_links_vel(links_idx_local=0, envs_idx=[1])[..., 0, :], posed_box.get_vel()[[1]], tol=tol
-    )
+    assert_allclose(posed_box.get_links_vel(links_idx_local=0, envs_idx=1)[..., 0, :], posed_box.get_vel()[1], tol=tol)
 
     # Make sure that it is not possible to end up in an inconsistent state for fixed geometries. These place entities
     # at absolute world positions, so they bypass the pose offset (relative=False).

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -705,8 +705,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
     robot_aabb_init, robot_base_aabb_init = robot.get_AABB(), robot.geoms[0].get_AABB()
     cube_aabb_init, cube_base_aabb_init = cube.get_AABB(), cube.geoms[0].get_AABB()
 
-    # Velocity and acceleration describe the same point as the position. Without rotation the user frame only
-    # translates with the link origin, so both frames report the same free fall.
+    # Without rotation the user frame only translates with the link origin, so both frames report the same free fall.
     scene.step()
     assert_allclose(posed_box.get_vel(relative=True), posed_box.get_vel(relative=False), tol=tol)
     assert_allclose(posed_box.get_links_acc(relative=True), posed_box.get_links_acc(relative=False), tol=tol)
@@ -729,8 +728,7 @@ def test_set_root_pose(batch_fixed_verts, relative, show_viewer, tol):
         - torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1),
         tol=tol,
     )
-    # Neither transported term is vacuous: each contributes more than the tolerance on its own, and both frames
-    # genuinely disagree while the box rotates.
+    # Neither transported term is vacuous: each exceeds the tolerance on its own.
     assert (torch.cross(alpha, offset_shift, dim=-1).abs() > tol).any()
     assert (torch.cross(omega, torch.cross(omega, offset_shift, dim=-1), dim=-1).abs() > tol).any()
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Description
- Add `relative` arg to accessors, which were not applying morph `offset_pos`/`offset_quat`.

## Related Issue
Related to https://github.com/Genesis-Embodied-AI/genesis-world/pull/2934 , https://github.com/Genesis-Embodied-AI/genesis-world/pull/2592

## Motivation and Context
`get_links_vel` and `get_links_acc` had no relative argument and always report the quantity referenced to the internal link origin. Anyone reading velocity or acceleration at a sensor or tool frame declared through a morph offset therefore has to redo the reference-point shift by hand `(v = v_origin + omega x delta)`, and silently gets the wrong signal if they forget.

## How Has This Been / Can This Be Tested?
`tests/rigid/test_api.py`

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Resolves SIM-292