### PR TITLE
[BUG FIX] Apply the per-geom density in MJCF asset.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1009,11 +1009,6 @@ class KinematicEntity(Entity):
                 # and estimated masses would make the anchor density-dependent, and a kinematic entity has no density
                 # to fall back on, so alignment could differ from the rigid counterpart. Require all-or-none and raise
                 # otherwise.
-                if None in mass_explicit:
-                    gs.raise_exception(
-                        f"Entity '{self.uid}': a link of an aligned free body mixes geoms with and without an "
-                        "authored density. Author a density on all of its geoms or none of them."
-                    )
                 if len(mass_explicit) > 1:
                     gs.raise_exception(
                         f"Entity '{self.uid}': an aligned free body mixes explicit (mass or authored per-geom "
@@ -1315,13 +1310,19 @@ class KinematicEntity(Entity):
     ):
         """Compute a link's load-time inertial data (see 'LinkInertialInfo').
 
-        The align-anchor inertial weighs each collision geom by its authored density, falling back to unit density,
-        so it never needs the material density - which a kinematic entity does not have. The geometry hint consumed
-        by 'RigidLink._build' uses the resolved material density as fallback instead, and falls back to the visual
-        geoms for a link without collision geometry.
+        The align-anchor inertial weighs each collision geom by its authored density, falling back to the default
+        density, so a link mixing authored and unauthored geoms still composes at the right relative weights. The
+        anchor never needs the material density - which a kinematic entity does not have - because a material that
+        states one drops every authored density (see '_add_by_info'), leaving the anchor density-independent. The
+        geometry hint consumed by 'RigidLink._build' uses the resolved material density instead, and falls back to
+        the visual geoms for a link without collision geometry.
         """
+        if self._solver._enable_mujoco_compatibility:
+            rho_default = RHO_MUJOCO
+        else:
+            rho_default = RHO_ROBOT if is_robot else RHO_OBJECT
         if cg_infos:
-            hint = compose_inertial_from_g_infos(cg_infos, rho=1.0)
+            hint = compose_inertial_from_g_infos(cg_infos, rho=rho_default)
         else:
             hint = InertialProperties(0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float))
         props = finalize_inertial(
@@ -1330,22 +1331,13 @@ class KinematicEntity(Entity):
         if explicit_mass is not None and explicit_mass > 0.0:
             is_mass_explicit = True
         else:
-            geoms_with_density = sum(g_info.get("density") is not None for g_info in cg_infos)
-            if geoms_with_density == 0:
-                is_mass_explicit = False
-            elif geoms_with_density == len(cg_infos):
-                is_mass_explicit = True
-            else:
-                is_mass_explicit = None
+            # A geom the asset weighs is anchored at that weight, and one it does not is anchored at the default the
+            # dynamics falls back on too, so any link the asset weighs at all anchors at its own dynamics mass.
+            is_mass_explicit = any(g_info.get("density") is not None for g_info in cg_infos)
 
         dynamics_hint = None
         if isinstance(self.material, gs.materials.Rigid):
-            rho = self.material.rho
-            if rho is None:
-                if self._solver._enable_mujoco_compatibility:
-                    rho = RHO_MUJOCO
-                else:
-                    rho = RHO_ROBOT if is_robot else RHO_OBJECT
+            rho = self.material.rho if self.material.rho is not None else rho_default
             hint_g_infos = cg_infos if cg_infos else vg_infos
             if hint_g_infos:
                 dynamics_hint = compose_inertial_from_g_infos(hint_g_infos, rho)

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1238,6 +1238,7 @@ class KinematicEntity(Entity):
         if isinstance(self.material, gs.materials.Rigid) and self.material.rho is not None:
             for g_info in g_infos:
                 g_info.pop("density", None)
+                g_info.pop("mass", None)
 
         cg_infos, vg_infos = [], []
         for g_info in g_infos:
@@ -1333,7 +1334,9 @@ class KinematicEntity(Entity):
         else:
             # A geom the asset weighs is anchored at that weight, and one it does not is anchored at the default the
             # dynamics falls back on too, so any link the asset weighs at all anchors at its own dynamics mass.
-            is_mass_explicit = any(g_info.get("density") is not None for g_info in cg_infos)
+            is_mass_explicit = any(
+                g_info.get("density") is not None or g_info.get("mass") is not None for g_info in cg_infos
+            )
 
         dynamics_hint = None
         if isinstance(self.material, gs.materials.Rigid):
@@ -1341,6 +1344,10 @@ class KinematicEntity(Entity):
             hint_g_infos = cg_infos if cg_infos else vg_infos
             if hint_g_infos:
                 dynamics_hint = compose_inertial_from_g_infos(hint_g_infos, rho)
+                # Collision geoms stating a zero mass leave nothing to weigh, so the visual geoms stand in as they
+                # do for a link carrying no collision geometry at all.
+                if dynamics_hint.mass <= gs.EPS and hint_g_infos is not vg_infos and vg_infos:
+                    dynamics_hint = compose_inertial_from_g_infos(vg_infos, rho)
             else:
                 dynamics_hint = InertialProperties(
                     0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float)

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -179,14 +179,13 @@ class LinkInertialInfo(NamedTuple):
 
     Computed while the parsed geom infos (and their authored per-geom densities) are still available, and consumed
     by the post-load passes. 'props' feeds the align anchor. 'is_mass_explicit' feeds the all-or-none source check
-    in '_align_free_roots': True when the mass is explicit in the asset (an explicit mass, or an authored density on
-    every geom), False for a pure geometry estimate (the true mass is a uniform material-density rescale of it), and
-    None when the link mixes geoms with and without an authored density (neither explicit nor uniformly rescalable).
+    in '_align_free_roots': True when the asset weighs the link (an explicit mass, or a density on any of its geoms),
+    False for a pure geometry estimate, whose true mass is a uniform material-density rescale of it.
     'hint' is the material-density-resolved geometry estimate consumed by 'RigidLink._build' (None for kinematic
     entities, which have no dynamics)."""
 
     props: LinkInertial
-    is_mass_explicit: bool | None
+    is_mass_explicit: bool
     hint: InertialProperties | None
 
 

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -146,20 +146,28 @@ def compose_inertial_from_g_infos(g_infos: Sequence[dict], rho: float) -> Inerti
     g_infos : list[dict]
         Parsed geom infos to compute inertial from.
     rho : float
-        Material density (kg/m^3), used for every geom info without its own authored density.
+        Material density (kg/m^3), used for every geom info that states neither a mass nor a density of its own.
     """
-    geoms_inertial_info = tuple(
-        GeomInertialInfo(
-            get_local_inertial_from_geom_info(
-                {"type": gs.GEOM_TYPE.MESH, "mesh": g_info["vmesh"]} if "vmesh" in g_info else g_info,
-                rho if g_info.get("density") is None else g_info["density"],
-            ),
-            np.asarray(g_info.get("pos", gu.zero_pos()), dtype=gs.np_float),
-            np.asarray(g_info.get("quat", gu.identity_quat()), dtype=gs.np_float),
+    geoms_inertial_info = []
+    for g_info in g_infos:
+        info = {"type": gs.GEOM_TYPE.MESH, "mesh": g_info["vmesh"]} if "vmesh" in g_info else g_info
+        geom_mass = g_info.get("mass")
+        if geom_mass is None:
+            props = get_local_inertial_from_geom_info(info, rho if g_info.get("density") is None else g_info["density"])
+        else:
+            # Unit density yields the volume as the mass, and both scale linearly with it, so a stated mass rescales
+            # them exactly. A volume-less geom (a plane) weighs nothing whatever it states.
+            props = get_local_inertial_from_geom_info(info, 1.0)
+            if props.mass > gs.EPS:
+                props = InertialProperties(geom_mass, props.com, props.i * (geom_mass / props.mass))
+        geoms_inertial_info.append(
+            GeomInertialInfo(
+                props,
+                np.asarray(g_info.get("pos", gu.zero_pos()), dtype=gs.np_float),
+                np.asarray(g_info.get("quat", gu.identity_quat()), dtype=gs.np_float),
+            )
         )
-        for g_info in g_infos
-    )
-    return compose_inertial_properties(geoms_inertial_info)
+    return compose_inertial_properties(tuple(geoms_inertial_info))
 
 
 class LinkInertial(NamedTuple):

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -507,6 +507,7 @@ def postprocess_collision_geoms(
         geom_type = g_info.get("type")
         friction = g_info.get("friction")
         density = g_info.get("density")
+        geom_mass = g_info.get("mass")
         sol_params = g_info.get("sol_params")
         key_parts += [
             np.ascontiguousarray(mesh.verts),
@@ -516,6 +517,7 @@ def postprocess_collision_geoms(
             int(g_info.get("conaffinity", 0)),
             float("nan") if friction is None else float(friction),
             float("nan") if density is None else float(density),
+            float("nan") if geom_mass is None else float(geom_mass),
             np.zeros(0) if sol_params is None else np.ascontiguousarray(sol_params, dtype=np.float64),
             np.ascontiguousarray(g_info.get("pos", gu.zero_pos()), dtype=np.float64),
             np.ascontiguousarray(g_info.get("quat", gu.identity_quat()), dtype=np.float64),
@@ -679,6 +681,10 @@ def _postprocess_collision_geoms_impl(
                     first_g_info = g_infos[fusion_group[0]]
                     if (
                         first_g_info["type"] not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN)
+                        # A fused geom carries one mass at most, which cannot stand for what several stated, so a
+                        # geom stating its own mass never joins a group.
+                        and first_g_info.get("mass") is None
+                        and g_info.get("mass") is None
                         and all(first_g_info.get(name) == g_info.get(name) for name in ("contype", "conaffinity"))
                         and all(
                             np.allclose(first_g_info.get(name, np.nan), g_info.get(name, np.nan), equal_nan=True)
@@ -799,7 +805,15 @@ def _postprocess_collision_geoms_impl(
                     )
                     for tmesh in tmeshes
                 ]
-                _g_infos += [{**g_info, **dict(mesh=mesh)} for mesh in meshes]
+                hull_infos = [{**g_info, **dict(mesh=mesh)} for mesh in meshes]
+                geom_mass = g_info.get("mass")
+                if geom_mass is not None:
+                    # A stated mass is extensive, so each hull takes the share of it that its volume represents.
+                    volumes = np.array([mesh.trimesh.volume for mesh in meshes])
+                    volume_total = volumes.sum()
+                    for hull_info, volume in zip(hull_infos, volumes):
+                        hull_info["mass"] = geom_mass * volume / volume_total if volume_total > gs.EPS else 0.0
+                _g_infos += hull_infos
             else:
                 _g_infos.append(g_info)
         g_infos = _g_infos

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -3,6 +3,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from itertools import chain
 from bisect import bisect_right
+from typing import NamedTuple
 
 # Note the importing mujoco with env var `MUJOCO_GL=EGL` forcibly defines `PYOPENGL_PLATFORM=egl`
 import mujoco
@@ -22,6 +23,19 @@ from .misc import get_assets_dir, redirect_libc_stderr
 
 
 MIN_TIMECONST = np.finfo(np.double).eps
+# Mujoco resolves every geom's density, so a geom authoring this value is indistinguishable from one authoring none.
+MUJOCO_DEFAULT_DENSITY = 1000.0
+
+
+class MjcfModel(NamedTuple):
+    """A compiled Mujoco model and the geom densities the asset authored, indexed by geom id.
+
+    The compiled model folds the density into the body mass, so it is read off the spec while still available.
+    'geoms_density' holds None wherever the asset left the density to Mujoco's default.
+    """
+
+    model: mujoco.MjModel
+    geoms_density: tuple[float | None, ...]
 
 
 def get_model_name(file_path):
@@ -225,7 +239,13 @@ def build_model(
         with open(os.devnull, "w") as stderr, redirect_libc_stderr(stderr):
             # Parse updated URDF file as a string
             data = ET.tostring(root, encoding="utf8")
-            mj = mujoco.MjModel.from_xml_string(data)
+            # Compiling through the spec keeps the authored densities reachable, its geom ids matching the model's.
+            spec = mujoco.MjSpec.from_string(data)
+            mj = spec.compile()
+            geoms_density = [None] * mj.ngeom
+            for spec_geom in spec.geoms:
+                if spec_geom.density != MUJOCO_DEFAULT_DENSITY:
+                    geoms_density[spec_geom.id] = spec_geom.density
 
             # Special treatment for URDF
             if is_urdf_file:
@@ -242,11 +262,12 @@ def build_model(
                 mj.geom_solref[:, 0] = MIN_TIMECONST
                 mj.eq_solref[:, 0] = MIN_TIMECONST
     elif isinstance(xml, mujoco.MjModel):
-        mj = xml
+        # An already-compiled model has no spec to read the authored densities from.
+        mj, geoms_density = xml, [None] * xml.ngeom
     else:
         gs.raise_exception(f"'{xml}' is not a valid MJCF or URDF file.")
 
-    return mj
+    return MjcfModel(mj, tuple(geoms_density))
 
 
 def parse_xml(morph, surface, rigid_options=None):
@@ -258,7 +279,7 @@ def parse_xml(morph, surface, rigid_options=None):
 
     # Build model from XML (either URDF or MJCF)
     exclude_ground_plane = isinstance(morph, gs.morphs.MJCF) and morph.exclude_ground_plane
-    mj = build_model(
+    mj, geoms_density = build_model(
         morph.file,
         not morph.visualization,
         morph.default_armature,
@@ -273,7 +294,7 @@ def parse_xml(morph, surface, rigid_options=None):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
+    links_g_infos = parse_geoms(mj, geoms_density, morph.scale, surface, morph.file)
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -517,7 +538,7 @@ def parse_links(mj, scale):
     return l_infos, j_infos
 
 
-def parse_geom(mj, i_g, scale, surface, xml_path):
+def parse_geom(mj, i_g, geom_density, scale, surface, xml_path):
     mj_geom = mj.geom(i_g)
 
     geom_size = mj_geom.size
@@ -740,6 +761,9 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
         "friction_rolling": mj_geom.friction[2] if mj_geom.condim[0] >= 6 else 0.0,
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
+    # Consumers read an absent key as 'no authored density', so an unauthored geom must not carry the key at all.
+    if geom_density is not None:
+        info["density"] = geom_density
     if is_col:
         info["mesh"] = mesh
     else:
@@ -748,7 +772,7 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, scale, surface, xml_path):
+def parse_geoms(mj, geoms_density, scale, surface, xml_path):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
@@ -758,7 +782,7 @@ def parse_geoms(mj, scale, surface, xml_path):
             continue
 
         # try parsing a given geometry
-        g_info = parse_geom(mj, i_g, scale, surface, xml_path)
+        g_info = parse_geom(mj, i_g, geoms_density[i_g], scale, surface, xml_path)
         if g_info is None:
             continue
 

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -27,15 +27,22 @@ MIN_TIMECONST = np.finfo(np.double).eps
 MUJOCO_DEFAULT_DENSITY = 1000.0
 
 
-class MjcfModel(NamedTuple):
-    """A compiled Mujoco model and the geom densities the asset authored, indexed by geom id.
+class GeomMassSource(NamedTuple):
+    """What a geom states about its own mass, as the two alternatives Mujoco accepts. Both None when it states
+    nothing, and 'mass' wins over 'density' where the asset gives both, as it does for Mujoco."""
 
-    The compiled model folds the density into the body mass, so it is read off the spec while still available.
-    'geoms_density' holds None wherever the asset left the density to Mujoco's default.
+    density: float | None
+    mass: float | None
+
+
+class MjcfModel(NamedTuple):
+    """A compiled Mujoco model and what each of its geoms states about its mass, indexed by geom id.
+
+    The compiled model folds both into the body mass, so they are read off the spec while still available.
     """
 
     model: mujoco.MjModel
-    geoms_density: tuple[float | None, ...]
+    geoms_mass_source: tuple[GeomMassSource, ...]
 
 
 def get_model_name(file_path):
@@ -242,10 +249,12 @@ def build_model(
             # Compiling through the spec keeps the authored densities reachable, its geom ids matching the model's.
             spec = mujoco.MjSpec.from_string(data)
             mj = spec.compile()
-            geoms_density = [None] * mj.ngeom
+            geoms_mass_source = [GeomMassSource(None, None)] * mj.ngeom
             for spec_geom in spec.geoms:
-                if spec_geom.density != MUJOCO_DEFAULT_DENSITY:
-                    geoms_density[spec_geom.id] = spec_geom.density
+                # Mujoco leaves the mass NaN unless the geom states one, and resolves the density either way.
+                geom_mass = None if np.isnan(spec_geom.mass) else spec_geom.mass
+                geom_density = spec_geom.density if spec_geom.density != MUJOCO_DEFAULT_DENSITY else None
+                geoms_mass_source[spec_geom.id] = GeomMassSource(geom_density, geom_mass)
 
             # Special treatment for URDF
             if is_urdf_file:
@@ -262,12 +271,12 @@ def build_model(
                 mj.geom_solref[:, 0] = MIN_TIMECONST
                 mj.eq_solref[:, 0] = MIN_TIMECONST
     elif isinstance(xml, mujoco.MjModel):
-        # An already-compiled model has no spec to read the authored densities from.
-        mj, geoms_density = xml, [None] * xml.ngeom
+        # An already-compiled model has no spec to read what its geoms state from.
+        mj, geoms_mass_source = xml, [GeomMassSource(None, None)] * xml.ngeom
     else:
         gs.raise_exception(f"'{xml}' is not a valid MJCF or URDF file.")
 
-    return MjcfModel(mj, tuple(geoms_density))
+    return MjcfModel(mj, tuple(geoms_mass_source))
 
 
 def parse_xml(morph, surface, rigid_options=None):
@@ -279,7 +288,7 @@ def parse_xml(morph, surface, rigid_options=None):
 
     # Build model from XML (either URDF or MJCF)
     exclude_ground_plane = isinstance(morph, gs.morphs.MJCF) and morph.exclude_ground_plane
-    mj, geoms_density = build_model(
+    mj, geoms_mass_source = build_model(
         morph.file,
         not morph.visualization,
         morph.default_armature,
@@ -294,7 +303,7 @@ def parse_xml(morph, surface, rigid_options=None):
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, geoms_density, morph.scale, surface, morph.file)
+    links_g_infos = parse_geoms(mj, geoms_mass_source, morph.scale, surface, morph.file)
 
     # Parse all bodies (links and joints)
     l_infos, links_j_infos = parse_links(mj, morph.scale)
@@ -538,7 +547,7 @@ def parse_links(mj, scale):
     return l_infos, j_infos
 
 
-def parse_geom(mj, i_g, geom_density, scale, surface, xml_path):
+def parse_geom(mj, i_g, geom_mass_source, scale, surface, xml_path):
     mj_geom = mj.geom(i_g)
 
     geom_size = mj_geom.size
@@ -761,9 +770,12 @@ def parse_geom(mj, i_g, geom_density, scale, surface, xml_path):
         "friction_rolling": mj_geom.friction[2] if mj_geom.condim[0] >= 6 else 0.0,
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
-    # Fusion grouping diffs the key against a nan default when it is absent, so a None would raise instead.
-    if geom_density is not None:
-        info["density"] = geom_density
+    # Fusion grouping diffs these keys against a nan default when absent, so a None would raise instead.
+    if geom_mass_source.density is not None:
+        info["density"] = geom_mass_source.density
+    if geom_mass_source.mass is not None:
+        # A density needs no scaling, whereas a stated mass tracks the volume the morph scale gives the geom.
+        info["mass"] = geom_mass_source.mass * scale**3
     if is_col:
         info["mesh"] = mesh
     else:
@@ -772,7 +784,7 @@ def parse_geom(mj, i_g, geom_density, scale, surface, xml_path):
     return info
 
 
-def parse_geoms(mj, geoms_density, scale, surface, xml_path):
+def parse_geoms(mj, geoms_mass_source, scale, surface, xml_path):
     links_g_info = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
@@ -782,7 +794,7 @@ def parse_geoms(mj, geoms_density, scale, surface, xml_path):
             continue
 
         # try parsing a given geometry
-        g_info = parse_geom(mj, i_g, geoms_density[i_g], scale, surface, xml_path)
+        g_info = parse_geom(mj, i_g, geoms_mass_source[i_g], scale, surface, xml_path)
         if g_info is None:
             continue
 

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -761,7 +761,7 @@ def parse_geom(mj, i_g, geom_density, scale, surface, xml_path):
         "friction_rolling": mj_geom.friction[2] if mj_geom.condim[0] >= 6 else 0.0,
         "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
     }
-    # Consumers read an absent key as 'no authored density', so an unauthored geom must not carry the key at all.
+    # Fusion grouping diffs the key against a nan default when it is absent, so a None would raise instead.
     if geom_density is not None:
         info["density"] = geom_density
     if is_col:

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -437,11 +437,11 @@ def joint_with_partial_dynamics(joint_damping, joint_friction):
 
 
 @pytest.fixture(scope="session")
-def authored_geom_density_mjcf():
+def authored_geom_mass_mjcf():
     """Generate an MJCF whose identical boxes state their mass as a geom density, a default-class density, a geom
     mass, and not at all, beside bodies pairing a stated geom with an unstated one, fusing two stated masses, and
     leaving a weightless collision geom beside a visual one."""
-    mjcf = ET.Element("mujoco", model="authored_geom_density")
+    mjcf = ET.Element("mujoco", model="authored_geom_mass")
     default = ET.SubElement(mjcf, "default")
     ET.SubElement(ET.SubElement(default, "default", {"class": "light"}), "geom", density="100")
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -438,8 +438,9 @@ def joint_with_partial_dynamics(joint_damping, joint_friction):
 
 @pytest.fixture(scope="session")
 def authored_geom_density_mjcf():
-    """Generate an MJCF whose three identical boxes take their density from the geom, a default class, and nothing,
-    beside a fourth body pairing a stated geom with an unstated one."""
+    """Generate an MJCF whose identical boxes state their mass as a geom density, a default-class density, a geom
+    mass, and not at all, beside bodies pairing a stated geom with an unstated one, fusing two stated masses, and
+    leaving a weightless collision geom beside a visual one."""
     mjcf = ET.Element("mujoco", model="authored_geom_density")
     default = ET.SubElement(mjcf, "default")
     ET.SubElement(ET.SubElement(default, "default", {"class": "light"}), "geom", density="100")
@@ -448,6 +449,7 @@ def authored_geom_density_mjcf():
     for name, attrib in (
         ("on_geom", dict(density="250")),
         ("on_class", {"class": "light"}),
+        ("on_mass", dict(mass="5")),
         ("unstated", {}),
     ):
         body = ET.SubElement(worldbody, "body", name=name, pos="0.0 0.0 1.0")
@@ -458,6 +460,25 @@ def authored_geom_density_mjcf():
     ET.SubElement(mixed, "freejoint")
     ET.SubElement(mixed, "geom", type="box", size="0.1 0.1 0.1", pos="-0.3 0.0 0.0", density="250")
     ET.SubElement(mixed, "geom", type="box", size="0.1 0.1 0.1", pos="0.3 0.0 0.0")
+
+    # A stated mass is extensive, so these two must survive the geom fusion that a shared mass source invites.
+    fused = ET.SubElement(worldbody, "body", name="fused", pos="0.0 0.0 1.0")
+    ET.SubElement(fused, "freejoint")
+    ET.SubElement(fused, "geom", type="box", size="0.1 0.1 0.1", pos="-0.3 0.0 0.0", mass="5")
+    ET.SubElement(fused, "geom", type="box", size="0.1 0.1 0.1", pos="0.3 0.0 0.0", mass="5")
+
+    # Convex decomposition splits one stated mass across the hulls it produces.
+    asset = ET.SubElement(mjcf, "asset")
+    ET.SubElement(asset, "mesh", name="bunny", file=os.path.join(get_assets_dir(), "meshes/bunny.obj"))
+    decomposed = ET.SubElement(worldbody, "body", name="decomposed", pos="0.0 0.0 1.0")
+    ET.SubElement(decomposed, "freejoint")
+    ET.SubElement(decomposed, "geom", type="mesh", mesh="bunny", mass="5")
+
+    # A collision geom weighing nothing leaves the visual geom to carry the link.
+    weightless = ET.SubElement(worldbody, "body", name="weightless", pos="0.0 0.0 1.0")
+    ET.SubElement(weightless, "freejoint")
+    ET.SubElement(weightless, "geom", type="box", size="0.1 0.1 0.1", mass="0")
+    ET.SubElement(weightless, "geom", type="box", size="0.1 0.1 0.1", contype="0", conaffinity="0")
     return ET.tostring(mjcf, encoding="unicode")
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -437,6 +437,25 @@ def joint_with_partial_dynamics(joint_damping, joint_friction):
 
 
 @pytest.fixture(scope="session")
+def authored_geom_density_mjcf():
+    """Generate an MJCF whose three identical boxes take their density from the geom, a default class, and nothing."""
+    mjcf = ET.Element("mujoco", model="authored_geom_density")
+    default = ET.SubElement(mjcf, "default")
+    ET.SubElement(ET.SubElement(default, "default", {"class": "light"}), "geom", density="100")
+
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    for name, attrib in (
+        ("on_geom", dict(density="250")),
+        ("on_class", {"class": "light"}),
+        ("unstated", {}),
+    ):
+        body = ET.SubElement(worldbody, "body", name=name, pos="0.0 0.0 1.0")
+        ET.SubElement(body, "freejoint")
+        ET.SubElement(body, "geom", type="box", size="0.1 0.1 0.1", **attrib)
+    return ET.tostring(mjcf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
 def undefined_inertia():
     """Generate a URDF with a single link that has no inertial element."""
     urdf = ET.Element("robot", name="undefined_inertia")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -438,7 +438,8 @@ def joint_with_partial_dynamics(joint_damping, joint_friction):
 
 @pytest.fixture(scope="session")
 def authored_geom_density_mjcf():
-    """Generate an MJCF whose three identical boxes take their density from the geom, a default class, and nothing."""
+    """Generate an MJCF whose three identical boxes take their density from the geom, a default class, and nothing,
+    beside a fourth body pairing a stated geom with an unstated one."""
     mjcf = ET.Element("mujoco", model="authored_geom_density")
     default = ET.SubElement(mjcf, "default")
     ET.SubElement(ET.SubElement(default, "default", {"class": "light"}), "geom", density="100")
@@ -452,6 +453,11 @@ def authored_geom_density_mjcf():
         body = ET.SubElement(worldbody, "body", name=name, pos="0.0 0.0 1.0")
         ET.SubElement(body, "freejoint")
         ET.SubElement(body, "geom", type="box", size="0.1 0.1 0.1", **attrib)
+
+    mixed = ET.SubElement(worldbody, "body", name="mixed", pos="0.0 0.0 1.0")
+    ET.SubElement(mixed, "freejoint")
+    ET.SubElement(mixed, "geom", type="box", size="0.1 0.1 0.1", pos="-0.3 0.0 0.0", density="250")
+    ET.SubElement(mixed, "geom", type="box", size="0.1 0.1 0.1", pos="0.3 0.0 0.0")
     return ET.tostring(mjcf, encoding="unicode")
 
 

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -236,6 +236,7 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
         morph=gs.morphs.MJCF(
             file=authored_geom_density_mjcf,
             recompute_inertia=True,
+            align=True,
         ),
     )
     scene.build()
@@ -246,6 +247,15 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
     # The geom stating nothing takes the density Genesis resolves for a non-robot entity, which pins that an
     # unauthored geom keeps falling back rather than picking up Mujoco's own default of 1000.
     assert_allclose(masses["unstated"], 600.0 * VOLUME, tol=gs.EPS)
+    assert_allclose(masses["mixed"], (250.0 + 600.0) * VOLUME, tol=gs.EPS)
+
+    # Anchoring a free root puts its frame on the composite center of mass, so the geoms of the mixed body must sit
+    # at first moments that cancel. They only do if the stated geom is weighed apart from the unstated one.
+    mixed_link = entity.get_link("mixed")
+    first_moment = sum(
+        density * VOLUME * np.asarray(geom.init_pos) for density, geom in zip((250.0, 600.0), mixed_link.geoms)
+    )
+    assert_allclose(first_moment, 0.0, tol=1e-6)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -220,7 +220,7 @@ def test_urdf_parsing(show_viewer, tol):
 
 
 @pytest.mark.required
-def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
+def test_mjcf_authored_geom_mass(authored_geom_mass_mjcf, show_viewer):
     # An authored density, on the geom or inherited from a default class, is what a recomputed inertial must weigh.
     HALF_EXTENT = 0.1
     VOLUME = (2.0 * HALF_EXTENT) ** 3
@@ -234,7 +234,7 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
     )
     entity = scene.add_entity(
         morph=gs.morphs.MJCF(
-            file=authored_geom_density_mjcf,
+            file=authored_geom_mass_mjcf,
             recompute_inertia=True,
             align=True,
             convexify=False,
@@ -244,7 +244,7 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
     # body is loaded a second time under it.
     entity_decomposed = scene.add_entity(
         morph=gs.morphs.MJCF(
-            file=authored_geom_density_mjcf,
+            file=authored_geom_mass_mjcf,
             recompute_inertia=True,
             align=True,
         ),

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -236,7 +236,6 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
         morph=gs.morphs.MJCF(
             file=authored_geom_density_mjcf,
             recompute_inertia=True,
-            align=False,
         ),
     )
     scene.build()
@@ -244,8 +243,9 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
     masses = {link.name: link.inertial_mass for link in entity.links}
     assert_allclose(masses["on_geom"], 250.0 * VOLUME, tol=gs.EPS)
     assert_allclose(masses["on_class"], 100.0 * VOLUME, tol=gs.EPS)
-    # The geom stating nothing takes the density Genesis resolves for the entity, which the authored ones displace.
-    assert masses["unstated"] not in (masses["on_geom"], masses["on_class"])
+    # The geom stating nothing takes the density Genesis resolves for a non-robot entity, which pins that an
+    # unauthored geom keeps falling back rather than picking up Mujoco's own default of 1000.
+    assert_allclose(masses["unstated"], 600.0 * VOLUME, tol=gs.EPS)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -219,6 +219,35 @@ def test_urdf_parsing(show_viewer, tol):
     _check_entity_positions(POS_OFFSET, tol=2e-3)
 
 
+@pytest.mark.required
+def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
+    # An authored density, on the geom or inherited from a default class, is what a recomputed inertial must weigh.
+    HALF_EXTENT = 0.1
+    VOLUME = (2.0 * HALF_EXTENT) ** 3
+
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.5, -1.5, 1.5),
+            camera_lookat=(0.0, 0.0, 1.0),
+        ),
+        show_viewer=show_viewer,
+    )
+    entity = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=authored_geom_density_mjcf,
+            recompute_inertia=True,
+            align=False,
+        ),
+    )
+    scene.build()
+
+    masses = {link.name: link.inertial_mass for link in entity.links}
+    assert_allclose(masses["on_geom"], 250.0 * VOLUME, tol=gs.EPS)
+    assert_allclose(masses["on_class"], 100.0 * VOLUME, tol=gs.EPS)
+    # The geom stating nothing takes the density Genesis resolves for the entity, which the authored ones displace.
+    assert masses["unstated"] not in (masses["on_geom"], masses["on_class"])
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_urdf_parsing_inertia_defaults(

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -237,6 +237,16 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
             file=authored_geom_density_mjcf,
             recompute_inertia=True,
             align=True,
+            convexify=False,
+        ),
+    )
+    # Fusion needs the convex path off, while splitting a stated mass across hulls needs it on, so the decomposed
+    # body is loaded a second time under it.
+    entity_decomposed = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=authored_geom_density_mjcf,
+            recompute_inertia=True,
+            align=True,
         ),
     )
     scene.build()
@@ -244,10 +254,18 @@ def test_mjcf_authored_geom_density(authored_geom_density_mjcf, show_viewer):
     masses = {link.name: link.inertial_mass for link in entity.links}
     assert_allclose(masses["on_geom"], 250.0 * VOLUME, tol=gs.EPS)
     assert_allclose(masses["on_class"], 100.0 * VOLUME, tol=gs.EPS)
+    assert_allclose(masses["on_mass"], 5.0, tol=gs.EPS)
     # The geom stating nothing takes the density Genesis resolves for a non-robot entity, which pins that an
     # unauthored geom keeps falling back rather than picking up Mujoco's own default of 1000.
     assert_allclose(masses["unstated"], 600.0 * VOLUME, tol=gs.EPS)
     assert_allclose(masses["mixed"], (250.0 + 600.0) * VOLUME, tol=gs.EPS)
+    # A stated mass is extensive: fusing the two boxes would weigh the body at one of them.
+    assert_allclose(masses["fused"], 10.0, tol=gs.EPS)
+    assert_allclose(masses["weightless"], 600.0 * VOLUME, tol=gs.EPS)
+    # Every hull takes a share of the one stated mass, so together they still weigh exactly it.
+    decomposed_link = entity_decomposed.get_link("decomposed")
+    assert len(decomposed_link.geoms) > 1
+    assert_allclose(decomposed_link.inertial_mass, 5.0, tol=1e-6)
 
     # Anchoring a free root puts its frame on the composite center of mass, so the geoms of the mixed body must sit
     # at first moments that cancel. They only do if the stated geom is weighed apart from the unstated one.

--- a/tests/utils/simulators.py
+++ b/tests/utils/simulators.py
@@ -46,7 +46,7 @@ def build_mujoco_sim(
         asset_path = get_hf_dataset(pattern=xml_path)
         file = os.path.join(asset_path, xml_path)
 
-    model = mju.build_model(
+    model, _ = mju.build_model(
         file, discard_visual=True, default_armature=None, merge_fixed_links=merge_fixed_links, links_to_keep=()
     )
 


### PR DESCRIPTION
## Description

- Apply `density` and `mass` from MJCF geom
- A collision geom weighing nothing leaves the visual geoms to carry the link, as they already do
  for a link with no collision geometry.
- The align anchor now weighs an unstated geom at the default density rather than unit density,
  so a link mixing stated and unstated geoms anchors at the right relative weights instead of
  being rejected as ambiguous.

With `recompute_inertia=True` this PR affects assets that author the Gym-style `density="5"`: `xml/ant.xml` 97.33 -> 0.324 kg (Mujoco: 0.327), `xml/one_tet.xml` 1600 -> 13.3, `xml/thin_box.xml` 0.0096 -> 8e-05. Default options are unaffected: link masses are same on MJCFs with `recompute_inertia=False`.

## Related Issue

## Motivation and Context

An asset that states what its geoms are made of should be weighed by it whenever Genesis computes the mass itself.

## How Has This Been / Can This Be Tested?

- `tests/rigid tests/parsers`
- `tests/rigid/test_asset_loading.py::test_mjcf_authored_geom_density`

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
