### PR TITLE
[CHANGING][MISC] Estimate link inertia from visual geometry.

### DIFF
--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -18,6 +18,7 @@ from typing import Any, Sequence, TypeVar
 
 import numpy as np
 import trimesh
+from scipy.spatial import QhullError
 from typing_extensions import Self
 
 import genesis as gs
@@ -50,10 +51,16 @@ from .inertial import (
     compose_inertial_from_g_infos,
     compose_inertial_properties,
     finalize_inertial,
+    select_mass_bearing_g_infos,
 )
 
 # Rounding a pose parsed from a file may carry, within which it reads as the identity
 POSE_EPS = 1e-9
+
+# Smallest share of its own convex hull that a closed wrap of a surface can enclose and still describe that surface.
+# A wrap sampled coarser than the walls it is closing drops them, leaving a sliver or an inverted scrap orders of
+# magnitude below this rather than merely a thin shell, so the exact value is not delicate.
+WRAP_MIN_HULL_RATIO = 1e-2
 
 
 @dataclass(kw_only=True)
@@ -66,9 +73,17 @@ class BaseRigidGeomDescription:
 
 @dataclass(kw_only=True)
 class RigidVisGeomDescription(BaseRigidGeomDescription):
-    """Describe one geometry a link is drawn with: where it sits on the link, and the mesh drawn there."""
+    """Describe one geometry a link is drawn with: where it sits on the link, the mesh drawn there, and the shape the
+    asset states it as.
+
+    An inertia estimated from this geometry is analytic wherever the shape is a primitive, so a link that starts
+    moving (see 'KinematicEntity.attach') estimates it exactly as the same asset does standing on its own. A
+    geometry the asset states no shape for is a mesh, the one it is drawn from.
+    """
 
     vmesh: "gs.Mesh"
+    type: GEOM_TYPE = GEOM_TYPE.MESH
+    data: np.ndarray | None = None
 
 
 @dataclass(kw_only=True)
@@ -495,6 +510,7 @@ class KinematicEntityDescription(EntityDescription):
                 variant_links = []
                 for i_link, (v_l_info, (cg_infos, vg_infos)) in enumerate(zip(v_l_infos, cg_vg_infos)):
                     inertial_info = self._resolve_inertial(
+                        morph,
                         None if is_inertia_recomputed else v_l_info.get("inertial_mass"),
                         None if is_inertia_recomputed else v_l_info.get("inertial_pos"),
                         None if is_inertia_recomputed else v_l_info.get("inertial_quat"),
@@ -532,7 +548,9 @@ class KinematicEntityDescription(EntityDescription):
                 offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
 
                 # Mesh/Primitive variants have no explicit inertial; the anchor inertia comes from their geometry.
-                inertial_info = self._resolve_inertial(None, None, None, None, cg_infos, vg_infos, False, resolution)
+                inertial_info = self._resolve_inertial(
+                    morph, None, None, None, None, cg_infos, vg_infos, False, resolution
+                )
                 resolution.links_inertial_info[0].append(inertial_info)
                 variant_link = self._describe_variant_link(0, None, cg_infos, vg_infos, morph, inertial_info)
 
@@ -1346,26 +1364,82 @@ class KinematicEntityDescription(EntityDescription):
         return cg_infos, vg_infos
 
     def _resolve_inertial(
-        self, explicit_mass, explicit_com, explicit_quat, explicit_inertia, cg_infos, vg_infos, is_robot, resolution
+        self,
+        morph,
+        explicit_mass,
+        explicit_com,
+        explicit_quat,
+        explicit_inertia,
+        cg_infos,
+        vg_infos,
+        is_robot,
+        resolution,
     ):
         """Compute a link's load-time inertial data (see 'LinkInertialInfo').
 
-        The align-anchor inertial weighs each collision geom by its authored density, falling back to unit density,
-        so it never needs the material density - which a kinematic entity does not have. The geometry hint consumed
-        by '_describe_link' uses the resolved material density as fallback instead, and falls back to the visual
-        geoms for a link without collision geometry.
+        The align-anchor inertial weighs each mass-bearing geom by its authored density, falling back to unit density,
+        so it never needs the material density - which a kinematic entity does not have. The geometry hint consumed by
+        '_describe_link' uses the resolved material density as fallback instead. Both compose the same geoms (see
+        'select_mass_bearing_g_infos'), so the anchor sits at the center of mass the dynamics inertia is built around.
         """
-        hint = compose_inertial_from_g_infos(cg_infos, rho=1.0)
+        is_file_morph = isinstance(morph, gs.options.morphs.FileMorph)
+        g_infos = select_mass_bearing_g_infos(cg_infos, vg_infos, is_file_morph and morph.inertia_from_visual)
+
+        # An open mesh encloses no volume, and 'Mesh.get_inertial_info' would fall back to its convex hull, which
+        # overestimates any concave shape. Wrapping it into a closed manifold first keeps the estimate faithful.
+        # Collision geoms arrive already closed from 'postprocess_collision_geoms'; visual ones - which assets rarely
+        # author watertight - are wrapped here, onto throwaway infos so the vgeom keeps rendering its own surface. The
+        # wrap costs seconds on a first load, so it is confined to links whose inertia is genuinely being estimated.
+        watertighten = morph.watertighten if is_file_morph else None
+        if g_infos is vg_infos and explicit_inertia is None:
+            wrapped = []
+            for g_info in g_infos:
+                tmesh = g_info["vmesh"].trimesh
+                # A visual info that names no type is a mesh, as 'compose_inertial_from_g_infos' reads it.
+                is_mesh = g_info.get("type", gs.GEOM_TYPE.MESH) == gs.GEOM_TYPE.MESH
+                # The hull bounding a surface is the reference both plausibility checks below judge it against. A
+                # geometry too degenerate to have one (fewer than 4 non-coplanar vertices) bounds no volume and so
+                # contributes nothing either way, exactly as 'Mesh.get_inertial_info' reports it.
+                hull_volume = 0.0
+                if is_mesh:
+                    try:
+                        hull_volume = tmesh.convex_hull.volume
+                    except QhullError:
+                        hull_volume = 0.0
+                # No solid encloses more than the hull that bounds it, so a mesh claiming to is not describing one -
+                # a doubled shell counts its interior twice, for instance. Its volume means nothing at any density,
+                # and unlike an open surface no wrap recovers it, so the link falls back to its collision geometry.
+                if hull_volume > 0.0 and abs(tmesh.volume) > hull_volume:
+                    wrapped = None
+                    break
+                if hull_volume == 0.0 or tmesh.is_watertight or tmesh.is_convex or watertighten is None:
+                    wrapped.append(g_info)
+                    continue
+                closed_tmesh = mu.watertighten_trimesh(tmesh, watertighten)
+                # A wrap that lost the walls it was closing describes nothing, and integrating it would leave the link
+                # all but massless, which is worse than the open mesh it replaces. Keep the authored mesh instead, whose
+                # own estimate stays bounded by the hull it sits in.
+                if closed_tmesh.volume < WRAP_MIN_HULL_RATIO * hull_volume:
+                    wrapped.append(g_info)
+                    continue
+                metadata = {**g_info["vmesh"].metadata, "watertightened": True}
+                wrapped.append({**g_info, "vmesh": gs.Mesh.from_trimesh(mesh=closed_tmesh, metadata=metadata)})
+            if wrapped is not None:
+                g_infos = wrapped
+            elif cg_infos:
+                g_infos = cg_infos
+
+        hint = compose_inertial_from_g_infos(g_infos, rho=1.0)
         props = finalize_inertial(
             explicit_mass, explicit_com, explicit_quat, explicit_inertia, *hint, clamp_min_mass=False
         )
         if explicit_mass is not None and explicit_mass > 0.0:
             is_mass_explicit = True
         else:
-            geoms_with_density = sum(g_info.get("density") is not None for g_info in cg_infos)
+            geoms_with_density = sum(g_info.get("density") is not None for g_info in g_infos)
             if geoms_with_density == 0:
                 is_mass_explicit = False
-            elif geoms_with_density == len(cg_infos):
+            elif geoms_with_density == len(g_infos):
                 is_mass_explicit = True
             else:
                 is_mass_explicit = None
@@ -1379,9 +1453,9 @@ class KinematicEntityDescription(EntityDescription):
                 else:
                     rho = RHO_ROBOT if is_robot else RHO_OBJECT
 
-            # The estimate comes from the collision geometry of the link when it has any, and from its visual
-            # geometry otherwise. A link with neither contributes nothing, so only the asset's values remain.
-            dynamics_hint = compose_inertial_from_g_infos(cg_infos or vg_infos, rho)
+            # The estimate comes from the geoms that carry the link's mass. A link with no geometry at all contributes
+            # nothing, so only the asset's values remain.
+            dynamics_hint = compose_inertial_from_g_infos(g_infos, rho)
         return LinkInertialInfo(props, is_mass_explicit, dynamics_hint)
 
     def _align_link(self, l_info, j_infos, cg_infos, vg_infos, morph, resolution: Resolution):
@@ -1399,6 +1473,7 @@ class KinematicEntityDescription(EntityDescription):
         # world-fixed, so it suffices to honor the morph flag here.
         is_inertia_recomputed = isinstance(morph, gs.options.morphs.FileMorph) and morph.recompute_inertia
         inertial_info = self._resolve_inertial(
+            morph,
             None if is_inertia_recomputed else l_info.get("inertial_mass"),
             None if is_inertia_recomputed else l_info.get("inertial_pos"),
             None if is_inertia_recomputed else l_info.get("inertial_quat"),
@@ -1431,11 +1506,12 @@ class KinematicEntityDescription(EntityDescription):
             # Auto: True for basic rigid objects (root with free joint only, no articulated descendants). A link
             # mixing geoms with and without an authored density (see 'LinkInertialInfo.is_mass_explicit') quietly
             # declines auto-alignment; asking for it with an explicit align=True raises at build instead.
-            geoms_with_density = sum(g_info.get("density") is not None for g_info in cg_infos)
+            density_g_infos = select_mass_bearing_g_infos(cg_infos, vg_infos, morph.inertia_from_visual)
+            geoms_with_density = sum(g_info.get("density") is not None for g_info in density_g_infos)
             is_aligned = (
                 not bool(l_info["is_robot"])
                 and all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
-                and geoms_with_density in (0, len(cg_infos))
+                and geoms_with_density in (0, len(density_g_infos))
             )
 
         # A free body opting into alignment (or any primitive, which is inherently principal-axis and COM-centered) has
@@ -1571,7 +1647,8 @@ class RigidEntityDescription(KinematicEntityDescription):
         if not is_fixed and inertial_info.hint is not None:
             hint = inertial_info.hint
 
-            # Compute the bounding box of the links using both visual and collision geometries to be conservative
+            # Bound the link with both its visual and collision geometry, so the box encloses the body however it
+            # is described and whichever description the estimate was composed from
             aabb_min = np.full((3,), float("inf"), dtype=gs.np_float)
             aabb_max = np.full((3,), float("-inf"), dtype=gs.np_float)
             for mesh, geom_pos, geom_quat in chain(
@@ -1632,8 +1709,8 @@ class RigidEntityDescription(KinematicEntityDescription):
         if mass is None or inertia is None:
             if not is_fixed and vg_infos and not cg_infos:
                 gs.logger.info(
-                    f"Mass is not specified and collision geoms can not be found for link '{l_info['name']}'. "
-                    f"Using visual geoms to compute inertial properties."
+                    f"Inertia is not specified and collision geoms can not be found for link '{l_info['name']}'. "
+                    f"Estimating the inertial properties from its visual geoms."
                 )
             # The parsed inverse weight matches the inertia the asset declares. The inertia recomputed here breaks
             # that match, so the value is discarded

--- a/genesis/engine/entities/rigid_entity/inertial.py
+++ b/genesis/engine/entities/rigid_entity/inertial.py
@@ -122,11 +122,30 @@ def compose_inertial_properties(geoms_inertial_info: Sequence[GeomInertialInfo])
     return InertialProperties(global_mass, global_com, global_inertia)
 
 
+def select_mass_bearing_g_infos(
+    cg_infos: Sequence[dict], vg_infos: Sequence[dict], is_from_visual: bool
+) -> Sequence[dict]:
+    """The geoms of a link that carry its mass, among its collision and visual ones.
+
+    The two lists are alternative descriptions of one body, so composing both would count its volume twice. Visual
+    geometry is the faithful description and collision geometry a deliberate simplification, so the visual set wins
+    where the asset provides one; a link described only one way is composed from whichever it has.
+
+    A density authored on a collision geom states what that geom weighs, which is a stronger claim about the body than
+    any shape estimate, and formats attach it to the collision geoms alone. Such a link therefore keeps composing from
+    them, so the authored value is honored rather than silently replaced by the material density.
+    """
+    if is_from_visual and vg_infos and all(g_info.get("density") is None for g_info in cg_infos):
+        return vg_infos
+    return cg_infos if cg_infos else vg_infos
+
+
 def compose_inertial_from_g_infos(g_infos: Sequence[dict], rho: float) -> InertialProperties:
     """Compose the inertial of the geoms one link holds, at 'rho' where a geom states no density of its own.
 
-    Every primitive collision type is handled analytically, and a mesh defers to its cached unit-density mass
-    properties. A geom the link is only drawn with is taken as its visual mesh, so one call covers either kind.
+    Every primitive type is handled analytically, and a mesh defers to its cached unit-density mass properties. A geom
+    the link is only drawn with is taken as its visual mesh, keeping its own type so a visual primitive stays analytic
+    rather than being integrated over its tessellation.
 
     Parameters
     ----------
@@ -144,8 +163,10 @@ def compose_inertial_from_g_infos(g_infos: Sequence[dict], rho: float) -> Inerti
         tuple(
             GeomInertialInfo(
                 get_local_inertial_from_geom(
-                    gs.GEOM_TYPE.MESH if "vmesh" in g_info else g_info["type"],
-                    None if "vmesh" in g_info else g_info.get("data"),
+                    # A visual info that names no type is a mesh; one that names a primitive keeps it, so a visual
+                    # sphere or box stays analytic instead of being integrated over its tessellation.
+                    g_info.get("type", gs.GEOM_TYPE.MESH),
+                    g_info.get("data"),
                     g_info["vmesh"] if "vmesh" in g_info else g_info["mesh"],
                     rho if g_info.get("density") is None else g_info["density"],
                 ),

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -562,6 +562,14 @@ class FileMorph(Morph):
     recompute_inertia : bool, optional
         Force recomputing spatial inertia of links from their geometry. This option is useful to import partially
         broken assets from external providers that cannot be re-exported from source. Default to False.
+    inertia_from_visual : bool, optional
+        Whether a link whose spatial inertia has to be estimated takes it from its visual geometry rather than its
+        collision geometry. Collision geometry is usually a deliberate simplification of the body (a convex hull, a
+        sphere around a fruit, capsules along a leg), so estimating from the visual shape lands much closer to the
+        real inertia; the cost is a slower first load, because an open visual mesh has to be closed before its
+        volume means anything (see ``watertighten``), and a visual shape that is decorative rather than
+        representative then skews the estimate. Set to False to estimate from collision geometry instead. Has no
+        effect on a link whose inertia the asset specifies. Defaults to True.
     align : bool, optional
         Whether to reframe root links so that the link origin coincides with the center of mass and its axes are
         aligned with the principal axes of inertia. This makes the inertia tensor diagonal, which improves numerical
@@ -600,6 +608,7 @@ class FileMorph(Morph):
     decompose_robot_error_threshold: float = Field(default=float("inf"), ge=0, allow_inf_nan=True)
     coacd_options: CoacdOptions | None = None
     recompute_inertia: StrictBool = False
+    inertia_from_visual: StrictBool = True
     align: StrictBool | None = None
     file_meshes_are_zup: StrictBool | None = True
     batch_fixed_verts: StrictBool = False
@@ -758,6 +767,14 @@ class Mesh(FileMorph, TetGenMixin):
     recompute_inertia : bool, optional
         Force recomputing spatial inertia of links from their geometry. This option is useful to import partially
         broken assets from external providers that cannot be re-exported from source. Default to False.
+    inertia_from_visual : bool, optional
+        Whether a link whose spatial inertia has to be estimated takes it from its visual geometry rather than its
+        collision geometry. Collision geometry is usually a deliberate simplification of the body (a convex hull, a
+        sphere around a fruit, capsules along a leg), so estimating from the visual shape lands much closer to the
+        real inertia; the cost is a slower first load, because an open visual mesh has to be closed before its
+        volume means anything (see ``watertighten``), and a visual shape that is decorative rather than
+        representative then skews the estimate. Set to False to estimate from collision geometry instead. Has no
+        effect on a link whose inertia the asset specifies. Defaults to True.
     merge_submeshes_for_collision : bool, optional
         Whether to merge submeshes for collision. Defaults to False. **This is only used for RigidEntity.**
     visualization : bool, optional
@@ -951,6 +968,14 @@ class MJCF(FileMorph):
     recompute_inertia : bool, optional
         Force recomputing spatial inertia of links from their geometry. This option is useful to import partially
         broken assets from external providers that cannot be re-exported from source. Default to False.
+    inertia_from_visual : bool, optional
+        Whether a link whose spatial inertia has to be estimated takes it from its visual geometry rather than its
+        collision geometry. Collision geometry is usually a deliberate simplification of the body (a convex hull, a
+        sphere around a fruit, capsules along a leg), so estimating from the visual shape lands much closer to the
+        real inertia; the cost is a slower first load, because an open visual mesh has to be closed before its
+        volume means anything (see ``watertighten``), and a visual shape that is decorative rather than
+        representative then skews the estimate. Set to False to estimate from collision geometry instead. Has no
+        effect on a link whose inertia the asset specifies. Defaults to True.
     parse_glb_with_zup : bool, optional
         This parameter is deprecated, see file_meshes_are_zup.
     file_meshes_are_zup : bool, optional
@@ -1086,6 +1111,14 @@ class URDF(FileMorph):
     recompute_inertia : bool, optional
         Force recomputing spatial inertia of links from their geometry. This option is useful to import partially
         broken assets from external providers that cannot be re-exported from source. Default to False.
+    inertia_from_visual : bool, optional
+        Whether a link whose spatial inertia has to be estimated takes it from its visual geometry rather than its
+        collision geometry. Collision geometry is usually a deliberate simplification of the body (a convex hull, a
+        sphere around a fruit, capsules along a leg), so estimating from the visual shape lands much closer to the
+        real inertia; the cost is a slower first load, because an open visual mesh has to be closed before its
+        volume means anything (see ``watertighten``), and a visual shape that is decorative rather than
+        representative then skews the estimate. Set to False to estimate from collision geometry instead. Has no
+        effect on a link whose inertia the asset specifies. Defaults to True.
     parse_glb_with_zup : bool, optional
         This parameter is deprecated, see file_meshes_are_zup.
     file_meshes_are_zup : bool, optional
@@ -1223,6 +1256,14 @@ class Drone(FileMorph):
     recompute_inertia : bool, optional
         Force recomputing spatial inertia of links from their geometry. This option is useful to import partially
         broken assets from external providers that cannot be re-exported from source. Default to False.
+    inertia_from_visual : bool, optional
+        Whether a link whose spatial inertia has to be estimated takes it from its visual geometry rather than its
+        collision geometry. Collision geometry is usually a deliberate simplification of the body (a convex hull, a
+        sphere around a fruit, capsules along a leg), so estimating from the visual shape lands much closer to the
+        real inertia; the cost is a slower first load, because an open visual mesh has to be closed before its
+        volume means anything (see ``watertighten``), and a visual shape that is decorative rather than
+        representative then skews the estimate. Set to False to estimate from collision geometry instead. Has no
+        effect on a link whose inertia the asset specifies. Defaults to True.
     parse_glb_with_zup : bool, optional
         This parameter is deprecated, see file_meshes_are_zup.
     file_meshes_are_zup : bool, optional
@@ -1569,6 +1610,14 @@ class USD(FileMorph):
     recompute_inertia : bool, optional
         Force recomputing spatial inertia of links from their geometry. This option is useful to import partially
         broken assets from external providers that cannot be re-exported from source. Default to False.
+    inertia_from_visual : bool, optional
+        Whether a link whose spatial inertia has to be estimated takes it from its visual geometry rather than its
+        collision geometry. Collision geometry is usually a deliberate simplification of the body (a convex hull, a
+        sphere around a fruit, capsules along a leg), so estimating from the visual shape lands much closer to the
+        real inertia; the cost is a slower first load, because an open visual mesh has to be closed before its
+        volume means anything (see ``watertighten``), and a visual shape that is decorative rather than
+        representative then skews the estimate. Set to False to estimate from collision geometry instead. Has no
+        effect on a link whose inertia the asset specifies. Defaults to True.
     align : bool, optional
         Whether to reframe root links so that the link origin coincides with the center of mass and its axes are
         aligned with the principal axes of inertia. Only applies to root (floating-base) links. Default to False.

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -464,6 +464,26 @@ def convex_decompose(mesh, coacd_options):
     return mesh_parts
 
 
+def watertighten_trimesh(tmesh, aggressiveness):
+    """Closed manifold wrap of a triangle soup, memoized on disk by (vertices, faces, aggressiveness).
+
+    `aggressiveness` is the integer 0..8 controlling the wrap's quadric-error decimation cost cutoff; see
+    `genesis.utils.watertighten.watertighten_mesh` for the full pipeline. The cache turns a repeated build on the
+    same geometry into a file read instead of a multi-second SDF + DC + QEM rebuild.
+    """
+    # Imported lazily because pulling in the wrap pipeline triggers Numba compilation, which every Genesis import
+    # would otherwise pay for whether or not any asset needs closing.
+    from .watertighten import watertighten_mesh
+
+    cache = get_wt_cache(tmesh.vertices, tmesh.faces, aggressiveness)
+    cached_mesh = cache.load()
+    if cached_mesh is None:
+        cached_mesh = watertighten_mesh(tmesh.vertices, tmesh.faces, aggressiveness=aggressiveness)
+        cache.save(cached_mesh)
+    verts, faces = cached_mesh
+    return trimesh.Trimesh(vertices=verts, faces=faces, process=False)
+
+
 # 512 MiB of processed collision geometry. Sized by the geometry footprint actually retained (vertices and faces of
 # the cached meshes), so a few large assets or many small ones are both bounded without an arbitrary entry count.
 _COLLISION_GEOMS_CACHE = SizeCappedCache(max_bytes=512 * 1024 * 1024)
@@ -745,8 +765,6 @@ def _postprocess_collision_geoms_impl(
     # Nonconvex: watertighten each fused surface into a closed mesh so the grid SDF is reliable. The convex path skips
     # this (its hull / decomposition replaces the surface anyway, so an alpha-wrap would be wasted work).
     if not convexify and watertighten is not None:
-        from .watertighten import watertighten_mesh
-
         for g_info, is_fused in zip(g_infos, geoms_is_fused):
             # Fused geoms are always watertightened, as their sub-meshes may overlap while being individually
             # watertight. Other geoms are skipped if they are not generic meshes or already watertight or convex.
@@ -754,15 +772,7 @@ def _postprocess_collision_geoms_impl(
             if not is_fused and (g_info["type"] != gs.GEOM_TYPE.MESH or tmesh.is_watertight or tmesh.is_convex):
                 continue
 
-            # On-disk cache keyed by (vertices, faces, aggressiveness): a repeated build on the same geom is a file read
-            # instead of a multi-second SDF + DC + QEM rebuild.
-            cache = get_wt_cache(tmesh.vertices, tmesh.faces, watertighten)
-            cached_mesh = cache.load()
-            if cached_mesh is None:
-                cached_mesh = watertighten_mesh(tmesh.vertices, tmesh.faces, aggressiveness=watertighten)
-                cache.save(cached_mesh)
-            v_out, f_out = cached_mesh
-            fused = trimesh.Trimesh(vertices=v_out, faces=f_out, process=False)
+            fused = watertighten_trimesh(tmesh, watertighten)
             metadata = g_info["mesh"].metadata.copy()
             metadata["watertightened"] = True
             g_info["mesh"] = gs.Mesh.from_trimesh(mesh=fused, surface=gs.surfaces.Collision(), metadata=metadata)

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -617,6 +617,43 @@ def undefined_inertia():
     return ET.tostring(urdf, encoding="unicode")
 
 
+def _add_simplified_collision_link(urdf, link_name, visual_mesh, scale):
+    """Append a link with no inertial element whose visual mesh is much bulkier than its collision sphere, the way an
+    asset simplifies collision geometry for speed."""
+    link = ET.SubElement(urdf, "link", name=link_name)
+    visual = ET.SubElement(link, "visual")
+    ET.SubElement(ET.SubElement(visual, "geometry"), "mesh", filename=visual_mesh, scale=f"{scale} {scale} {scale}")
+    collision = ET.SubElement(link, "collision")
+    ET.SubElement(ET.SubElement(collision, "geometry"), "sphere", radius="0.04")
+
+
+@pytest.fixture(scope="session")
+def simplified_collision_sphere():
+    """Generate a URDF whose single link carries a watertight sphere visual mesh and a smaller collision sphere."""
+    urdf = ET.Element("robot", name="simplified_collision_sphere")
+    _add_simplified_collision_link(urdf, "base_link", os.path.join(get_assets_dir(), "meshes", "sphere.obj"), 0.05)
+    return ET.tostring(urdf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
+def simplified_collision_open_mesh(asset_tmp_path):
+    """Generate a URDF like 'simplified_collision_sphere' whose visual mesh is an open pipe, returned alongside the
+    volume the pipe encloses once closed.
+
+    The pipe is the two lateral surfaces of an annulus, so it is open at both ends and its bore - far wider than the
+    wrap can bridge - keeps its convex hull almost three times the volume of the shape itself.
+    """
+    pipe = trimesh.creation.annulus(r_min=0.08, r_max=0.1, height=0.2)
+    closed_volume = pipe.volume
+    pipe.update_faces(np.abs(pipe.face_normals[:, 2]) < 0.5)
+    mesh_path = str(asset_tmp_path / "open_pipe.obj")
+    pipe.export(mesh_path)
+
+    urdf = ET.Element("robot", name="simplified_collision_open_mesh")
+    _add_simplified_collision_link(urdf, "base_link", mesh_path, 1.0)
+    return ET.tostring(urdf, encoding="unicode"), closed_volume
+
+
 @pytest.fixture(scope="session")
 def undefined_inertia_arm():
     """Generate a URDF of two links joined by a revolute joint, neither authoring an inertial element."""

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -228,6 +228,8 @@ def test_parsing_inertia_defaults(
     degenerate_inertials,
     zero_density_marker_mjcf,
     implicit_inertial_origin_chain,
+    simplified_collision_sphere,
+    simplified_collision_open_mesh,
     show_viewer,
     tol,
     caplog,
@@ -245,6 +247,8 @@ def test_parsing_inertia_defaults(
     SPHERE_INERTIA_PER_MASS = 2.0 * 0.06**2 / 5.0
     BOX_INERTIA_PER_MASS = 2.0 * 0.2**2 / 12.0
     GRAVITY = (0.0, 0.0, -9.81)
+    # Density is read back by the estimate assertions below, so it must be pinned rather than left to resolve.
+    RHO = 1000.0
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -405,6 +409,40 @@ def test_parsing_inertia_defaults(
     )
     stacked_tip.attach(stacked_middle, parent_link_name=stacked_middle.base_link.name, pos=(0.0, 0.0, 0.2))
     stacked_middle.attach(stacked_base, parent_link_name=stacked_base.base_link.name, pos=(0.0, 0.0, 0.2))
+    # A link whose collision geometry is a deliberate simplification of its visual mesh: the estimate must describe
+    # the body rather than the proxy, and 'inertia_from_visual' must be able to select the proxy back.
+    entity_from_visual = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=simplified_collision_sphere,
+            pos=(2.4, 1.0, 0.5),
+            align=False,
+        ),
+        material=gs.materials.Rigid(
+            rho=RHO,
+        ),
+    )
+    entity_from_collision = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=simplified_collision_sphere,
+            pos=(3.2, 1.0, 0.5),
+            align=False,
+            inertia_from_visual=False,
+        ),
+        material=gs.materials.Rigid(
+            rho=RHO,
+        ),
+    )
+    open_mesh_urdf, open_mesh_closed_volume = simplified_collision_open_mesh
+    entity_open_visual = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=open_mesh_urdf,
+            pos=(4.0, 1.0, 0.5),
+            align=False,
+        ),
+        material=gs.materials.Rigid(
+            rho=RHO,
+        ),
+    )
 
     with caplog.at_level("WARNING"):
         scene.build()
@@ -465,6 +503,34 @@ def test_parsing_inertia_defaults(
 
     # Every asset above is parsed by MuJoCo, a zero or missing inertial included.
     assert not any("legacy URDF parser" in record.getMessage() for record in caplog.records)
+
+    # An estimated inertia describes the visual shape, so it matches the visual mesh integrated at the material
+    # density rather than the collision sphere standing in for it, and the mesh's own tensor rather than an
+    # analytical sphere's, which its faceting departs from.
+    visual_tmesh = entity_from_visual.base_link.vgeoms[0].vmesh.trimesh
+    assert_allclose(entity_from_visual.base_link.desc.mass, RHO * visual_tmesh.volume, tol=tol)
+    assert_allclose(
+        np.linalg.eigvalsh(entity_from_visual.base_link.desc.inertia),
+        np.linalg.eigvalsh(RHO * visual_tmesh.moment_inertia),
+        tol=tol,
+    )
+
+    # Opting out recovers the collision sphere, which encloses about half the volume of the mesh it stands in for.
+    collision_radius = entity_from_collision.base_link.geoms[0].data[0]
+    collision_mass = RHO * (4.0 / 3.0) * np.pi * collision_radius**3
+    assert_allclose(entity_from_collision.base_link.desc.mass, collision_mass, tol=tol)
+    assert_allclose(
+        np.linalg.eigvalsh(entity_from_collision.base_link.desc.inertia),
+        (2.0 / 5.0) * collision_mass * collision_radius**2,
+        tol=tol,
+    )
+
+    # An open visual mesh encloses no volume of its own, so it has to be closed before being integrated: the estimate
+    # recovers the volume the pipe bounds. Filling its convex hull instead, which is what an open mesh otherwise falls
+    # back to, would bore-and-all hand it almost three times that.
+    open_tmesh = entity_open_visual.base_link.vgeoms[0].vmesh.trimesh
+    assert not open_tmesh.is_watertight
+    assert_allclose(entity_open_visual.base_link.desc.mass, RHO * open_mesh_closed_volume, rtol=1e-2)
 
     # Resolving the center of mass to the link frame can place it outside the geometry, which stays worth reporting.
     # Only the link whose geometry is offset qualifies, once per copy of the robot.


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> This PR is stacked on #3261 and contains its commits. This PR will be left as draft until 3261 is merged.

- Estimate link inertia/mass from visual geom instead of collision mesh by default (`inertia_from_visual=True`), since visual geom is more accurate than collision mesh.
- On non-watertight visual meshes, apply alpha wrap

## Related Issue

Resolves SIM-193.

## Motivation and Context

Need a usable inertia for objects that have not been physically weighed and measured. The visual mesh is the best available description of the item.

## How Has This Been / Can This Be Tested?

- `pytest tests/rigid tests/parsers`

`tests/rigid/test_asset_loading.py::test_parsing_inertia_defaults`

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.