### PR TITLE
[BUG FIX] Fix path smoothing corrupting or aborting a plan on backends without a boolean type.

### DIFF
--- a/genesis/utils/path_planning.py
+++ b/genesis/utils/path_planning.py
@@ -291,7 +291,10 @@ class PathPlanner(ABC):
                 _pos=_pos,
                 _quat=_quat,
             )  # B
-            path[:, ~collision_mask] = result_path[:, ~collision_mask]
+            # Compared against zero rather than negated: the mask is integer-typed on the backends without a boolean
+            # one, where a bitwise negation would turn it into an index instead of the selection it reads as.
+            is_shortcut_free = collision_mask == 0
+            path[:, is_shortcut_free] = result_path[:, is_shortcut_free]
         return path
 
 

--- a/tests/rigid/test_kinematics.py
+++ b/tests/rigid/test_kinematics.py
@@ -1,4 +1,3 @@
-import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -629,8 +628,6 @@ def test_path_planning_avoidance(backend, n_envs, show_viewer, tol):
     CUBE_SIZE = 0.07
 
     # FIXME: Implement a more robust plan planning algorithm
-    if sys.platform == "darwin" and backend == gs.gpu:
-        pytest.skip(reason="This algorithm is very fragile and fail to converge on MacOS.")
 
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(


### PR DESCRIPTION
## Description

`PathPlanner.shortcut_path` keeps a shortcut candidate for the environments it is collision-free in, selecting them with `~collision_mask`. That mask carries the boolean type the backend provides, which is an integer one wherever quadrants has no boolean of its own, and a bitwise negation of it yields -1 and -2 rather than a selection. The assignment then reads those as indices into the batch: the shortcut was written into the last environments rather than the free ones, and indexed outside the batch entirely as soon as one environment collided, which ends the plan with `index -2 is out of bounds`.

The mask is now compared against zero, which yields a boolean selection whatever the mask is typed as.

## Motivation and Context

Path planning is unusable on such a backend: a plan either fails outright or comes back smoothed with waypoints belonging to another environment. The planning test was skipped there, attributing the failure to the convergence of the algorithm; the skip is removed, since what it was hiding is this.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_kinematics.py::test_path_planning_avoidance` covers it, and it now runs on the backends the skip excluded. Put the negation back and the test ends in `torch.AcceleratorError: index -2 is out of bounds` from the first shortcut iteration, at the assignment.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.