### PR TITLE
[BUG FIX] Fix moving debug objects in batched scenes.

### DIFF
--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -736,7 +736,9 @@ class Viewer(pyglet.window.Window):
         env_separate_rigid=None,
     ):
         if not self.is_active:
-            gs.raise_exception("Viewer already closed.")
+            # A viewer in its own thread stores what ended it rather than raising it where nobody waits, so the call
+            # that finds the viewer gone is where that exception surfaces.
+            gs.raise_exception_from("Viewer already closed.", self._exception)
 
         if rgb and seg:
             gs.raise_exception("RGB and segmentation map cannot be rendered in the same forward pass.")

--- a/genesis/vis/rasterizer_context.py
+++ b/genesis/vis/rasterizer_context.py
@@ -1111,17 +1111,20 @@ class RasterizerContext:
         return node
 
     def update_debug_objects(self, objs, poses):
-        n_envs = len(self.rendered_envs_idx)
         for obj, pose in zip(objs, poses):
             if not any(
                 obj.name.startswith(prefix)
                 for prefix in ("debug_sphere_", "debug_frame_", "debug_mesh_", "debug_arrow_")
             ):
                 gs.raise_exception("This method is only supported by individual spheres, frames, meshes, and arrows.")
+            # An object is placed again at the instances it was drawn with: an arrow drawn for every environment at
+            # once holds one shared instance where a sphere, a frame and a mesh hold one per environment, and the
+            # buffers sized on that count - the model buffer here, the sorting centre in jit_render - take it whole.
+            n_instances = len(obj.primitives[0].poses)
             pose = tensor_to_array(pose)
             if pose.ndim != 3:
-                pose = np.tile(pose[np.newaxis], (n_envs, 1, 1))
-            assert len(pose) == n_envs, "Inconsistent batch size."
+                pose = np.tile(pose[np.newaxis], (n_instances, 1, 1))
+            assert len(pose) == n_instances, "Inconsistent batch size."
             obj.primitives[0].poses = pose
             node = self.external_nodes[obj.name]
             self.jit.update_buffer(node, "model", pose.transpose((0, 2, 1)))

--- a/tests/rendering/test_debug_draw.py
+++ b/tests/rendering/test_debug_draw.py
@@ -40,7 +40,7 @@ def test_draw_debug(renderer, show_viewer):
     rgb_array, *_ = cam.render(rgb=True, depth=False, segmentation=False, colorize_seg=False, normal=False)
     assert_allclose(np.std(rgb_array.reshape((-1, 3)), axis=0), 0.0, tol=gs.EPS)
 
-    scene.draw_debug_arrow(
+    arrow_obj = scene.draw_debug_arrow(
         pos=(0, 0.4, 0.1),
         vec=(0, 0.3, 0.8),
         color=(1, 0, 0),
@@ -76,10 +76,13 @@ def test_draw_debug(renderer, show_viewer):
     assert (np.std(rgb_array_flat, axis=0) > 10.0).any()
     rgb_array_prev = rgb_array_flat
 
+    # An arrow drawn for every environment at once holds one shared instance while a frame and a sphere hold one
+    # per environment, so placing all three again is what says an object keeps the instances it was drawn with.
     poses = gu.trans_to_T(np.zeros((2, 2, 3)))
     for i in range(2):
         poses[:, i] = gu.trans_quat_to_T(2.0 * (np.random.rand(2, 3) - 0.5), np.random.rand(2, 4))
-        scene.update_debug_objects([frame_obj, sphere_obj], poses)
+        arrow_pose = gu.trans_quat_to_T(2.0 * (np.random.rand(3) - 0.5), np.random.rand(4))
+        scene.update_debug_objects([frame_obj, sphere_obj, arrow_obj], [*poses, arrow_pose])
         scene.visualizer.update()
         rgb_array, *_ = cam.render(rgb=True, depth=False, segmentation=False, colorize_seg=False, normal=False)
         rgb_array_flat = rgb_array.reshape((-1, 3)).astype(np.int32)


### PR DESCRIPTION
## Description

An arrow drawn for every environment at once holds a single shared instance, while a sphere, a frame and a mesh hold one per environment. Placing one again tiled the transform to the environment count whatever the object held, so an arrow moved in a batched scene grew from one instance to as many as there are environments. The renderer then wrote its per-instance sorting centre - a buffer sized on the count the object was drawn with - past its end, and the exception killed the viewer's own thread mid-frame. An update now keeps the count the object has.

A viewer running in its own thread stores what ended it rather than raising it there, so the first call that found the viewer gone reported only `Viewer already closed.` It now chains what killed it, which is how the above was found.

## Motivation and Context

`tests/rendering/test_interactive_viewer.py::test_mouse_interaction_plugin` fails on the batched cells: the mouse plugin draws a hover arrow and moves it every frame, which is exactly the growth above. On Linux the viewer runs in its own thread, so the death surfaces later as `GenesisException: Viewer already closed.` at the next offscreen render, with no traceback.

## How Has This Been / Can This Be Tested?

`tests/rendering/test_debug_draw.py::test_draw_debug` now places the arrow again beside the frame and the sphere, which is what makes the growth reachable without a viewer at all. Without the fix it raises:

```
ValueError: could not broadcast input array from shape (2,3) into shape (1,3)
genesis/ext/pyrender/jit_render.py:219
```

`tests/rendering/test_interactive_viewer.py::test_mouse_interaction_plugin` covers the path the failure was reported on.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
