### PR TITLE
[CHANGING] Honor an MJCF's collision masks across entities.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -160,6 +160,9 @@ class KinematicEntity(Entity):
         self.terrain_scale: np.ndarray | None = None
         self._terrain_height_field: torch.Tensor | None = None
 
+        # Set before '_load_model' so a morph whose parser produces none still answers.
+        self._excluded_links_name: list[tuple[str, str]] = []
+
         self._load_model()
 
         # Initialize target variables and checkpoint
@@ -635,7 +638,10 @@ class KinematicEntity(Entity):
         # initialized undetermined physics parameters.
         if isinstance(morph, gs.morphs.MJCF):
             # Mujoco's unified MJCF+URDF parser systematically for MJCF files
-            l_infos, links_j_infos, links_g_infos, eqs_info = mju.parse_xml(morph, surface, self._solver._options)
+            l_infos, links_j_infos, links_g_infos, eqs_info, excluded_links_name = mju.parse_xml(
+                morph, surface, self._solver._options
+            )
+            self._excluded_links_name = excluded_links_name
         elif isinstance(morph, (gs.morphs.URDF, gs.morphs.Drone)):
             # Custom "legacy" URDF parser for loading geometries (visual and collision) and equality constraints.
             # This is necessary because Mujoco cannot parse visual geometries (meshes) reliably for URDF.
@@ -646,7 +652,7 @@ class KinematicEntity(Entity):
             try:
                 # Mujoco's unified MJCF+URDF parser for URDF files.
                 # Note that Mujoco URDF parser completely ignores equality constraints.
-                l_infos_mj, links_j_infos_mj, links_g_infos_mj, _ = mju.parse_xml(morph_, surface)
+                l_infos_mj, links_j_infos_mj, links_g_infos_mj, _, _ = mju.parse_xml(morph_, surface)
 
                 # Unset link inertial properties that are actually undefined to force recomputation by genesis
                 if not morph._enable_mujoco_compatibility:
@@ -3056,11 +3062,12 @@ class RigidEntity(KinematicEntity):
 
     def _load_model(self):
         self._equalities = gs.List()
-        # MJCF and USD express in-model collision filtering (MJCF '<contact><exclude>', USD CollisionGroup /
-        # FilteredPairsAPI) through synthesized contype/conaffinity bitmasks. Those masks are only consistent within
-        # the entity: applied across entities, they would spuriously disable collision against geoms whose default
-        # masks happen not to overlap (e.g. the ground plane).
-        self._is_local_collision_mask = isinstance(self._morph, (gs.morphs.MJCF, gs.morphs.USD))
+        # USD expresses in-model collision filtering (CollisionGroup / FilteredPairsAPI) through synthesized
+        # contype/conaffinity bitmasks, which are only consistent within the entity they were solved over: applied
+        # across entities they would spuriously disable collision against geoms whose masks happen not to overlap
+        # (e.g. the ground plane). MJCF masks are the ones the model file wrote, so they mean the same thing
+        # everywhere; its own '<contact><exclude>' travels separately as 'excluded_links_name'.
+        self._is_local_collision_mask = isinstance(self._morph, gs.morphs.USD)
 
         super()._load_model()
 
@@ -4628,3 +4635,8 @@ class RigidEntity(KinematicEntity):
     def is_local_collision_mask(self):
         """Whether the contype and conaffinity bitmasks of this entity only applies to self-collision."""
         return self._is_local_collision_mask
+
+    @property
+    def excluded_links_name(self):
+        """Link-name pairs that must never collide, as stated by an MJCF '<contact><exclude>'."""
+        return self._excluded_links_name

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -237,7 +237,20 @@ class KinematicEntity(Entity):
             if isinstance(morph, (gs.morphs.URDF, gs.morphs.MJCF)):
                 # Parse variant scene file
                 morph._enable_mujoco_compatibility = self._morph._enable_mujoco_compatibility
-                v_l_infos, v_links_j_infos, v_links_g_infos, _ = self._parse_scene(morph, self._surface)
+                v_l_infos, v_links_j_infos, v_links_g_infos, _, v_excluded_links_name = self._parse_scene(
+                    morph, self._surface
+                )
+
+                # The '<contact><exclude>' pairs are filtered per link and the variants share the primary's links,
+                # so a per-variant exclusion cannot be represented; require the lists to agree like the joint
+                # structure below.
+                if {frozenset(pair) for pair in v_excluded_links_name} != {
+                    frozenset(pair) for pair in self._excluded_links_name
+                }:
+                    gs.raise_exception(
+                        f"Heterogeneous variant declares contact exclusions {v_excluded_links_name}, but primary "
+                        f"declares {self._excluded_links_name}. All variants must declare the same exclusions."
+                    )
 
                 # Validate that the variant has the same joint structure as the primary
                 if len(v_l_infos) != n_links:
@@ -636,12 +649,12 @@ class KinematicEntity(Entity):
         # First, it would happen when loading visual meshes having supported format (i.e. Collada files '.dae').
         # Second, it does not take into account URDF 'mimic' joint constraints. However, it does a better job at
         # initialized undetermined physics parameters.
+        excluded_links_name: list[tuple[str, str]] = []
         if isinstance(morph, gs.morphs.MJCF):
             # Mujoco's unified MJCF+URDF parser systematically for MJCF files
             l_infos, links_j_infos, links_g_infos, eqs_info, excluded_links_name = mju.parse_xml(
                 morph, surface, self._solver._options
             )
-            self._excluded_links_name = excluded_links_name
         elif isinstance(morph, (gs.morphs.URDF, gs.morphs.Drone)):
             # Custom "legacy" URDF parser for loading geometries (visual and collision) and equality constraints.
             # This is necessary because Mujoco cannot parse visual geometries (meshes) reliably for URDF.
@@ -926,10 +939,10 @@ class KinematicEntity(Entity):
         # Exclude joints with 0 dofs to align with Mujoco
         links_j_infos = [[j_info for j_info in link_j_infos if j_info["n_dofs"] > 0] for link_j_infos in links_j_infos]
 
-        return l_infos, links_j_infos, links_g_infos, eqs_info
+        return l_infos, links_j_infos, links_g_infos, eqs_info, excluded_links_name
 
     def _load_scene(self, morph, surface):
-        l_infos, links_j_infos, links_g_infos, _eqs_info = self._parse_scene(morph, surface)
+        l_infos, links_j_infos, links_g_infos, _eqs_info, self._excluded_links_name = self._parse_scene(morph, surface)
 
         # Add (link, joints, geoms) tuples sequentially
         for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
@@ -3074,7 +3087,7 @@ class RigidEntity(KinematicEntity):
     def _load_scene(self, morph, surface):
         from genesis.engine.couplers import IPCCoupler
 
-        l_infos, links_j_infos, links_g_infos, eqs_info = self._parse_scene(morph, surface)
+        l_infos, links_j_infos, links_g_infos, eqs_info, self._excluded_links_name = self._parse_scene(morph, surface)
 
         # Make sure that the entity is not object
         if (

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -412,12 +412,21 @@ class Collider:
         if not self._solver._enable_self_collision:
             valid &= ~same_root
 
-        # Weld constraint filtering
-        if weld_pairs:
+        # Link pairs the model forbids outright: welded together, or named by an MJCF '<contact><exclude>'. Both are
+        # stated per link rather than per geom, so both are filtered here instead of through the masks tested above,
+        # which stay the ones the model file wrote (see 'excluded_links_name' in genesis/utils/mjcf.py).
+        forbidden_link_pairs = set(weld_pairs)
+        for entity in self._solver.entities:
+            for name_1, name_2 in entity.excluded_links_name:
+                idx_1, idx_2 = entity.get_link(name=name_1).idx, entity.get_link(name=name_2).idx
+                forbidden_link_pairs.add((min(idx_1, idx_2), max(idx_1, idx_2)))
+        if forbidden_link_pairs:
             link_min = np.minimum(link_a, link_b)
             link_max = np.maximum(link_a, link_b)
-            is_weld = np.array([(link_min[i], link_max[i]) in weld_pairs for i in range(len(row))], dtype=bool)
-            valid &= ~is_weld
+            is_forbidden = np.array(
+                [(link_min[i], link_max[i]) in forbidden_link_pairs for i in range(len(row))], dtype=bool
+            )
+            valid &= ~is_forbidden
 
         # --- Self-collision: adjacent and neutral overlap checks (Python loop, only same-root pairs) ---
         # These checks only apply when self_collision is enabled and the pair passed all vectorized filters

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -1,7 +1,6 @@
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from itertools import chain
 from bisect import bisect_right
 
 # Note the importing mujoco with env var `MUJOCO_GL=EGL` forcibly defines `PYOPENGL_PLATFORM=egl`
@@ -17,7 +16,6 @@ from genesis.ext import urdfpy
 
 from . import geom as gu
 from . import urdf as uu
-from .collision import solve_contype_conaffinity
 from .misc import get_assets_dir, redirect_libc_stderr
 
 
@@ -273,7 +271,7 @@ def parse_xml(morph, surface, rigid_options=None):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
+    links_g_infos, excluded_links_name = parse_geoms(mj, morph.scale, surface, morph.file)
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -305,7 +303,7 @@ def parse_xml(morph, surface, rigid_options=None):
                 "'enable_rolling_friction' to honor the parsed coefficients."
             )
 
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    return l_infos, links_j_infos, links_g_infos, eqs_info, excluded_links_name
 
 
 def parse_link(mj, i_l, scale):
@@ -770,55 +768,18 @@ def parse_geoms(mj, scale, surface, xml_path):
         link_idx = mj.geom_bodyid[i_g]
         links_g_info[link_idx].append(g_info)
 
-    # Update contype and conaffinity to take into account any additional list of explicitly excluded collision pairs
-    if mj.nexclude:
-        # Extract the list of collision geometries
-        cg_infos = []
-        for g_info in chain.from_iterable(links_g_info):
-            if g_info["contype"] or g_info["conaffinity"]:
-                cg_infos.append(g_info)
-
-        # Compute the original of all the excluded collision pairs
-        invalid_set = set()
-        for i, g_info_1 in enumerate(cg_infos):
-            for j, g_info_2 in enumerate(cg_infos):
-                if i >= j:
-                    continue
-                if g_info_1["contype"] & g_info_2["conaffinity"]:
-                    continue
-                if g_info_2["contype"] & g_info_1["conaffinity"]:
-                    continue
-                invalid_set.add(frozenset((i, j)))
-
-        # Append all the explicitly excluded collision pairs
-        for exclude_signature in mj.exclude_signature:
-            body_1 = (exclude_signature >> 16) & 0xFFFF
-            body_2 = exclude_signature & 0xFFFF
-
-            geoms_1, geoms_2 = [], []
-            for body_idx, geoms_idx in ((body_1, geoms_1), (body_2, geoms_2)):
-                for g_info in links_g_info[body_idx]:
-                    for geom_idx, cg_info in enumerate(cg_infos):
-                        if g_info is cg_info:
-                            geoms_idx.append(geom_idx)
-                            break
-
-            for geom_1 in geoms_1:
-                for geom_2 in geoms_2:
-                    invalid_set.add(frozenset((geom_1, geom_2)))
-
-        # Compute updated contype and conaffinity from the complete list of invalid collision pairs
-        masks = solve_contype_conaffinity(len(cg_infos), invalid_set)
-        if masks is None:
-            gs.logger.warning(
-                "Compatible collision geometries cannot be described using bitmasks 'contype' and 'conaffinity'. "
-                "Using default values..."
-            )
-            for g_info in cg_infos:
-                g_info["contype"], g_info["conaffinity"] = 1, 1
-        else:
-            for g_info, (contype, conaffinity) in zip(cg_infos, masks):
-                g_info["contype"], g_info["conaffinity"] = contype, conaffinity
+    # MJCF states forbidden pairs two ways: the contype / conaffinity masks, and '<contact><exclude>'. Carry the
+    # second one out as link-name pairs and leave the masks as the file wrote them, so they keep meaning the same
+    # thing in every entity. The collider applies the pairs in '_compute_collision_pair_idx'.
+    excluded_links_name: list[tuple[str, str]] = []
+    for exclude_signature in mj.exclude_signature:
+        idx_1 = (exclude_signature >> 16) & 0xFFFF
+        idx_2 = exclude_signature & 0xFFFF
+        name_1 = mujoco.mj_id2name(mj, mujoco.mjtObj.mjOBJ_BODY, idx_1)
+        name_2 = mujoco.mj_id2name(mj, mujoco.mjtObj.mjOBJ_BODY, idx_2)
+        if not name_1 or not name_2:
+            gs.raise_exception(f"(MJCF) '<contact><exclude>' names an unnamed link (indices {idx_1}, {idx_2}).")
+        excluded_links_name.append((name_1, name_2))
 
     # Inform the user that collision geometries are not displayed by default
     if is_any_col and surface.vis_mode != "collision":
@@ -847,7 +808,7 @@ def parse_geoms(mj, scale, surface, xml_path):
                 g_info = {**g_info, "vmesh": vmesh, "contype": 0, "conaffinity": 0}
                 link_g_info.append(g_info)
 
-    return links_g_info
+    return links_g_info, excluded_links_name
 
 
 def parse_equalities(mj, scale):

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -1407,3 +1407,115 @@ def test_neutral_self_collision_masks_across_merged_entities(merged_overlapping_
     palm_geom = hand.get_link("palm").geoms[0].idx
     assert_equal(collision_pair_idx[a2_geom, palm_geom], -1)
     assert_equal(collision_pair_idx[palm_geom, a2_geom], -1)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_mjcf_authored_masks_and_contact_exclude(n_envs, show_viewer):
+    # An MJCF states forbidden collision pairs two ways, and the two are independent: the per-geom contype /
+    # conaffinity masks, and '<contact><exclude>'. The masks have to survive import unchanged, because a mask is
+    # compared against the masks of every other entity in the scene and only the model file knows what its bits
+    # mean; the exclusions have to be honored without touching them. Both probes are paired with a control so a
+    # filter that blocks everything fails: 'lander' beside 'floater' on the masks, 'armC' beside 'armB' on the
+    # exclusion. Gravity is off and every sphere starts overlapping what it is meant to touch, so the contacts are
+    # geometry rather than a settling transient.
+    GROUND_MASK = 1
+    PROBES = (
+        ("lander", "0.0 -0.3 0.05", "1", "1"),
+        ("floater", "0.0 0.3 0.05", "2", "2"),
+        ("armA", "0.5 0.0 1.0", "1", "1"),
+        ("armB", "0.62 0.0 1.0", "1", "1"),
+        ("armC", "0.38 0.0 1.0", "1", "1"),
+    )
+
+    mjcf = ET.Element("mujoco", model="exclude_probe")
+    ET.SubElement(mjcf, "compiler", angle="radian", autolimits="true")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    # A pair of geoms both fixed with respect to the world is dropped before any mask is read, so the probes hang
+    # off a free root.
+    carrier = ET.SubElement(worldbody, "body", name="carrier", pos="0.0 0.0 0.0")
+    ET.SubElement(carrier, "freejoint", name="carrier_free")
+    ET.SubElement(
+        carrier,
+        "geom",
+        name="carrier_geom",
+        type="sphere",
+        size="0.05",
+        pos="0.0 0.0 1.0",
+        contype="1",
+        conaffinity="1",
+    )
+    for name, pos, contype, conaffinity in PROBES:
+        # One link per probe: a jointless body is welded into its parent and stops being its own link, which would
+        # leave the exclusion naming one link twice, and a contact can only be attributed by the link it sits on.
+        body = ET.SubElement(carrier, "body", name=name, pos=pos)
+        ET.SubElement(body, "joint", name=f"{name}_hinge", type="hinge", axis="0.0 0.0 1.0", range="0.0 0.0")
+        ET.SubElement(
+            body,
+            "geom",
+            name=f"{name}_geom",
+            type="sphere",
+            size="0.1",
+            contype=contype,
+            conaffinity=conaffinity,
+        )
+    ET.SubElement(ET.SubElement(mjcf, "contact"), "exclude", body1="armA", body2="armB")
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, 0.0),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            enable_self_collision=True,
+            # The arm probes overlap at qpos0 on purpose, which the collider otherwise drops as a
+            # convex-decomposition artifact.
+            enable_neutral_collision=True,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.6, -1.6, 1.2),
+            camera_lookat=(0.3, 0.0, 0.5),
+            camera_fov=40,
+        ),
+        show_viewer=show_viewer,
+    )
+    # A primitive's masks default to 0xFFFF, which shares a bit with every probe and would make the mask checks
+    # vacuous. 1 / 1 is what a MuJoCo ground carries.
+    plane = scene.add_entity(
+        gs.morphs.Plane(
+            contype=GROUND_MASK,
+            conaffinity=GROUND_MASK,
+        )
+    )
+    robot = scene.add_entity(
+        gs.morphs.MJCF(
+            file=ET.tostring(mjcf, encoding="unicode"),
+        )
+    )
+    scene.build(n_envs=n_envs)
+
+    for name, _, contype, conaffinity in PROBES:
+        for geom in robot.get_link(name=name).geoms:
+            assert_equal((geom.contype, geom.conaffinity), (int(contype), int(conaffinity)))
+
+    for _ in range(3):
+        scene.step()
+
+    contacts = scene.rigid_solver.collider.get_contacts(as_tensor=True, to_torch=False)
+    links_idx = np.array([geom.link.idx for geom in scene.rigid_solver.geoms])
+    pairs = np.stack(
+        [
+            np.minimum(links_idx[np.atleast_2d(contacts["geom_a"])], links_idx[np.atleast_2d(contacts["geom_b"])]),
+            np.maximum(links_idx[np.atleast_2d(contacts["geom_a"])], links_idx[np.atleast_2d(contacts["geom_b"])]),
+        ],
+        axis=-1,
+    )
+    ground_idx = plane.base_link.idx
+
+    def is_touching(name_1, idx_2):
+        idx_1 = robot.get_link(name=name_1).idx
+        return (pairs == (min(idx_1, idx_2), max(idx_1, idx_2))).all(axis=-1).any(axis=-1)
+
+    assert is_touching("lander", ground_idx).all()
+    assert not is_touching("floater", ground_idx).any()
+    assert not is_touching("armA", robot.get_link(name="armB").idx).any()
+    assert is_touching("armA", robot.get_link(name="armC").idx).all()

--- a/tests/rigid/test_heterogeneous.py
+++ b/tests/rigid/test_heterogeneous.py
@@ -395,3 +395,27 @@ def test_articulated_structure_mismatch():
                 gs.morphs.URDF(file="urdf/simple/two_link_arm.urdf", pos=(0, 0, 0.1)),
             ]
         )
+
+    # The '<contact><exclude>' pairs are filtered per link and the variants share the primary's links, so a variant
+    # cannot carry its own exclusions; the lists must agree like the joint structure above.
+    MJCF_HINGED = (
+        '<mujoco><worldbody><body name="base"><joint type="free"/><geom type="sphere" size="0.1"/>'
+        '<body name="jaw" pos="0.3 0 0"><joint name="jaw_hinge" type="hinge" range="0 0"/>'
+        '<geom type="sphere" size="0.1"/></body></body></worldbody>{contact}</mujoco>'
+    )
+    EXCLUDE = '<contact><exclude body1="base" body2="jaw"/></contact>'
+    EXCLUDE_REVERSED = '<contact><exclude body1="jaw" body2="base"/></contact>'
+    with pytest.raises(gs.GenesisException, match="same exclusions"):
+        scene.add_entity(
+            morph=[
+                gs.morphs.MJCF(file=MJCF_HINGED.format(contact=EXCLUDE), pos=(0, 0, 0.5)),
+                gs.morphs.MJCF(file=MJCF_HINGED.format(contact=""), pos=(0, 0, 0.5)),
+            ]
+        )
+    # The same pair declared in the opposite order is the same exclusion, so this must be accepted.
+    scene.add_entity(
+        morph=[
+            gs.morphs.MJCF(file=MJCF_HINGED.format(contact=EXCLUDE), pos=(0, 0, 0.5)),
+            gs.morphs.MJCF(file=MJCF_HINGED.format(contact=EXCLUDE_REVERSED), pos=(0, 0, 0.5)),
+        ]
+    )


### PR DESCRIPTION
## Description

- `<contact><exclude>` is carried out of the MJCF as link-name pairs and applied in the collider beside the weld-pair filter, which is link-level for the same reason. The authored contype / conaffinity are imported unchanged. Previously both were folded into a fresh entity-local z3 bitmask assignment, discarding the authored values.
- With the authored masks now preserved, `is_local_collision_mask` is restricted to USD (whose importer still synthesizes), so MJCF masks filter cross-entity pairs the way they do in MuJoCo.
- Carried by name rather than body index because the parser's MuJoCo body indices need not survive scene construction; resolved against the built links on the build-time host path. No kernel change.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3267

## Motivation and Context

Any MJCF declaring at least one `exclude` has ALL of its masks rewritten by the entity-local solve, and the rewritten bits are not constrained to preserve their meaning against other entities.. Measured on the model in the linked issue, against a 1/1 ground: a sphere authored 1/1 came back 2/2 and a 2/2 one came back 0/1, with the exclusion naming neither of them. This is also why MJCF masks had
to be ignored across entities, so an MJCF that masks a geom off the floor cannot be reproduced today.

BEHAVIOUR CHANGE: contype / conaffinity on an MJCF entity now filter cross-entity pairs. Assets using only the default 1/1 are unaffected. For a model with exclusions, pairs the authored masks forbid stay forbidden by those masks, and the exclusions stay forbidden by the list.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_collision.py::test_mjcf_authored_masks_and_contact_exclude` (n_envs 0 and 2). Four checks, a control per mechanism: a 1/1 sphere touches a 1/1 ground while a 2/2 one does not (mask filtering, and that it was not "fixed" by disabling filtering); the excluded pair produces no contact while an identical non-excluded pair does (exclusion, and that it does not over-block). On main it fails at the first mask readback: actual (2, 2), desired (1, 1). `tests/rigid` run before and after: identical outcomes apart from the new test.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the documentation accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.