### PR TITLE
[BUG FIX] Recover a usable inertia for URDF links stating a zero mass or inertia.

### DIFF
--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -942,26 +942,31 @@ class KinematicEntityDescription(EntityDescription):
 
         # Force recomputing inertial information based on geometry if ill-defined for some reason.
         # A moving link needs a well-defined inertia only for its own rigid body; a rigidly-attached (fixed-joint) child
-        # folds its mass into the parent's composite-rigid-body inertia.
+        # folds its mass into the parent's composite-rigid-body inertia. A link contributes to that composite only
+        # through the mass it ends up with, and an authored non-positive mass stands for a rigidly-attached link, so
+        # its geometry adds nothing.
         has_links_subtree_mass = [
-            bool(link_g_infos) or (l_info.get("inertial_mass") or 0.0) > 0.0
+            bool(link_g_infos) if l_info.get("inertial_mass") is None else l_info["inertial_mass"] > 0.0
             for link_g_infos, l_info in zip(links_g_infos, l_infos)
         ]
+        has_links_fixed_child_mass = [False] * len(l_infos)
         for i_l in reversed(range(len(l_infos))):
             parent_idx = l_infos[i_l]["parent_idx"]
             if parent_idx >= 0 and all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in links_j_infos[i_l]):
                 has_links_subtree_mass[parent_idx] |= has_links_subtree_mass[i_l]
+                has_links_fixed_child_mass[parent_idx] |= has_links_subtree_mass[i_l]
 
-        for i_l, (l_info, link_g_infos, link_j_infos, has_link_subtree_mass) in enumerate(
-            zip(l_infos, links_g_infos, links_j_infos, has_links_subtree_mass)
+        for l_info, link_g_infos, link_j_infos, has_link_subtree_mass, has_link_fixed_child_mass in zip(
+            l_infos, links_g_infos, links_j_infos, has_links_subtree_mass, has_links_fixed_child_mass
         ):
-            # Fixed links are subsumed into their parent's composite; only moving links need a well-defined inertia.
-            if all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in link_j_infos):
+            # A fixed link contributes its own inertia to its parent's composite, so recover it when it has geometry.
+            is_fixed_link = all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in link_j_infos)
+            if not link_g_infos and is_fixed_link:
                 continue
-            if not (
-                (l_info.get("inertial_mass") is None or l_info["inertial_mass"] <= 0.0)
-                or (l_info.get("inertial_i") is None or (np.diag(l_info["inertial_i"]) <= 0.0).any())
-            ):
+            is_mass_degenerate = (l_info.get("inertial_mass") or 0.0) <= 0.0
+            inertia = l_info.get("inertial_i")
+            is_inertia_degenerate = inertia is None or (np.diag(inertia) <= 0.0).any()
+            if not (is_mass_degenerate or is_inertia_degenerate):
                 continue
 
             # The own inertia is degenerate, so the parsed inverse weight (derived from it) must be recomputed
@@ -969,20 +974,29 @@ class KinematicEntityDescription(EntityDescription):
             is_inertia_invalid = True
 
             # A geometry-less moving link whose rigidly-attached (fixed-joint) subtree carries the mass keeps its
-            # (near-)zero own inertia: the composite-rigid-body inertia is finite, so leave it as parsed. Otherwise
-            # recompute from its own geometry, warning only when nothing in the rigid subtree provides mass.
+            # (near-)zero own inertia: the composite-rigid-body inertia is finite, so leave it as parsed.
             if not link_g_infos and has_link_subtree_mass:
                 continue
+            # Without geometry there is nothing to recover an inertial from, so the parsed values stand as they are
+            # and a non-positive mass ends up floored at 'gs.EPS' when the link is built.
             if not link_g_infos:
                 gs.logger.warning(
                     f"Moving link '{l_info['name']}' has no mass, inertia or geometry, and no rigidly-attached "
                     "child provides any. Setting its mass to 'gs.EPS'."
                 )
-            elif l_info.get("inertial_mass") is not None or l_info.get("inertial_i") is not None:
+                continue
+            if l_info.get("inertial_mass") is not None or inertia is not None:
                 gs.logger.debug(
                     f"Invalid or undefined inertia for link '{l_info['name']}'. Force recomputing it based on geometry."
                 )
-            l_info["inertial_i"] = None
+            # A stated zero mass stands for a rigidly-attached link, and for a moving link whose rigidly-attached
+            # children carry mass, since the composite is finite in both cases. Anywhere else it leaves the link
+            # singular, so the geometry supplies the mass too.
+            if is_mass_degenerate and not is_fixed_link and not has_link_fixed_child_mass:
+                l_info["inertial_mass"] = None
+            # An authored inertia stands on its own unless the mass it was sized for is being replaced too.
+            if is_inertia_degenerate or l_info.get("inertial_mass") is None:
+                l_info["inertial_i"] = None
         if is_inertia_invalid:
             for l_info, link_j_infos in zip(l_infos, links_j_infos):
                 l_info["invweight"] = np.full((2,), fill_value=-1.0)
@@ -1601,11 +1615,6 @@ class RigidEntityDescription(KinematicEntityDescription):
                     f"Mass is not specified and collision geoms can not be found for link '{l_info['name']}'. "
                     f"Using visual geoms to compute inertial properties."
                 )
-            if com is not None and inertia is None:
-                gs.logger.warning(
-                    f"Ignoring center of mass of link '{l_info['name']}' because inertia matrix is not specified."
-                )
-
             # The parsed inverse weight matches the inertia the asset declares. The inertia recomputed here breaks
             # that match, so the value is discarded
             invweight = None

--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -942,9 +942,8 @@ class KinematicEntityDescription(EntityDescription):
 
         # Force recomputing inertial information based on geometry if ill-defined for some reason.
         # A moving link needs a well-defined inertia only for its own rigid body; a rigidly-attached (fixed-joint) child
-        # folds its mass into the parent's composite-rigid-body inertia. A link contributes to that composite only
-        # through the mass it ends up with, and an authored non-positive mass stands for a rigidly-attached link, so
-        # its geometry adds nothing.
+        # folds its mass into the parent's composite-rigid-body inertia. An authored mass counts only when positive, and
+        # a link without an authored mass counts when it has geometry.
         has_links_subtree_mass = [
             bool(link_g_infos) if l_info.get("inertial_mass") is None else l_info["inertial_mass"] > 0.0
             for link_g_infos, l_info in zip(links_g_infos, l_infos)
@@ -959,13 +958,18 @@ class KinematicEntityDescription(EntityDescription):
         for l_info, link_g_infos, link_j_infos, has_link_subtree_mass, has_link_fixed_child_mass in zip(
             l_infos, links_g_infos, links_j_infos, has_links_subtree_mass, has_links_fixed_child_mass
         ):
-            # A fixed link contributes its own inertia to its parent's composite, so recover it when it has geometry.
             is_fixed_link = all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in link_j_infos)
-            if not link_g_infos and is_fixed_link:
-                continue
+            is_fixed_child = is_fixed_link and l_info["parent_idx"] >= 0
             is_mass_degenerate = (l_info.get("inertial_mass") or 0.0) <= 0.0
             inertia = l_info.get("inertial_i")
             is_inertia_degenerate = inertia is None or (np.diag(inertia) <= 0.0).any()
+            # The world or the parent carries a fixed link without geometry, so its values stay as authored.
+            if is_fixed_link and not link_g_infos:
+                continue
+            # A fixed child keeps its authored mass, zero included. Its inertia contributes to the parent composite, so a
+            # degenerate inertia is recovered from geometry.
+            if is_fixed_child and not is_inertia_degenerate:
+                continue
             if not (is_mass_degenerate or is_inertia_degenerate):
                 continue
 
@@ -977,8 +981,6 @@ class KinematicEntityDescription(EntityDescription):
             # (near-)zero own inertia: the composite-rigid-body inertia is finite, so leave it as parsed.
             if not link_g_infos and has_link_subtree_mass:
                 continue
-            # Without geometry there is nothing to recover an inertial from, so the parsed values stand as they are
-            # and a non-positive mass ends up floored at 'gs.EPS' when the link is built.
             if not link_g_infos:
                 gs.logger.warning(
                     f"Moving link '{l_info['name']}' has no mass, inertia or geometry, and no rigidly-attached "
@@ -989,12 +991,12 @@ class KinematicEntityDescription(EntityDescription):
                 gs.logger.debug(
                     f"Invalid or undefined inertia for link '{l_info['name']}'. Force recomputing it based on geometry."
                 )
-            # A stated zero mass stands for a rigidly-attached link, and for a moving link whose rigidly-attached
-            # children carry mass, since the composite is finite in both cases. Anywhere else it leaves the link
-            # singular, so the geometry supplies the mass too.
-            if is_mass_degenerate and not is_fixed_link and not has_link_fixed_child_mass:
+            # A moving link with a massless fixed subtree has a singular composite, so its mass comes from the geometry
+            # estimate. A fixed link, or a moving link with mass-bearing fixed children, keeps its zero mass because the
+            # composite is finite.
+            if is_mass_degenerate and not is_fixed_child and not has_link_fixed_child_mass:
                 l_info["inertial_mass"] = None
-            # An authored inertia stands on its own unless the mass it was sized for is being replaced too.
+            # The authored inertia fits the authored mass, so the mass reset also discards the inertia.
             if is_inertia_degenerate or l_info.get("inertial_mass") is None:
                 l_info["inertial_i"] = None
         if is_inertia_invalid:
@@ -1545,12 +1547,11 @@ class RigidEntityDescription(KinematicEntityDescription):
         inertia = None if is_inertia_recomputed else l_info.get("inertial_i")
         invweight = l_info.get("invweight")
 
-        # The world carries a fixed link, so no geometry estimate applies and the asset's values stand as is. A
-        # fixed link holding no geometry keeps the mass 'finalize_inertial' floors at 'gs.EPS'
+        # A link holding no geometry keeps the mass 'finalize_inertial' floors at 'gs.EPS'.
         hint = InertialProperties(0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float))
-        if not is_fixed and inertial_info.hint is not None:
+        if inertial_info.hint is not None:
             hint = inertial_info.hint
-
+        if not is_fixed and inertial_info.hint is not None:
             # Compute the bounding box of the links using both visual and collision geometries to be conservative
             aabb_min = np.full((3,), float("inf"), dtype=gs.np_float)
             aabb_max = np.full((3,), float("-inf"), dtype=gs.np_float)

--- a/genesis/engine/entities/rigid_entity/inertial.py
+++ b/genesis/engine/entities/rigid_entity/inertial.py
@@ -190,24 +190,27 @@ def finalize_inertial(
 ) -> LinkInertial:
     """Resolve a link's local inertial from its parsed explicit values and a geometry-derived estimate (hint).
 
-    Explicit values are used when given; otherwise the geometry estimate is used, and an explicit mass rescales a
-    geometry-derived inertia. An omitted center of mass defaults to the link-frame origin when an explicit inertia
-    matrix is provided. The hint comes from the load-time inertial info, computed from the geometry the link holds
-    and used by both the link description and the align anchor. One resolution path keeps the rigid dynamics inertia
-    and the align anchor in lockstep.
+    Each explicit value is used when given, and the geometry estimate fills in the rest. An explicit mass rescales a
+    geometry-derived inertia to it. An omitted center of mass falls back to the geometry estimate, except when an
+    explicit inertia matrix is given, in which case it is the link-frame origin.
+
+    The geometry estimate is computed once from the geometry the link holds. Both the link description and the align
+    anchor resolve their inertial here, so the rigid dynamics inertia and the align anchor agree.
 
     With ``clamp_min_mass`` the resolved mass is floored at ``gs.EPS`` so a geometry-less moving link stays
-    non-singular in the dynamics; the align stash passes ``False`` so a genuinely massless link keeps its ``0.0``
-    mass and is excluded from the fixed-subtree composite (it must not inflate the composite by ``gs.EPS``).
+    non-singular in the dynamics. The align stash passes ``False``, so a genuinely massless link keeps its ``0.0``
+    mass and does not inflate the fixed-subtree composite by ``gs.EPS``.
     """
     mass, com, quat, inertia = explicit_mass, explicit_com, explicit_quat, explicit_inertia
-    if (mass or hint_mass) > MASS_EPS and hint_mass > gs.EPS and mass is not None:
+    if mass is not None and hint_mass > gs.EPS:
         hint_inertia = hint_inertia * (mass / hint_mass)
         hint_mass = mass
     if mass is None:
         mass = hint_mass
     if inertia is None:
-        com, inertia, quat = hint_com, hint_inertia, gu.identity_quat()
+        if com is None:
+            com = hint_com
+        inertia, quat = hint_inertia, gu.identity_quat()
     elif com is None:
         # Falling back to the geometry estimate here would discard an otherwise complete authored inertia.
         com = gu.zero_pos()

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -21,7 +21,6 @@ from .description import (
     RigidEqualityDescription,
     RigidLinkDescription,
 )
-from .inertial import MASS_EPS, RHO_MUJOCO, RHO_OBJECT, RHO_ROBOT, compose_inertial_from_g_infos, finalize_inertial
 from .rigid_equality import RigidEquality
 from .rigid_geom import RigidGeom
 from .rigid_joint import RigidJoint
@@ -408,37 +407,12 @@ class KinematicEntity(Entity):
         # links of other trees declared in the same file keep their own root, as do the fixed flag and invweight.
         for link in self._solver.links:
             if link.root_idx == base_link.idx:
-                was_fixed = link.is_fixed
                 link._root_idx = parent_link.root_idx
                 link._is_fixed &= parent_link.is_fixed
 
                 # The attach moves this link into another kinematic tree, so its old tree's inverse weight no longer
                 # applies. The sentinel makes the solver recompute it during its refresh.
                 link.desc.invweight = np.full((2,), fill_value=-1.0, dtype=gs.np_float)
-
-                # Inertial resolution skips the geometry estimate for a world-carried link, so a link that starts
-                # moving recomputes it from its geoms at the entity's simulated density. Values the asset states
-                # still win over the estimate.
-                if was_fixed and not link.is_fixed and isinstance(link.desc, RigidLinkDescription):
-                    desc = link.desc
-                    # An entity attached beneath this one shares its root, so the density comes from the link's own
-                    # entity rather than from this one.
-                    rho = link.entity.material.rho
-                    if rho is None:
-                        if self._solver._enable_mujoco_compatibility:
-                            rho = RHO_MUJOCO
-                        else:
-                            rho = RHO_ROBOT if desc.is_robot else RHO_OBJECT
-
-                    # A geom description holds the fields a parse states it with, so one composition serves either.
-                    hint = compose_inertial_from_g_infos([vars(g_desc) for g_desc in (desc.geoms or desc.vgeoms)], rho)
-                    stated_mass = desc.mass if desc.mass > MASS_EPS else None
-                    stated_inertia = desc.inertia if desc.inertia is not None and desc.inertia.any() else None
-                    stated_com = desc.inertial_pos if stated_inertia is not None else None
-                    stated_quat = desc.inertial_quat if stated_inertia is not None else None
-                    desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia = finalize_inertial(
-                        stated_mass, stated_com, stated_quat, stated_inertia, *hint
-                    )
 
         # Apply the explicit mounting transform. Forward kinematics interprets the base link's local pose relative to
         # its (new) parent link, so overwriting it here mounts the entity at (pos, quat) in the parent link frame.

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -230,13 +230,23 @@ def build_model(
 
             # Special treatment for URDF
             if is_urdf_file:
-                # Discard placeholder inertias that were used to avoid parsing failure
+                # Restore the authored mass and inertia over the 'boundmass' / 'boundinertia' placeholder applied
+                # above, so a stated zero survives to the degeneracy check that recovers it from the geometry (see
+                # 'KinematicEntity._parse_scene').
                 for link in robot.links:
-                    if link.inertial is None:
-                        body = mj.body(link.name)
+                    inertial = link.inertial
+                    mass = (inertial.mass or 0.0) if inertial is not None else 0.0
+                    is_inertia_defined = inertial is not None and np.linalg.norm(inertial.inertia, np.inf) > 0.0
+                    if mass > 0.0 and is_inertia_defined:
+                        continue
+                    body = mj.body(link.name)
+                    body.mass[:] = mass
+                    # An inertia that was authored at all is kept, so that a malformed one is still reported.
+                    if not is_inertia_defined:
                         body.inertia[:] = 0.0
-                        body.mass[:] = 0.0
-                        body.invweight0[:] = 0.0
+                    # The inverse weight is derived from the compiled mass and inertia, so it goes stale as soon as
+                    # either of them is replaced here.
+                    body.invweight0[:] = 0.0
 
                 # Set default constraint solver time constant
                 mj.jnt_solref[:, 0] = MIN_TIMECONST

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -207,12 +207,12 @@ def build_model(
                 autolimits="true",
             )
 
-            # Bound mass and inertia if necessary
-            if not all(link.inertial is not None for link in robot.links):
-                compiler.attrib |= dict(
-                    boundmass=str(MIN_TIMECONST),
-                    boundinertia=str(MIN_TIMECONST),
-                )
+            # MuJoCo rejects a moving body whose mass or inertia is below 'mjMINVAL'. Bounding both at that value keeps
+            # a zero or missing inertial compilable, and the placeholder is discarded below.
+            compiler.attrib |= dict(
+                boundmass=str(mujoco.mjMINVAL),
+                boundinertia=str(mujoco.mjMINVAL),
+            )
 
             # Resolve relative mesh paths
             for elem in root.findall(".//mesh"):
@@ -230,9 +230,7 @@ def build_model(
 
             # Special treatment for URDF
             if is_urdf_file:
-                # Restore the authored mass and inertia over the 'boundmass' / 'boundinertia' placeholder applied
-                # above, so a stated zero survives to the degeneracy check that recovers it from the geometry (see
-                # 'KinematicEntity._parse_scene').
+                # Discard placeholder inertias that were used to avoid parsing failure
                 for link in robot.links:
                     inertial = link.inertial
                     mass = (inertial.mass or 0.0) if inertial is not None else 0.0
@@ -241,11 +239,10 @@ def build_model(
                         continue
                     body = mj.body(link.name)
                     body.mass[:] = mass
-                    # An inertia that was authored at all is kept, so that a malformed one is still reported.
+                    # Keep non-zero authored inertia with invalid diagonal so the consistency check reports it
                     if not is_inertia_defined:
                         body.inertia[:] = 0.0
-                    # The inverse weight is derived from the compiled mass and inertia, so it goes stale as soon as
-                    # either of them is replaced here.
+                    # invweight0 derives from placeholder mass and inertia; zero triggers recomputation
                     body.invweight0[:] = 0.0
 
                 # Set default constraint solver time constant

--- a/tests/parsers/test_usd.py
+++ b/tests/parsers/test_usd.py
@@ -143,8 +143,8 @@ def test_massapi_invalid_defaults_mjcf_vs_usd(asset_tmp_path, scale):
     # principalAxes (0, 0, 0, 0), diagonalInertia (0, 0, 0), mass (0) - that must be treated as unset and
     # recomputed from geometry, matching an MJCF scene without inertial element. Leaving only 'centerOfMass' at
     # its sentinel keeps the authored mass and inertia and places the center of mass at the link frame, matching an
-    # MJCF body whose inertial frame is the body origin. Leaving only 'diagonalInertia' at its sentinel is the
-    # mirror image: the authored center of mass places the inertia the geometry supplies.
+    # MJCF body whose inertial frame is the body origin. Leaving only 'diagonalInertia' at its sentinel keeps the
+    # authored mass and center of mass and takes the inertia from geometry.
     MASS = 64.0
     HALF_EXTENT = 0.2
     COM = (0.1, 0.0, 0.0)

--- a/tests/parsers/test_usd.py
+++ b/tests/parsers/test_usd.py
@@ -143,7 +143,12 @@ def test_massapi_invalid_defaults_mjcf_vs_usd(asset_tmp_path, scale):
     # principalAxes (0, 0, 0, 0), diagonalInertia (0, 0, 0), mass (0) - that must be treated as unset and
     # recomputed from geometry, matching an MJCF scene without inertial element. Leaving only 'centerOfMass' at
     # its sentinel keeps the authored mass and inertia and places the center of mass at the link frame, matching an
-    # MJCF body whose inertial frame is the body origin.
+    # MJCF body whose inertial frame is the body origin. Leaving only 'diagonalInertia' at its sentinel is the
+    # mirror image: the authored center of mass places the inertia the geometry supplies.
+    MASS = 64.0
+    HALF_EXTENT = 0.2
+    COM = (0.1, 0.0, 0.0)
+    BOX_INERTIA = MASS * 2.0 * (2.0 * HALF_EXTENT) ** 2 / 12.0
     mjcf = ET.Element("mujoco", model="massapi_test")
 
     worldbody = ET.SubElement(mjcf, "worldbody")
@@ -159,6 +164,17 @@ def test_massapi_invalid_defaults_mjcf_vs_usd(asset_tmp_path, scale):
     ET.SubElement(inertia_box, "inertial", pos="0. 0. 0.", mass="64.", diaginertia="1.5 1.7 2.0")
     ET.SubElement(inertia_box, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.")
     ET.SubElement(inertia_box, "joint", name="/worldbody/inertia_box_joint", type="free")
+
+    com_box = ET.SubElement(worldbody, "body", name="/worldbody/com_box", pos="1.2 0. 0.3")
+    ET.SubElement(
+        com_box,
+        "inertial",
+        pos=f"{COM[0]} {COM[1]} {COM[2]}",
+        mass=str(MASS),
+        diaginertia=f"{BOX_INERTIA} {BOX_INERTIA} {BOX_INERTIA}",
+    )
+    ET.SubElement(com_box, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.")
+    ET.SubElement(com_box, "joint", name="/worldbody/com_box_joint", type="free")
 
     xml_tree = ET.ElementTree(mjcf)
     xml_file = str(asset_tmp_path / "massapi_test.xml")
@@ -210,6 +226,22 @@ def test_massapi_invalid_defaults_mjcf_vs_usd(asset_tmp_path, scale):
     inertia_mass_api = UsdPhysics.MassAPI.Apply(inertia_box.GetPrim())
     inertia_mass_api.CreateMassAttr(64.0)
     inertia_mass_api.CreateDiagonalInertiaAttr(Gf.Vec3f(1.5, 1.7, 2.0))
+
+    com_box = UsdGeom.Cube.Define(stage, "/worldbody/com_box")
+    com_box.AddTranslateOp().Set(Gf.Vec3d(1.2, 0.0, 0.3))
+    com_box.GetSizeAttr().Set(2.0 * HALF_EXTENT)
+
+    com_box_joint = UsdPhysics.Joint.Define(stage, "/worldbody/com_box_joint")
+    com_box_joint.CreateBody0Rel().SetTargets([root_prim.GetPath()])
+    com_box_joint.CreateBody1Rel().SetTargets([com_box.GetPrim().GetPath()])
+    com_box_joint.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+    com_box_joint.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+
+    UsdPhysics.RigidBodyAPI.Apply(com_box.GetPrim()).GetKinematicEnabledAttr().Set(False)
+
+    com_mass_api = UsdPhysics.MassAPI.Apply(com_box.GetPrim())
+    com_mass_api.CreateMassAttr(MASS)
+    com_mass_api.CreateCenterOfMassAttr(Gf.Vec3f(*COM))
 
     stage.Save()
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -642,11 +642,11 @@ def free_bodies_in_one_model():
 
 @pytest.fixture(scope="session")
 def degenerate_inertials():
-    """Generate a URDF stating a degenerate inertial on all but three of its links: a zero mass on the root, a zero
+    """Generate a URDF stating a degenerate inertial on several of its links: a zero mass on the root, a zero
     mass beside geometry on a fixed child, a zero mass above a fixed child that carries all of it, a zero inertia
-    beside an authored center of mass, and a zero inertia on a fixed child. One link states no inertial element at
-    all, so the parser bounds every stated zero. MuJoCo rejects a moving body whose rigid subtree carries no inertia,
-    so each degenerate branch either roots the robot or holds a fixed child that authors one."""
+    beside an authored center of mass, and a zero inertia on a fixed child. MuJoCo rejects a moving body whose rigid
+    subtree carries no inertia, so each degenerate branch either roots the robot or holds a fixed child that authors
+    one."""
     urdf = ET.Element("robot", name="degenerate_inertials")
     _add_sphere_link(urdf, "base_link", "0.0 0.0 0.09", mass=0.0, inertia=(0.11, 0.01, 0.02, 0.22, 0.03, 0.30))
     _add_sphere_link(urdf, "massless_marker", "0.0 0.0 0.09", mass=0.0, inertia=(0.0,) * 6)
@@ -683,8 +683,8 @@ def degenerate_inertials():
 
 @pytest.fixture(scope="session")
 def zero_density_marker_mjcf():
-    """Generate an MJCF whose jointless child body carries a zero-density geom, weighing nothing beside the hull that
-    holds it. The two share a frame, so the marker's center of mass stays inside its own geometry."""
+    """Generate an MJCF with a free body holding a jointless child body whose geom has a zero density. The two bodies
+    share one frame, so the center of mass of the child lies inside its own geometry."""
     mjcf = ET.Element("mujoco", model="zero_density_marker")
     worldbody = ET.SubElement(mjcf, "worldbody")
     hull = ET.SubElement(worldbody, "body", name="hull", pos="0.0 -2.0 0.5")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -536,12 +536,14 @@ def double_pendulum():
     return _build_multi_pendulum(n=2, joint_damping=0.0, joint_friction=0.0)
 
 
-def _add_sphere_link(urdf, link_name, geom_pos, mass=None, inertia=None):
+def _add_sphere_link(urdf, link_name, geom_pos, mass=None, inertia=None, inertial_pos=None):
     """Append a link carrying a single sphere geometry offset by 'geom_pos' from the link frame, optionally authoring
-    an inertial element whose origin is left omitted."""
+    an inertial element, whose origin is left omitted unless 'inertial_pos' is given."""
     link = ET.SubElement(urdf, "link", name=link_name)
     if mass is not None:
         inertial = ET.SubElement(link, "inertial")
+        if inertial_pos is not None:
+            ET.SubElement(inertial, "origin", xyz=inertial_pos, rpy="0.0 0.0 0.0")
         ET.SubElement(inertial, "mass", value=str(mass))
         ixx, ixy, ixz, iyy, iyz, izz = (str(value) for value in inertia)
         ET.SubElement(inertial, "inertia", ixx=ixx, ixy=ixy, ixz=ixz, iyy=iyy, iyz=iyz, izz=izz)
@@ -635,6 +637,61 @@ def free_bodies_in_one_model():
         body = ET.SubElement(worldbody, "body", name=f"free_{i_body}", pos=f"{i_body} 4.0 0.4")
         ET.SubElement(body, "freejoint")
         ET.SubElement(body, "geom", type="box", size="0.05 0.05 0.05", mass=str(mass))
+    return ET.tostring(mjcf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
+def degenerate_inertials():
+    """Generate a URDF stating a degenerate inertial on all but three of its links: a zero mass on the root, a zero
+    mass beside geometry on a fixed child, a zero mass above a fixed child that carries all of it, a zero inertia
+    beside an authored center of mass, and a zero inertia on a fixed child. One link states no inertial element at
+    all, so the parser bounds every stated zero. MuJoCo rejects a moving body whose rigid subtree carries no inertia,
+    so each degenerate branch either roots the robot or holds a fixed child that authors one."""
+    urdf = ET.Element("robot", name="degenerate_inertials")
+    _add_sphere_link(urdf, "base_link", "0.0 0.0 0.09", mass=0.0, inertia=(0.11, 0.01, 0.02, 0.22, 0.03, 0.30))
+    _add_sphere_link(urdf, "massless_marker", "0.0 0.0 0.09", mass=0.0, inertia=(0.0,) * 6)
+    _add_sphere_link(urdf, "implicit_origin", "0.0 0.0 0.09", mass=2.5, inertia=(0.11, 0.01, 0.02, 0.22, 0.03, 0.30))
+    _add_sphere_link(urdf, "no_inertial", "0.0 0.0 0.09")
+    _add_sphere_link(urdf, "connector", "0.0 0.0 0.09", mass=0.0, inertia=(0.0,) * 6)
+    _add_sphere_link(
+        urdf, "bob", "0.0 0.0 0.09", mass=1.0, inertia=(1e-3, 0.0, 0.0, 1e-3, 0.0, 1e-3), inertial_pos="0.0 0.0 0.09"
+    )
+    _add_sphere_link(urdf, "zero_inertia", "0.0 0.0 0.09", mass=2.5, inertia=(0.0,) * 6, inertial_pos="0.0 0.0 0.11")
+    _add_sphere_link(urdf, "tip", "0.0 0.0 0.09", mass=1e-5, inertia=(0.0,) * 6)
+    # Every sphere sits at the same offset from its own link frame, so that the whole robot rests flat.
+    # The revolute axis is aligned with gravity so that neither branch swings on the way down.
+    for name, origin in (("implicit_origin", "0.4 0.0 0.0"), ("connector", "-0.4 0.0 0.0")):
+        joint = ET.SubElement(urdf, "joint", name=f"{name}_joint", type="continuous")
+        ET.SubElement(joint, "origin", xyz=origin, rpy="0.0 0.0 0.0")
+        ET.SubElement(joint, "axis", xyz="0.0 0.0 1.0")
+        ET.SubElement(joint, "parent", link="base_link")
+        ET.SubElement(joint, "child", link=name)
+    # Only the four links whose sphere is left at ground level touch it, as a triangle wide enough to stand on.
+    for name, parent, origin in (
+        ("massless_marker", "base_link", "0.0 0.0 0.3"),
+        ("no_inertial", "implicit_origin", "0.0 0.0 0.3"),
+        ("bob", "connector", "0.0 0.0 0.3"),
+        ("zero_inertia", "connector", "0.0 0.4 0.0"),
+        ("tip", "zero_inertia", "0.0 0.0 0.3"),
+    ):
+        joint = ET.SubElement(urdf, "joint", name=f"{name}_joint", type="fixed")
+        ET.SubElement(joint, "origin", xyz=origin, rpy="0.0 0.0 0.0")
+        ET.SubElement(joint, "parent", link=parent)
+        ET.SubElement(joint, "child", link=name)
+    return ET.tostring(urdf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
+def zero_density_marker_mjcf():
+    """Generate an MJCF whose jointless child body carries a zero-density geom, weighing nothing beside the hull that
+    holds it. The two share a frame, so the marker's center of mass stays inside its own geometry."""
+    mjcf = ET.Element("mujoco", model="zero_density_marker")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    hull = ET.SubElement(worldbody, "body", name="hull", pos="0.0 -2.0 0.5")
+    ET.SubElement(hull, "freejoint")
+    ET.SubElement(hull, "geom", type="box", size="0.1 0.1 0.1")
+    marker = ET.SubElement(hull, "body", name="marker")
+    ET.SubElement(marker, "geom", type="sphere", size="0.05", density="0")
     return ET.tostring(mjcf, encoding="unicode")
 
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -221,21 +221,28 @@ def test_urdf_parsing(show_viewer, tol):
 
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
-def test_urdf_parsing_inertia_defaults(
+def test_parsing_inertia_defaults(
     undefined_inertia,
     undefined_inertia_arm,
-    implicit_inertial_origin,
+    degenerate_inertials,
+    zero_density_marker_mjcf,
     implicit_inertial_origin_chain,
     show_viewer,
     tol,
     caplog,
 ):
     GEOM_POS = (0.0, 0.0, 0.09)
+    INERTIAL_POS = (0.0, 0.0, 0.11)
+    TIP_MASS = 1e-5
+    BOB_INERTIA_PER_MASS = 1e-3
     INERTIA = (
         (0.11, 0.01, 0.02),
         (0.01, 0.22, 0.03),
         (0.02, 0.03, 0.30),
     )
+    # Principal moments per unit mass of the two geometries a recovered inertia is derived from.
+    SPHERE_INERTIA_PER_MASS = 2.0 * 0.06**2 / 5.0
+    BOX_INERTIA_PER_MASS = 2.0 * 0.2**2 / 12.0
     GRAVITY = (0.0, 0.0, -9.81)
 
     scene = gs.Scene(
@@ -244,40 +251,37 @@ def test_urdf_parsing_inertia_defaults(
             gravity=GRAVITY,
         ),
         viewer_options=gs.options.ViewerOptions(
-            camera_pos=(0.5, 0.5, 0.5),
-            camera_lookat=(0.0, 0.0, 0.0),
+            camera_pos=(1.5, -3.5, 1.5),
+            camera_lookat=(0.0, 0.0, 0.2),
         ),
         show_viewer=show_viewer,
     )
     scene.add_entity(gs.morphs.Plane())
 
-    # Anchoring a root link on its center of mass erases the inertial frame under test, so it is disabled for the
-    # single-link entities. The chain keeps it enabled, comparing the composite inertia that anchoring preserves.
-    entity_without_inertia = scene.add_entity(
+    # The fixed-jointed branches must survive parsing for their own inertial to be under test.
+    entity = scene.add_entity(
         morph=gs.morphs.URDF(
-            file=undefined_inertia,
-            pos=(-0.3, 0.0, 0.1),
-            align=False,
+            file=degenerate_inertials,
+            pos=(0.0, 0.0, 0.1),
+            merge_fixed_links=False,
         ),
     )
-    entity_with_implicit_origin = scene.add_entity(
-        morph=gs.morphs.URDF(
-            file=implicit_inertial_origin,
-            pos=(0.0, 0.0, 0.1),
-            align=False,
+    entity_zero_density = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=zero_density_marker_mjcf,
         ),
     )
     entity_chain_unmerged = scene.add_entity(
         morph=gs.morphs.URDF(
             file=implicit_inertial_origin_chain,
-            pos=(0.8, 0.0, 0.5),
+            pos=(0.0, 2.0, 0.5),
             merge_fixed_links=False,
         ),
     )
     entity_chain_merged = scene.add_entity(
         morph=gs.morphs.URDF(
             file=implicit_inertial_origin_chain,
-            pos=(1.6, 0.0, 0.5),
+            pos=(0.8, 2.0, 0.5),
         ),
     )
     entity_chain_unmerged_unaligned = scene.add_entity(
@@ -379,18 +383,40 @@ def test_urdf_parsing_inertia_defaults(
     assert_allclose(stacked_middle.base_link.get_mass(), 2000.0 * 0.1**3, tol=gs.EPS)
     assert_allclose(stacked_tip.base_link.get_mass(), 8000.0 * 0.1**3, tol=gs.EPS)
 
-    # An omitted inertial origin places the center of mass at the link frame, whereas a link without any inertial
-    # element derives it from the geometry.
-    assert_allclose(entity_without_inertia.base_link.desc.inertial_pos, GEOM_POS, tol=tol)
-    assert_allclose(entity_with_implicit_origin.base_link.desc.inertial_pos, 0.0, tol=gs.EPS)
-    assert_allclose(entity_with_implicit_origin.base_link.desc.mass, 2.5, tol=gs.EPS)
-    # The tensor is stored in its principal frame, whose parsed quaternion is markedly less accurate than the tensor
-    # itself, so compare the rotation-invariant principal moments rather than the tensor rotated back.
-    assert_allclose(
-        np.linalg.eigvalsh(entity_with_implicit_origin.base_link.desc.inertia),
-        np.linalg.eigvalsh(INERTIA),
-        tol=tol,
-    )
+    # A link with no inertial element at all derives its whole inertial from geometry. Its mass is the material
+    # density applied to the sphere every branch below carries, so the recovered masses are measured against it.
+    estimate = entity.get_link("no_inertial").desc
+    assert_allclose(estimate.inertial_pos, GEOM_POS, tol=tol)
+    assert_allclose(np.linalg.eigvalsh(estimate.inertia) / estimate.mass, SPHERE_INERTIA_PER_MASS, tol=tol)
+
+    # The tensors are stored in their principal frame, whose parsed quaternion is markedly less accurate than the
+    # tensor itself, so compare the rotation-invariant principal moments rather than the tensor rotated back.
+    for link, expected_mass, expected_com, expected_inertia_per_mass in (
+        # A stated zero mass is as undefined as a stated zero inertia, so the geometry supplies the whole inertial.
+        # The fixed child holding geometry does not stand in the way, since its own stated zero stands.
+        (entity.base_link, estimate.mass, GEOM_POS, SPHERE_INERTIA_PER_MASS),
+        (entity.get_link("massless_marker"), gs.EPS, GEOM_POS, 0.0),
+        # An omitted inertial origin places the center of mass at the link frame.
+        (entity.get_link("implicit_origin"), 2.5, (0.0, 0.0, 0.0), np.linalg.eigvalsh(INERTIA) / 2.5),
+        # A stated zero inertia is recovered from the geometry, while the authored center of mass stands.
+        (entity.get_link("zero_inertia"), 2.5, INERTIAL_POS, SPHERE_INERTIA_PER_MASS),
+        # A fixed child's own inertia makes up its parent's composite, so a zero stated there is recovered too.
+        (entity.get_link("tip"), TIP_MASS, GEOM_POS, SPHERE_INERTIA_PER_MASS),
+        # A zero stated where a fixed child carries the mass is the connector idiom, so the geometry supplies neither.
+        (entity.get_link("connector"), gs.EPS, GEOM_POS, 0.0),
+        (entity.get_link("bob"), 1.0, GEOM_POS, BOB_INERTIA_PER_MASS),
+        # A zero-density geom weighs nothing by design, and the composite holding it is finite without it.
+        (entity_zero_density.get_link("hull"), 8.0, (0.0, 0.0, 0.0), BOX_INERTIA_PER_MASS),
+        (entity_zero_density.get_link("marker"), gs.EPS, (0.0, 0.0, 0.0), 0.0),
+    ):
+        assert_allclose(link.desc.mass, expected_mass, rtol=1e-6, err_msg=link.name)
+        assert_allclose(link.desc.inertial_pos, expected_com, tol=tol, err_msg=link.name)
+        assert_allclose(
+            np.linalg.eigvalsh(link.desc.inertia) / link.desc.mass,
+            expected_inertia_per_mass,
+            tol=tol,
+            err_msg=link.name,
+        )
 
     # Resolving the center of mass to the link frame can place it outside the geometry, which stays worth reporting.
     # Only the link whose geometry is offset qualifies; a geometry-derived center of mass never does.
@@ -474,10 +500,13 @@ def test_urdf_parsing_inertia_defaults(
     # loses a little volume, so the measured mass lands slightly below the closed form.
     assert_allclose(mounted_arm.base_link.get_mass(), 1500.0 * 4.0 / 3.0 * np.pi * 0.06**3, rtol=0.1)
 
-    for _ in range(30):
+    # A recovered inertia has to hold up in the dynamics, so the robot comes to rest on the spheres of its branches.
+    # The tolerance covers the steady-state penetration of the soft contact constraint, which is how far below the
+    # height they touch the ground at the robot settles.
+    for _ in range(40):
         scene.step()
-    assert_allclose(entity_without_inertia.get_pos(), (-0.3, 0.0, -0.03), tol=1e-3)
-    assert_allclose(entity_with_implicit_origin.get_pos(), (0.0, 0.0, -0.03), tol=1e-3)
+    assert_allclose(entity.get_dofs_velocity(), 0.0, atol=1e-4)
+    assert_allclose(entity.get_pos(), (0.0, 0.0, -0.03), atol=5e-4)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -258,11 +258,20 @@ def test_parsing_inertia_defaults(
     )
     scene.add_entity(gs.morphs.Plane())
 
-    # The fixed-jointed branches must survive parsing for their own inertial to be under test.
+    # merge_fixed_links=False keeps every fixed link as a link of its own, so the test can check its inertial.
     entity = scene.add_entity(
         morph=gs.morphs.URDF(
             file=degenerate_inertials,
             pos=(0.0, 0.0, 0.1),
+            merge_fixed_links=False,
+        ),
+    )
+    # The same asset welded to the world resolves every link exactly as the free copy does.
+    entity_welded = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=degenerate_inertials,
+            pos=(0.0, -4.0, 0.1),
+            fixed=True,
             merge_fixed_links=False,
         ),
     )
@@ -383,8 +392,8 @@ def test_parsing_inertia_defaults(
     assert_allclose(stacked_middle.base_link.get_mass(), 2000.0 * 0.1**3, tol=gs.EPS)
     assert_allclose(stacked_tip.base_link.get_mass(), 8000.0 * 0.1**3, tol=gs.EPS)
 
-    # A link with no inertial element at all derives its whole inertial from geometry. Its mass is the material
-    # density applied to the sphere every branch below carries, so the recovered masses are measured against it.
+    # The link 'no_inertial' has no inertial element, so its whole inertial is the geometry estimate. Every link carries
+    # the same sphere, so this mass is the reference for the recovered masses below.
     estimate = entity.get_link("no_inertial").desc
     assert_allclose(estimate.inertial_pos, GEOM_POS, tol=tol)
     assert_allclose(np.linalg.eigvalsh(estimate.inertia) / estimate.mass, SPHERE_INERTIA_PER_MASS, tol=tol)
@@ -392,20 +401,21 @@ def test_parsing_inertia_defaults(
     # The tensors are stored in their principal frame, whose parsed quaternion is markedly less accurate than the
     # tensor itself, so compare the rotation-invariant principal moments rather than the tensor rotated back.
     for link, expected_mass, expected_com, expected_inertia_per_mass in (
-        # A stated zero mass is as undefined as a stated zero inertia, so the geometry supplies the whole inertial.
-        # The fixed child holding geometry does not stand in the way, since its own stated zero stands.
+        # The root states a zero mass and a valid inertia, and the geometry estimate replaces both. Its fixed child
+        # 'massless_marker' keeps its zero mass, so the root has no mass-bearing child.
         (entity.base_link, estimate.mass, GEOM_POS, SPHERE_INERTIA_PER_MASS),
         (entity.get_link("massless_marker"), gs.EPS, GEOM_POS, 0.0),
         # An omitted inertial origin places the center of mass at the link frame.
         (entity.get_link("implicit_origin"), 2.5, (0.0, 0.0, 0.0), np.linalg.eigvalsh(INERTIA) / 2.5),
-        # A stated zero inertia is recovered from the geometry, while the authored center of mass stands.
+        # Geometry supplies the inertia scaled to the authored mass, and the link keeps its authored center of mass.
         (entity.get_link("zero_inertia"), 2.5, INERTIAL_POS, SPHERE_INERTIA_PER_MASS),
-        # A fixed child's own inertia makes up its parent's composite, so a zero stated there is recovered too.
+        # The fixed link 'tip' contributes to its parent composite, so geometry recovers its zero inertia at the
+        # authored mass.
         (entity.get_link("tip"), TIP_MASS, GEOM_POS, SPHERE_INERTIA_PER_MASS),
-        # A zero stated where a fixed child carries the mass is the connector idiom, so the geometry supplies neither.
+        # The fixed child 'bob' carries the mass, so 'connector' keeps a zero inertia and a zero mass floored at gs.EPS.
         (entity.get_link("connector"), gs.EPS, GEOM_POS, 0.0),
         (entity.get_link("bob"), 1.0, GEOM_POS, BOB_INERTIA_PER_MASS),
-        # A zero-density geom weighs nothing by design, and the composite holding it is finite without it.
+        # The geom of 'marker' has a zero density and 'hull' carries the mass, so the marker keeps a zero mass.
         (entity_zero_density.get_link("hull"), 8.0, (0.0, 0.0, 0.0), BOX_INERTIA_PER_MASS),
         (entity_zero_density.get_link("marker"), gs.EPS, (0.0, 0.0, 0.0), 0.0),
     ):
@@ -417,11 +427,18 @@ def test_parsing_inertia_defaults(
             tol=tol,
             err_msg=link.name,
         )
+    for link, link_welded in zip(entity.links, entity_welded.links):
+        assert_allclose(link_welded.desc.mass, link.desc.mass, tol=gs.EPS, err_msg=link.name)
+        assert_allclose(link_welded.desc.inertial_pos, link.desc.inertial_pos, tol=gs.EPS, err_msg=link.name)
+        assert_allclose(link_welded.desc.inertia, link.desc.inertia, tol=gs.EPS, err_msg=link.name)
+
+    # Every asset above is parsed by MuJoCo, a zero or missing inertial included.
+    assert not any("legacy URDF parser" in record.getMessage() for record in caplog.records)
 
     # Resolving the center of mass to the link frame can place it outside the geometry, which stays worth reporting.
-    # Only the link whose geometry is offset qualifies; a geometry-derived center of mass never does.
+    # Only the link whose geometry is offset qualifies, once per copy of the robot.
     dubious_com_records = [record for record in caplog.records if "dubious center of mass" in record.getMessage()]
-    assert len(dubious_com_records) == 1
+    assert len(dubious_com_records) == 2
 
     # Every link of an aligned free body keeps its own mass, so each link reads its authored mass. The two totals are
     # accumulated by independent code paths, so their agreement is bounded by that cross-path floor.
@@ -500,9 +517,8 @@ def test_parsing_inertia_defaults(
     # loses a little volume, so the measured mass lands slightly below the closed form.
     assert_allclose(mounted_arm.base_link.get_mass(), 1500.0 * 4.0 / 3.0 * np.pi * 0.06**3, rtol=0.1)
 
-    # A recovered inertia has to hold up in the dynamics, so the robot comes to rest on the spheres of its branches.
-    # The tolerance covers the steady-state penetration of the soft contact constraint, which is how far below the
-    # height they touch the ground at the robot settles.
+    # The rest on the spheres after the fall checks that the recovered inertias give stable dynamics. The position
+    # tolerance covers the steady-state penetration of the soft contact.
     for _ in range(40):
         scene.step()
     assert_allclose(entity.get_dofs_velocity(), 0.0, atol=1e-4)


### PR DESCRIPTION
## Description

A URDF link with `<inertia ixx="0" ... izz="0"/>` reaches the solver with an isotropic inertia of `2**-52` kg.m2. `genesis-world` catches it but does not apply the fix:

```
[WARNING] Link 'yellow_plastic_bowl' has dubious inertia [ixx=2.220e-16,iyy=2.220e-16,izz=2.220e-16] 
                  compared to the estimate from geometry [ixx=1.125e-04,iyy=1.993e-04,izz=1.125e-04].
```

- `genesis/utils/mjcf.py` passes boundmass and boundinertia to MuJoCo whenever any link in the URDF is missing <inertial>, MuJoCo then clamps it to 2.22e-16
- genesis/engine/entities/rigid_entity/rigid_entity.py tests for degeneracy, but since 2.22e-16 is positive, the repaired value is not used.

The other assets which are .glb/.gltf do not go through the MuJoCo parser. Also, when `merge_fixed_links=True`, no `bound*` is passed, so MuJoCo returns 0 for mass and so the repaired value is used, so the error happens when the URDF is combined with `merge_fixed_links=False`.

Three degenerate authored inertials are now recovered from the geometry:

- **A stated zero inertia.** The `boundmass` / `boundinertia` placeholder is discarded per link rather than only for links with no `<inertial>` at all, so the stated zero survives to the degeneracy check. An authored center of mass is kept, since the geometry only describes how the mass is laid out.
- **A stated zero inertia on a fixed-jointed child.** A fixed link is subsumed into its parent's composite, which its own inertia contributes to, so it is recovered too whenever it has geometry to derive one from. Its stated mass is honored however far it sits from what the geometry alone would weigh.
- **A stated zero mass.** Rescaling the recovered inertia to a zero mass annihilates the tensor, leaving the link at `gs.EPS` with no inertia at all, which drives the constraint solve to NaN. A non-positive mass is therefore treated as undefined and comes from the geometry too - but only where no rigidly-attached (fixed-joint) child carries any, since a stated zero above a mass-bearing child is the massless-connector idiom rather than an omission, and the composite is finite without it.

## Motivation and Context

genesis-world should catch these degenerate inertia cases.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Related to SIM-373
