### PR TITLE
[BUG FIX] Fix 'RigidEntity.plan_path' ignoring runtime joint limits.

### DIFF
--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2530,25 +2530,33 @@ class KinematicEntity(Entity):
         """The base joint of the entity"""
         return self._joints[0][0]
 
-    def _init_q_limit(self):
-        if self.n_dofs == 0:
-            return
+    @property
+    @gs.assert_built
+    def q_limit(self):
+        """The build-time positional limits of the entity's generalised coordinates, lower row then upper row.
 
-        # Joint limits in q space, also read by path planning.
-        q_limit_lower = []
-        q_limit_upper = []
+        A joint holding its orientation as a quaternion, a free or a ball joint, contributes the unit bounds of that
+        quaternion, which is normalized rather than limited.
+        """
+        return self._q_limit
+
+    def _init_q_limit(self):
+        q_limit_lower, q_limit_upper = [], []
         for joint in self.joints:
-            if joint.type == gs.JOINT_TYPE.FREE:
-                q_limit_lower.append(joint.dofs_limit[:3, 0])
-                q_limit_lower.append(-np.ones(4))  # quaternion lower bound
-                q_limit_upper.append(joint.dofs_limit[:3, 1])
-                q_limit_upper.append(np.ones(4))  # quaternion upper bound
-            elif joint.type == gs.JOINT_TYPE.FIXED:
-                pass
-            else:
+            if joint.type in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.SPHERICAL):
+                # A quaternion takes four of the coordinates of such a joint; whatever remains is a translation,
+                # carried by the first of its degrees of freedom.
+                n_translation = joint.n_qs - 4
+                q_limit_lower += [joint.dofs_limit[:n_translation, 0], -np.ones(4)]
+                q_limit_upper += [joint.dofs_limit[:n_translation, 1], np.ones(4)]
+            elif joint.type != gs.JOINT_TYPE.FIXED:
                 q_limit_lower.append(joint.dofs_limit[:, 0])
                 q_limit_upper.append(joint.dofs_limit[:, 1])
-        self.q_limit = np.stack(
+        if not q_limit_lower:
+            # An entity that no degree of freedom moves holds no coordinate, hence a limit of width zero.
+            self._q_limit = np.zeros((2, self.n_qs), dtype=gs.np_float)
+            return
+        self._q_limit = np.stack(
             (np.concatenate(q_limit_lower), np.concatenate(q_limit_upper)), axis=0, dtype=gs.np_float
         )
 

--- a/genesis/utils/path_planning.py
+++ b/genesis/utils/path_planning.py
@@ -94,6 +94,23 @@ class PathPlanner(ABC):
 
         return qpos_cur, qpos_goal, qpos_start, envs_idx
 
+    def _get_dofs_limit(self, qpos_goal, envs_idx):
+        """Limits to sample within, one row per environment being planned for, and which goals they rule out.
+
+        Planning is refused for the joints whose coordinates are not their degrees of freedom, which are the free and
+        the ball joint, so the limits of the degrees of freedom are the limits of the coordinates sampled here.
+        """
+        is_batched = self._solver._options.batch_dofs_info
+        lower, upper = self._entity.get_dofs_limit(envs_idx=envs_idx if is_batched else None)
+        is_goal_out_of_limit = ((qpos_goal < lower) | (qpos_goal > upper)).any(dim=-1)
+        # One row per environment, laid out rather than broadcast: the limits come as a strided view of the pair they
+        # are stored in, and limits shared by every environment come without an environment dimension at all, while a
+        # kernel argument can be neither.
+        shape = (len(envs_idx), self._entity.n_dofs)
+        lower = torch.broadcast_to(lower, shape).contiguous()
+        upper = torch.broadcast_to(upper, shape).contiguous()
+        return lower, upper, is_goal_out_of_limit
+
     def get_exclude_geom_pairs(self, qposs, envs_idx):
         """
         Parameters
@@ -330,19 +347,29 @@ class RRT(PathPlanner):
 
     @qd.kernel
     def _kernel_rrt_init(
-        self, qpos_start: qd.types.ndarray(), envs_idx: qd.types.ndarray(), qpos_goal: qd.types.ndarray()
+        self,
+        qpos_start: qd.types.ndarray(),
+        envs_idx: qd.types.ndarray(),
+        qpos_goal: qd.types.ndarray(),
+        q_limit_lower: qd.types.ndarray(),
+        q_limit_upper: qd.types.ndarray(),
     ):
         qd.loop_config(serialize=self._solver._para_level < gs.PARA_LEVEL.ALL)
         for i_b_ in range(envs_idx.shape[0]):
             i_b = envs_idx[i_b_]
+            # Every sample lies within the limits, so a goal outside them cannot be reached. Such an environment
+            # is left out of the search, and the plan reports it through the valid mask it returns.
+            is_goal_within_limit = True
             for i_q in range(self._entity.n_qs):
                 # save original qpos
                 self._rrt_start_configuration[i_q, i_b] = qpos_start[i_b_, i_q]
                 self._rrt_goal_configuration[i_q, i_b] = qpos_goal[i_b_, i_q]
                 self._rrt_node_info[0, i_b].configuration[i_q] = qpos_start[i_b_, i_q]
+                if qpos_goal[i_b_, i_q] < q_limit_lower[i_b_, i_q] or qpos_goal[i_b_, i_q] > q_limit_upper[i_b_, i_q]:
+                    is_goal_within_limit = False
             self._rrt_node_info[0, i_b].parent_idx = 0
             self._rrt_tree_size[i_b] = 1
-            self._rrt_is_active[i_b] = True
+            self._rrt_is_active[i_b] = is_goal_within_limit
 
     @qd.kernel
     def _kernel_rrt_step1(
@@ -368,7 +395,8 @@ class RRT(PathPlanner):
             if self._rrt_is_active[i_b]:
                 random_sample = qd.Vector(
                     [
-                        q_limit_lower[i_q] + qd.random(dtype=gs.qd_float) * (q_limit_upper[i_q] - q_limit_lower[i_q])
+                        q_limit_lower[i_b_, i_q]
+                        + qd.random(dtype=gs.qd_float) * (q_limit_upper[i_b_, i_q] - q_limit_lower[i_b_, i_q])
                         for i_q in range(self._entity.n_qs)
                     ]
                 )
@@ -490,6 +518,14 @@ class RRT(PathPlanner):
 
         qpos_cur, qpos_goal, qpos_start, envs_idx = self._sanitize_qposs(qpos_goal, qpos_start, envs_idx)
         ignore_geom_pairs = self.get_exclude_geom_pairs((qpos_goal, qpos_start), envs_idx)
+        q_limit_lower, q_limit_upper, is_goal_out_of_limit = self._get_dofs_limit(qpos_goal, envs_idx)
+        if is_goal_out_of_limit.all():
+            # No sample leaves the limits, so no tree would reach any of these goals. Growing one, and retrying
+            # afterwards, would give the same answer at the price of the whole search.
+            gs.logger.debug("Every goal lies outside the joint limits, so there is nothing to plan.")
+            self._entity.set_qpos(qpos_cur, envs_idx=envs_idx if self._solver.n_envs else None, zero_velocity=False)
+            sol = torch.zeros((num_waypoints, len(envs_idx), self._entity.n_qs), dtype=gs.tc_float, device=gs.device)
+            return sol, is_goal_out_of_limit
 
         is_plan_with_obj = False
         _pos, _quat = None, None
@@ -503,7 +539,7 @@ class RRT(PathPlanner):
 
         self._init_rrt_fields(max_nodes=max_nodes, max_step_size=resolution)
         self._reset_rrt_fields()
-        self._kernel_rrt_init(qpos_start, envs_idx, qpos_goal)
+        self._kernel_rrt_init(qpos_start, envs_idx, qpos_goal, q_limit_lower, q_limit_upper)
 
         gs.logger.debug("Start RRT planning...")
         time_start = time.time()
@@ -511,8 +547,8 @@ class RRT(PathPlanner):
             if self._rrt_is_active.to_torch().any():
                 self._kernel_rrt_step1(
                     envs_idx,
-                    self._entity.q_limit[0],
-                    self._entity.q_limit[1],
+                    q_limit_lower,
+                    q_limit_upper,
                     self._solver.dyn_state,
                     self._solver.dyn_info,
                     self._solver.rigid_info,
@@ -538,7 +574,7 @@ class RRT(PathPlanner):
 
         gs.logger.debug(f"RRT planning time: {time.time() - time_start}")
 
-        is_invalid = self._rrt_is_active.to_torch(device=gs.device).bool()[envs_idx]
+        is_invalid = self._rrt_is_active.to_torch(device=gs.device).bool()[envs_idx] | is_goal_out_of_limit
         ts = self._rrt_tree_size.to_torch(device=gs.device)
         g_n = self._rrt_goal_reached_node_idx.to_torch(device=gs.device)[envs_idx]  # B
 
@@ -556,10 +592,7 @@ class RRT(PathPlanner):
         sol = configurations[res_idx, envs_idx]  # N, B, DoF
 
         if is_invalid.all():
-            if self._solver.n_envs > 0:
-                self._entity.set_qpos(qpos_cur, envs_idx=envs_idx, zero_velocity=False)
-            else:
-                self._entity.set_qpos(qpos_cur, zero_velocity=False)
+            self._entity.set_qpos(qpos_cur, envs_idx=envs_idx if self._solver.n_envs else None, zero_velocity=False)
             sol = torch.zeros((num_waypoints, len(envs_idx), sol.shape[-1]), dtype=gs.tc_float, device=gs.device)
             return sol, is_invalid
 
@@ -609,10 +642,7 @@ class RRT(PathPlanner):
             else:
                 is_invalid |= self.check_collision(sol, ignore_geom_pairs, envs_idx).bool()
 
-        if self._solver.n_envs > 0:
-            self._entity.set_qpos(qpos_cur, envs_idx=envs_idx, zero_velocity=False)
-        else:
-            self._entity.set_qpos(qpos_cur, zero_velocity=False)
+        self._entity.set_qpos(qpos_cur, envs_idx=envs_idx if self._solver.n_envs else None, zero_velocity=False)
 
         if is_plan_with_obj:
             self.update_object(ee_link_idx, obj_link_idx, _pos, _quat, envs_idx)
@@ -657,22 +687,31 @@ class RRTConnect(PathPlanner):
 
     @qd.kernel
     def _kernel_rrt_connect_init(
-        self, qpos_start: qd.types.ndarray(), envs_idx: qd.types.ndarray(), qpos_goal: qd.types.ndarray()
+        self,
+        qpos_start: qd.types.ndarray(),
+        envs_idx: qd.types.ndarray(),
+        qpos_goal: qd.types.ndarray(),
+        q_limit_lower: qd.types.ndarray(),
+        q_limit_upper: qd.types.ndarray(),
     ):
         # NOTE: run IK before this
         qd.loop_config(serialize=self._solver._para_level < gs.PARA_LEVEL.ALL)
         for i_b_ in range(envs_idx.shape[0]):
             i_b = envs_idx[i_b_]
+            # See the note in RRT: a goal outside the limits cannot be reached, which the valid mask reports.
+            is_goal_within_limit = True
             for i_q in range(self._entity.n_qs):
                 # save original qpos
                 self._rrt_start_configuration[i_q, i_b] = qpos_start[i_b_, i_q]
                 self._rrt_goal_configuration[i_q, i_b] = qpos_goal[i_b_, i_q]
                 self._rrt_node_info[0, i_b].configuration[i_q] = qpos_start[i_b_, i_q]
                 self._rrt_node_info[1, i_b].configuration[i_q] = qpos_goal[i_b_, i_q]
+                if qpos_goal[i_b_, i_q] < q_limit_lower[i_b_, i_q] or qpos_goal[i_b_, i_q] > q_limit_upper[i_b_, i_q]:
+                    is_goal_within_limit = False
             self._rrt_node_info[0, i_b].parent_idx = 0
             self._rrt_node_info[1, i_b].child_idx = 1
             self._rrt_tree_size[i_b] = 2
-            self._rrt_is_active[i_b] = True
+            self._rrt_is_active[i_b] = is_goal_within_limit
 
     @qd.kernel
     def _kernel_rrt_connect_step1(
@@ -700,7 +739,8 @@ class RRTConnect(PathPlanner):
             if self._rrt_is_active[i_b]:
                 random_sample = qd.Vector(
                     [
-                        q_limit_lower[i_q] + qd.random(dtype=gs.qd_float) * (q_limit_upper[i_q] - q_limit_lower[i_q])
+                        q_limit_lower[i_b_, i_q]
+                        + qd.random(dtype=gs.qd_float) * (q_limit_upper[i_b_, i_q] - q_limit_lower[i_b_, i_q])
                         for i_q in range(self._entity.n_qs)
                     ]
                 )
@@ -855,6 +895,14 @@ class RRTConnect(PathPlanner):
 
         qpos_cur, qpos_goal, qpos_start, envs_idx = self._sanitize_qposs(qpos_goal, qpos_start, envs_idx)
         ignore_geom_pairs = self.get_exclude_geom_pairs([qpos_goal, qpos_start], envs_idx)
+        q_limit_lower, q_limit_upper, is_goal_out_of_limit = self._get_dofs_limit(qpos_goal, envs_idx)
+        if is_goal_out_of_limit.all():
+            # No sample leaves the limits, so no tree would reach any of these goals. Growing one, and retrying
+            # afterwards, would give the same answer at the price of the whole search.
+            gs.logger.debug("Every goal lies outside the joint limits, so there is nothing to plan.")
+            self._entity.set_qpos(qpos_cur, envs_idx=envs_idx if self._solver.n_envs else None, zero_velocity=False)
+            sol = torch.zeros((num_waypoints, len(envs_idx), self._entity.n_qs), dtype=gs.tc_float, device=gs.device)
+            return sol, is_goal_out_of_limit
 
         is_plan_with_obj = False
         _pos, _quat = None, None
@@ -868,7 +916,7 @@ class RRTConnect(PathPlanner):
 
         self._init_rrt_connect_fields(max_nodes=max_nodes, max_step_size=resolution)
         self._reset_rrt_connect_fields()
-        self._kernel_rrt_connect_init(qpos_start, envs_idx, qpos_goal)
+        self._kernel_rrt_connect_init(qpos_start, envs_idx, qpos_goal, q_limit_lower, q_limit_upper)
 
         gs.logger.debug("Start RRTConnect planning...")
         time_start = time.time()
@@ -877,8 +925,8 @@ class RRTConnect(PathPlanner):
             self._kernel_rrt_connect_step1(
                 envs_idx,
                 self._solver.qpos,
-                self._entity.q_limit[0],
-                self._entity.q_limit[1],
+                q_limit_lower,
+                q_limit_upper,
                 self._solver.dyn_state,
                 self._solver.dyn_info,
                 self._solver.rigid_info,
@@ -910,7 +958,7 @@ class RRTConnect(PathPlanner):
             gs.logger.info(f"RRTConnect planning exceeded maximum number of nodes ({self._rrt_max_nodes}).")
 
         gs.logger.debug(f"RRTConnect planning time: {time.time() - time_start}")
-        is_invalid = self._rrt_is_active.to_torch(device=gs.device).bool()[envs_idx]
+        is_invalid = self._rrt_is_active.to_torch(device=gs.device).bool()[envs_idx] | is_goal_out_of_limit
         ts = self._rrt_tree_size.to_torch(device=gs.device)
         g_n = self._rrt_goal_reached_node_idx.to_torch(device=gs.device)[envs_idx]  # B
 
@@ -938,10 +986,7 @@ class RRTConnect(PathPlanner):
         sol = configurations[res_idx, envs_idx]  # N, B, DoF
 
         if is_invalid.all():
-            if self._solver.n_envs > 0:
-                self._entity.set_qpos(qpos_cur, envs_idx=envs_idx, zero_velocity=False)
-            else:
-                self._entity.set_qpos(qpos_cur, zero_velocity=False)
+            self._entity.set_qpos(qpos_cur, envs_idx=envs_idx if self._solver.n_envs else None, zero_velocity=False)
             return torch.zeros(num_waypoints, len(envs_idx), sol.shape[-1], device=gs.device), is_invalid
 
         mask = rrt_connect_valid_mask(res_idx)
@@ -990,10 +1035,7 @@ class RRTConnect(PathPlanner):
             else:
                 is_invalid |= self.check_collision(sol, ignore_geom_pairs, envs_idx).bool()
 
-        if self._solver.n_envs > 0:
-            self._entity.set_qpos(qpos_cur, envs_idx=envs_idx, zero_velocity=False)
-        else:
-            self._entity.set_qpos(qpos_cur, zero_velocity=False)
+        self._entity.set_qpos(qpos_cur, envs_idx=envs_idx if self._solver.n_envs else None, zero_velocity=False)
 
         if is_plan_with_obj:
             self.update_object(ee_link_idx, obj_link_idx, _pos, _quat, envs_idx)

--- a/genesis/utils/path_planning.py
+++ b/genesis/utils/path_planning.py
@@ -308,7 +308,10 @@ class PathPlanner(ABC):
                 _pos=_pos,
                 _quat=_quat,
             )  # B
-            path[:, ~collision_mask] = result_path[:, ~collision_mask]
+            # Compared against zero rather than negated: the mask is integer-typed on the backends without a boolean
+            # one, where a bitwise negation would turn it into an index instead of the selection it reads as.
+            is_shortcut_free = collision_mask == 0
+            path[:, is_shortcut_free] = result_path[:, is_shortcut_free]
         return path
 
 

--- a/tests/rigid/test_kinematics.py
+++ b/tests/rigid/test_kinematics.py
@@ -623,10 +623,11 @@ def test_multi_robot_inverse_kinematics(show_viewer, tol):
 
 @pytest.mark.slow("gpu")  # gpu ~300s
 @pytest.mark.required
-@pytest.mark.parametrize("n_envs", [0, 2])
+@pytest.mark.parametrize("n_envs, batch_dofs_info", [(0, True), (2, False), (2, True)])
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_path_planning_avoidance(backend, n_envs, show_viewer, tol):
+def test_path_planning_avoidance(backend, n_envs, batch_dofs_info, show_viewer, tol):
     CUBE_SIZE = 0.07
+    DOF_LIMIT = 0.5
 
     # FIXME: Implement a more robust plan planning algorithm
     if sys.platform == "darwin" and backend == gs.gpu:
@@ -635,6 +636,9 @@ def test_path_planning_avoidance(backend, n_envs, show_viewer, tol):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=0.01,
+        ),
+        rigid_options=gs.options.RigidOptions(
+            batch_dofs_info=batch_dofs_info,
         ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(3, 1, 1.5),
@@ -742,6 +746,36 @@ def test_path_planning_avoidance(backend, n_envs, show_viewer, tol):
         hand_quat_diff = gu.transform_quat_by_quat(gu.inv_quat(hand_quat_ref), hand.get_quat())
         theta = 2 * torch.arctan2(torch.linalg.norm(hand_quat_diff[..., 1:]), torch.abs(hand_quat_diff[..., 0]))
         assert_allclose(theta, 0.0, tol=5e-3)
+
+    # A limit tightened once the scene is built is the one the planner samples within: a goal it excludes cannot be
+    # reached, while one it allows still can, and no waypoint leaves what the solver would let the robot hold.
+    scene.rigid_solver.set_dofs_limit(-DOF_LIMIT, DOF_LIMIT, dofs_idx=range(franka.dof_start, franka.dof_start + 7))
+    assert_allclose(franka.get_dofs_limit()[1][..., :7], DOF_LIMIT, tol=gs.EPS)
+    franka.set_qpos(torch.zeros_like(qpos_goal))
+
+    qpos_goal_within = torch.zeros_like(qpos_goal)
+    qpos_goal_within[..., :7] = 0.5 * DOF_LIMIT
+    within_path, within_valid_mask = franka.plan_path(
+        qpos_goal=qpos_goal_within,
+        num_waypoints=300,
+        ignore_collision=True,
+        resolution=0.05,
+        return_valid_mask=True,
+    )
+    assert within_valid_mask.all()
+    np.testing.assert_array_less(tensor_to_array(within_path[..., :7].abs()), DOF_LIMIT + tol)
+
+    # Reachable for the limits the model was parsed with, which is what a snapshot taken at build would hold.
+    qpos_goal_beyond = torch.zeros_like(qpos_goal)
+    qpos_goal_beyond[..., 0] = 2.0 * DOF_LIMIT
+    _, beyond_valid_mask = franka.plan_path(
+        qpos_goal=qpos_goal_beyond,
+        num_waypoints=300,
+        ignore_collision=True,
+        resolution=0.05,
+        return_valid_mask=True,
+    )
+    assert not beyond_valid_mask.any()
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

The path planner reads the joint limits from the solver on every plan, one row per environment, instead of from the snapshot taken at build. A goal outside them is reported unreachable through the valid mask, and nothing is planned when every goal is outside them.

`q_limit` is unchanged apart from its docstring, which now says it holds the authored limits, and from counting the quaternion of a ball joint among the coordinates it reports.

Path smoothing selects the environments a shortcut is collision-free in by comparing the mask against zero rather than negating it bitwise: that mask is integer-typed on the backends without a boolean of their own, where the negation yielded -1 and -2 and the assignment read them as indices into the batch, writing the shortcut into the last environments and reaching outside the batch once one environment collided.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3173

## Motivation and Context

A limit written with `set_dofs_limit` never reached the planner, which kept sampling the authored ones and reported success for goals the solver would clamp.

## How Has This Been / Can This Be Tested?

`test_path_planning_avoidance` tightens the limits after build, then plans to a goal they allow and to one they rule out; it fails when the planner is pointed back at the authored limits. The smoothing fix shows on a backend whose boolean is integer-typed: run that test there with the platform skip lifted and the bitwise negation put back, and it ends at the assignment with `index -2 is out of bounds`.

```python
scene.rigid_solver.set_dofs_limit(-0.5, 0.5, dofs_idx=range(7))
qpos_goal = np.zeros(9)
qpos_goal[0] = 2.0  # authorized by the authored limits only
path, is_valid = franka.plan_path(qpos_goal=qpos_goal, num_waypoints=50, return_valid_mask=True)
print(bool(is_valid), float(path[-1][0]))  # False, and the path stays within reach
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


