### PR TITLE
[BUG FIX] Fix parsing URDF for partially specified dynamics attributes.

### DIFF
--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -373,7 +373,10 @@ def parse_urdf(morph, surface):
 
         joint_friction, joint_damping = 0.0, 0.0
         if joint.dynamics is not None:
-            joint_friction, joint_damping = joint.dynamics.friction, joint.dynamics.damping
+            if joint.dynamics.friction is not None:
+                joint_friction = joint.dynamics.friction
+            if joint.dynamics.damping is not None:
+                joint_damping = joint.dynamics.damping
         j_info["dofs_frictionloss"] = np.full(j_info["n_dofs"], joint_friction)
         j_info["dofs_damping"] = np.full(j_info["n_dofs"], joint_damping)
         j_info["dofs_armature"] = np.zeros(j_info["n_dofs"])

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -342,7 +342,11 @@ def _build_multi_pendulum(n, joint_damping, joint_friction):
         ET.SubElement(joint, "parent", link=parent_link)
         ET.SubElement(joint, "child", link=f"PendulumArm_{i}")
         ET.SubElement(joint, "limit", effort=str(100.0 * (n - i)), velocity="30.0")
-        ET.SubElement(joint, "dynamics", damping=str(joint_damping), friction=str(joint_friction))
+        dynamics = ET.SubElement(joint, "dynamics")
+        if joint_damping is not None:
+            dynamics.set("damping", str(joint_damping))
+        if joint_friction is not None:
+            dynamics.set("friction", str(joint_friction))
 
         # Arm link
         arm = ET.SubElement(urdf, "link", name=f"PendulumArm_{i}")
@@ -409,6 +413,27 @@ def _add_sphere_link(urdf, link_name, geom_pos, mass=None, inertia=None):
         geom_prop = ET.SubElement(link, tag)
         ET.SubElement(geom_prop, "origin", xyz=geom_pos, rpy="0.0 0.0 0.0")
         ET.SubElement(ET.SubElement(geom_prop, "geometry"), "sphere", radius="0.06")
+
+
+@pytest.fixture
+def joint_with_partial_dynamics(joint_damping, joint_friction):
+    # Inertia is deliberately left undefined: recomputing it from geometry is the path along which an unset
+    # <dynamics> attribute reaches the solver instead of being replaced beforehand.
+    urdf = ET.Element("robot", name="joint_with_partial_dynamics")
+    _add_sphere_link(urdf, "base_link", "0.0 0.0 0.0")
+    _add_sphere_link(urdf, "PendulumArm_0", "0.0 0.0 0.09")
+    joint = ET.SubElement(urdf, "joint", name="PendulumJoint_0", type="continuous")
+    ET.SubElement(joint, "origin", xyz="0.0 0.0 0.0", rpy="0.0 0.0 0.0")
+    ET.SubElement(joint, "axis", xyz="1 0 0")
+    ET.SubElement(joint, "parent", link="base_link")
+    ET.SubElement(joint, "child", link="PendulumArm_0")
+    ET.SubElement(joint, "limit", effort="100.0", velocity="30.0")
+    dynamics = ET.SubElement(joint, "dynamics")
+    if joint_damping is not None:
+        dynamics.set("damping", str(joint_damping))
+    if joint_friction is not None:
+        dynamics.set("friction", str(joint_friction))
+    return urdf
 
 
 @pytest.fixture(scope="session")

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -467,9 +467,11 @@ def test_urdf_capsule(tmp_path, show_viewer, tol):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("model_name", ["pendulum_with_joint_dynamics"])
-@pytest.mark.parametrize("joint_damping, joint_friction", [(1.0, 2.0)])
+@pytest.mark.parametrize("model_name", ["pendulum_with_joint_dynamics", "joint_with_partial_dynamics"])
+@pytest.mark.parametrize("joint_damping, joint_friction", [(1.0, 2.0), (1.0, None), (None, 2.0)])
 def test_urdf_joint_dynamics(joint_damping, joint_friction, xml_path):
+    # A <dynamics> tag authoring only one of damping/friction leaves the other one unset. It must fall back to zero
+    # like an absent tag rather than reaching the solver as a null value.
     scene = gs.Scene()
     robot = scene.add_entity(
         gs.morphs.URDF(
@@ -478,10 +480,13 @@ def test_urdf_joint_dynamics(joint_damping, joint_friction, xml_path):
             convexify=True,
         ),
     )
+    scene.build()
+    expected_damping = 0.0 if joint_damping is None else joint_damping
+    expected_frictionloss = 0.0 if joint_friction is None else joint_friction
     assert_allclose(robot.joints[0].dofs_damping, 0.0, tol=gs.EPS)
-    assert_allclose(robot.joints[1].dofs_damping, joint_damping, tol=gs.EPS)
+    assert_allclose(robot.joints[1].dofs_damping, expected_damping, tol=gs.EPS)
     assert_allclose(robot.joints[0].dofs_frictionloss, 0.0, tol=gs.EPS)
-    assert_allclose(robot.joints[1].dofs_frictionloss, joint_friction, tol=gs.EPS)
+    assert_allclose(robot.joints[1].dofs_frictionloss, expected_frictionloss, tol=gs.EPS)
 
 
 @pytest.mark.slow  # ~200s


### PR DESCRIPTION
## Description

`parse_urdf` applied its `0.0` fallbacks for `friction` / `damping` only when the `<dynamics>` tag was absent altogether. A tag authoring just one of the two left the other one as `None`, which flowed into `np.full` and produced an object array that `np.concatenate` refused to cast when initializing the dof fields:

```
TypeError: Cannot cast array data from dtype('O') to dtype('float32') according to the rule 'same_kind'
```

The fallback is now applied per attribute rather than per tag, so a partially authored tag behaves like an absent one for the attribute it omits.

Both attributes are affected, not only the one in the report: omitting `friction` breaks `dofs_frictionloss` (`kinematic_solver.py:420`) and omitting `damping` breaks `dofs_damping` (`kinematic_solver.py:419`).

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3258

## Motivation and Context

`<dynamics damping="0.3"/>` without a `friction` attribute is valid URDF and appears in real assets - the report hit it on a Franka `fr3_finger_joint2`. Loading such a robot aborts `scene.build()` with a `TypeError` that points at the solver rather than at the joint responsible, and the only workaround is editing the asset to author the missing attribute explicitly.

Worth flagging for review: the null only reaches the solver when the model has no authored `<inertial>`. When inertia is valid it is replaced before the solver sees it, which is why the existing `pendulum_with_joint_dynamics` model cannot reproduce the failure and the new `joint_with_partial_dynamics` model leaves inertia undefined.

## How Has This Been / Can This Be Tested?

Minimal reproducer - raises the `TypeError` above on `main`, builds fine with this change:

```python
import genesis as gs

URDF = """<?xml version="1.0"?>
<robot name="t">
  <link name="base_link"/>
  <link name="finger"/>
  <joint name="finger_joint" type="prismatic">
    <parent link="base_link"/><child link="finger"/>
    <origin xyz="0 0 0" rpy="0 0 0"/><axis xyz="0 0 1"/>
    <limit effort="100" lower="0" upper="0.04" velocity="0.2"/>
    <dynamics damping="0.3"/>
  </joint>
</robot>
"""
open("arm.urdf", "w").write(URDF)

gs.init(backend=gs.cpu)
scene = gs.Scene(show_viewer=False)
scene.add_entity(gs.morphs.URDF(file="arm.urdf", fixed=True))
scene.build()
```

`test_urdf_joint_dynamics` is extended with a `(joint_damping, joint_friction)` sweep covering the partially authored cases, over both the existing pendulum and the new undefined-inertia model:

```
pytest -v tests/rigid/test_asset_loading.py -k test_urdf_joint_dynamics
```

- with the source change reverted: 2 failed, 4 passed (both failures are the `TypeError` above)
- with the source change: 6 passed
- whole file: 39 passed, 2 skipped (`gs.gpu` not available on this machine)

Environment: Ubuntu 24.04, Python 3.12, CPU backend.

## Screenshots (if appropriate):

N/A

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
