### PR TITLE
[BUG FIX] Fix multidimensional tensor recording as CSV file.

### DIFF
--- a/genesis/recorders/file_writers.py
+++ b/genesis/recorders/file_writers.py
@@ -132,7 +132,7 @@ class CSVFileWriter(BaseFileWriter):
                 if isinstance(data, dict):
                     for key, val in data.items():
                         if hasattr(val, "__len__"):
-                            header.extend([f"{key}_{i}" for i in range(len(val))])
+                            header.extend([f"{key}_{i}" for i in range(len(self._sanitize_to_list(val)))])
                         else:
                             header.append(key)
                 else:

--- a/tests/core/test_recorders.py
+++ b/tests/core/test_recorders.py
@@ -218,6 +218,12 @@ def test_file_writers(tmp_path):
     csv_writer = gs.recorders.CSVFile(filename=csv_file, header=("in_contact",))
     contact_sensor.start_recording(csv_writer)
 
+    csv_array_file = tmp_path / "array_data.csv"
+    scene.start_recording(
+        data_func=lambda: {"batch": np.arange(6).reshape(2, 3)},
+        rec_options=gs.recorders.CSVFile(filename=csv_array_file),
+    )
+
     npz_file = tmp_path / "scene_data.npz"
     scene.start_recording(
         data_func=lambda: {"box_pos": box.get_pos(), "dummy": 1},
@@ -239,6 +245,14 @@ def test_file_writers(tmp_path):
         assert len(rows) == STEPS + 1  # header + data rows
         assert rows[1][1] in ("False", "0")  # not in contact initially
         assert rows[-1][1] in ("True", "1")  # in contact after falling
+
+    assert csv_array_file.exists()
+    with open(csv_array_file, "r") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+        assert rows[0] == ["timestamp", "batch_0", "batch_1", "batch_2", "batch_3", "batch_4", "batch_5"]
+        assert rows[1][1:] == ["0", "1", "2", "3", "4", "5"]
 
     assert npz_file.exists()
     data = np.load(npz_file)


### PR DESCRIPTION
## Description

Generate automatic CSV headers from the same sanitized list used to build each data row. This keeps existing scalar and one-dimensional naming unchanged while giving multidimensional NumPy values one header per flattened element.

The existing file-writer integration test now records a `(2, 3)` dictionary value and verifies both the generated `batch_0` through `batch_5` header and the flattened data row.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3265

## Motivation and Context

`CSVFile` documents support for N-dimensional arrays, but dictionary values were flattened to six data columns while their automatic headers used only `len(value)`, which is two for a `(2, 3)` array. The resulting length mismatch stopped the recorder before it could write the first row.

## How Has This Been / Can This Be Tested?

Tested with Python 3.12.14 and Quadrants 1.3.0 on Ubuntu 22.04.5:

```bash
python -m pytest -q -n 0 tests/core/test_recorders.py::test_file_writers --backend=cpu -p no:pytest-retry -p no:rerunfailures
python -m pytest -q -n 0 tests/core/test_recorders.py::test_file_writers --backend=gpu -p no:pytest-retry -p no:rerunfailures
ruff check genesis/recorders/file_writers.py tests/core/test_recorders.py
ruff format --check genesis/recorders/file_writers.py tests/core/test_recorders.py
```

Both backend runs pass. A focused compatibility check also confirms unchanged automatic headers for scalar and one-dimensional dictionary values.

## Screenshots (if appropriate):

Not applicable.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests relevant to this focused change passed.
