### PR TITLE
[BREAKING][BUG FIX] Report the correct mass from getters.

### DIFF
--- a/examples/ipc/ipc_momentum.py
+++ b/examples/ipc/ipc_momentum.py
@@ -78,7 +78,7 @@ def main():
     blob_radius = blob.morph.radius
     blob_rho = blob.material.rho
     blob_mass = (4.0 / 3.0) * np.pi * (blob_radius**3) * blob_rho
-    cube_mass = rigid_cube.get_mass()
+    cube_mass = float(rigid_cube.get_mass())
 
     initial_momentum = 4.0 * cube_mass
 

--- a/examples/rigid/domain_randomization.py
+++ b/examples/rigid/domain_randomization.py
@@ -50,8 +50,10 @@ def main():
     link.set_mass(1)
     print("diff mass", robot.get_links_inertial_mass() - ori_mass)
 
+    # Quoted as a fraction of each link's own mass, so the lightest link stays positive whatever the draw.
+    mass_ratio = -0.2 + 0.4 * torch.rand(scene.n_envs, robot.n_links, device=gs.device)
     robot.set_mass_shift(
-        mass_shift=-0.5 + torch.rand(scene.n_envs, robot.n_links),
+        mass_shift=mass_ratio * robot.get_links_mass(),
         links_idx_local=np.arange(0, robot.n_links),
     )
     robot.set_COM_shift(

--- a/examples/rigid/set_phys_attr.py
+++ b/examples/rigid/set_phys_attr.py
@@ -135,7 +135,7 @@ def main():
         motors_dof_idx,
     )
     print("=== set mass ===\n", franka.get_dofs_damping())
-    original_mass = float(franka.get_mass(envs_idx=[0]))
+    original_mass = franka.get_mass(envs_idx=[0])
     franka.set_mass(2.0 * original_mass)
 
     print("=== invweight ===\n", franka.get_dofs_invweight())

--- a/examples/rigid/set_phys_attr.py
+++ b/examples/rigid/set_phys_attr.py
@@ -135,9 +135,8 @@ def main():
         motors_dof_idx,
     )
     print("=== set mass ===\n", franka.get_dofs_damping())
-    original_mass = franka.get_mass()
-    new_mass = original_mass * 2
-    franka.set_mass(new_mass)
+    original_mass = float(franka.get_mass(envs_idx=[0]))
+    franka.set_mass(2.0 * original_mass)
 
     print("=== invweight ===\n", franka.get_dofs_invweight())
     links_inertial_mass = np.array(

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -22,7 +22,7 @@ from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
 from genesis.utils import terrain as tu
 from genesis.utils import urdf as uu
-from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_numpy, qd_to_torch, tensor_to_array
+from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_torch, tensor_to_array
 
 from ..base_entity import Entity
 from .rigid_equality import RigidEquality
@@ -3563,6 +3563,25 @@ class RigidEntity(KinematicEntity):
     # ------------------------------------------------------------------------------------
 
     @gs.assert_built
+    def get_links_mass(self, links_idx_local=None, envs_idx=None):
+        """
+        Get the mass of the links in kg, ie their inertial mass plus their mass shift (see `set_mass_shift`).
+
+        Parameters
+        ----------
+        links_idx_local : None | array_like, optional
+            The indices of the links. If None, all links will be considered. Defaults to None.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        mass : torch.Tensor, shape (n_links,) or (n_envs, n_links)
+        """
+        links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
+        return self._solver.get_links_mass(links_idx, envs_idx)
+
+    @gs.assert_built
     def get_links_inertial_mass(self, links_idx_local=None, envs_idx=None):
         links_idx = self._get_global_idx(links_idx_local, self.n_links, self._link_start, unsafe=True)
         return self._solver.get_links_inertial_mass(links_idx, envs_idx)
@@ -4421,12 +4440,13 @@ class RigidEntity(KinematicEntity):
 
     def set_mass_shift(self, mass_shift, links_idx_local=None, envs_idx=None):
         """
-        Set the mass shift of specified links.
+        Set the mass shift of specified links, ie a per-environment offset added to their inertial mass. The mass the
+        links are simulated with, offset included, is reported by `get_links_mass` and `get_mass`.
 
         Parameters
         ----------
-        mass : torch.Tensor, shape (n_envs, n_links)
-            The mass shift
+        mass_shift : torch.Tensor, shape (n_envs, n_links)
+            The mass shift.
         links_idx_local : array_like
             The indices of the links to set mass shift.
         envs_idx : None | array_like, optional
@@ -4441,8 +4461,8 @@ class RigidEntity(KinematicEntity):
 
         Parameters
         ----------
-        com : torch.Tensor, shape (n_envs, n_links, 3)
-            The COM shift
+        com_shift : torch.Tensor, shape (n_envs, n_links, 3)
+            The COM shift.
         links_idx_local : array_like
             The indices of the links to set COM shift.
         envs_idx : None | array_like, optional
@@ -4467,41 +4487,35 @@ class RigidEntity(KinematicEntity):
     @gs.assert_built
     def set_mass(self, mass):
         """
-        Set the mass of the entity.
+        Set the total inertial mass of the entity, distributed over its links in proportion to their current inertial
+        mass. Any mass shift already applied stays on top of it (see `set_mass_shift`).
 
         Parameters
         ----------
         mass : float
             The mass to set.
         """
-        ratio = float(mass) / self.get_mass()
-        for link in self.links:
-            link.set_mass(link.get_mass() * ratio)
+        links_inertial_mass = tensor_to_array(self.get_links_inertial_mass())
+        ratio = float(mass) / links_inertial_mass.sum(axis=-1)
+        for i_l, link in enumerate(self.links):
+            link.set_mass(ratio * links_inertial_mass[..., i_l])
 
     @gs.assert_built
-    def get_mass(self):
+    def get_mass(self, envs_idx=None):
         """
-        Get the total mass of the entity in kg.
+        Get the total mass of the entity in kg, ie the sum over its links of their inertial mass plus their mass shift
+        (see `set_mass_shift`).
 
-        For heterogeneous entities, returns an array of masses for each environment.
-        For non-heterogeneous entities, returns a scalar mass.
+        Parameters
+        ----------
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
 
         Returns
         -------
-        mass : float | np.ndarray
-            The total mass of the entity in kg. For heterogeneous entities, returns
-            an array of shape (n_envs,) with per-environment masses.
+        mass : torch.Tensor, shape () or (n_envs,)
         """
-        if self._enable_heterogeneous:
-            links_idx = slice(self.link_start, self.link_end)
-            links_mass = qd_to_numpy(self._solver.dyn_info.links.inertial_mass, None, links_idx, transpose=True)
-            return links_mass.sum(axis=1)
-
-        # Original behavior: sum link masses to scalar
-        mass = 0.0
-        for link in self.links:
-            mass += link.get_mass()
-        return mass
+        return self.get_links_mass(envs_idx=envs_idx).sum(dim=-1)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -4445,7 +4445,9 @@ class RigidEntity(KinematicEntity):
         Parameters
         ----------
         mass_shift : torch.Tensor, shape (n_envs, n_links)
-            The mass shift in kg.
+            The mass shift in kg, added to the link's inertial mass. Negative values are allowed as long as every link
+            keeps a strictly positive total: a link left at zero or below has no solvable dynamics, and the step ends
+            with a non-finite force or acceleration.
         links_idx_local : array_like
             The indices of the links to set mass shift.
         envs_idx : None | array_like, optional
@@ -4461,7 +4463,8 @@ class RigidEntity(KinematicEntity):
         Parameters
         ----------
         com_shift : torch.Tensor, shape (n_envs, n_links, 3)
-            The COM shift in meters, expressed in the link frame.
+            The COM shift in meters, added to the link's inertial position in the link frame. That frame is the one the
+            solver holds, so a morph pose offset ('offset_pos' / 'offset_quat') rotates the shift along with it.
         links_idx_local : array_like
             The indices of the links to set COM shift.
         envs_idx : None | array_like, optional
@@ -4487,7 +4490,8 @@ class RigidEntity(KinematicEntity):
     def set_mass(self, mass):
         """
         Set the total inertial mass of the entity, distributed over its links in proportion to their current inertial
-        mass. This does not affect the mass shift set from `set_mass_shift`.
+        mass. Every environment reaches that same total, a heterogeneous entity whose variants start from different
+        masses included. This does not affect the mass shift set from `set_mass_shift`.
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -3565,7 +3565,7 @@ class RigidEntity(KinematicEntity):
     @gs.assert_built
     def get_links_mass(self, links_idx_local=None, envs_idx=None):
         """
-        Get the mass of the links in kg, ie their inertial mass plus their mass shift (see `set_mass_shift`).
+        Get the mass of the links in kg, ie their inertial mass plus their mass shift.
 
         Parameters
         ----------
@@ -4440,13 +4440,12 @@ class RigidEntity(KinematicEntity):
 
     def set_mass_shift(self, mass_shift, links_idx_local=None, envs_idx=None):
         """
-        Set the mass shift of specified links, ie a per-environment offset added to their inertial mass. The mass the
-        links are simulated with, offset included, is reported by `get_links_mass` and `get_mass`.
+        Set the mass shift of specified links, ie a per-environment offset added to their inertial mass.
 
         Parameters
         ----------
         mass_shift : torch.Tensor, shape (n_envs, n_links)
-            The mass shift.
+            The mass shift in kg.
         links_idx_local : array_like
             The indices of the links to set mass shift.
         envs_idx : None | array_like, optional
@@ -4462,7 +4461,7 @@ class RigidEntity(KinematicEntity):
         Parameters
         ----------
         com_shift : torch.Tensor, shape (n_envs, n_links, 3)
-            The COM shift.
+            The COM shift in meters, expressed in the link frame.
         links_idx_local : array_like
             The indices of the links to set COM shift.
         envs_idx : None | array_like, optional
@@ -4488,12 +4487,12 @@ class RigidEntity(KinematicEntity):
     def set_mass(self, mass):
         """
         Set the total inertial mass of the entity, distributed over its links in proportion to their current inertial
-        mass. Any mass shift already applied stays on top of it (see `set_mass_shift`).
+        mass. This does not affect the mass shift set from `set_mass_shift`.
 
         Parameters
         ----------
         mass : float
-            The mass to set.
+            The mass to set in kg.
         """
         links_inertial_mass = tensor_to_array(self.get_links_inertial_mass())
         ratio = float(mass) / links_inertial_mass.sum(axis=-1)
@@ -4503,8 +4502,7 @@ class RigidEntity(KinematicEntity):
     @gs.assert_built
     def get_mass(self, envs_idx=None):
         """
-        Get the total mass of the entity in kg, ie the sum over its links of their inertial mass plus their mass shift
-        (see `set_mass_shift`).
+        Get the total mass of the entity in kg, ie the sum over its links of their inertial mass plus their mass shift.
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -1045,7 +1045,8 @@ class RigidLink(KinematicLink):
     @gs.assert_built
     def set_mass(self, mass: LaxPositiveFArrayType):
         """
-        Set the mass of the link.
+        Set the inertial mass of the link, scaling its inertia matrix accordingly. Any mass shift already applied stays
+        on top of it (see `RigidEntity.set_mass_shift`).
 
         Parameters
         ----------
@@ -1065,18 +1066,37 @@ class RigidLink(KinematicLink):
                 "'RigidOptions.batch_links_info=True'."
             )
 
+        # The solver holds the inertial mass the link is simulated with, which the authored value no longer matches
+        # once a variant or an earlier setter has moved it, so the solver-side ratio is quoted on the solver value.
+        # The cached inertia and invweight below are the authored ones, hence scale with the authored mass.
+        inertial_mass = tensor_to_array(self._solver.get_links_inertial_mass(self._idx))[..., 0]
+        if mass.shape not in ((), inertial_mass.shape):
+            gs.raise_exception(
+                f"Attempt to set mass of link '{self.name}' from an array of shape {mass.shape}. Expected a scalar "
+                f"or an array of shape {inertial_mass.shape}."
+            )
+        self._solver.set_links_inertia(mass / inertial_mass, [self.idx])
+
         ratio = mass / self._inertial_mass
-        self._solver.set_links_inertia(ratio, [self.idx])
         self._inertial_mass = mass
         self._inertial_i = self._inertial_i * ratio[..., None, None]
         self._invweight = self._invweight / ratio[..., None]
 
     @gs.assert_built
-    def get_mass(self):
+    def get_mass(self, envs_idx=None):
         """
-        Get the mass of the link.
+        Get the mass of the link in kg, ie its inertial mass plus its mass shift (see `RigidEntity.set_mass_shift`).
+
+        Parameters
+        ----------
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments will be considered. Defaults to None.
+
+        Returns
+        -------
+        mass : torch.Tensor, shape () or (n_envs,)
         """
-        return self._inertial_mass
+        return self._solver.get_links_mass(self._idx, envs_idx)[..., 0]
 
     def set_friction(self, friction):
         """

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -1045,13 +1045,13 @@ class RigidLink(KinematicLink):
     @gs.assert_built
     def set_mass(self, mass: LaxPositiveFArrayType):
         """
-        Set the inertial mass of the link, scaling its inertia matrix accordingly. Any mass shift already applied stays
-        on top of it (see `RigidEntity.set_mass_shift`).
+        Set the inertial mass of the link, scaling its inertia matrix accordingly. This does not affect the mass shift
+        set from `RigidEntity.set_mass_shift`.
 
         Parameters
         ----------
         mass : float | array_like, shape (n_envs,)
-            The mass to set.
+            The mass to set in kg.
         """
         if self.is_fixed:
             gs.logger.warning("Updating the mass of a link that is fixed wrt world has no effect, skipping.")
@@ -1085,7 +1085,7 @@ class RigidLink(KinematicLink):
     @gs.assert_built
     def get_mass(self, envs_idx=None):
         """
-        Get the mass of the link in kg, ie its inertial mass plus its mass shift (see `RigidEntity.set_mass_shift`).
+        Get the mass of the link in kg, ie its inertial mass plus its mass shift.
 
         Parameters
         ----------

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1380,7 +1380,7 @@ class RigidSolver(KinematicSolver):
         )
         self._is_forward_pos_updated = True
 
-    def invalidate_cartesian_space(self):
+    def _invalidate_cartesian_space(self):
         """Mark the Cartesian-space data as stale, so that the next step recomputes it.
 
         A step skips that update when it is already current for the pose, so a change to any of its inputs - link mass
@@ -2378,8 +2378,21 @@ class RigidSolver(KinematicSolver):
         )
         if self.n_envs == 0:
             mass = mass[None]
+
+        # A link whose inertial mass and shift sum to zero or below has no solvable dynamics, and the step would only
+        # fail later on with a non-finite force. Checking before the write leaves the state untouched on failure. See
+        # 'get_links_mass' for the 'envs_idx' gate below.
+        inertial_mass = self.get_links_inertial_mass(links_idx, envs_idx if self._options.batch_links_info else None)
+        links_mass = inertial_mass + mass
+        if (links_mass < gs.EPS).any():
+            i_l = int(links_mass.min(dim=0).values.argmin())
+            gs.raise_exception(
+                f"Mass shift leaves link '{self.links[int(links_idx[i_l])].name}' with a mass of "
+                f"{links_mass.min():.3g} kg. The mass of a link must be strictly positive."
+            )
+
         kernel_set_links_mass_shift(links_idx, envs_idx, mass, self.dyn_state, self.rigid_config)
-        self.invalidate_cartesian_space()
+        self._invalidate_cartesian_space()
 
     def set_links_COM_shift(self, com, links_idx=None, envs_idx=None):
         com, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2388,7 +2401,7 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0:
             com = com[None]
         kernel_set_links_COM_shift(links_idx, envs_idx, com, self.dyn_state, self.rigid_config)
-        self.invalidate_cartesian_space()
+        self._invalidate_cartesian_space()
 
     def set_links_inertial_mass(self, mass, links_idx=None, envs_idx=None):
         mass, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2403,10 +2416,10 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0 and self._options.batch_links_info:
             mass = mass[None]
         kernel_set_links_inertial_mass(links_idx, envs_idx, mass, self.dyn_info, self.rigid_config)
-        self.invalidate_cartesian_space()
+        self._invalidate_cartesian_space()
 
     def set_links_inertia(self, ratio, links_idx=None, envs_idx=None):
-        self.invalidate_cartesian_space()
+        self._invalidate_cartesian_space()
 
         if gs.use_zerocopy:
             mass_data = qd_to_torch(self.dyn_info.links.inertial_mass, transpose=True, copy=False)
@@ -2969,8 +2982,7 @@ class RigidSolver(KinematicSolver):
         Returns the mass that the links are simulated with, ie their inertial mass plus their mass shift.
         """
         mass_shift = qd_to_torch(self.dyn_state.links.mass_shift, envs_idx, links_idx, transpose=True)
-        # `get_links_inertial_mass` only accepts `envs_idx` when links info is batched, since all the environments
-        # share the very same link masses otherwise.
+        # All the environments share the very same link masses unless links info is batched, hence the `envs_idx` gate.
         inertial_mass = self.get_links_inertial_mass(links_idx, envs_idx if self._options.batch_links_info else None)
         tensor = inertial_mass + mass_shift
         return tensor[0] if self.n_envs == 0 else tensor

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2369,6 +2369,11 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0:
             mass = mass[None]
         kernel_set_links_mass_shift(links_idx, envs_idx, mass, self.dyn_state, self.rigid_config)
+        # The composite inertia the mass matrix is assembled from is a by-product of the Cartesian-space update, which
+        # a step skips when it is already up to date for the current pose. Invalidating it is what carries a mass or
+        # inertia change into the dynamics of the next step instead of leaving the previous composite in place.
+        self._is_forward_pos_updated = False
+        self._is_forward_vel_updated = False
 
     def set_links_COM_shift(self, com, links_idx=None, envs_idx=None):
         com, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2377,6 +2382,9 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0:
             com = com[None]
         kernel_set_links_COM_shift(links_idx, envs_idx, com, self.dyn_state, self.rigid_config)
+        # See 'set_links_mass_shift' for why the Cartesian-space update must be invalidated.
+        self._is_forward_pos_updated = False
+        self._is_forward_vel_updated = False
 
     def set_links_inertial_mass(self, mass, links_idx=None, envs_idx=None):
         mass, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2391,8 +2399,15 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0 and self._options.batch_links_info:
             mass = mass[None]
         kernel_set_links_inertial_mass(links_idx, envs_idx, mass, self.dyn_info, self.rigid_config)
+        # See 'set_links_mass_shift' for why the Cartesian-space update must be invalidated.
+        self._is_forward_pos_updated = False
+        self._is_forward_vel_updated = False
 
     def set_links_inertia(self, ratio, links_idx=None, envs_idx=None):
+        # See 'set_links_mass_shift' for why the Cartesian-space update must be invalidated.
+        self._is_forward_pos_updated = False
+        self._is_forward_vel_updated = False
+
         if gs.use_zerocopy:
             mass_data = qd_to_torch(self.dyn_info.links.inertial_mass, transpose=True, copy=False)
             inertial_i_data = qd_to_torch(self.dyn_info.links.inertial_i, transpose=True, copy=False)
@@ -2949,6 +2964,17 @@ class RigidSolver(KinematicSolver):
         tensor = qd_to_torch(self.dyn_state.links.i_pos_shift, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
 
+    def get_links_mass(self, links_idx=None, envs_idx=None):
+        """
+        Returns the mass that the links are simulated with, ie their inertial mass plus their mass shift.
+        """
+        mass_shift = qd_to_torch(self.dyn_state.links.mass_shift, envs_idx, links_idx, transpose=True)
+        # `get_links_inertial_mass` only accepts `envs_idx` when links info is batched, since all the environments
+        # share the very same link masses otherwise.
+        inertial_mass = self.get_links_inertial_mass(links_idx, envs_idx if self._options.batch_links_info else None)
+        tensor = inertial_mass + mass_shift
+        return tensor[0] if self.n_envs == 0 else tensor
+
     def get_links_inertial_mass(self, links_idx=None, envs_idx=None):
         if not self._options.batch_links_info and envs_idx is not None:
             gs.raise_exception("`envs_idx` cannot be specified for non-batched links info.")
@@ -3203,9 +3229,7 @@ class RigidSolver(KinematicSolver):
         """
         gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
         links_pos = self.get_links_pos(links_idx, envs_idx, ref=link_ref_frame.link_COM)  # (..., n_links, 3)
-        # `get_links_inertial_mass` only accepts `envs_idx` when links info is batched, since all the environments
-        # share the very same link masses otherwise.
-        links_mass = self.get_links_inertial_mass(links_idx, envs_idx if self._options.batch_links_info else None)
+        links_mass = self.get_links_mass(links_idx, envs_idx)
 
         # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
         # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1380,6 +1380,16 @@ class RigidSolver(KinematicSolver):
         )
         self._is_forward_pos_updated = True
 
+    def invalidate_cartesian_space(self):
+        """Mark the Cartesian-space data as stale, so that the next step recomputes it.
+
+        A step skips that update when it is already current for the pose, so a change to any of its inputs - link mass
+        and inertia, and the shifts applied on top of them - only reaches the dynamics through this invalidation. The
+        composite inertia the mass matrix is assembled from is one of its by-products.
+        """
+        self._is_forward_pos_updated = False
+        self._is_forward_vel_updated = False
+
     def substep(self, f):
         # from genesis.utils.tools import create_timer
         from genesis.engine.couplers import SAPCoupler
@@ -2369,11 +2379,7 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0:
             mass = mass[None]
         kernel_set_links_mass_shift(links_idx, envs_idx, mass, self.dyn_state, self.rigid_config)
-        # The composite inertia the mass matrix is assembled from is a by-product of the Cartesian-space update, which
-        # a step skips when it is already up to date for the current pose. Invalidating it is what carries a mass or
-        # inertia change into the dynamics of the next step instead of leaving the previous composite in place.
-        self._is_forward_pos_updated = False
-        self._is_forward_vel_updated = False
+        self.invalidate_cartesian_space()
 
     def set_links_COM_shift(self, com, links_idx=None, envs_idx=None):
         com, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2382,9 +2388,7 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0:
             com = com[None]
         kernel_set_links_COM_shift(links_idx, envs_idx, com, self.dyn_state, self.rigid_config)
-        # See 'set_links_mass_shift' for why the Cartesian-space update must be invalidated.
-        self._is_forward_pos_updated = False
-        self._is_forward_vel_updated = False
+        self.invalidate_cartesian_space()
 
     def set_links_inertial_mass(self, mass, links_idx=None, envs_idx=None):
         mass, links_idx, envs_idx = self._sanitize_io_variables(
@@ -2399,14 +2403,10 @@ class RigidSolver(KinematicSolver):
         if self.n_envs == 0 and self._options.batch_links_info:
             mass = mass[None]
         kernel_set_links_inertial_mass(links_idx, envs_idx, mass, self.dyn_info, self.rigid_config)
-        # See 'set_links_mass_shift' for why the Cartesian-space update must be invalidated.
-        self._is_forward_pos_updated = False
-        self._is_forward_vel_updated = False
+        self.invalidate_cartesian_space()
 
     def set_links_inertia(self, ratio, links_idx=None, envs_idx=None):
-        # See 'set_links_mass_shift' for why the Cartesian-space update must be invalidated.
-        self._is_forward_pos_updated = False
-        self._is_forward_vel_updated = False
+        self.invalidate_cartesian_space()
 
         if gs.use_zerocopy:
             mass_data = qd_to_torch(self.dyn_info.links.inertial_mass, transpose=True, copy=False)

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -128,7 +128,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
             if ray_hit.geom is not None and isinstance(ray_hit.geom.link, RigidLink) and not ray_hit.geom.link.is_fixed:
                 link = ray_hit.geom.link
                 hit_env_idx = ray_hit.env_idx
-                mass = float(link.get_mass())
+                mass = float(link.get_mass(envs_idx=hit_env_idx))
 
                 # Validate mass is not too small to prevent numerical instability
                 if mass < MIN_PICKABLE_MASS:
@@ -276,7 +276,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
                 self._sim_running
                 and isinstance(link, RigidLink)
                 and not link.is_fixed
-                and float(link.get_mass()) >= MIN_PICKABLE_MASS
+                and float(link.get_mass(envs_idx=closest_hit.env_idx)) >= MIN_PICKABLE_MASS
             )
             if is_pickable:
                 arrow_T = gu.trans_R_to_T(closest_hit.position, gu.z_up_to_R(closest_hit.normal))
@@ -370,7 +370,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         inv_inertia_world = np.linalg.inv(inertia_world)
 
         pos_err_v = control_point_env_local - held_point_env_local
-        mass = float(self._held_link.get_mass())
+        mass = float(self._held_link.get_mass(envs_idx=envs_idx))
         inv_mass = 1.0 / mass
 
         # A link at rest hangs below its center of mass with the spring carrying its whole weight, so the slack alone

--- a/tests/ipc/test_rigid.py
+++ b/tests/ipc/test_rigid.py
@@ -614,7 +614,7 @@ def test_momentum_conservation(n_envs, show_viewer):
     assert rigid_link.idx in ipc_links_idx
     assert rigid_link in coupler._abd_slots_by_link
 
-    cube_mass = rigid_cube.get_mass()
+    cube_mass = float(rigid_cube.get_mass(envs_idx=[0]))
 
     # Read actual FEM mass from IPC geometry (mesh mass != analytical sphere mass due to tet discretization).
     blob_radius = blob.morph.radius

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -148,6 +148,7 @@ def test_data_accessor(n_envs, batched, tol):
         (gs_s.n_links, n_envs, gs_s.get_links_root_COM, None, gs_s.dyn_state.links.root_COM),
         (gs_s.n_links, n_envs, gs_s.get_links_mass_shift, gs_s.set_links_mass_shift, gs_s.dyn_state.links.mass_shift),
         (gs_s.n_links, n_envs, gs_s.get_links_COM_shift, gs_s.set_links_COM_shift, gs_s.dyn_state.links.i_pos_shift),
+        (gs_s.n_links, n_envs, gs_s.get_links_mass, None, None),
         (
             gs_s.n_links,
             -1,
@@ -213,14 +214,14 @@ def test_data_accessor(n_envs, batched, tol):
         (-1, n_envs, gs_robot.get_links_net_contact_force, None, None),
         (-1, n_envs, gs_robot.get_pos, gs_robot.set_pos, None),
         (-1, n_envs, gs_robot.get_quat, gs_robot.set_quat, None),
-        (-1, -1, gs_robot.get_mass, gs_robot.set_mass, None),
+        (-1, n_envs, gs_robot.get_mass, None, None),
         (-1, -1, gs_robot.get_verts, None, None),
         (-1, -1, gs_robot.get_AABB, None, None),
         (-1, -1, gs_robot.get_vAABB, None, None),
         # LINK
         (-1, -1, gs_link.get_pos, None, None),
         (-1, -1, gs_link.get_quat, None, None),
-        (-1, -1, gs_link.get_mass, gs_link.set_mass, None),
+        (-1, n_envs, gs_link.get_mass, None, None),
         (-1, -1, gs_link.get_verts, None, None),
         (-1, -1, gs_link.get_AABB, None, None),
         (-1, -1, gs_link.get_vAABB, None, None),
@@ -769,7 +770,7 @@ def test_normalized_quat(show_viewer, tol):
 
 
 @pytest.mark.required
-def test_mass_setters(tol):
+def test_mass_accessors(show_viewer, tol):
     # Batched links info (default): entity- and link-level set_mass apply, link masses may differ per env, and a
     # wrong-length array is rejected. The heterogeneous entity gives each env a distinct starting mass.
     scene = gs.Scene(show_viewer=False)
@@ -791,12 +792,36 @@ def test_mass_setters(tol):
     link.set_mass(target_mass)
     assert_allclose(link.get_mass(), target_mass, tol=tol)
 
-    # Non-batched links info: link mass is shared across envs, so a scalar applies uniformly and a per-env array raises.
+    # The mass shift is an offset on top of the inertial mass: the reported mass follows it while the inertial mass
+    # keeps whatever the setters gave it.
+    mass_shift = torch.tensor((0.05, -0.1, 0.3, -0.2), dtype=gs.tc_float, device=gs.device)
+    mass_before = het_obj.get_mass()
+    het_obj.set_mass_shift(mass_shift, links_idx_local=[link.idx_local])
+    inertial_mass = het_obj.get_links_inertial_mass(links_idx_local=[link.idx_local])[..., 0]
+    assert_allclose(inertial_mass, target_mass, tol=tol)
+    assert_allclose(link.get_mass(), inertial_mass + mass_shift, tol=tol)
+    assert_allclose(het_obj.get_mass(), mass_before + mass_shift, tol=tol)
+
+    # Non-batched links info: link mass is shared across envs, so a scalar applies uniformly and a per-env array
+    # raises. The shift stays per-env even then, and it is the mass the solver integrates: a known force applied to a
+    # free box mid-simulation accelerates each env by force / mass on top of gravity.
+    DT = 0.01
+    GRAVITY = 9.81
+    FORCE = 5.0
+
     scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+            gravity=(0.0, 0.0, -GRAVITY),
+        ),
         rigid_options=gs.options.RigidOptions(
             batch_links_info=False,
         ),
-        show_viewer=False,
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.8, 0.0, 0.2),
+            camera_lookat=(0.0, 0.0, -0.1),
+        ),
+        show_viewer=show_viewer,
     )
     obj = scene.add_entity(
         morph=gs.morphs.Box(
@@ -809,6 +834,14 @@ def test_mass_setters(tol):
     assert_allclose(link.get_mass(), 2.0, tol=tol)
     with pytest.raises(gs.GenesisException):
         link.set_mass((1.0, 2.0, 3.0, 4.0))
+
+    scene.step()
+    obj.set_mass_shift((0.0, 1.0, 2.0, 3.0), links_idx_local=[link.idx_local])
+    vel_z = obj.get_dofs_velocity()[..., 2]
+    obj.control_dofs_force(FORCE, dofs_idx_local=2)
+    scene.step()
+    accel = (obj.get_dofs_velocity()[..., 2] - vel_z) / DT
+    assert_allclose(accel, FORCE / obj.get_mass() - GRAVITY, tol=tol)
 
 
 @pytest.mark.slow  # ~250s

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -792,8 +792,7 @@ def test_mass_accessors(show_viewer, tol):
     link.set_mass(target_mass)
     assert_allclose(link.get_mass(), target_mass, tol=tol)
 
-    # The mass shift is an offset on top of the inertial mass: the reported mass follows it while the inertial mass
-    # keeps whatever the setters gave it.
+    # The reported mass follows the shift applied on top of it, the inertial mass keeps what the setters gave it.
     mass_shift = torch.tensor((0.05, -0.1, 0.3, -0.2), dtype=gs.tc_float, device=gs.device)
     mass_before = het_obj.get_mass()
     het_obj.set_mass_shift(mass_shift, links_idx_local=[link.idx_local])
@@ -802,9 +801,13 @@ def test_mass_accessors(show_viewer, tol):
     assert_allclose(link.get_mass(), inertial_mass + mass_shift, tol=tol)
     assert_allclose(het_obj.get_mass(), mass_before + mass_shift, tol=tol)
 
-    # Non-batched links info: link mass is shared across envs, so a scalar applies uniformly and a per-env array
-    # raises. The shift stays per-env even then, and it is the mass the solver integrates: a known force applied to a
-    # free box mid-simulation accelerates each env by force / mass on top of gravity.
+    # A shift that would leave a link without a positive mass is rejected, and rejected before it lands.
+    with pytest.raises(gs.GenesisException):
+        het_obj.set_mass_shift(-inertial_mass, links_idx_local=[link.idx_local])
+    assert_allclose(link.get_mass(), inertial_mass + mass_shift, tol=tol)
+
+    # Non-batched links info: a scalar mass applies to every env and a per-env array raises, while the shift stays
+    # per-env and is what the solver integrates, so a known force accelerates each env by force / mass plus gravity.
     DT = 0.01
     GRAVITY = 9.81
     FORCE = 5.0

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -1407,7 +1407,8 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     assert mass.shape == (scene.n_envs,)
     assert_allclose(mass[0], mass[1], tol=tol)
     assert_allclose(mass[2], mass[3], tol=tol)
-    assert not np.allclose(mass[0], mass[2], atol=tol, rtol=tol), "Variant A and B masses should differ"
+    with pytest.raises(AssertionError):
+        assert_allclose(mass[0], mass[2], tol=tol)
     # Variant B total mass should match the explicit URDF inertial values
     assert_allclose(mass[0], sphere_base_mass + sphere_moving_mass, tol=tol)
 

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -488,7 +488,7 @@ def test_contact_forces(show_viewer):
     )
     scene.build(n_envs=5)
 
-    cube_weight = scene.rigid_solver._gravity[0] * cube.get_mass()
+    cube_weight = tensor_to_array(scene.rigid_solver.get_gravity(envs_idx=[0])[0] * cube.get_mass(envs_idx=[0]))
     motors_dof = np.arange(7)
     fingers_dof = np.arange(7, 9)
     qpos = np.array([-1.0124, 1.5559, 1.3662, -1.6878, -1.5799, 1.7757, 1.4602, 0.04, 0.04])

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -229,7 +229,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
     end_effector_link_idx = robot.links[-1].idx
     end_effector_link_idx_local = robot.links[-1].idx_local
     duck_link_idx = duck.links[0].idx
-    duck_mass = duck.get_mass()
+    duck_mass = float(duck.get_mass())
     duck_init_link_pos, duck_init_link_R = duck.base_link.pos, gu.quat_to_R(duck.base_link.quat)
     # The duck is held at rest by cancelling gravity, but the cancelling force is applied away from its center of mass
     # so that the moment arm of 'pos' is exercised: the spurious torque it generates is undone by an opposite torque

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -417,7 +417,7 @@ def test_static_hold_unaffected_by_press_on_separate_body(show_viewer):
         scene.step()
     hold_z = held_box.get_pos()[..., 2]
 
-    press_mass = float(presser.get_mass(envs_idx=[0]))
+    press_mass = presser.get_mass(envs_idx=[0])
     presser.set_dofs_kp(PRESS_KP * press_mass, dofs_idx_local=[2])
     presser.set_dofs_kv(0.1 * PRESS_KP * press_mass, dofs_idx_local=[2])
     presser.control_dofs_position([[0.5 * PRESS_SIZE], [0.5 * PRESS_SIZE - PRESS_DEPTH]], dofs_idx_local=[2])
@@ -483,7 +483,7 @@ def test_elliptic_cone_coulomb_isotropy(sparse_solve, use_contact_island, show_v
         ),
     )
     scene.build(n_envs=N_ENVS)
-    mass = float(box.get_mass(envs_idx=[0]))
+    mass = box.get_mass(envs_idx=[0])
     normal_force = MU * mass * (-GRAVITY)
 
     yaw = 2.0 * torch.pi * torch.rand(N_ENVS, device=gs.device)
@@ -848,7 +848,7 @@ def test_elliptic_cone_push_isotropy(contact_resolution, is_box_mesh, scale, pre
     # Quoted per unit mass, the linear gains are accelerations per unit error, fixed so the pusher tracks the same
     # path at any scale; the angular ones act on the inertia, two powers of length ahead of the mass, and carry that
     # difference.
-    pusher_mass = float(pusher.get_mass(envs_idx=[0]))
+    pusher_mass = pusher.get_mass(envs_idx=[0])
     pusher.set_dofs_kp(2000.0 * pusher_mass, dofs_idx_local=[0, 1])
     pusher.set_dofs_kv(200.0 * pusher_mass, dofs_idx_local=[0, 1])
     pusher.set_dofs_kp(5000.0 * pusher_mass * scale**2, dofs_idx_local=[5])

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -417,7 +417,7 @@ def test_static_hold_unaffected_by_press_on_separate_body(show_viewer):
         scene.step()
     hold_z = held_box.get_pos()[..., 2]
 
-    press_mass = presser.get_mass()
+    press_mass = float(presser.get_mass(envs_idx=[0]))
     presser.set_dofs_kp(PRESS_KP * press_mass, dofs_idx_local=[2])
     presser.set_dofs_kv(0.1 * PRESS_KP * press_mass, dofs_idx_local=[2])
     presser.control_dofs_position([[0.5 * PRESS_SIZE], [0.5 * PRESS_SIZE - PRESS_DEPTH]], dofs_idx_local=[2])
@@ -483,7 +483,7 @@ def test_elliptic_cone_coulomb_isotropy(sparse_solve, use_contact_island, show_v
         ),
     )
     scene.build(n_envs=N_ENVS)
-    mass = box.get_mass()
+    mass = float(box.get_mass(envs_idx=[0]))
     normal_force = MU * mass * (-GRAVITY)
 
     yaw = 2.0 * torch.pi * torch.rand(N_ENVS, device=gs.device)
@@ -848,7 +848,7 @@ def test_elliptic_cone_push_isotropy(contact_resolution, is_box_mesh, scale, pre
     # Quoted per unit mass, the linear gains are accelerations per unit error, fixed so the pusher tracks the same
     # path at any scale; the angular ones act on the inertia, two powers of length ahead of the mass, and carry that
     # difference.
-    pusher_mass = float(pusher.get_mass())
+    pusher_mass = float(pusher.get_mass(envs_idx=[0]))
     pusher.set_dofs_kp(2000.0 * pusher_mass, dofs_idx_local=[0, 1])
     pusher.set_dofs_kv(200.0 * pusher_mass, dofs_idx_local=[0, 1])
     pusher.set_dofs_kp(5000.0 * pusher_mass * scale**2, dofs_idx_local=[5])
@@ -1081,7 +1081,8 @@ def test_kinetic_friction(n_envs, show_viewer):
     # The height above measures this through the geometry; the contact force states it directly. A sliding contact
     # carries the weight and nothing more, however much tangential force the slide is asking of it.
     normal_force = torch.stack([box.get_links_net_contact_force().sum(dim=-2)[..., 2] for box in boxes])
-    assert_allclose(normal_force[is_sliding], boxes[0].get_mass() * GRAVITY, rtol=0.01)
+    weight = (boxes[0].get_mass() * GRAVITY).expand_as(height_0)
+    assert_allclose(normal_force[is_sliding], weight[is_sliding], rtol=0.01)
 
     # Each box decelerates at its own mu * g, independently of how fast it was launched.
     deceleration = (speed_0 - speed_1) / (N_SLIDE * scene.sim.dt)

--- a/tests/rigid/test_heterogeneous.py
+++ b/tests/rigid/test_heterogeneous.py
@@ -77,7 +77,8 @@ def test_physics_parity(show_viewer, tol):
     # heterogeneous entity through a different arithmetic than its own reference.
     assert_allclose(ref_pos - het_obj.get_pos(), REFERENCE_OFFSETS, tol=1e-5)
     assert_allclose(het_obj.get_vel(), ref_vel, tol=2e-4)
-    assert_allclose(het_obj.get_mass(), [ref_obj.get_mass() for ref_obj in ref_objs], tol=tol)
+    ref_mass = torch.cat([ref_obj.get_mass(envs_idx=[i_env]) for i_env, ref_obj in enumerate(ref_objs)])
+    assert_allclose(het_obj.get_mass(), ref_mass, tol=tol)
 
     # The variants are genuinely distinct: their masses are not all equal.
     with pytest.raises(AssertionError):
@@ -113,7 +114,8 @@ def test_variant_inertia_matches_standalone(undefined_inertia, implicit_inertial
     )
     scene.build(n_envs=len(files))
 
-    assert_allclose(het_obj.get_mass(), [reference.get_mass() for reference in references], tol=tol)
+    ref_mass = torch.cat([reference.get_mass(envs_idx=[i_env]) for i_env, reference in enumerate(references)])
+    assert_allclose(het_obj.get_mass(), ref_mass, tol=tol)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

`RigidLink.get_mass` returned the authored inertial mass and `RigidEntity.get_mass` summed those, so
both ignored the per-environment mass shift that forward kinematics and forward dynamics actually
integrate, and neither could select environments.

- Add `RigidSolver.get_links_mass(links_idx, envs_idx)`**
- Return a `torch.Tensor` of shape `()` or `(n_envs,)` instead of a float, since an effective mass
  is per-environment
- Fixed `RigidSolver.get_potential_energy` to use effective mass
- Fixed bug where composite inertia was not updated.
- Fixed bug where `set_mass` scaled on current mass instead of initial mass.

## Related Issue

Resolves https://github.com/Genesis-Embodied-AI/genesis-world/discussions/2892

## Motivation and Context

A user randomizing masses had no way to read back the mass being simulated: `set_mass_shift` moved the
dynamics while every getter kept reporting the authored value, and the only per-environment mass in
reach was a raw solver field. The two setter bugs surfaced while asserting that the reported mass is
the one the solver integrates, which is the whole point of the getter.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_api.py::test_mass_setters` 

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Resolves SIM-326