### PR TITLE
[FEATURE] Add ray_alignment and link exclusion to the raycaster.

### DIFF
--- a/examples/sensors/raycaster_alignment.py
+++ b/examples/sensors/raycaster_alignment.py
@@ -1,0 +1,126 @@
+"""Visualize the raycaster's ``ray_alignment`` (base / yaw / world).
+
+Three carrier boxes hang side by side over a box obstacle each. A dense ray
+grid (0.2 m resolution) hangs from each carrier. The carriers move in two
+phases so each pair of alignment modes is compared where it differs most:
+
+Phase 1 - pitch swing (about x, amplitude 60 deg, 1.0 Hz)
+    ``base`` tilts its grid with the body, ``yaw``/``world`` stay level.
+    Highlights the base vs yaw/world difference.
+
+Phase 2 - yaw rotation (about z, the yaw axis)
+    ``base`` and ``yaw`` rotate their grid footprint with the body, ``world``
+    keeps the grid fixed in the world frame. Highlights the yaw vs world
+    difference.
+
+The rays point straight down (0, 0, -1), so in phase 2 the ray grid's
+rectangular footprint on the ground rotates for ``base``/``yaw`` while it
+stays put for ``world``.
+
+Each raycaster draws its rays and hit points (``draw_debug``).
+
+Run:  python examples/sensors/raycaster_alignment.py
+Add ``--headless`` to run without a window, and ``--seconds N`` to auto-stop.
+"""
+
+import argparse
+import math
+import os
+import time
+
+import genesis as gs
+from genesis.utils.geom import euler_to_quat
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--headless", action="store_true", help="Run without the viewer")
+    parser.add_argument("--seconds", type=float, default=0.0, help="Auto-stop after N seconds (0 = run until closed)")
+    parser.add_argument("--phase1", type=float, default=8.0, help="Pitch-swing phase length (s)")
+    parser.add_argument("--phase2", type=float, default=8.0, help="Yaw-rotation phase length (s)")
+    parser.add_argument("--swing", type=float, default=60.0, help="Pitch swing amplitude (deg)")
+    parser.add_argument("--yaw_rate", type=float, default=90.0, help="Yaw rotation rate (deg/s)")
+    args = parser.parse_args()
+
+    gs.init(logging_level="warning")
+    scene = gs.Scene(
+        vis_options=gs.options.VisOptions(show_world_frame=True),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(-2.0, -7.0, 6.0),
+            camera_lookat=(0.0, 0.0, 1.0),
+        ),
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=not args.headless,
+    )
+
+    # Ground plane (link 0); one box obstacle (1x1x1, top at z=1.0) per column.
+    scene.add_entity(gs.morphs.Plane())
+
+    columns = ("base", "yaw", "world")
+    xs = {"base": -3.0, "yaw": 0.0, "world": 3.0}
+    obstacles = {
+        label: scene.add_entity(gs.morphs.Box(size=(1.0, 1.0, 1.0), pos=(xs[label], 0.0, 0.5), fixed=True))
+        for label in columns
+    }
+    carriers = {
+        label: scene.add_entity(gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(xs[label], 0.0, 3.0), fixed=True))
+        for label in columns
+    }
+
+    rcs = {}
+    for label in columns:
+        rcs[label] = scene.add_sensor(
+            gs.sensors.Raycaster(
+                pattern=gs.sensors.raycaster.GridPattern(resolution=0.2, size=(2.0, 2.0), direction=(0.0, 0.0, -1.0)),
+                entity_idx=carriers[label].idx,
+                max_range=5.0,
+                ray_alignment=label,
+                return_points=True,
+                return_world_frame=True,
+                draw_debug=True,
+                debug_ray_start_color=(0.0, 0.0, 0.0, 0.0),
+                debug_ray_hit_color=(1.0, 0.0, 0.0, 1.0),
+                pos_offset=(0.0, 0.0, -0.5),
+            )
+        )
+
+    scene.build(n_envs=1)
+    for _ in range(3):
+        scene.step()
+
+    print("\nRaycaster ray_alignment demo (two-phase motion)")
+    print("-" * 64)
+    print(f"Phase 1 ({args.phase1}s): pitch swing, amplitude {args.swing:.0f} deg, 1.0 Hz")
+    print("  -> compares base (tilts) vs yaw/world (level)")
+    print(f"Phase 2 ({args.phase2}s): yaw rotation, {args.yaw_rate:.0f} deg/s")
+    print("  -> compares yaw (grid follows) vs world (grid fixed)")
+
+    print("\nClose the viewer window (or Ctrl+C) to exit.")
+    try:
+        start = time.time()
+        t = 0.0
+        while True:
+            if t < args.phase1:
+                # Phase 1: pitch swing about x at 0.5 Hz.
+                pitch = math.radians(args.swing) * math.sin(2.0 * math.pi * 1.0 * t)
+                quat = euler_to_quat((pitch, 0.0, 0.0))
+            else:
+                # Phase 2: continuous yaw rotation about z.
+                yaw = math.radians(args.yaw_rate) * (t - args.phase1)
+                quat = euler_to_quat((0.0, 0.0, yaw))
+            for carrier in carriers.values():
+                carrier.set_quat(quat, relative=False)
+            scene.step()
+            t += scene.dt
+            if args.seconds and time.time() - start > args.seconds:
+                break
+            if "PYTEST_VERSION" in os.environ:
+                break
+    except KeyboardInterrupt:
+        gs.logger.info("Simulation interrupted, exiting.")
+    finally:
+        gs.logger.info("Simulation finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sensors/raycaster_exclude_go2.py
+++ b/examples/sensors/raycaster_exclude_go2.py
@@ -1,0 +1,119 @@
+"""Visualize the raycaster's ``exclude_link_idx`` on a Unitree Go2.
+
+Two identical hovering Go2 robots sit side by side. Each has a downward grid
+raycaster on its base, so the two cases never overlap in the viewer:
+
+- left  ``no_exclude``: rays hit the robot's own legs (short distances, hit
+  points on the body), so the scan reads the robot itself instead of the
+  terrain.
+- right ``exclude_go2``: ``exclude_link_idx`` removes that robot's every link
+  from the cast, so its rays pass through the body and read the ground height
+  below it, the behaviour a terrain height scan needs.
+
+Each raycaster draws its rays and hit points (``draw_debug``).
+
+Run:  python examples/sensors/raycaster_exclude_go2.py
+Add ``--headless`` to run without a window, and ``--seconds N`` to auto-stop.
+"""
+
+import argparse
+import os
+import time
+
+import numpy as np
+
+import genesis as gs
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--headless", action="store_true", help="Run without the viewer")
+    parser.add_argument("--seconds", type=float, default=0.0, help="Auto-stop after N seconds (0 = run until closed)")
+    args = parser.parse_args()
+
+    gs.init(logging_level="warning")
+    scene = gs.Scene(
+        vis_options=gs.options.VisOptions(show_world_frame=True),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.0, -7.0, 5.0),
+            camera_lookat=(0.0, 0.0, 1.0),
+        ),
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=not args.headless,
+    )
+
+    scene.add_entity(gs.morphs.Plane())
+
+    # Two identical hovering Go2 robots, one per raycaster.
+    def make_go2(x):
+        return scene.add_entity(
+            gs.morphs.URDF(
+                file="urdf/go2/urdf/go2.urdf",
+                pos=(x, 0.0, 0.8),
+                fixed=True,
+            ),
+        )
+
+    go2_no = make_go2(-2.0)
+    go2_ex = make_go2(2.0)
+    go2_ex_link_idx = [link.idx for link in go2_ex.links]
+
+    def grid_raycaster(entity, exclude):
+        return scene.add_sensor(
+            gs.sensors.Raycaster(
+                pattern=gs.sensors.raycaster.GridPattern(resolution=0.1, size=(1.2, 0.6), direction=(0.0, 0.0, -1.0)),
+                entity_idx=entity.idx,
+                max_range=3.0,
+                ray_alignment="world",
+                exclude_link_idx=exclude,
+                return_points=True,
+                return_world_frame=True,
+                draw_debug=True,
+                debug_ray_start_color=(0.0, 0.0, 0.0, 0.0),
+                debug_ray_hit_color=(1.0, 0.0, 0.0, 1.0),
+            )
+        )
+
+    rcs = {
+        "no_exclude": grid_raycaster(go2_no, ()),
+        "exclude_go2": grid_raycaster(go2_ex, go2_ex_link_idx),
+    }
+
+    scene.build(n_envs=1)
+    for _ in range(3):
+        scene.step()
+
+    print("\nRaycaster exclude_link_idx demo (Go2)")
+    print("-" * 64)
+    print(f"{'sensor':14s} {'x':6s} {'min_dist':10s} {'mean_dist':10s} {'hits_on_robot'}")
+    for name, (x, rc) in (("no_exclude", (-2.0, rcs["no_exclude"])), ("exclude_go2", (2.0, rcs["exclude_go2"]))):
+        data = rc.read()
+        dist = data.distances.cpu().numpy().reshape(-1)
+        pts = data.points.cpu().numpy().reshape(-1, 3)
+        # A hit on the robot sits well above the ground (z >> 0); ground hits
+        # cluster near z=0.
+        robot_hits = int((pts[:, 2] > 0.2).sum())
+        hit = dist[dist < 2.9]
+        print(f"{name:14s} {x:6.1f} {hit.min():10.3f} {hit.mean():10.3f} {robot_hits:14d}")
+
+    print("\nViewer legend (color-coded hit points):")
+    print("  left  no_exclude : rays hit the robot's own legs (red on the body)")
+    print("  right exclude    : rays pass through the robot and read the ground")
+
+    print("\nClose the viewer window (or Ctrl+C) to exit.")
+    try:
+        start = time.time()
+        while True:
+            scene.step()
+            if args.seconds and time.time() - start > args.seconds:
+                break
+            if "PYTEST_VERSION" in os.environ:
+                break
+    except KeyboardInterrupt:
+        gs.logger.info("Simulation interrupted, exiting.")
+    finally:
+        gs.logger.info("Simulation finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/genesis/engine/sensors/raycaster.py
+++ b/genesis/engine/sensors/raycaster.py
@@ -482,6 +482,13 @@ class RaycasterSharedMetadata(KinematicSensorMetadataMixin, SimpleSensorMetadata
     max_ranges: torch.Tensor = make_tensor_field((0,))
     no_hit_values: torch.Tensor = make_tensor_field((0,))
     return_world_frame: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_bool)
+    # Per-sensor ray alignment code (0=base, 1=yaw, 2=world), encoded in build().
+    ray_alignments: torch.Tensor = make_tensor_field((0,), dtype_factory=lambda: gs.tc_int)
+    # Per-sensor bool link-exclusion mask [n_sensors, n_links]; row i is all-ones
+    # (no exclusion) when sensor i filters nothing.
+    link_excluded: torch.Tensor | None = None
+    # Per-sensor excluded link indices (global solver link space), appended in build().
+    exclude_link_indices: list[torch.Tensor] = field(default_factory=list)
 
     patterns: list[RaycastPattern] = field(default_factory=list)
     ray_dirs: torch.Tensor = make_tensor_field((0, 3))
@@ -565,6 +572,15 @@ class RaycasterSensor(
         self._shared_metadata.return_world_frame = concat_with_tensor(
             self._shared_metadata.return_world_frame, self._options.return_world_frame
         )
+        self._shared_metadata.ray_alignments = concat_with_tensor(
+            self._shared_metadata.ray_alignments,
+            {"base": 0, "yaw": 1, "world": 2}[self._options.ray_alignment],
+        )
+        self._shared_metadata.exclude_link_indices.append(
+            torch.as_tensor(self._options.exclude_link_idx, dtype=gs.tc_int, device=gs.device)
+            if self._options.exclude_link_idx is not None
+            else torch.empty(0, dtype=gs.tc_int, device=gs.device)
+        )
         self._shared_metadata.min_ranges = concat_with_tensor(self._shared_metadata.min_ranges, self._options.min_range)
         self._shared_metadata.max_ranges = concat_with_tensor(self._shared_metadata.max_ranges, self._options.max_range)
         self._shared_metadata.no_hit_values = concat_with_tensor(
@@ -609,6 +625,15 @@ class RaycasterSensor(
                 B, shared_metadata.n_sensors, 4, device=gs.device, dtype=gs.tc_float
             )
             shared_metadata.links_quat[:, :, 0] = 1.0
+            # Per-sensor link-exclusion mask, all-ones (no exclusion) rows filled
+            # with zeros at the sensor's excluded link columns. Built once here:
+            # the per-face link mapping is static, so the mask is constant.
+            n_links = bvh_contexts[0].solver.n_links
+            mask = torch.ones(shared_metadata.n_sensors, n_links, dtype=gs.tc_bool, device=gs.device)
+            for s, idx in enumerate(shared_metadata.exclude_link_indices):
+                if idx.numel():
+                    mask[s, idx] = 0
+            shared_metadata.link_excluded = mask
 
         # Gather link poses per sensor. Sensors are pre-bucketed into shared_metadata.solver_groups at build time so
         # this loop issues one bulk get_links_pos / get_links_quat per solver with already-tensor-typed indices.
@@ -622,6 +647,29 @@ class RaycasterSensor(
                 quat = quat[None]
             links_pos[:, group.sensor_cols, :] = pos
             links_quat[:, group.sensor_cols, :] = quat
+
+        # Apply per-sensor ray alignment: "yaw" keeps only the frame link's yaw
+        # (rays stay horizontal on slopes), "world" fixes rays in the world frame
+        # (identity orientation). Both keep the frame link's position as origin.
+        alignments = shared_metadata.ray_alignments.to(links_quat.device)
+        world_mask = alignments == 2
+        if world_mask.any():
+            links_quat[:, world_mask, :] = 0.0
+            links_quat[:, world_mask, 0] = 1.0
+        yaw_mask = alignments == 1
+        if yaw_mask.any():
+            q = links_quat[:, yaw_mask, :]
+            # Extract the yaw angle from the link quaternion (w,x,y,z order) and
+            # rebuild a pure-yaw quaternion, dropping pitch/roll without a full
+            # euler decomposition.
+            yaw = torch.atan2(
+                2.0 * (q[..., 0] * q[..., 3] + q[..., 1] * q[..., 2]),
+                1.0 - 2.0 * (q[..., 2] * q[..., 2] + q[..., 3] * q[..., 3]),
+            )
+            links_quat[:, yaw_mask, 0] = torch.cos(yaw * 0.5)
+            links_quat[:, yaw_mask, 1] = 0.0
+            links_quat[:, yaw_mask, 2] = 0.0
+            links_quat[:, yaw_mask, 3] = torch.sin(yaw * 0.5)
 
         # The entries chain into one output buffer: the first initializes every slot (is_merge=False), each subsequent
         # one merges in closer hits, and the final one (is_last) settles misses to no_hit_value - see write_ray_hit.
@@ -643,11 +691,12 @@ class RaycasterSensor(
                 shared_metadata.sensor_point_offsets,
                 shared_metadata.sensor_point_counts,
                 shared_metadata.sensor_return_points,
-                raw_data_T,
             )
             if entry.raycast_mask is None:
                 kernel_cast_rays(
                     *args_common,
+                    shared_metadata.link_excluded,
+                    raw_data_T,
                     solver.dyn_state,
                     solver.dyn_info,
                     eps=gs.EPS,
@@ -655,10 +704,16 @@ class RaycasterSensor(
                     is_last=i == len(bvh_contexts) - 1,
                     # One tree serving several envs wants the env-major thread mapping (see kernel_cast_rays).
                     is_env_major=entry.aabb.n_batches < solver._B,
+                    # Compile-time flag: true if any sensor excludes links. It is
+                    # global across sensors (quadrants template flags cannot vary
+                    # per element), so one filtering sensor makes every ray pay
+                    # the per-leaf mask lookup.
+                    is_link_excluded=any(idx.numel() for idx in shared_metadata.exclude_link_indices),
                 )
             else:
                 kernel_cast_rays_visual(
                     *args_common,
+                    raw_data_T,
                     solver.dyn_state,
                     solver.dyn_info,
                     eps=gs.EPS,

--- a/genesis/options/sensors/options.py
+++ b/genesis/options/sensors/options.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Annotated, Any, Generic, NamedTuple, Sequence, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, Generic, Literal, NamedTuple, Sequence, TypeVar
 
 import numpy as np
 from pydantic import BeforeValidator, Field, StrictBool, StrictInt, field_validator
@@ -641,10 +641,41 @@ class Raycaster(KinematicSensorOptionsMixin["RaycasterSensor"], SimpleSensorOpti
     no_hit_value: float | None = None
     return_world_frame: StrictBool = False
     return_points: StrictBool = True
+    ray_alignment: Literal["base", "yaw", "world"] = "base"
+    """How the ray pattern is oriented relative to the sensor's frame link.
+
+    - ``"base"`` (default): rays follow the link's full orientation; the grid
+      tilts and rotates with the body.
+    - ``"yaw"``: rays follow only the link's yaw (ignores pitch/roll), so the
+      grid stays horizontal on slopes but no longer tilts with the body. Pick
+      for height maps that must stay level on tilted surfaces.
+    - ``"world"``: rays are fixed in the world frame, always pointing the same
+      direction regardless of the link orientation; the grid never follows the
+      body. Pick for scans that must keep a fixed world reference.
+    """
+
+    exclude_link_idx: OptionalIArrayType = Field(default_factory=tuple)
+    """Global rigid link indices (solver link space) whose geometry this
+    sensor's rays must ignore.
+
+    A ray that would hit a face owned by one of these links reports no hit, so
+    the scan becomes blind to those links (rays pass through them). Set it to
+    e.g. the robot's own links so a terrain height scan sees the ground instead
+    of the robot's legs.
+    """
 
     debug_sphere_radius: PositiveFloat = 0.02
     debug_ray_start_color: Vec4FType = (0.5, 0.5, 1.0, 1.0)
     debug_ray_hit_color: Vec4FType = (1.0, 0.5, 0.5, 1.0)
+
+    def validate_scene(self, scene: "Scene"):
+        super().validate_scene(scene)
+        if self.exclude_link_idx:
+            n_links = scene.sim.rigid_solver.n_links
+            if np.any(np.array(self.exclude_link_idx) < 0) or np.any(np.array(self.exclude_link_idx) >= n_links):
+                gs.raise_exception(
+                    f"{type(self).__name__}: exclude_link_idx must be in [0, {n_links}). Got {self.exclude_link_idx}."
+                )
 
     def model_post_init(self, context: Any) -> None:
         if self.no_hit_value is None:

--- a/genesis/utils/raycast_qd.py
+++ b/genesis/utils/raycast_qd.py
@@ -41,14 +41,17 @@ def get_triangle_vertices(i_f: int, i_b: int, dyn_state: array_class.DynState, d
 def bvh_ray_cast(
     i_t: int,
     i_b: int,
+    i_s: int,  # sensor index selecting the link_excluded row
     ray_start: qd.types.vector(3),
     ray_dir: qd.types.vector(3),
     max_range: float,
     bvh_nodes: qd.template(),
     bvh_morton_codes: qd.template(),
+    link_excluded: qd.types.ndarray(ndim=2),  # [n_sensors, n_links] bool - 0 marks an excluded link
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
     eps: float,
+    is_link_excluded: qd.template(),  # compile-time: whether any sensor excludes links
 ):
     """
     Cast a ray through a BVH and find the closest intersection.
@@ -56,6 +59,9 @@ def bvh_ray_cast(
     ``i_t`` selects the BVH tree slot (nodes / morton codes) and ``i_b`` the env whose verts back the leaf
     triangles: ``i_t == i_b`` for a per-env BVH, while a grouped static BVH shared by several envs routes ``i_t``
     through ``env_bvh_idx`` (the routed envs have bit-identical verts, so each env reads its own).
+
+    ``i_s`` selects the sensor whose ``link_excluded`` row a leaf is checked against; when ``is_link_excluded``
+    is False (compile time) that check is compiled out, so non-filtering sensors pay no per-leaf cost.
 
     Returns
     -------
@@ -72,6 +78,9 @@ def bvh_ray_cast(
     hit_face = -1
     closest_distance = gs.qd_float(max_range)
     hit_normal = qd.math.vec3(0.0, 0.0, 0.0)
+    # Declared before the compile-time branch: stays 0 (not excluded) when
+    # is_link_excluded is False, keeping that path a no-op.
+    is_excluded = gs.qd_int(0)
 
     axes, shear, is_valid_dir = ray_projection(ray_dir, eps)
 
@@ -105,7 +114,13 @@ def bvh_ray_cast(
                 # Perform ray-triangle intersection
                 hit_distance = ray_triangle_intersection(axes, ray_start, shear, v0, v1, v2, eps)
 
-                if hit_distance >= 0.0 and hit_distance < closest_distance:
+                if qd.static(is_link_excluded):
+                    # A ray must not hit faces owned by this sensor's excluded
+                    # links (e.g. the robot's own links for a terrain scan).
+                    # mask[row, link] == 0 marks an excluded link.
+                    is_excluded = link_excluded[i_s, dyn_info.geoms.link_idx[dyn_info.faces.geom_idx[i_f]]] == 0
+
+                if is_excluded == 0 and hit_distance >= 0.0 and hit_distance < closest_distance:
                     closest_distance = hit_distance
                     hit_face = i_f
                     hit_normal = triangle_face_normal(v0, v1, v2)
@@ -677,18 +692,24 @@ def kernel_cast_ray(
                 eps,
             )
         else:
+            # Single-ray (viewer) path: no per-sensor context, so i_s=0, an
+            # empty link_excluded mask and is_link_excluded=False (no filtering).
             cur_hit_face, cur_distance, cur_hit_normal = bvh_ray_cast(
                 i_b,
                 i_b,
+                0,
                 ray_start_world - env_offset,
                 ray_direction_world,
                 max_range,
                 bvh_nodes,
                 bvh_morton_codes,
+                None,
                 dyn_state,
                 dyn_info,
                 eps,
+                False,
             )
+
         if cur_hit_face >= 0:
             result.distance[i_b] = cur_distance
             if qd.static(is_visual):
@@ -780,6 +801,7 @@ def kernel_cast_rays(
     sensor_point_offsets: qd.types.ndarray(ndim=1),  # [n_sensors] - point start index for each sensor
     sensor_point_counts: qd.types.ndarray(ndim=1),  # [n_sensors] - number of points for each sensor
     sensor_return_points: qd.types.ndarray(ndim=1),  # [n_sensors] - True to store hit points, False for distances-only
+    link_excluded: qd.types.ndarray(ndim=2),  # [n_sensors, n_links] bool - 0 marks an excluded link's faces
     output_hits: qd.types.ndarray(ndim=2),  # [total_cache_size, n_env]
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
@@ -787,6 +809,7 @@ def kernel_cast_rays(
     is_merge: qd.template(),
     is_last: qd.template(),
     is_env_major: qd.template(),
+    is_link_excluded: qd.template(),
 ):
     """Cast rays against a collision-mesh BVH.
 
@@ -829,14 +852,17 @@ def kernel_cast_rays(
         hit_face, hit_distance, _hit_normal = bvh_ray_cast(
             env_bvh_idx[i_b],
             i_b,
+            i_s,
             ray_start_world,
             ray_direction_world,
             max_ranges[i_s],
             bvh_nodes,
             bvh_morton_codes,
+            link_excluded,
             dyn_state,
             dyn_info,
             eps,
+            is_link_excluded,
         )
 
         i_p_sensor = i_p - sensor_point_offsets[i_s]

--- a/tests/sensors/test_raycaster.py
+++ b/tests/sensors/test_raycaster.py
@@ -950,3 +950,112 @@ def test_static_dynamic_bvh_split_merge(show_viewer, n_envs, tol):
     # subset keeps one tree per env by construction.
     assert static_entry.aabb.n_batches == 1
     assert dynamic_entry.aabb.n_batches == max(n_envs, 1)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_ray_alignment(show_viewer, n_envs):
+    """ray_alignment: base tilts the ray grid with the carrier, yaw/world keep it level."""
+    PITCH = 30.0
+    scene = gs.Scene(
+        vis_options=gs.options.VisOptions(rendered_envs_idx=(0,)),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.0, -3.0, 2.0),
+            camera_lookat=(0.0, 0.0, 0.8),
+        ),
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    # A box obstacle (top at z=1.0) under the tilted carrier.
+    scene.add_entity(gs.morphs.Box(size=(1.0, 1.0, 1.0), pos=(0.0, 0.0, 0.5), fixed=True))
+    carrier = scene.add_entity(
+        gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(0.0, 0.0, 3.0), fixed=True, euler=(PITCH, 0.0, 0.0))
+    )
+
+    rcs = {}
+    for alignment in ("base", "yaw", "world"):
+        rcs[alignment] = scene.add_sensor(
+            gs.sensors.Raycaster(
+                pattern=gs.sensors.raycaster.GridPattern(resolution=0.5, size=(2.0, 2.0), direction=(0.0, 0.0, -1.0)),
+                entity_idx=carrier.idx,
+                max_range=5.0,
+                ray_alignment=alignment,
+                return_points=True,
+                return_world_frame=True,
+                draw_debug=show_viewer,
+                debug_ray_start_color=(0.0, 0.0, 0.0, 0.0),
+                debug_ray_hit_color=(1.0, 0.0, 0.0, 1.0),
+            )
+        )
+
+    scene.build(n_envs=n_envs)
+    for _ in range(3):
+        scene.step()
+
+    def dist_range(rc):
+        d = rc.read().distances
+        if n_envs == 0:
+            d = d.unsqueeze(0)
+        # Ignore the carrier's own near-zero hits (0.1): base rays tilt and reach
+        # farther ground than the level yaw/world grids, so their distance range
+        # is wider.
+        d = d[d > 0.5]
+        return d.max() - d.min()
+
+    base_range = dist_range(rcs["base"])
+    level_range = dist_range(rcs["yaw"])
+    # base tilts with the carrier, so its rays reach a wider range of hit depths
+    # than the level yaw/world grids.
+    assert base_range > level_range + 0.3
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_exclude_link_idx(show_viewer, n_envs):
+    """exclude_link_idx: a ray passes through an excluded link's geometry."""
+    scene = gs.Scene(
+        vis_options=gs.options.VisOptions(rendered_envs_idx=(0,)),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(0.0, -3.0, 2.0),
+            camera_lookat=(0.0, 0.0, 0.8),
+        ),
+        profiling_options=gs.options.ProfilingOptions(show_FPS=False),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(gs.morphs.Plane())
+    # The obstacle (global link idx 1) sits between the carrier and the ground.
+    obstacle = scene.add_entity(gs.morphs.Box(size=(1.0, 1.0, 1.0), pos=(0.0, 0.0, 0.5), fixed=True))
+    carrier = scene.add_entity(gs.morphs.Box(size=(0.2, 0.2, 0.2), pos=(0.0, 0.0, 3.0), fixed=True))
+
+    def make_raycaster(exclude):
+        return scene.add_sensor(
+            gs.sensors.Raycaster(
+                pattern=gs.sensors.raycaster.GridPattern(resolution=0.5, size=(2.0, 2.0), direction=(0.0, 0.0, -1.0)),
+                entity_idx=carrier.idx,
+                max_range=5.0,
+                ray_alignment="world",
+                exclude_link_idx=exclude,
+                draw_debug=show_viewer,
+                debug_ray_start_color=(0.0, 0.0, 0.0, 0.0),
+            )
+        )
+
+    rc_all = make_raycaster(())
+    rc_excl = make_raycaster([obstacle.links[0].idx])
+
+    scene.build(n_envs=n_envs)
+    for _ in range(3):
+        scene.step()
+
+    all_dist = rc_all.read().distances
+    excl_dist = rc_excl.read().distances
+    if n_envs == 0:
+        all_dist = all_dist.unsqueeze(0)
+        excl_dist = excl_dist.unsqueeze(0)
+    # Center rays hit the obstacle top at ~dist 2.0 unless the obstacle's link
+    # is excluded, in which case they pass through to the ground at ~dist 3.0.
+    obstacle_hit = all_dist[(all_dist > 1.5) & (all_dist < 2.5)]
+    excl_obstacle_hit = excl_dist[(excl_dist > 1.5) & (excl_dist < 2.5)]
+    assert obstacle_hit.numel() > 0
+    assert excl_obstacle_hit.numel() == 0


### PR DESCRIPTION
## Description
This PR extends the raycaster with two capabilities that are common in legged-locomotion terrain perception:
1. ray_alignment ("base" / "yaw" / "world") — controls how the ray grid is oriented relative to the sensor's frame link:
  - "base" (default): rays follow the link's full orientation.
  - "yaw": rays follow only the link's yaw (ignore pitch/roll), keeping the grid horizontal on slopes.
  - "world": rays are fixed in the world frame, independent of the link orientation.
2. exclude_link_idx — global rigid link indices whose geometry the rays ignore. A ray that would hit a face owned by an excluded link reports no hit, so the scan passes through the robot's own links to read the terrain below. This is the behaviour a terrain height scan needs.
Both features are applied per-sensor. ray_alignment is resolved at cast time by correcting the gathered link quaternion; exclude_link_idx is compiled into the ray-cast kernel as a per-sensor link mask, gated by a compile-time flag so non-filtering sensors pay no per-leaf cost.

## Related Issue
None

## Motivation and Context
Terrain perception for quadruped locomotion needs a downward height scan that (a) stays horizontal when the robot pitches/rolls on slopes (yaw/world) and (b) ignores the robot's own body so the scan reads the ground instead of the legs. Without these, a base-mounted grid raycast both tilts with the body and self-intersects the robot's geometry.

## How Has This Been / Can This Be Tested?
Unit tests were added to tests/sensors/test_raycaster.py (run with the project's required CI command):
`pytest -v --forked -m required ./tests/sensors/test_raycaster.py`
- test_ray_alignment — a carrier tilted 30 deg about x; asserts the base grid's hit-distance range is wider than the level yaw/world grids.
- test_exclude_link_idx — asserts that excluding an obstacle's link removes the obstacle-top hit so the rays pass through to the ground.
Two runnable examples demonstrate the features visually:
```python
python examples/sensors/raycaster_alignment.py          # base/yaw/world under two-phase motion
python examples/sensors/raycaster_exclude_go2.py        # go2 self-exclusion for a terrain scan
```

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
<!--- Optionally -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
