### PR TITLE
[BREAKING][MISC] Separate the static description of a rigid entity from its runtime state.

### DIFF
--- a/examples/rigid/friction_breakaway.py
+++ b/examples/rigid/friction_breakaway.py
@@ -100,9 +100,9 @@ def measure_stiction(friction_cone, show_viewer):
     )
     scene.build()
 
-    box_load_coulomb = box.geoms[0].friction * float(box.get_mass()) * GRAVITY
-    spinner_load_coulomb = spinner.geoms[0].friction_torsional * float(spinner.get_mass()) * GRAVITY
-    roller_load_coulomb = roller.geoms[0].friction_rolling * float(roller.get_mass()) * GRAVITY
+    box_load_coulomb = box.geoms[0].get_friction() * box.get_mass() * GRAVITY
+    spinner_load_coulomb = spinner.geoms[0].get_friction_torsional() * spinner.get_mass() * GRAVITY
+    roller_load_coulomb = roller.geoms[0].get_friction_rolling() * roller.get_mass() * GRAVITY
 
     is_load_held = []
     for load_ratio in LOAD_RATIOS:

--- a/examples/sensors/tactile_franka.py
+++ b/examples/sensors/tactile_franka.py
@@ -303,8 +303,8 @@ def main() -> None:
         franka.set_qpos(qpos[motor_dofs_idx], motor_dofs_idx)
         toggle_gripper(False)
 
-        cube.set_pos(cube.base_link.pos)
-        sphere.set_pos(sphere.base_link.pos)
+        cube.set_pos(cube.base_link.desc.pos)
+        sphere.set_pos(sphere.base_link.desc.pos)
 
     reset_robot()
 

--- a/genesis/engine/couplers/ipc_coupler/coupler.py
+++ b/genesis/engine/couplers/ipc_coupler/coupler.py
@@ -530,7 +530,7 @@ class IPCCoupler(RBC):
                     if entity.solver._enable_mujoco_compatibility:
                         rho = RHO_MUJOCO
                     else:
-                        rho = RHO_ROBOT if target_link._is_robot else RHO_OBJECT
+                        rho = RHO_ROBOT if target_link.desc.is_robot else RHO_OBJECT
                 self._ipc_abd.apply_to(rigid_link_geom, kappa=ABD_KAPPA * uipc.unit.MPa, mass_density=rho)
 
                 # Apply SoftTransformConstraint and animator for coupled links

--- a/genesis/engine/couplers/ipc_coupler/data.py
+++ b/genesis/engine/couplers/ipc_coupler/data.py
@@ -66,9 +66,9 @@ class IPCCouplingData:
         self.abd_body_idx_by_link = abd_body_idx_by_link
         self.links_idx = [link.idx for link in links]
         self.link_to_idx_local = {link: i for i, link in enumerate(links)}
-        self.links_mass = np.array([link.inertial_mass for link in links], dtype=gs.np_float)
+        self.links_mass = np.array([link.desc.mass for link in links], dtype=gs.np_float)
         if links:
-            self.links_inertia_i = np.stack([link.inertial_i for link in links], axis=0, dtype=gs.np_float)
+            self.links_inertia_i = np.stack([link.desc.inertia for link in links], axis=0, dtype=gs.np_float)
         else:
             self.links_inertia_i = np.empty((0, 0, 3, 3), dtype=gs.np_float)
 

--- a/genesis/engine/couplers/ipc_coupler/utils.py
+++ b/genesis/engine/couplers/ipc_coupler/utils.py
@@ -89,7 +89,7 @@ def compute_link_to_link_transform(from_link, to_link):
     while link is not to_link:
         if link.parent_idx < 0:
             gs.raise_exception(f"Cannot compute transform from link {from_link} to {to_link}")
-        pos, quat = gu.transform_pos_quat_by_trans_quat(pos, quat, link.pos, link.quat)
+        pos, quat = gu.transform_pos_quat_by_trans_quat(pos, quat, link.desc.pos, link.desc.quat)
         link = entity.links[link.parent_idx - entity.link_start]
 
     return pos, quat

--- a/genesis/engine/entities/hybrid_entity.py
+++ b/genesis/engine/entities/hybrid_entity.py
@@ -508,11 +508,11 @@ def augment_link_world_coords(part_rigid):
         if (link.joints and link.joints[0].type == gs.JOINT_TYPE.FREE) or (
             i_p == -1 and (not link.joints or link.joints[0].type == gs.JOINT_TYPE.FIXED)
         ):
-            link.init_x_pos = link.pos
-            link.init_x_quat = link.quat
+            link.init_x_pos = link.desc.pos
+            link.init_x_quat = link.desc.quat
         else:
             link.init_x_pos, link.init_x_quat = gu.transform_pos_quat_by_trans_quat(
-                link.pos, link.quat, parent_pos, parent_quat
+                link.desc.pos, link.desc.quat, parent_pos, parent_quat
             )
             for joint in link.joints:
                 link.init_x_pos, link.init_x_quat = gu.transform_pos_quat_by_trans_quat(

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1,6 +1,7 @@
 import inspect
 import math
 import os
+from dataclasses import replace
 from functools import wraps
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Hashable
@@ -14,14 +15,18 @@ from genesis.constants import link_ref_frame
 from genesis.engine.materials.base import Material
 from genesis.engine.mesh import InertialProperties
 from genesis.engine.states.entities import RigidEntityState
-from genesis.options.morphs import Morph
-from genesis.options.surfaces import Surface
 from genesis.typing import UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
 from genesis.utils import mesh as mu
 from genesis.utils import mjcf as mju
 from genesis.utils import terrain as tu
 from genesis.utils import urdf as uu
+from genesis.utils.description import (
+    EqualityDescription,
+    GeomDescription,
+    JointDescription,
+    LinkDescription,
+)
 from genesis.utils.misc import DeprecationError, broadcast_tensor, qd_to_torch, tensor_to_array
 
 from ..base_entity import Entity
@@ -36,13 +41,17 @@ from .rigid_link import (
     KinematicLink,
     LinkInertial,
     LinkInertialInfo,
+    LinkVariant,
     RigidLink,
-    compose_inertial_from_g_infos,
+    compose_inertial_from_geoms,
     compose_inertial_properties,
     finalize_inertial,
 )
 
 if TYPE_CHECKING:
+    from genesis.options.morphs import Morph
+    from genesis.options.surfaces import Surface
+
     from genesis.engine.scene import Scene
     from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
     from genesis.engine.solvers.kinematic_solver import KinematicSolver
@@ -98,8 +107,8 @@ class KinematicEntity(Entity):
         scene: "Scene",
         solver: "KinematicSolver",
         material: Material,
-        morph: Morph,
-        surface: Surface,
+        morph: "Morph",
+        surface: "Surface",
         idx: int,
         idx_in_solver,
         link_start: int,
@@ -111,7 +120,7 @@ class KinematicEntity(Entity):
         vface_start: int,
         custom_vvert_start: int,
         custom_vface_start: int,
-        morph_heterogeneous: list[Morph] | None = None,
+        morph_heterogeneous: "list[Morph] | None" = None,
         name: str | None = None,
     ):
         # Set heterogeneous support before super().__init__() because _get_morph_identifier() needs it
@@ -187,7 +196,7 @@ class KinematicEntity(Entity):
     def init_ckpt(self):
         pass
 
-    def _load_morph(self, morph: Morph):
+    def _load_morph(self, morph: "Morph"):
         """Load a single morph into the entity."""
         if isinstance(morph, gs.morphs.Mesh):
             self._load_mesh(morph, self._surface)
@@ -234,36 +243,36 @@ class KinematicEntity(Entity):
             if isinstance(morph, (gs.morphs.URDF, gs.morphs.MJCF)):
                 # Parse variant scene file
                 morph._enable_mujoco_compatibility = self._morph._enable_mujoco_compatibility
-                v_l_infos, v_links_j_infos, v_links_g_infos, _ = self._parse_scene(morph, self._surface)
+                v_l_descs, v_links_j_descs, v_links_g_descs, _ = self._parse_scene(morph, self._surface)
 
                 # Validate that the variant has the same joint structure as the primary
-                if len(v_l_infos) != n_links:
+                if len(v_l_descs) != n_links:
                     gs.raise_exception(
-                        f"Heterogeneous variant has {len(v_l_infos)} links, "
+                        f"Heterogeneous variant has {len(v_l_descs)} links, "
                         f"but primary has {n_links}. All variants must have the same link count."
                     )
-                for i_l, (link, v_j_infos) in enumerate(zip(self._links, v_links_j_infos)):
+                for i_l, (link, v_j_descs) in enumerate(zip(self._links, v_links_j_descs)):
                     primary_joints = link.joints
-                    if len(v_j_infos) != len(primary_joints):
+                    if len(v_j_descs) != len(primary_joints):
                         gs.raise_exception(
-                            f"Heterogeneous variant link {i_l} has {len(v_j_infos)} joints, "
+                            f"Heterogeneous variant link {i_l} has {len(v_j_descs)} joints, "
                             f"but primary has {len(primary_joints)}."
                         )
-                    for p_joint, v_j_info in zip(primary_joints, v_j_infos):
-                        if p_joint.name != v_j_info["name"]:
+                    for p_joint, v_j_desc in zip(primary_joints, v_j_descs):
+                        if p_joint.name != v_j_desc.name:
                             gs.raise_exception(
                                 f"Joint name mismatch at link {i_l}: primary has '{p_joint.name}', "
-                                f"variant has '{v_j_info['name']}'. All variants must have the same joint names."
+                                f"variant has '{v_j_desc.name}'. All variants must have the same joint names."
                             )
-                        if p_joint.type != v_j_info["type"]:
+                        if p_joint.type != v_j_desc.type:
                             gs.raise_exception(
                                 f"Joint type mismatch for '{p_joint.name}': primary has {p_joint.type}, "
-                                f"variant has {v_j_info['type']}."
+                                f"variant has {v_j_desc.type}."
                             )
-                        if p_joint.n_dofs != v_j_info["n_dofs"]:
+                        if p_joint.n_dofs != v_j_desc.n_dofs:
                             gs.raise_exception(
                                 f"DoF count mismatch for joint '{p_joint.name}': primary has {p_joint.n_dofs}, "
-                                f"variant has {v_j_info['n_dofs']}."
+                                f"variant has {v_j_desc.n_dofs}."
                             )
 
                 # Post-process each link's geoms. The COM/principal-axis anchoring of the floating base is deferred to
@@ -271,20 +280,20 @@ class KinematicEntity(Entity):
                 # only the morph pose offset is composed into the variant's init_qpos and offset.
                 offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
                 offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
-                cg_vg_infos = []
-                for v_l_info, v_j_infos, v_g_infos in zip(v_l_infos, v_links_j_infos, v_links_g_infos):
-                    is_robot = v_l_info.get("is_robot", np.array(False, dtype=np.bool_))
-                    cg_infos, vg_infos = self._postprocess_geoms_info(morph, v_g_infos, is_robot)
-                    cg_vg_infos.append((cg_infos, vg_infos))
+                cg_vg_descs = []
+                for v_l_desc, v_j_descs, v_g_descs in zip(v_l_descs, v_links_j_descs, v_links_g_descs):
+                    is_robot = v_l_desc.is_robot
+                    cg_descs, vg_descs = self._postprocess_geoms(morph, v_g_descs, is_robot)
+                    cg_vg_descs.append((cg_descs, vg_descs))
 
-                # Extract variant's init_qpos from parsed joint infos, composing the morph offset into the free joint so
-                # relative getters report the variant's user frame.
+                # Extract the init_qpos of the variant from its joints, composing the morph offset into the free
+                # joint so that relative getters report the user frame of the variant
                 variant_init_qpos_parts = []
-                for v_l_info, v_j_infos in zip(v_l_infos, v_links_j_infos):
-                    is_root = v_l_info["parent_idx"] == -1
-                    for j_info in v_j_infos:
-                        qpos = j_info["init_qpos"]
-                        if is_root and j_info["type"] == gs.JOINT_TYPE.FREE:
+                for v_l_desc, v_j_descs in zip(v_l_descs, v_links_j_descs):
+                    is_root = v_l_desc.parent_idx == -1
+                    for j_desc in v_j_descs:
+                        qpos = j_desc.init_qpos
+                        if is_root and j_desc.type == gs.JOINT_TYPE.FREE:
                             init_pos, init_quat = gu.transform_pos_quat_by_trans_quat(
                                 np.array(morph.offset_pos, dtype=gs.np_float),
                                 np.array(morph.offset_quat, dtype=gs.np_float),
@@ -302,41 +311,41 @@ class KinematicEntity(Entity):
 
                 # Add geoms per link and stash this variant's finalized inertia for the align anchor.
                 recompute = morph.recompute_inertia
-                for i_link, (link, v_l_info, (cg_infos, vg_infos)) in enumerate(
-                    zip(self._links, v_l_infos, cg_vg_infos)
+                for i_link, (link, v_l_desc, (cg_descs, vg_descs)) in enumerate(
+                    zip(self._links, v_l_descs, cg_vg_descs)
                 ):
-                    self._add_heterogeneous_variant(link, cg_infos, vg_infos)
-                    self._on_heterogeneous_scene_variant_loaded(link, morph, v_l_info)
+                    self._add_heterogeneous_variant(link, cg_descs, vg_descs)
+                    self._on_heterogeneous_scene_variant_loaded(link, morph, v_l_desc)
                     self._links_inertial_info[i_link].append(
                         self._finalize_inertial(
-                            None if recompute else v_l_info.get("inertial_mass"),
-                            None if recompute else v_l_info.get("inertial_pos"),
-                            None if recompute else v_l_info.get("inertial_quat"),
-                            None if recompute else v_l_info.get("inertial_i"),
-                            cg_infos,
-                            vg_infos,
-                            v_l_info.get("is_robot", False),
+                            None if recompute else v_l_desc.mass,
+                            None if recompute else v_l_desc.inertial_pos,
+                            None if recompute else v_l_desc.inertial_quat,
+                            None if recompute else v_l_desc.inertia,
+                            cg_descs,
+                            vg_descs,
+                            v_l_desc.is_robot,
                         )
                     )
 
             elif isinstance(morph, (gs.morphs.Mesh, gs.morphs.Primitive)):
                 if isinstance(morph, gs.morphs.Mesh):
-                    g_infos = self._load_mesh(morph, self._surface, load_geom_only_for_heterogeneous=True)
+                    g_descs = self._load_mesh(morph, self._surface, load_geom_only_for_heterogeneous=True)
                 else:
-                    g_infos = self._load_primitive(morph, self._surface, load_geom_only_for_heterogeneous=True)
+                    g_descs = self._load_primitive(morph, self._surface, load_geom_only_for_heterogeneous=True)
                 if morph.fixed != self._morph.fixed:
                     gs.raise_exception("Mixing fixed and non-fixed morphs in heterogeneous entities is not supported.")
-                cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, is_robot=False)
+                cg_descs, vg_descs = self._postprocess_geoms(morph, g_descs, is_robot=False)
 
                 # The COM/principal-axis anchoring is deferred to '_align_free_roots' after build; compose only the
                 # morph pose offset here.
                 offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
                 offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
 
-                self._add_heterogeneous_variant(self._links[0], cg_infos, vg_infos)
+                self._add_heterogeneous_variant(self._links[0], cg_descs, vg_descs)
                 # Mesh/Primitive variants have no explicit inertial; the anchor inertia comes from their geometry.
                 self._links_inertial_info[0].append(
-                    self._finalize_inertial(None, None, None, None, cg_infos, vg_infos, is_robot=False)
+                    self._finalize_inertial(None, None, None, None, cg_descs, vg_descs, is_robot=False)
                 )
 
                 if morph.fixed:
@@ -361,20 +370,16 @@ class KinematicEntity(Entity):
         if len(self._links) > 1:
             self._reassign_heterogeneous_indices()
 
-    def _add_heterogeneous_variant(self, link, cg_infos, vg_infos):
+    def _add_heterogeneous_variant(self, link, cg_descs, vg_descs):
         """Add a heterogeneous variant's visual geoms to a link.
 
         RigidEntity overrides to additionally add collision geoms.
         """
-        for g_info in vg_infos:
-            link._add_vgeom(
-                vmesh=g_info["vmesh"],
-                init_pos=g_info.get("pos", gu.zero_pos()),
-                init_quat=g_info.get("quat", gu.identity_quat()),
-            )
-        link._record_variant_vgeom_range(len(vg_infos))
+        for g_desc in vg_descs:
+            link._add_vgeom(g_desc)
+        link._record_variant_vgeom_range(len(vg_descs))
 
-    def _on_heterogeneous_scene_variant_loaded(self, link, morph, v_l_info):
+    def _on_heterogeneous_scene_variant_loaded(self, link, morph, v_l_desc):
         """Hook for subclasses after a scene variant's geoms have been added to a link."""
 
     def _reassign_heterogeneous_indices(self):
@@ -459,51 +464,53 @@ class KinematicEntity(Entity):
             gs.raise_exception("Unsupported primitive shape")
 
         # contains one visual geom (vgeom) and one collision geom (geom)
-        g_infos = []
+        g_descs = []
         if morph.visualization:
-            g_infos.append(
-                dict(contype=0, conaffinity=0, vmesh=gs.Mesh.from_trimesh(tmesh, surface=surface, metadata=metadata))
+            g_descs.append(
+                GeomDescription(
+                    contype=0,
+                    conaffinity=0,
+                    vmesh=gs.Mesh.from_trimesh(tmesh, surface=surface, metadata=metadata),
+                )
             )
         if (morph.contype or morph.conaffinity) and morph.collision:
-            g_infos.append(
-                dict(
+            g_descs.append(
+                GeomDescription(
                     contype=morph.contype,
                     conaffinity=morph.conaffinity,
-                    mesh=gs.Mesh.from_trimesh(cmesh, surface=gs.surfaces.Collision()),
                     type=geom_type,
                     data=geom_data,
+                    mesh=gs.Mesh.from_trimesh(cmesh, surface=gs.surfaces.Collision()),
                     sol_params=gu.default_solver_params(),
                 )
             )
 
         # For heterogeneous simulation, only return geometry info without creating link/joint
         if load_geom_only_for_heterogeneous:
-            return g_infos
+            return g_descs
 
-        self._add_by_info(
-            l_info=dict(
-                is_robot=False,
+        self._add_by_description(
+            l_desc=LinkDescription(
                 name=f"{link_name_prefix}_baselink",
+                parent_idx=-1,
                 pos=np.array(morph.pos),
                 quat=np.array(morph.quat),
                 inertial_pos=None,  # we will compute the COM later based on the geometry
                 inertial_quat=gu.identity_quat(),
-                parent_idx=-1,
+                is_robot=False,
             ),
-            j_infos=[
-                dict(
+            j_descs=[
+                JointDescription(
                     name=f"{link_name_prefix}_baselink_joint",
-                    n_qs=n_qs,
-                    n_dofs=n_dofs,
                     type=joint_type,
                     init_qpos=init_qpos,
                 )
             ],
-            g_infos=g_infos,
+            g_descs=g_descs,
             morph=morph,
             surface=surface,
         )
-        return g_infos
+        return g_descs
 
     def _load_mesh(self, morph, surface, load_geom_only_for_heterogeneous=False):
         # Load meshes
@@ -522,10 +529,18 @@ class KinematicEntity(Entity):
             n_dofs = 6
             init_qpos = np.concatenate([link_pos, link_quat])
 
-        g_infos = []
+        g_descs = []
         if morph.visualization:
             for mesh in meshes:
-                g_infos.append(dict(contype=0, conaffinity=0, vmesh=mesh, pos=gu.zero_pos(), quat=gu.identity_quat()))
+                g_descs.append(
+                    GeomDescription(
+                        contype=0,
+                        conaffinity=0,
+                        pos=gu.zero_pos(),
+                        quat=gu.identity_quat(),
+                        vmesh=mesh,
+                    )
+                )
         if morph.collision:
             if morph.merge_submeshes_for_collision and len(meshes) > 1:
                 # Merge every submesh into a single collision geom if requested.
@@ -553,34 +568,44 @@ class KinematicEntity(Entity):
                 else:
                     tmesh = trimesh.util.concatenate([submesh.trimesh for submesh in group])
                     mesh = gs.Mesh.from_trimesh(mesh=tmesh, surface=gs.surfaces.Collision())
-                g_infos.append(
-                    dict(
+                g_descs.append(
+                    GeomDescription(
                         contype=morph.contype,
                         conaffinity=morph.conaffinity,
-                        mesh=mesh,
                         type=gs.GEOM_TYPE.MESH,
-                        sol_params=gu.default_solver_params(),
                         pos=gu.zero_pos(),
                         quat=gu.identity_quat(),
+                        mesh=mesh,
+                        sol_params=gu.default_solver_params(),
                     )
                 )
 
         # For heterogeneous simulation, only return geometry info without creating link/joint
         if load_geom_only_for_heterogeneous:
-            return g_infos
+            return g_descs
 
         link_name = os.path.basename(morph.file).replace(".", "_")
 
-        self._add_by_info(
-            l_info=dict(is_robot=False, name=f"{link_name}_baselink", pos=link_pos, quat=link_quat, parent_idx=-1),
-            j_infos=[
-                dict(name=f"{link_name}_baselink_joint", n_qs=n_qs, n_dofs=n_dofs, type=joint_type, init_qpos=init_qpos)
+        self._add_by_description(
+            l_desc=LinkDescription(
+                name=f"{link_name}_baselink",
+                parent_idx=-1,
+                pos=link_pos,
+                quat=link_quat,
+                is_robot=False,
+            ),
+            j_descs=[
+                JointDescription(
+                    name=f"{link_name}_baselink_joint",
+                    type=joint_type,
+                    init_qpos=init_qpos,
+                )
             ],
-            g_infos=g_infos,
+            g_descs=g_descs,
             morph=morph,
             surface=surface,
         )
-        return g_infos
+        return g_descs
 
     def _load_terrain(self, morph, surface):
         vmesh, mesh, terrain_hf = tu.parse_terrain(morph, surface)
@@ -590,35 +615,35 @@ class KinematicEntity(Entity):
         # including kinematic ones.
         self._terrain_height_field = torch.as_tensor(self.terrain_hf, dtype=gs.tc_float, device=gs.device)
 
-        g_infos = []
+        g_descs = []
         if morph.visualization:
-            g_infos.append(dict(contype=0, conaffinity=0, vmesh=vmesh))
+            g_descs.append(GeomDescription(contype=0, conaffinity=0, vmesh=vmesh))
         if morph.collision:
-            g_infos.append(
-                dict(
+            g_descs.append(
+                GeomDescription(
                     contype=1,
                     conaffinity=1,
-                    mesh=mesh,
                     type=gs.GEOM_TYPE.TERRAIN,
+                    mesh=mesh,
                     sol_params=gu.default_solver_params(),
                 )
             )
 
-        self._add_by_info(
-            l_info=dict(
-                is_robot=False,
+        self._add_by_description(
+            l_desc=LinkDescription(
                 name="baselink",
+                parent_idx=-1,
                 pos=np.array(morph.pos),
                 quat=np.array(morph.quat),
                 inertial_pos=None,
                 inertial_quat=gu.identity_quat(),
-                inertial_i=None,
-                inertial_mass=None,
-                parent_idx=-1,
+                inertia=None,
+                mass=None,
                 invweight=None,
+                is_robot=False,
             ),
-            j_infos=[dict(name="joint_baselink", n_qs=0, n_dofs=0, type=gs.JOINT_TYPE.FIXED)],
-            g_infos=g_infos,
+            j_descs=[JointDescription(name="joint_baselink", type=gs.JOINT_TYPE.FIXED)],
+            g_descs=g_descs,
             morph=morph,
             surface=surface,
         )
@@ -635,70 +660,85 @@ class KinematicEntity(Entity):
         # initialized undetermined physics parameters.
         if isinstance(morph, gs.morphs.MJCF):
             # Mujoco's unified MJCF+URDF parser systematically for MJCF files
-            l_infos, links_j_infos, links_g_infos, eqs_info = mju.parse_xml(morph, surface, self._solver._options)
+            l_descs, links_j_descs, links_g_descs, eq_descs = mju.parse_xml(morph, surface, self._solver._options)
         elif isinstance(morph, (gs.morphs.URDF, gs.morphs.Drone)):
             # Custom "legacy" URDF parser for loading geometries (visual and collision) and equality constraints.
             # This is necessary because Mujoco cannot parse visual geometries (meshes) reliably for URDF.
-            l_infos, links_j_infos, links_g_infos, eqs_info = uu.parse_urdf(morph, surface)
+            l_descs, links_j_descs, links_g_descs, eq_descs = uu.parse_urdf(morph, surface)
 
             # Mujoco's unified MJCF+URDF parser for only link, joints, and collision geometries properties
             morph_ = morph.model_copy(update=dict(visualization=False))
             try:
                 # Mujoco's unified MJCF+URDF parser for URDF files.
                 # Note that Mujoco URDF parser completely ignores equality constraints.
-                l_infos_mj, links_j_infos_mj, links_g_infos_mj, _ = mju.parse_xml(morph_, surface)
+                l_descs_mj, links_j_infos_mj, links_g_descs_mj, _ = mju.parse_xml(morph_, surface)
 
                 # Unset link inertial properties that are actually undefined to force recomputation by genesis
                 if not morph._enable_mujoco_compatibility:
-                    for l_info_gs in l_infos:
-                        for l_info_mj in l_infos_mj:
-                            if l_info_gs["name"] == l_info_mj["name"]:
-                                for key, value in l_info_gs.items():
-                                    if value is None:
-                                        l_info_mj[key] = None
-                                        is_inertia_invalid = True
-                                break
-                l_infos = l_infos_mj
+                    links_desc_gs = {l_desc.name: l_desc for l_desc in l_descs}
+                    for i_l, l_desc_mj in enumerate(l_descs_mj):
+                        l_desc_gs = links_desc_gs.get(l_desc_mj.name)
+                        if l_desc_gs is None:
+                            continue
+                        # Clear the inertial values the asset leaves unset, so that the build estimates them from
+                        # the geometry rather than reading the ones MuJoCo initialized
+                        unset = {
+                            name: None
+                            for name, value in (
+                                ("inertial_pos", l_desc_gs.inertial_pos),
+                                ("inertial_quat", l_desc_gs.inertial_quat),
+                                ("inertia", l_desc_gs.inertia),
+                                ("mass", l_desc_gs.mass),
+                            )
+                            if value is None
+                        }
+                        if unset:
+                            l_descs_mj[i_l] = replace(l_desc_mj, **unset)
+                            is_inertia_invalid = True
+                l_descs = l_descs_mj
 
                 # Mujoco is not parsing actuators properties
-                for j_info_gs in chain.from_iterable(links_j_infos):
-                    for j_info_mj in chain.from_iterable(links_j_infos_mj):
-                        if j_info_mj["name"] == j_info_gs["name"]:
-                            for name in ("dofs_force_range", "dofs_armature", "dofs_act_gain", "dofs_act_bias"):
-                                j_info_mj[name] = j_info_gs[name]
-                            break
-                links_j_infos = links_j_infos_mj
+                joints_desc_gs = {j_desc.name: j_desc for j_desc in chain.from_iterable(links_j_descs)}
+                for j_desc_mj in chain.from_iterable(links_j_infos_mj):
+                    j_desc_gs = joints_desc_gs.get(j_desc_mj.name)
+                    if j_desc_gs is None:
+                        continue
+                    j_desc_mj.dofs_force_range = j_desc_gs.dofs_force_range
+                    j_desc_mj.dofs_armature = j_desc_gs.dofs_armature
+                    j_desc_mj.dofs_act_gain = j_desc_gs.dofs_act_gain
+                    j_desc_mj.dofs_act_bias = j_desc_gs.dofs_act_bias
+                links_j_descs = links_j_infos_mj
 
                 # Must invalidate invweight if default rotor armature inertia has been specified
                 if morph.default_armature is not None:
-                    for link_j_infos in links_j_infos:
-                        for j_info in link_j_infos:
-                            if j_info["type"] not in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED):
+                    for link_j_descs in links_j_descs:
+                        for j_desc in link_j_descs:
+                            if j_desc.type not in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED):
                                 is_inertia_invalid = True
                                 break
 
                 # Take into account 'world' body if it was added automatically for our legacy URDF parser
-                if len(links_g_infos_mj) == len(links_g_infos) + 1:
-                    assert not links_g_infos_mj[0]
-                    links_g_infos.insert(0, [])
-                assert len(links_g_infos_mj) == len(links_g_infos)
+                if len(links_g_descs_mj) == len(links_g_descs) + 1:
+                    assert not links_g_descs_mj[0]
+                    links_g_descs.insert(0, [])
+                assert len(links_g_descs_mj) == len(links_g_descs)
 
                 # Update collision geometries, ignoring fake" visual geometries returned by Mujoco, (which is using
                 # collision as visual to avoid loading mesh files), and keeping the true visual geometries provided
                 # by our custom legacy URDF parser.
                 # Note that the Kinematic tree ordering is stable between Mujoco and Genesis (Hopefully!).
-                for link_g_infos, link_g_infos_mj in zip(links_g_infos, links_g_infos_mj):
+                for link_g_descs, link_g_descs_mj in zip(links_g_descs, links_g_descs_mj):
                     # Remove collision geometries from our legacy URDF parser
-                    for i_g, g_info in tuple(enumerate(link_g_infos))[::-1]:
-                        is_col = g_info["contype"] or g_info["conaffinity"]
+                    for i_g, g_desc in tuple(enumerate(link_g_descs))[::-1]:
+                        is_col = g_desc.contype or g_desc.conaffinity
                         if is_col:
-                            del link_g_infos[i_g]
+                            del link_g_descs[i_g]
 
                     # Add visual geometries from Mujoco's unified MJCF+URDF parser
-                    for g_info in link_g_infos_mj:
-                        is_col = g_info["contype"] or g_info["conaffinity"]
+                    for g_desc in link_g_descs_mj:
+                        is_col = g_desc.contype or g_desc.conaffinity
                         if is_col:
-                            link_g_infos.append(g_info)
+                            link_g_descs.append(g_desc)
             except (ValueError, AssertionError) as e:
                 gs.logger.warning(
                     "Falling back to legacy URDF parser. Default values of physics properties may be off:\n"
@@ -708,12 +748,12 @@ class KinematicEntity(Entity):
             from genesis.utils.usd import parse_usd_rigid_entity
 
             # Unified parser handles both articulations and rigid bodies
-            l_infos, links_j_infos, links_g_infos, eqs_info = parse_usd_rigid_entity(morph, surface)
+            l_descs, links_j_descs, links_g_descs, eq_descs = parse_usd_rigid_entity(morph, surface)
 
         # Make sure that the inertia matrix of all links is valid
         if not morph.recompute_inertia:
-            for l_info in l_infos:
-                inertia_i = l_info.get("inertial_i")
+            for l_desc in l_descs:
+                inertia_i = l_desc.inertia
                 if inertia_i is None:
                     continue
 
@@ -723,7 +763,7 @@ class KinematicEntity(Entity):
                 # Make sure that all eigenvalues are positive, ignoring rounding errors
                 if (inertia_diag < -gs.EPS).any():
                     gs.raise_exception(
-                        f"Inertia matrix of link '{l_info['name']}' not positive definite (eigenvalues: {inertia_diag})."
+                        f"Inertia matrix of link '{l_desc.name}' not positive definite (eigenvalues: {inertia_diag})."
                     )
 
                 # Make sure that the inertia matrix is physically valid (nothing to do with numerical conditioning)
@@ -732,13 +772,13 @@ class KinematicEntity(Entity):
                     for i in range(3)
                 ):
                     gs.raise_exception(
-                        f"Inertia matrix of link '{l_info['name']}' does not satisfy A+B>=C for all permutations "
+                        f"Inertia matrix of link '{l_desc.name}' does not satisfy A+B>=C for all permutations "
                         f"(eigenvalues: {inertia_diag}). Please fix manually you morph file '{morph.file}' or specify "
                         "`recompute_inertia=True`."
                     )
 
                 # Make sure that the inertia matrix is symmetric with positive eigenvalues
-                l_info["inertial_i"] = Q @ np.diag(np.maximum(inertia_diag, 0.0)) @ Q.T
+                l_desc.inertia = Q @ np.diag(np.maximum(inertia_diag, 0.0)) @ Q.T
 
         # Remove any "virtual" root link that was not present in the original file morph.
         # Mujoco unified parser and our legacy parser have different behaviors.
@@ -747,97 +787,85 @@ class KinematicEntity(Entity):
         # * Our legacy parser adds a root 'world' link if the root joint is not a fixed joint in file morph.
         # Remove this virtual world link if the child has a free joint (the free joint absorbs the full pose into
         # 'init_qpos' regardless of pos/quat), or if the child has an identity transform.
-        base_j_info, base_g_info = links_j_infos[0], links_g_infos[0]
-        if len(l_infos) > 1 and (sum(j_info["n_dofs"] for j_info in base_j_info) == 0) and not base_g_info:
-            child_has_freejoint = any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in links_j_infos[1])
-            child_is_identity = (np.abs(l_infos[1]["pos"]) < gs.EPS).all() and (
-                np.abs(l_infos[1]["quat"] - (1, 0, 0, 0)) < gs.EPS
+        base_j_descs, base_g_descs = links_j_descs[0], links_g_descs[0]
+        if len(l_descs) > 1 and (sum(j_desc.n_dofs for j_desc in base_j_descs) == 0) and not base_g_descs:
+            child_has_freejoint = any(j_desc.type == gs.JOINT_TYPE.FREE for j_desc in links_j_descs[1])
+            child_is_identity = (np.abs(l_descs[1].pos) < gs.EPS).all() and (
+                np.abs(l_descs[1].quat - (1, 0, 0, 0)) < gs.EPS
             ).all()
             if child_has_freejoint or child_is_identity:
-                del l_infos[0], links_j_infos[0], links_g_infos[0]
-                for l_info in l_infos:
-                    l_info["parent_idx"] = max(l_info["parent_idx"] - 1, -1)
-                    if "root_idx" in l_info:
-                        l_info["root_idx"] = max(l_info["root_idx"] - 1, -1)
+                del l_descs[0], links_j_descs[0], links_g_descs[0]
+                for l_desc in l_descs:
+                    l_desc.parent_idx = max(l_desc.parent_idx - 1, -1)
+                    if l_desc.root_idx is not None:
+                        l_desc.root_idx = max(l_desc.root_idx - 1, -1)
 
         # URDF is a robot description file so all links have same root_idx
         if isinstance(morph, gs.morphs.URDF) and not morph._enable_mujoco_compatibility:
-            for l_info in l_infos:
-                l_info["root_idx"] = 0
+            for l_desc in l_descs:
+                l_desc.root_idx = 0
 
         # Genesis requires links associated with free joints to be attached to the world directly
-        for l_info, link_j_infos in zip(l_infos, links_j_infos):
-            if all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in link_j_infos):
-                l_info["parent_idx"] = -1
+        for l_desc, link_j_descs in zip(l_descs, links_j_descs):
+            if all(j_desc.type == gs.JOINT_TYPE.FREE for j_desc in link_j_descs):
+                l_desc.parent_idx = -1
 
         # Add free floating joint at root if necessary
         if (
             (isinstance(morph, gs.morphs.Drone) or (isinstance(morph, gs.morphs.URDF) and not morph.fixed))
-            and links_j_infos
-            and sum(j_info["n_dofs"] for j_info in links_j_infos[0]) == 0
+            and links_j_descs
+            and sum(j_desc.n_dofs for j_desc in links_j_descs[0]) == 0
         ):
             # Define free joint
-            j_info = dict()
-            j_info["name"] = "root_joint"
-            j_info["type"] = gs.JOINT_TYPE.FREE
-            j_info["n_qs"] = 7
-            j_info["n_dofs"] = 6
-            j_info["init_qpos"] = np.concatenate([gu.zero_pos(), gu.identity_quat()])
-            j_info["pos"] = gu.zero_pos()
-            j_info["quat"] = gu.identity_quat()
-            j_info["dofs_motion_ang"] = np.eye(6, 3, -3)
-            j_info["dofs_motion_vel"] = np.eye(6, 3)
-            j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (6, 1))
-            j_info["dofs_stiffness"] = np.zeros(6)
-            j_info["dofs_invweight"] = np.zeros(6)
-            j_info["dofs_frictionloss"] = np.zeros(6)
-            j_info["dofs_damping"] = np.zeros(6)
+            dofs_damping = np.zeros(6)
             if isinstance(morph, gs.morphs.Drone):
                 # FIXME: This pattern not ideal because the inertial mass may be unknown at this point.
-                mass_tot = sum(l_info.get("inertial_mass") or 0.0 for l_info in l_infos)
-                j_info["dofs_damping"][3:] = mass_tot * morph.default_base_ang_damping_scale
-            j_info["dofs_armature"] = np.zeros(6)
-            j_info["dofs_act_gain"] = np.zeros((6,), dtype=gs.np_float)
-            j_info["dofs_act_bias"] = np.zeros((6, 3), dtype=gs.np_float)
-            j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (6, 1))
-            links_j_infos[0] = [j_info]
+                mass_tot = sum(l_desc.mass or 0.0 for l_desc in l_descs)
+                dofs_damping[3:] = mass_tot * morph.default_base_ang_damping_scale
+            links_j_descs[0] = [
+                JointDescription(
+                    name="root_joint",
+                    type=gs.JOINT_TYPE.FREE,
+                    init_qpos=np.concatenate([gu.zero_pos(), gu.identity_quat()]),
+                    dofs_damping=dofs_damping,
+                )
+            ]
 
             # The base link is now moving, which merges every kinematic tree connected to it into a single tree rooted
             # at it. Parser-provided root indices assume a base welded to the world, so recompute them by propagating
             # each parent's root (parents precede children); links with no parent root their own tree.
-            for i_l, l_info in enumerate(l_infos):
-                if "root_idx" in l_info:
-                    parent_idx = l_info["parent_idx"]
-                    l_info["root_idx"] = l_infos[parent_idx]["root_idx"] if parent_idx != -1 else i_l
+            for i_l, l_desc in enumerate(l_descs):
+                if l_desc.root_idx is not None:
+                    parent_idx = l_desc.parent_idx
+                    l_desc.root_idx = l_descs[parent_idx].root_idx if parent_idx != -1 else i_l
 
             # Must invalidate invweight for all child links and joints because the root joint was fixed when it was
             # initially computed. Re-initialize it to some strictly negative value to trigger recomputation in solver.
-            for i_l in range(len(l_infos)):
-                l_infos[i_l]["invweight"] = np.full((2,), fill_value=-1.0)
-                for j_info in links_j_infos[i_l]:
-                    j_info["dofs_invweight"] = np.full((j_info["n_dofs"],), fill_value=-1.0)
+            for i_l in range(len(l_descs)):
+                l_descs[i_l].invweight = np.full((2,), fill_value=-1.0)
+                for j_desc in links_j_descs[i_l]:
+                    j_desc.dofs_invweight = np.full((j_desc.n_dofs,), fill_value=-1.0)
 
         # Force recomputing inertial information based on geometry if ill-defined for some reason.
         # A moving link needs a well-defined inertia only for its own rigid body; a rigidly-attached (fixed-joint) child
         # folds its mass into the parent's composite-rigid-body inertia.
         has_links_subtree_mass = [
-            bool(link_g_infos) or (l_info.get("inertial_mass") or 0.0) > 0.0
-            for link_g_infos, l_info in zip(links_g_infos, l_infos)
+            bool(link_g_descs) or (l_desc.mass or 0.0) > 0.0 for link_g_descs, l_desc in zip(links_g_descs, l_descs)
         ]
-        for i in reversed(range(len(l_infos))):
-            parent_idx = l_infos[i]["parent_idx"]
-            if parent_idx >= 0 and all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in links_j_infos[i]):
+        for i in reversed(range(len(l_descs))):
+            parent_idx = l_descs[i].parent_idx
+            if parent_idx >= 0 and all(j_desc.type == gs.JOINT_TYPE.FIXED for j_desc in links_j_descs[i]):
                 has_links_subtree_mass[parent_idx] |= has_links_subtree_mass[i]
 
-        for i, (l_info, link_g_infos, link_j_infos, has_link_subtree_mass) in enumerate(
-            zip(l_infos, links_g_infos, links_j_infos, has_links_subtree_mass)
+        for i, (l_desc, link_g_descs, link_j_descs, has_link_subtree_mass) in enumerate(
+            zip(l_descs, links_g_descs, links_j_descs, has_links_subtree_mass)
         ):
             # Fixed links are subsumed into their parent's composite; only moving links need a well-defined inertia.
-            if all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in link_j_infos):
+            if all(j_desc.type == gs.JOINT_TYPE.FIXED for j_desc in link_j_descs):
                 continue
             if not (
-                (l_info.get("inertial_mass") is None or l_info["inertial_mass"] <= 0.0)
-                or (l_info.get("inertial_i") is None or (np.diag(l_info["inertial_i"]) <= 0.0).any())
+                (l_desc.mass is None or l_desc.mass <= 0.0)
+                or (l_desc.inertia is None or (np.diag(l_desc.inertia) <= 0.0).any())
             ):
                 continue
 
@@ -848,57 +876,67 @@ class KinematicEntity(Entity):
             # A geometry-less moving link whose rigidly-attached (fixed-joint) subtree carries the mass keeps its
             # (near-)zero own inertia: the composite-rigid-body inertia is finite, so leave it as parsed. Otherwise
             # recompute from its own geometry, warning only when nothing in the rigid subtree provides mass.
-            if not link_g_infos and has_link_subtree_mass:
+            if not link_g_descs and has_link_subtree_mass:
                 continue
-            if not link_g_infos:
+            if not link_g_descs:
                 gs.logger.warning(
-                    f"Moving link '{l_info['name']}' has no mass, inertia or geometry, and no rigidly-attached "
+                    f"Moving link '{l_desc.name}' has no mass, inertia or geometry, and no rigidly-attached "
                     "child provides any. Setting its mass to 'gs.EPS'."
                 )
-            elif l_info.get("inertial_mass") is not None or l_info.get("inertial_i") is not None:
+            elif l_desc.mass is not None or l_desc.inertia is not None:
                 gs.logger.debug(
-                    f"Invalid or undefined inertia for link '{l_info['name']}'. Force recomputing it based on geometry."
+                    f"Invalid or undefined inertia for link '{l_desc.name}'. Force recomputing it based on geometry."
                 )
-            l_info["inertial_i"] = None
+            l_desc.inertia = None
         if is_inertia_invalid:
-            for l_info, link_j_infos in zip(l_infos, links_j_infos):
-                l_info["invweight"] = np.full((2,), fill_value=-1.0)
-                for j_info in link_j_infos:
-                    j_info["dofs_invweight"] = np.full((j_info["n_dofs"],), fill_value=-1.0)
+            for l_desc, link_j_descs in zip(l_descs, links_j_descs):
+                l_desc.invweight = np.full((2,), fill_value=-1.0)
+                for j_desc in link_j_descs:
+                    j_desc.dofs_invweight = np.full((j_desc.n_dofs,), fill_value=-1.0)
 
         # Check if there is something weird with the options
-        non_physical_fieldnames = ("dofs_frictionloss", "dofs_damping", "dofs_armature")
-        for j_info in (
-            j_info for link_j_infos in links_j_infos for j_info in link_j_infos if j_info["type"] == gs.JOINT_TYPE.FREE
+        for j_desc in (
+            j_desc for link_j_descs in links_j_descs for j_desc in link_j_descs if j_desc.type == gs.JOINT_TYPE.FREE
         ):
-            if not all((j_info[name] < gs.EPS).all() for name in non_physical_fieldnames if name in j_info):
+            if not all(
+                (values < gs.EPS).all()
+                for values in (j_desc.dofs_frictionloss, j_desc.dofs_damping, j_desc.dofs_armature)
+            ):
                 gs.logger.warning(
                     "Some free joint has non-zero frictionloss, damping or armature parameters. Beware it is "
                     "non-physical."
                 )
 
-        # Define a flag that determines whether the link at hand is associated with a robot.
-        # Note that 0d array is used rather than native type because this algo requires mutable objects.
-        for l_info, link_j_infos in zip(l_infos, links_j_infos):
-            if not link_j_infos or all(j_info["type"] == gs.JOINT_TYPE.FIXED for j_info in link_j_infos):
-                if l_info["parent_idx"] >= 0:
-                    l_info["is_robot"] = l_infos[l_info["parent_idx"]]["is_robot"]
-                else:
-                    l_info["is_robot"] = np.array(False, dtype=np.bool_)
-            elif all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in link_j_infos):
-                l_info["is_robot"] = np.array(False, dtype=np.bool_)
+        # Define a flag that determines whether the link at hand is associated with a robot. A link whose joints are
+        # all fixed shares the flag of its parent, so one flag covers a whole run of such links. An articulated link
+        # raises the flag of its own run and of its parent's, which the links sharing either flag then read, whichever
+        # order the loop reached them in.
+        links_flag = []
+        flags_is_robot = []
+        for l_desc, link_j_descs in zip(l_descs, links_j_descs):
+            is_carried = not link_j_descs or all(j_desc.type == gs.JOINT_TYPE.FIXED for j_desc in link_j_descs)
+            if is_carried and l_desc.parent_idx >= 0:
+                links_flag.append(links_flag[l_desc.parent_idx])
             else:
-                l_info["is_robot"] = np.array(True, dtype=np.bool_)
-                if l_info["parent_idx"] >= 0:
-                    l_infos[l_info["parent_idx"]]["is_robot"][()] = True
+                links_flag.append(len(flags_is_robot))
+                flags_is_robot.append(False)
+            is_articulated = bool(link_j_descs) and not all(
+                j_desc.type in (gs.JOINT_TYPE.FIXED, gs.JOINT_TYPE.FREE) for j_desc in link_j_descs
+            )
+            if is_articulated:
+                flags_is_robot[links_flag[-1]] = True
+                if l_desc.parent_idx >= 0:
+                    flags_is_robot[links_flag[l_desc.parent_idx]] = True
+        for l_desc, i_flag in zip(l_descs, links_flag):
+            l_desc.is_robot = flags_is_robot[i_flag]
 
         # Apply morph pos and quat if specified
-        for l_info, link_j_infos in zip(l_infos, links_j_infos):
-            if l_info["parent_idx"] < 0:
+        for l_desc, link_j_descs in zip(l_descs, links_j_descs):
+            if l_desc.parent_idx < 0:
                 if morph.pos is not None or morph.quat is not None:
                     gs.logger.debug("Applying offset to base link's pose with user provided value in morph.")
-                    pos = np.asarray(l_info.get("pos", (0.0, 0.0, 0.0)))
-                    quat = np.asarray(l_info.get("quat", (1.0, 0.0, 0.0, 0.0)))
+                    pos = l_desc.pos
+                    quat = l_desc.quat
                     if morph.pos is None:
                         pos_offset = np.zeros((3,))
                     else:
@@ -907,27 +945,25 @@ class KinematicEntity(Entity):
                         quat_offset = np.array((1.0, 0.0, 0.0, 0.0))
                     else:
                         quat_offset = np.asarray(morph.quat)
-                    l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
-                        pos, quat, pos_offset, quat_offset
-                    )
+                    l_desc.pos, l_desc.quat = gu.transform_pos_quat_by_trans_quat(pos, quat, pos_offset, quat_offset)
 
-                for j_info in link_j_infos:
-                    if j_info["type"] == gs.JOINT_TYPE.FREE:
-                        # in this case, l_info['pos'] and l_info['quat'] are actually not used in solver,
+                for j_desc in link_j_descs:
+                    if j_desc.type == gs.JOINT_TYPE.FREE:
+                        # in this case, l_desc.pos and l_desc.quat are actually not used in solver,
                         # but this initial value will be reflected
-                        j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+                        j_desc.init_qpos = np.concatenate([l_desc.pos, l_desc.quat])
 
         # Exclude joints with 0 dofs to align with Mujoco
-        links_j_infos = [[j_info for j_info in link_j_infos if j_info["n_dofs"] > 0] for link_j_infos in links_j_infos]
+        links_j_descs = [[j_desc for j_desc in link_j_descs if j_desc.n_dofs > 0] for link_j_descs in links_j_descs]
 
-        return l_infos, links_j_infos, links_g_infos, eqs_info
+        return l_descs, links_j_descs, links_g_descs, eq_descs
 
     def _load_scene(self, morph, surface):
-        l_infos, links_j_infos, links_g_infos, _eqs_info = self._parse_scene(morph, surface)
+        l_descs, links_j_descs, links_g_descs, _eq_descs = self._parse_scene(morph, surface)
 
         # Add (link, joints, geoms) tuples sequentially
-        for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
-            self._add_by_info(l_info, link_j_infos, link_g_infos, morph, surface)
+        for l_desc, link_j_descs, link_g_descs in zip(l_descs, links_j_descs, links_g_descs):
+            self._add_by_description(l_desc, link_j_descs, link_g_descs, morph, surface)
 
     def _build(self):
         for link in self._links:
@@ -972,8 +1008,8 @@ class KinematicEntity(Entity):
                     articulated = True
                     break
                 pose_in_root[link.idx] = gu.transform_pos_quat_by_trans_quat(
-                    np.asarray(link.pos, dtype=gs.np_float),
-                    np.asarray(link.quat, dtype=gs.np_float),
+                    np.asarray(link.desc.pos, dtype=gs.np_float),
+                    np.asarray(link.desc.quat, dtype=gs.np_float),
                     *pose_in_root[link.parent_idx],
                 )
                 subtree.append(link)
@@ -1047,11 +1083,11 @@ class KinematicEntity(Entity):
                         geoms = list(link.vgeoms)
                     for geom in geoms:
                         pos, quat = gu.transform_pos_quat_by_trans_quat(
-                            geom._init_pos, geom._init_quat, link_pos, link_quat
+                            geom.init_pos, geom.init_quat, link_pos, link_quat
                         )
                         pos, quat = gu.inv_transform_pos_quat_by_trans_quat(pos, quat, com_root, principal_quat)
                         pos, quat = gu.inv_transform_pos_quat_by_trans_quat(pos, quat, link_pos, link_quat)
-                        geom._init_pos, geom._init_quat = pos, quat
+                        geom.desc.pos, geom.desc.quat = pos, quat
                         geom._init_pos_tc = torch.from_numpy(pos).to(device=gs.device, dtype=gs.tc_float)
                         geom._init_quat_tc = torch.from_numpy(quat).to(device=gs.device, dtype=gs.tc_float)
 
@@ -1062,7 +1098,7 @@ class KinematicEntity(Entity):
                     # links skipped above (a geometry-less link carries only the 'gs.EPS' placeholder) must not
                     # inflate the composite.
                     real_total = sum(
-                        float(link._variant_inertial[v][0] if is_heterogeneous else link.inertial_mass)
+                        float(link._variant_inertial[v][0] if is_heterogeneous else link.desc.mass)
                         for link in composite_links
                     )
                     scale = real_total / mass_total
@@ -1075,7 +1111,8 @@ class KinematicEntity(Entity):
                         if is_heterogeneous:
                             link._variant_inertial[v] = props
                         else:
-                            link._inertial_mass, link._inertial_pos, link._inertial_quat, link._inertial_i = props
+                            desc = link.desc
+                            desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia = props
 
                 # Fold the anchoring into the offset (relative getters keep reporting the user frame) and the root
                 # free-joint init_qpos (the body frame moves to old_pose o (com_root, principal), keeping the
@@ -1104,153 +1141,126 @@ class KinematicEntity(Entity):
                         self._offset_pos, self._offset_quat = self._links_offset_pos[0], self._links_offset_quat[0]
                     for joint in root.joints:
                         if joint.type == gs.JOINT_TYPE.FREE:
-                            new_pos = gu.transform_by_trans_quat(com_root, joint._init_qpos[:3], joint._init_qpos[3:7])
-                            new_quat = gu.transform_quat_by_quat(principal_quat, joint._init_qpos[3:7])
-                            joint._init_qpos = np.concatenate([new_pos, new_quat])
-                    root._pos = gu.transform_by_trans_quat(com_root, np.asarray(root.pos, dtype=gs.np_float), root.quat)
-                    root._quat = gu.transform_quat_by_quat(principal_quat, np.asarray(root.quat, dtype=gs.np_float))
+                            init_qpos = joint.desc.init_qpos
+                            new_pos = gu.transform_by_trans_quat(com_root, init_qpos[:3], init_qpos[3:7])
+                            new_quat = gu.transform_quat_by_quat(principal_quat, init_qpos[3:7])
+                            joint.desc.init_qpos = np.concatenate([new_pos, new_quat])
+                    root_pos = np.asarray(root.desc.pos, dtype=gs.np_float)
+                    root_quat = np.asarray(root.desc.quat, dtype=gs.np_float)
+                    root.desc.pos = gu.transform_by_trans_quat(com_root, root_pos, root_quat)
+                    root.desc.quat = gu.transform_quat_by_quat(principal_quat, root_quat)
 
         # The load-time inertial info was only needed for the build-time estimates and the anchors; drop it now that
         # the alignment lives in the persistent geometry, offset and init_qpos.
         self._links_inertial_info = []
 
-    def _create_joints(self, j_infos, link_idx, joint_start):
-        """Create RigidJoint objects from joint info dicts.
+    def _create_joints(self, j_descs, link_idx, joint_start):
+        """Create the RigidJoint objects of one link from its described joints.
 
-        Shared by KinematicEntity._add_by_info and RigidEntity._add_by_info.
+        Shared by KinematicEntity._add_by_description and RigidEntity._add_by_description.
         """
         joints = gs.List()
         self._joints.append(joints)
-        for i_j_, j_info in enumerate(j_infos):
-            n_dofs = j_info["n_dofs"]
-
-            sol_params = np.array(j_info.get("sol_params", gu.default_solver_params()), copy=True)
+        for i_j_, j_desc in enumerate(j_descs):
+            sol_params = j_desc.sol_params
             if (
                 len(sol_params.shape) == 2
                 and sol_params.shape[0] == 1
                 and (sol_params[0][3] >= 1.0 or sol_params[0][2] >= sol_params[0][3])
             ):
                 gs.logger.warning(
-                    f"Joint {j_info['name']}'s sol_params {sol_params[0]} look not right, change to default."
+                    f"Joint {j_desc.name}'s sol_params {sol_params[0]} look not right, change to default."
                 )
-                sol_params = gu.default_solver_params()
+                j_desc.sol_params = gu.default_solver_params()
 
-            dofs_motion_ang = j_info.get("dofs_motion_ang")
-            if dofs_motion_ang is None:
-                if n_dofs == 6:
-                    dofs_motion_ang = np.eye(6, 3, -3)
-                elif n_dofs == 0:
-                    dofs_motion_ang = np.zeros((0, 3))
-                else:
-                    assert False
-
-            dofs_motion_vel = j_info.get("dofs_motion_vel")
-            if dofs_motion_vel is None:
-                if n_dofs == 6:
-                    dofs_motion_vel = np.eye(6, 3)
-                elif n_dofs == 0:
-                    dofs_motion_vel = np.zeros((0, 3))
-                else:
-                    assert False
+            if j_desc.dofs_motion_ang is None or j_desc.dofs_motion_vel is None:
+                gs.raise_exception(
+                    f"Joint '{j_desc.name}' holds {j_desc.n_dofs} degrees of freedom, whose motion axes the asset "
+                    "must describe."
+                )
 
             joint = RigidJoint(
                 entity=self,
-                name=j_info["name"],
                 idx=joint_start + i_j_,
                 link_idx=link_idx,
                 q_start=self.n_qs + self._q_start,
                 dof_start=self.n_dofs + self._dof_start,
-                n_qs=j_info["n_qs"],
-                n_dofs=n_dofs,
-                type=j_info["type"],
-                pos=j_info.get("pos", gu.zero_pos()),
-                quat=j_info.get("quat", gu.identity_quat()),
-                init_qpos=j_info.get("init_qpos", np.zeros(n_dofs)),
-                sol_params=sol_params,
-                dofs_motion_ang=dofs_motion_ang,
-                dofs_motion_vel=dofs_motion_vel,
-                dofs_limit=j_info.get("dofs_limit", np.tile([[-np.inf, np.inf]], [n_dofs, 1])),
-                dofs_invweight=j_info.get("dofs_invweight", np.zeros(n_dofs)),
-                dofs_frictionloss=j_info.get("dofs_frictionloss", np.zeros(n_dofs)),
-                dofs_stiffness=j_info.get("dofs_stiffness", np.zeros(n_dofs)),
-                dofs_damping=j_info.get("dofs_damping", np.zeros(n_dofs)),
-                dofs_armature=j_info.get("dofs_armature", np.zeros(n_dofs)),
-                dofs_act_gain=j_info.get("dofs_act_gain", np.zeros(n_dofs)),
-                dofs_act_bias=j_info.get("dofs_act_bias", np.zeros((n_dofs, 3))),
-                dofs_force_range=j_info.get("dofs_force_range", np.tile([[-np.inf, np.inf]], [n_dofs, 1])),
+                desc=j_desc,
             )
             joints.append(joint)
 
         return joints
 
-    def _add_by_info(self, l_info, j_infos, g_infos, morph, surface):
-        if len(j_infos) > 1 and any(j_info["type"] in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_info in j_infos):
+    def _add_by_description(self, l_desc, j_descs, g_descs, morph, surface):
+        if len(j_descs) > 1 and any(j_desc.type in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_desc in j_descs):
             raise ValueError(
                 "Compounding joints of types 'FREE' or 'FIXED' with any other joint on the same body not supported"
             )
 
-        parent_idx = l_info["parent_idx"]
+        parent_idx = l_desc.parent_idx
         if parent_idx >= 0:
             parent_idx += self._link_start
-        root_idx = l_info.get("root_idx")
+        root_idx = l_desc.root_idx
         if root_idx is not None and root_idx >= 0:
             root_idx += self._link_start
         link_idx = self.n_links + self._link_start
         joint_start = self.n_joints + self._joint_start
 
-        cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
-        self._align_link(l_info, j_infos, cg_infos, vg_infos, morph, link_idx)
+        cg_descs, vg_descs = self._postprocess_geoms(morph, g_descs, l_desc.is_robot)
+        self._align_link(l_desc, j_descs, cg_descs, vg_descs, morph, link_idx)
 
-        joints = self._create_joints(j_infos, link_idx, joint_start)
+        joints = self._create_joints(j_descs, link_idx, joint_start)
+
+        # A kinematic link stays where the kinematics puts it, so it holds zero mass, zero inertia and zero inverse
+        # weight, whatever its asset described
+        l_desc.inertial_pos = gu.zero_pos()
+        l_desc.inertial_quat = gu.identity_quat()
+        l_desc.mass = 0.0
+        l_desc.inertia = np.zeros((3, 3), dtype=gs.np_float)
+        l_desc.invweight = np.zeros(2, dtype=gs.np_float)
 
         # Add child link
         link = KinematicLink(
             entity=self,
-            name=l_info["name"],
             idx=link_idx,
+            parent_idx=parent_idx,
+            root_idx=root_idx,
             joint_start=joint_start,
-            n_joints=len(j_infos),
+            n_joints=len(j_descs),
             vgeom_start=self.n_vgeoms + self._vgeom_start,
             vvert_start=self.n_vverts + self._vvert_start,
             vface_start=self.n_vfaces + self._vface_start,
-            pos=l_info["pos"],
-            quat=l_info["quat"],
-            parent_idx=parent_idx,
-            root_idx=root_idx,
-            aligned=l_info.get("aligned", False),
+            desc=l_desc,
         )
         self._links.append(link)
 
         # Add visual geometries
-        for g_info in vg_infos:
-            link._add_vgeom(
-                vmesh=g_info["vmesh"],
-                init_pos=g_info.get("pos", gu.zero_pos()),
-                init_quat=g_info.get("quat", gu.identity_quat()),
-            )
+        for g_desc in vg_descs:
+            link._add_vgeom(g_desc)
 
         return link, joints
 
-    def _postprocess_geoms_info(self, morph, g_infos, is_robot):
+    def _postprocess_geoms(self, morph, g_descs, is_robot):
         """
-        Split g_infos into (cg_infos, vg_infos) collision and visual lists, then
-        post-process collision meshes (convexification / decomposition).
-        Used for both normal loading and heterogeneous simulation.
+        Split the described geoms into a collision list and a visual list, and post-process the collision meshes.
+
+        Post-processing convexifies the collision meshes, decomposing the ones a single hull cannot approximate within
+        the threshold the morph carries. A plain load and a heterogeneous variant both go through here.
         """
         # An explicitly set material density overrides any asset-authored per-geom density, as material friction does
-        # for authored frictions. Dropping the keys up front keeps the align anchor, its all-or-none source check,
-        # and the build-time inertial estimate consistently uniform-density.
+        # for authored frictions. Clearing them up front keeps the align anchor, its all-or-none source check, and the
+        # build-time inertial estimate consistently uniform-density.
         if isinstance(self.material, gs.materials.Rigid) and self.material.rho is not None:
-            for g_info in g_infos:
-                g_info.pop("density", None)
+            for g_desc in g_descs:
+                g_desc.density = None
 
-        cg_infos, vg_infos = [], []
-        for g_info in g_infos:
-            is_col = g_info["contype"] or g_info["conaffinity"]
+        cg_descs, vg_descs = [], []
+        for g_desc in g_descs:
+            is_col = g_desc.contype or g_desc.conaffinity
             if morph.collision and is_col:
-                cg_infos.append(g_info)
+                cg_descs.append(g_desc)
             if morph.visualization and not is_col:
-                vg_infos.append(g_info)
+                vg_descs.append(g_desc)
 
         # Post-process all collision meshes at once.
         # Destroying the original geometries should be avoided if possible as it will change the way objects
@@ -1278,22 +1288,26 @@ class KinematicEntity(Entity):
             # whatever is left unset. Post-processing merges geoms within a call, so each set of effective options
             # gets its own call; geoms without overrides share one, preserving the whole-entity merge behavior.
             # Thresholds match under gs.EPS tolerance so float noise cannot split a group.
-            cg_infos_by_options: list[tuple[tuple, list]] = []
-            for g_info in cg_infos:
-                convexify = g_info.pop("convexify", morph.convexify)
-                decimate = g_info.pop("decimate", morph.decimate)
-                threshold = g_info.pop("decompose_error_threshold", decompose_error_threshold)
-                for options, options_cg_infos in cg_infos_by_options:
+            cg_descs_by_options: list[tuple[tuple, list]] = []
+            for g_desc in cg_descs:
+                convexify = morph.convexify if g_desc.convexify is None else g_desc.convexify
+                decimate = morph.decimate if g_desc.decimate is None else g_desc.decimate
+                threshold = (
+                    decompose_error_threshold
+                    if g_desc.decompose_error_threshold is None
+                    else g_desc.decompose_error_threshold
+                )
+                for options, options_cg_descs in cg_descs_by_options:
                     if options[:2] == (convexify, decimate) and math.isclose(options[2], threshold, abs_tol=gs.EPS):
-                        options_cg_infos.append(g_info)
+                        options_cg_descs.append(g_desc)
                         break
                 else:
-                    cg_infos_by_options.append(((convexify, decimate, threshold), [g_info]))
+                    cg_descs_by_options.append(((convexify, decimate, threshold), [g_desc]))
 
-            cg_infos = []
-            for (convexify, decimate, threshold), options_cg_infos in cg_infos_by_options:
-                cg_infos += mu.postprocess_collision_geoms(
-                    options_cg_infos,
+            cg_descs = []
+            for (convexify, decimate, threshold), options_cg_descs in cg_descs_by_options:
+                cg_descs += mu.postprocess_collision_geoms(
+                    options_cg_descs,
                     decimate,
                     morph.decimate_face_num,
                     morph.decimate_aggressiveness,
@@ -1304,14 +1318,14 @@ class KinematicEntity(Entity):
                 )
 
         # Randomize collision mesh colors. This is especially useful to check convex decomposition.
-        for g_info in cg_infos:
-            mesh = g_info["mesh"]
+        for g_desc in cg_descs:
+            mesh = g_desc.mesh
             mesh.set_color((*np.random.rand(3), 0.7))
 
-        return cg_infos, vg_infos
+        return cg_descs, vg_descs
 
     def _finalize_inertial(
-        self, explicit_mass, explicit_com, explicit_quat, explicit_inertia, cg_infos, vg_infos, is_robot
+        self, explicit_mass, explicit_com, explicit_quat, explicit_inertia, cg_descs, vg_descs, is_robot
     ):
         """Compute a link's load-time inertial data (see 'LinkInertialInfo').
 
@@ -1320,8 +1334,8 @@ class KinematicEntity(Entity):
         by 'RigidLink._build' uses the resolved material density as fallback instead, and falls back to the visual
         geoms for a link without collision geometry.
         """
-        if cg_infos:
-            hint = compose_inertial_from_g_infos(cg_infos, rho=1.0)
+        if cg_descs:
+            hint = compose_inertial_from_geoms(cg_descs, rho=1.0)
         else:
             hint = InertialProperties(0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float))
         props = finalize_inertial(
@@ -1330,10 +1344,10 @@ class KinematicEntity(Entity):
         if explicit_mass is not None and explicit_mass > 0.0:
             is_mass_explicit = True
         else:
-            geoms_with_density = sum(g_info.get("density") is not None for g_info in cg_infos)
+            geoms_with_density = sum(g_desc.density is not None for g_desc in cg_descs)
             if geoms_with_density == 0:
                 is_mass_explicit = False
-            elif geoms_with_density == len(cg_infos):
+            elif geoms_with_density == len(cg_descs):
                 is_mass_explicit = True
             else:
                 is_mass_explicit = None
@@ -1346,16 +1360,16 @@ class KinematicEntity(Entity):
                     rho = RHO_MUJOCO
                 else:
                     rho = RHO_ROBOT if is_robot else RHO_OBJECT
-            hint_g_infos = cg_infos if cg_infos else vg_infos
-            if hint_g_infos:
-                dynamics_hint = compose_inertial_from_g_infos(hint_g_infos, rho)
+            hint_g_descs = cg_descs if cg_descs else vg_descs
+            if hint_g_descs:
+                dynamics_hint = compose_inertial_from_geoms(hint_g_descs, rho)
             else:
                 dynamics_hint = InertialProperties(
                     0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float)
                 )
         return LinkInertialInfo(props, is_mass_explicit, dynamics_hint)
 
-    def _align_link(self, l_info, j_infos, cg_infos, vg_infos, morph, link_idx):
+    def _align_link(self, l_desc, j_descs, cg_descs, vg_descs, morph, link_idx):
         """Carry the morph pose offset into a root link and record its offset, and stash each link's finalized inertia.
 
         Only root (floating-base) links carry the morph 'offset_pos'/'offset_quat' and the 'aligned' flag; the resulting
@@ -1371,38 +1385,36 @@ class KinematicEntity(Entity):
         self._links_inertial_info.append(
             [
                 self._finalize_inertial(
-                    None if recompute else l_info.get("inertial_mass"),
-                    None if recompute else l_info.get("inertial_pos"),
-                    None if recompute else l_info.get("inertial_quat"),
-                    None if recompute else l_info.get("inertial_i"),
-                    cg_infos,
-                    vg_infos,
-                    l_info.get("is_robot", False),
+                    None if recompute else l_desc.mass,
+                    None if recompute else l_desc.inertial_pos,
+                    None if recompute else l_desc.inertial_quat,
+                    None if recompute else l_desc.inertia,
+                    cg_descs,
+                    vg_descs,
+                    l_desc.is_robot,
                 )
             ]
         )
 
-        if l_info["parent_idx"] != -1:
+        if l_desc.parent_idx != -1:
             return
 
         # Compose the morph pose offset into the root link's world pose. The solver strips the matching offset in
         # relative getters, so the user frame is unchanged.
         offset_pos = np.array(morph.offset_pos, dtype=gs.np_float)
         offset_quat = np.array(morph.offset_quat, dtype=gs.np_float)
-        l_info["pos"], l_info["quat"] = gu.transform_pos_quat_by_trans_quat(
-            offset_pos, offset_quat, l_info["pos"], l_info["quat"]
-        )
+        l_desc.pos, l_desc.quat = gu.transform_pos_quat_by_trans_quat(offset_pos, offset_quat, l_desc.pos, l_desc.quat)
 
         align = morph.align if isinstance(morph, gs.options.morphs.FileMorph) else False
         if align is None:
             # Auto: True for basic rigid objects (root with free joint only, no articulated descendants). A link
             # mixing geoms with and without an authored density (see 'LinkInertialInfo.is_mass_explicit') quietly
             # declines auto-alignment; asking for it with an explicit align=True raises at build instead.
-            geoms_with_density = sum(g_info.get("density") is not None for g_info in cg_infos)
+            geoms_with_density = sum(g_desc.density is not None for g_desc in cg_descs)
             align = (
-                not bool(l_info.get("is_robot", False))
-                and all(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos)
-                and geoms_with_density in (0, len(cg_infos))
+                not bool(l_desc.is_robot)
+                and all(j_desc.type == gs.JOINT_TYPE.FREE for j_desc in j_descs)
+                and geoms_with_density in (0, len(cg_descs))
             )
 
         # A free body opting into alignment (or any primitive, which is inherently principal-axis and COM-centered) has
@@ -1410,14 +1422,14 @@ class KinematicEntity(Entity):
         # to '_align_free_roots' after build, where the finalized composite inertia of the fixed subtree is known and
         # can be applied per heterogeneous variant. Here only the morph pose offset is composed (child link poses are
         # defined relative to it); the anchoring transform is folded in later.
-        l_info["aligned"] = any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in j_infos) and (
+        l_desc.is_aligned = any(j_desc.type == gs.JOINT_TYPE.FREE for j_desc in j_descs) and (
             align or isinstance(morph, gs.options.morphs.Primitive)
         )
 
         # Refresh the free joint init_qpos to reflect the composed world pose.
-        for j_info in j_infos:
-            if j_info["type"] == gs.JOINT_TYPE.FREE:
-                j_info["init_qpos"] = np.concatenate([l_info["pos"], l_info["quat"]])
+        for j_desc in j_descs:
+            if j_desc.type == gs.JOINT_TYPE.FREE:
+                j_desc.init_qpos = np.concatenate([l_desc.pos, l_desc.quat])
 
         # Record the body-frame offset; the base link's also seeds the heterogeneous-variant offset.
         if not self._links_offset_quat:
@@ -1568,14 +1580,14 @@ class KinematicEntity(Entity):
             if link.root_idx == base_link.idx:
                 link._root_idx = parent_link.root_idx
                 link._is_fixed &= parent_link.is_fixed
-                link._invweight = None
+                link.desc.invweight = None
 
         # Apply the explicit mounting transform. Forward kinematics interprets the base link's local pose relative to
         # its (new) parent link, so overwriting it here mounts the entity at (pos, quat) in the parent link frame.
         # Compose with the morph frame offset exactly as '_align_link' does for the morph pose at load time, so the
         # relative pose getters keep stripping the offset correctly.
         if is_mounting:
-            base_link._pos, base_link._quat = gu.transform_pos_quat_by_trans_quat(
+            base_link.desc.pos, base_link.desc.quat = gu.transform_pos_quat_by_trans_quat(
                 self._offset_pos, self._offset_quat, mount_pos, mount_quat
             )
 
@@ -2547,11 +2559,11 @@ class KinematicEntity(Entity):
                 # A quaternion takes four of the coordinates of such a joint; whatever remains is a translation,
                 # carried by the first of its degrees of freedom.
                 n_translation = joint.n_qs - 4
-                q_limit_lower += [joint.dofs_limit[:n_translation, 0], -np.ones(4)]
-                q_limit_upper += [joint.dofs_limit[:n_translation, 1], np.ones(4)]
+                q_limit_lower += [joint.desc.dofs_limit[:n_translation, 0], -np.ones(4)]
+                q_limit_upper += [joint.desc.dofs_limit[:n_translation, 1], np.ones(4)]
             elif joint.type != gs.JOINT_TYPE.FIXED:
-                q_limit_lower.append(joint.dofs_limit[:, 0])
-                q_limit_upper.append(joint.dofs_limit[:, 1])
+                q_limit_lower.append(joint.desc.dofs_limit[:, 0])
+                q_limit_upper.append(joint.desc.dofs_limit[:, 1])
         if not q_limit_lower:
             # An entity that no degree of freedom moves holds no coordinate, hence a limit of width zero.
             self._q_limit = np.zeros((2, self.n_qs), dtype=gs.np_float)
@@ -2909,8 +2921,8 @@ class RigidEntity(KinematicEntity):
         scene: "Scene",
         solver: "RigidSolver",
         material: Material,
-        morph: Morph,
-        surface: Surface,
+        morph: "Morph",
+        surface: "Surface",
         idx: int,
         idx_in_solver,
         link_start: int = 0,
@@ -2931,7 +2943,7 @@ class RigidEntity(KinematicEntity):
         custom_vface_start=0,
         equality_start=0,
         visualize_contact: bool = False,
-        morph_heterogeneous: list[Morph] | None = None,
+        morph_heterogeneous: "list[Morph] | None" = None,
         name: str | None = None,
     ):
         self._geom_start = geom_start
@@ -2969,40 +2981,26 @@ class RigidEntity(KinematicEntity):
             name,
         )
 
-    def _add_heterogeneous_variant(self, link, cg_infos, vg_infos):
+    def _add_heterogeneous_variant(self, link, cg_descs, vg_descs):
         # Add collision geometries
         coup_links = self.material.coup_links
-        for g_info in cg_infos:
-            friction = self.material.friction
-            if friction is None:
-                friction = g_info.get("friction", gu.default_friction())
-            friction_torsional = self.material.friction_torsional
-            if friction_torsional is None:
-                friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
-            friction_rolling = self.material.friction_rolling
-            if friction_rolling is None:
-                friction_rolling = g_info.get("friction_rolling", gu.default_friction_rolling())
+        for g_desc in cg_descs:
+            # An explicitly set material friction overrides the authored one, and the geom is built from its
+            # description, so the override is written there
+            if self.material.friction is not None:
+                g_desc.friction = self.material.friction
+            if self.material.friction_torsional is not None:
+                g_desc.friction_torsional = self.material.friction_torsional
+            if self.material.friction_rolling is not None:
+                g_desc.friction_rolling = self.material.friction_rolling
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
-            link._add_geom(
-                mesh=g_info["mesh"],
-                init_pos=g_info.get("pos", gu.zero_pos()),
-                init_quat=g_info.get("quat", gu.identity_quat()),
-                type=g_info["type"],
-                friction=friction,
-                friction_torsional=friction_torsional,
-                friction_rolling=friction_rolling,
-                sol_params=g_info["sol_params"],
-                data=g_info.get("data"),
-                needs_coup=needs_coup,
-                contype=g_info["contype"],
-                conaffinity=g_info["conaffinity"],
-            )
+            link._add_geom(g_desc, needs_coup=needs_coup)
 
         # Add visual geoms and record vgeom range via parent
-        super()._add_heterogeneous_variant(link, cg_infos, vg_infos)
+        super()._add_heterogeneous_variant(link, cg_descs, vg_descs)
 
         # Record geom range on the link (vgeom range already recorded by parent)
-        link._record_variant_geom_range(len(cg_infos))
+        link._record_variant_geom_range(len(cg_descs))
 
     def _reassign_heterogeneous_indices(self):
         """Reassign collision and visual geom indices for multi-link heterogeneous entities."""
@@ -3048,19 +3046,11 @@ class RigidEntity(KinematicEntity):
                 link._variant_geom_ranges.append((geom_cursor, geom_cursor + count))
                 geom_cursor += count
 
-    def _on_heterogeneous_scene_variant_loaded(self, link, morph, v_l_info):
-        """Store parsed inertial from the variant file for use during link._build()."""
-        if link._variant_scene_inertial is None:
-            link._variant_scene_inertial = []
-        link._variant_scene_inertial.append(
-            (
-                morph,
-                v_l_info.get("inertial_mass"),
-                v_l_info.get("inertial_pos"),
-                v_l_info.get("inertial_quat"),
-                v_l_info.get("inertial_i"),
-            )
-        )
+    def _on_heterogeneous_scene_variant_loaded(self, link, morph, v_l_desc):
+        """Store what the variant file describes this link with, for 'link._build' to resolve its inertial from."""
+        if link._variant_sources is None:
+            link._variant_sources = []
+        link._variant_sources.append(LinkVariant(morph, v_l_desc))
 
     def _load_model(self):
         self._equalities = gs.List()
@@ -3075,29 +3065,23 @@ class RigidEntity(KinematicEntity):
     def _load_scene(self, morph, surface):
         from genesis.engine.couplers import IPCCoupler
 
-        l_infos, links_j_infos, links_g_infos, eqs_info = self._parse_scene(morph, surface)
+        l_descs, links_j_descs, links_g_descs, eq_descs = self._parse_scene(morph, surface)
 
         # Make sure that the entity is not object
         if (
             isinstance(self.sim.coupler, IPCCoupler)
             and self.material.coup_type == "ipc_only"
-            and any(l_info["is_robot"] for l_info in l_infos)
+            and any(l_desc.is_robot for l_desc in l_descs)
         ):
             gs.raise_exception("`RigidMaterial.coup_type='ipc_only'` only supported by rigid non-articulated objects.")
 
         # Add (link, joints, geoms) tuples sequentially
-        for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
-            self._add_by_info(l_info, link_j_infos, link_g_infos, morph, surface)
+        for l_desc, link_j_descs, link_g_descs in zip(l_descs, links_j_descs, links_g_descs):
+            self._add_by_description(l_desc, link_j_descs, link_g_descs, morph, surface)
 
         # Add equality constraints sequentially
-        for eq_info in eqs_info:
-            self._add_equality(
-                name=eq_info["name"],
-                type=eq_info["type"],
-                objs_name=eq_info["objs_name"],
-                data=eq_info["data"],
-                sol_params=eq_info["sol_params"],
-            )
+        for eq_desc in eq_descs:
+            self._add_equality(eq_desc)
 
     def _build(self):
         self._n_geoms = self.n_geoms
@@ -3123,16 +3107,16 @@ class RigidEntity(KinematicEntity):
 
         self._init_q_limit()
 
-    def _add_by_info(self, l_info, j_infos, g_infos, morph, surface):
-        if len(j_infos) > 1 and any(j_info["type"] in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_info in j_infos):
+    def _add_by_description(self, l_desc, j_descs, g_descs, morph, surface):
+        if len(j_descs) > 1 and any(j_desc.type in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED) for j_desc in j_descs):
             raise ValueError(
                 "Compounding joints of types 'FREE' or 'FIXED' with any other joint on the same body not supported"
             )
 
-        parent_idx = l_info["parent_idx"]
+        parent_idx = l_desc.parent_idx
         if parent_idx >= 0:
             parent_idx += self._link_start
-        root_idx = l_info.get("root_idx")
+        root_idx = l_desc.root_idx
         if root_idx is not None and root_idx >= 0:
             root_idx += self._link_start
         link_idx = self.n_links + self._link_start
@@ -3146,20 +3130,21 @@ class RigidEntity(KinematicEntity):
 
         # Split and convexify collision geometry. Must be done before alignment so that
         # convexified geoms are used to compute the inertia frame.
-        cg_infos, vg_infos = self._postprocess_geoms_info(morph, g_infos, l_info.get("is_robot", False))
+        cg_descs, vg_descs = self._postprocess_geoms(morph, g_descs, l_desc.is_robot)
 
         # Carry the morph pose offset into root links and align them to their collision-geometry COM/principal axes.
-        self._align_link(l_info, j_infos, cg_infos, vg_infos, morph, link_idx)
+        self._align_link(l_desc, j_descs, cg_descs, vg_descs, morph, link_idx)
 
-        joints = self._create_joints(j_infos, link_idx, joint_start)
+        joints = self._create_joints(j_descs, link_idx, joint_start)
 
         # Add child link
         link = RigidLink(
             entity=self,
-            name=l_info["name"],
             idx=link_idx,
+            parent_idx=parent_idx,
+            root_idx=root_idx,
             joint_start=joint_start,
-            n_joints=len(j_infos),
+            n_joints=len(j_descs),
             geom_start=self.n_geoms + self._geom_start,
             cell_start=self.n_cells + self._cell_start,
             vert_start=self.n_verts + self._vert_start,
@@ -3170,87 +3155,54 @@ class RigidEntity(KinematicEntity):
             vgeom_start=self.n_vgeoms + self._vgeom_start,
             vvert_start=self.n_vverts + self._vvert_start,
             vface_start=self.n_vfaces + self._vface_start,
-            pos=l_info["pos"],
-            quat=l_info["quat"],
-            inertial_pos=l_info.get("inertial_pos"),
-            inertial_quat=l_info.get("inertial_quat"),
-            inertial_i=l_info.get("inertial_i"),
-            inertial_mass=l_info.get("inertial_mass"),
-            parent_idx=parent_idx,
-            root_idx=root_idx,
-            invweight=l_info.get("invweight"),
             visualize_contact=self.visualize_contact,
-            is_robot=l_info.get("is_robot", root_idx != -1),
-            aligned=l_info.get("aligned", False),
+            desc=l_desc,
         )
         self._links.append(link)
 
         if not link.is_fixed and isinstance(morph, gs.options.morphs.FileMorph) and morph.recompute_inertia:
-            link._inertial_pos = None
-            link._inertial_quat = None
-            link._inertial_i = None
-            link._inertial_mass = None
+            l_desc.inertial_pos = None
+            l_desc.inertial_quat = None
+            l_desc.inertia = None
+            l_desc.mass = None
 
         # Add visual geometries
-        for g_info in vg_infos:
-            link._add_vgeom(
-                vmesh=g_info["vmesh"],
-                init_pos=g_info.get("pos", gu.zero_pos()),
-                init_quat=g_info.get("quat", gu.identity_quat()),
-            )
+        for g_desc in vg_descs:
+            link._add_vgeom(g_desc)
 
         # Add collision geometries
         coup_links = self.material.coup_links
-        for g_info in cg_infos:
-            friction = self.material.friction
-            if friction is None:
-                friction = g_info.get("friction", gu.default_friction())
-            friction_torsional = self.material.friction_torsional
-            if friction_torsional is None:
-                friction_torsional = g_info.get("friction_torsional", gu.default_friction_torsional())
-            friction_rolling = self.material.friction_rolling
-            if friction_rolling is None:
-                friction_rolling = g_info.get("friction_rolling", gu.default_friction_rolling())
+        for g_desc in cg_descs:
+            # An explicitly set material friction overrides the authored one, and the geom is built from its
+            # description, so the override is written there
+            if self.material.friction is not None:
+                g_desc.friction = self.material.friction
+            if self.material.friction_torsional is not None:
+                g_desc.friction_torsional = self.material.friction_torsional
+            if self.material.friction_rolling is not None:
+                g_desc.friction_rolling = self.material.friction_rolling
             needs_coup = self.material.needs_coup and (coup_links is None or link.name in coup_links)
-            link._add_geom(
-                mesh=g_info["mesh"],
-                init_pos=g_info.get("pos", gu.zero_pos()),
-                init_quat=g_info.get("quat", gu.identity_quat()),
-                type=g_info["type"],
-                friction=friction,
-                friction_torsional=friction_torsional,
-                friction_rolling=friction_rolling,
-                sol_params=g_info["sol_params"],
-                data=g_info.get("data"),
-                needs_coup=needs_coup,
-                contype=g_info["contype"],
-                conaffinity=g_info["conaffinity"],
-            )
+            link._add_geom(g_desc, needs_coup=needs_coup)
 
         return link, joints
 
-    def _add_equality(self, name, type, objs_name, data, sol_params):
-        objs_id = []
-        for obj_name in objs_name:
-            if type == gs.EQUALITY_TYPE.CONNECT:
-                obj_id = self.get_link(obj_name).idx
-            elif type == gs.EQUALITY_TYPE.JOINT:
-                obj_id = self.get_joint(obj_name).idx
-            elif type == gs.EQUALITY_TYPE.WELD:
-                obj_id = self.get_link(obj_name).idx
-            else:
-                gs.raise_exception(f"Equality type {type} not supported. Only CONNECT, JOINT, and WELD are supported.")
-            objs_id.append(obj_id)
+    def _add_equality(self, desc: EqualityDescription):
+        match desc.type:
+            case gs.EQUALITY_TYPE.CONNECT | gs.EQUALITY_TYPE.WELD:
+                objs_id = [self.get_link(obj_name).idx for obj_name in desc.objs_name]
+            case gs.EQUALITY_TYPE.JOINT:
+                objs_id = [self.get_joint(obj_name).idx for obj_name in desc.objs_name]
+            case _:
+                gs.raise_exception(
+                    f"Equality type {desc.type} not supported. Only CONNECT, JOINT, and WELD are supported."
+                )
 
         equality = RigidEquality(
             entity=self,
-            name=name,
             idx=self.n_equalities + self._equality_start,
-            type=type,
             eq_obj1id=objs_id[0],
             eq_obj2id=objs_id[1],
-            eq_data=data,
-            sol_params=sol_params,
+            desc=desc,
         )
         self._equalities.append(equality)
         return equality

--- a/genesis/engine/entities/rigid_entity/rigid_equality.py
+++ b/genesis/engine/entities/rigid_entity/rigid_equality.py
@@ -1,5 +1,6 @@
 import genesis as gs
 from genesis.repr_base import RBC
+from genesis.utils.description import EqualityDescription
 
 
 class RigidEquality(RBC):
@@ -7,29 +8,16 @@ class RigidEquality(RBC):
     Equality class for rigid body entities.
     """
 
-    def __init__(
-        self,
-        entity,
-        name,
-        idx,
-        type,
-        eq_obj1id,
-        eq_obj2id,
-        eq_data,
-        sol_params,
-    ):
-        self._name = name
+    def __init__(self, entity, idx, eq_obj1id, eq_obj2id, desc: EqualityDescription):
+        self.desc: EqualityDescription = desc
         self._entity = entity
         self._solver = entity.solver
 
         self._uid = gs.UID()
         self._idx = idx
-        self._type = type
 
         self._eq_obj1id = eq_obj1id
         self._eq_obj2id = eq_obj2id
-        self._eq_data = eq_data
-        self._sol_params = sol_params
 
     # ------------------------------------------------------------------------------------
     # -------------------------------- real-time state -----------------------------------
@@ -42,16 +30,14 @@ class RigidEquality(RBC):
         if self._solver.is_built:
             self._solver.set_sol_params(sol_params, eqs_idx=self._idx, envs_idx=None)
         else:
-            self._sol_params = sol_params
+            self.desc.sol_params = sol_params
 
-    @property
-    def sol_params(self):
+    @gs.assert_built
+    def get_sol_params(self):
         """
-        Returns the solver parameters of this equality constraint.
+        Get the solver parameters the simulation is currently using for this equality constraint.
         """
-        if self._solver.is_built:
-            return self._solver.get_sol_params(eqs_idx=self._idx, envs_idx=None)[..., 0, :]
-        return self._sol_params
+        return self._solver.get_sol_params(eqs_idx=self._idx, envs_idx=None)[..., 0, :]
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
@@ -69,7 +55,7 @@ class RigidEquality(RBC):
         """
         Returns the name of the equality.
         """
-        return self._name
+        return self.desc.name
 
     @property
     def entity(self):
@@ -107,7 +93,7 @@ class RigidEquality(RBC):
         """
         Returns the type of the equality.
         """
-        return self._type
+        return self.desc.type
 
     @property
     def eq_obj1id(self):
@@ -128,7 +114,7 @@ class RigidEquality(RBC):
         """
         Returns the eq_data of this equality constraint.
         """
-        return self._eq_data
+        return self.desc.data
 
     @property
     def is_built(self):

--- a/genesis/engine/entities/rigid_entity/rigid_geom.py
+++ b/genesis/engine/entities/rigid_entity/rigid_geom.py
@@ -12,7 +12,8 @@ import genesis as gs
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 from genesis.repr_base import RBC
-from genesis.utils.misc import tensor_to_array, qd_to_torch, DeprecationError
+from genesis.utils.description import GeomDescription
+from genesis.utils.misc import DeprecationError, qd_to_torch, tensor_to_array
 
 if TYPE_CHECKING:
     from genesis.engine.materials.rigid import Rigid as RigidMaterial
@@ -41,36 +42,20 @@ class RigidGeom(RBC):
         face_start: int,
         edge_start: int,
         verts_state_start: int,
-        mesh: "Mesh",
-        type: gs.GEOM_TYPE,
-        friction: float,
-        friction_torsional: float,
-        friction_rolling: float,
-        sol_params,
-        init_pos,
-        init_quat,
         needs_coup: bool,
-        contype,
-        conaffinity,
+        desc: GeomDescription,
         center_init=None,
-        data=None,
     ):
+        mesh = desc.mesh
+        self.desc: GeomDescription = desc
         self._link: "RigidLink" = link
         self._entity: "RigidEntity" = link.entity
         self._material: "RigidMaterial" = link.entity.material
         self._solver: "RigidSolver" = link.entity.solver
-        self._mesh: "Mesh" = mesh
 
         self._uid = gs.UID()
         self._idx = idx
-        self._type: gs.GEOM_TYPE = type
-        self._friction: float = friction
-        self._friction_torsional: float = friction_torsional
-        self._friction_rolling: float = friction_rolling
-        self._sol_params = sol_params
         self._needs_coup: bool = needs_coup
-        self._contype = int(contype)
-        self._conaffinity = int(conaffinity)
         self._is_convex: bool = mesh.is_convex
         self._cell_start: int = cell_start
         self._vert_start: int = vert_start
@@ -81,9 +66,6 @@ class RigidGeom(RBC):
         self._coup_softness: float = self._material.coup_softness
         self._coup_friction: float = self._material.coup_friction
         self._coup_restitution: float = self._material.coup_restitution
-
-        self._init_pos: np.ndarray = init_pos
-        self._init_quat: np.ndarray = init_quat
 
         # For heterogeneous simulation: which environments this geom is active in (None = all envs)
         self.active_envs_mask: torch.Tensor | None = None
@@ -103,9 +85,10 @@ class RigidGeom(RBC):
             )
         else:
             self._init_center_pos = np.array(center_init)
+        # The solver reads a row of fixed width, so copy the described shape data into one
         self._data = np.zeros([7])
-        if data is not None:
-            self._data[: len(data)] = data
+        if desc.data is not None:
+            self._data[: len(desc.data)] = desc.data
 
         # verts and faces for sdf genertaion
         if "sdf_mesh" in self._metadata:
@@ -150,7 +133,7 @@ class RigidGeom(RBC):
             # The wall-thickness probe only makes sense on a closed surface: on an open mesh the inward rays escape
             # through the holes, so keep the material target there. The sdf mesh probed by 'get_wall_thickness' is a
             # proxy for this collision mesh and must share its watertightness, hence it raises if that does not hold.
-            if self._mesh.is_watertight:
+            if self.desc.mesh.is_watertight:
                 wall_thickness = mu.get_wall_thickness(self._sdf_verts, self._sdf_faces)
                 cell_size_target = min(cell_size_target, wall_thickness / 2.0)
             else:
@@ -281,7 +264,7 @@ class RigidGeom(RBC):
         """
         Get the geom's trimesh object.
         """
-        return self._mesh.trimesh
+        return self.desc.mesh.trimesh
 
     def get_sdf_trimesh(self, color=[1.0, 1.0, 0.6, 1.0]):
         """
@@ -466,20 +449,18 @@ class RigidGeom(RBC):
         if self._solver.is_built:
             self._solver.set_sol_params(sol_params, geoms_idx=self._idx, envs_idx=None)
         else:
-            self._sol_params = sol_params
-
-    @property
-    def sol_params(self):
-        """
-        Get the solver parameters of this geometry.
-        """
-        if self._solver.is_built:
-            return self._solver.get_sol_params(geoms_idx=self._idx, envs_idx=None)[0]
-        return self._sol_params
+            self.desc.sol_params = sol_params
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
     # ------------------------------------------------------------------------------------
+
+    @gs.assert_built
+    def get_sol_params(self):
+        """
+        Get the solver parameters the simulation is currently using for this geom.
+        """
+        return self._solver.get_sol_params(geoms_idx=self._idx, envs_idx=None)[0]
 
     @property
     def uid(self):
@@ -500,28 +481,7 @@ class RigidGeom(RBC):
         """
         Get the type of the geom.
         """
-        return self._type
-
-    @property
-    def friction(self):
-        """
-        Get the build-time friction coefficient of the geom.
-        """
-        return self._friction
-
-    @property
-    def friction_torsional(self):
-        """
-        Get the build-time torsional friction coefficient of the geom (see 'gs.materials.Rigid').
-        """
-        return self._friction_torsional
-
-    @property
-    def friction_rolling(self):
-        """
-        Get the build-time rolling friction coefficient of the geom (see 'gs.materials.Rigid').
-        """
-        return self._friction_rolling
+        return self.desc.type
 
     @property
     def data(self):
@@ -567,7 +527,7 @@ class RigidGeom(RBC):
 
     @property
     def mesh(self) -> "Mesh":
-        return self._mesh
+        return self.desc.mesh
 
     @property
     def needs_coup(self) -> bool:
@@ -586,7 +546,7 @@ class RigidGeom(RBC):
         `(geom1.contype & geom2.conaffinity) || (geom2.contype & geom1.conaffinity) == True`. This is a powerful
         mechanism borrowed from Open Dynamics Engine.
         """
-        return self._contype
+        return self.desc.contype
 
     @property
     def conaffinity(self) -> int:
@@ -595,7 +555,7 @@ class RigidGeom(RBC):
 
         See `contype` documentation for details.
         """
-        return self._conaffinity
+        return self.desc.conaffinity
 
     @property
     def coup_softness(self) -> float:
@@ -623,14 +583,14 @@ class RigidGeom(RBC):
         """
         Get the initial position of the geom.
         """
-        return self._init_pos
+        return self.desc.pos
 
     @property
     def init_quat(self) -> np.ndarray:
         """
         Get the initial quaternion of the geom.
         """
-        return self._init_quat
+        return self.desc.quat
 
     @property
     def init_verts(self):
@@ -904,16 +864,16 @@ class RigidVisGeom(RBC):
     A `RigidVisGeom` is a counterpart of `RigidGeom`, but for visualization purposes. This can be accessed via `link.vis_geoms`.
     """
 
-    def __init__(self, link, idx, vvert_start, vface_start, vmesh, init_pos, init_quat):
+    def __init__(self, link, idx, vvert_start, vface_start, desc: GeomDescription):
+        self.desc: GeomDescription = desc
         self._link = link
         self._entity = link.entity
         self._material = link.entity.material
         self._solver = link.entity.solver
-        self._vmesh = vmesh
 
         # Lazy-initialize low-res geometry because it is usually unused and may be slow to compute
-        self._init_pos_tc = torch.from_numpy(init_pos).to(device=gs.device, dtype=gs.tc_float)
-        self._init_quat_tc = torch.from_numpy(init_quat).to(device=gs.device, dtype=gs.tc_float)
+        self._init_pos_tc = torch.from_numpy(desc.pos).to(device=gs.device, dtype=gs.tc_float)
+        self._init_quat_tc = torch.from_numpy(desc.quat).to(device=gs.device, dtype=gs.tc_float)
         self._aabb_verts: torch.Tensor | None = None
 
         self._uid = gs.UID()
@@ -922,20 +882,9 @@ class RigidVisGeom(RBC):
         self._vvert_start = vvert_start
         self._vface_start = vface_start
 
-        self._init_pos: np.ndarray = init_pos
-        self._init_quat: np.ndarray = init_quat
-
         # For heterogeneous simulation: which environments this vgeom is active in (None = all envs)
         self.active_envs_mask: torch.Tensor | None = None
         self.active_envs_idx: np.ndarray | None = None
-
-        self._init_vverts = vmesh.verts
-        self._init_vfaces = vmesh.faces
-        self._init_vnormals = vmesh.normals
-        self._uvs = vmesh.uvs
-        self._surface = vmesh.surface
-        self._metadata = vmesh.metadata
-        self._color = vmesh._color
 
     def _build(self):
         pass
@@ -944,7 +893,7 @@ class RigidVisGeom(RBC):
         """
         Get trimesh object.
         """
-        return self._vmesh.trimesh
+        return self.desc.vmesh.trimesh
 
     # ------------------------------------------------------------------------------------
     # -------------------------------- real-time state -----------------------------------
@@ -1070,7 +1019,7 @@ class RigidVisGeom(RBC):
 
     @property
     def vmesh(self):
-        return self._vmesh
+        return self.desc.vmesh
 
     @property
     def solver(self):
@@ -1084,70 +1033,70 @@ class RigidVisGeom(RBC):
         """
         Get the metadata of the vgeom.
         """
-        return self._metadata
+        return self.desc.vmesh.metadata
 
     @property
     def init_pos(self):
         """
         Get the initial position of the vgeom.
         """
-        return self._init_pos
+        return self.desc.pos
 
     @property
     def init_quat(self):
         """
         Get the initial quaternion of the vgeom.
         """
-        return self._init_quat
+        return self.desc.quat
 
     @property
     def init_vverts(self):
         """
         Get the initial vertices of the vgeom.
         """
-        return self._init_vverts
+        return self.desc.vmesh.verts
 
     @property
     def init_vfaces(self):
         """
         Get the initial faces of the vgeom.
         """
-        return self._init_vfaces
+        return self.desc.vmesh.faces
 
     @property
     def init_vnormals(self):
         """
         Get the initial normals of the vgeom.
         """
-        return self._init_vnormals
+        return self.desc.vmesh.normals
 
     @property
     def uvs(self):
         """
         Get the UV coordinates of the vgeom.
         """
-        return self._uvs
+        return self.desc.vmesh.uvs
 
     @property
     def surface(self):
         """
         Get the surface object of the vgeom.
         """
-        return self._surface
+        return self.desc.vmesh.surface
 
     @property
     def n_vverts(self):
         """
         Number of vertices of the vgeom.
         """
-        return len(self._init_vverts)
+        return len(self.desc.vmesh.verts)
 
     @property
     def n_vfaces(self):
         """
         Number of faces of the vgeom.
         """
-        return len(self._init_vfaces)
+        return len(self.desc.vmesh.faces)
 
     @property
     def vvert_start(self):

--- a/genesis/engine/entities/rigid_entity/rigid_joint.py
+++ b/genesis/engine/entities/rigid_entity/rigid_joint.py
@@ -1,13 +1,13 @@
 import numpy as np
-import quadrants as qd
-import torch
+
 
 import genesis as gs
 import genesis.utils.geom as gu
 from genesis.engine.entities.rigid_entity.rigid_link import RigidLink
-from genesis.utils import array_class
-from genesis.utils.misc import DeprecationError, tensor_to_array
 from genesis.repr_base import RBC
+from genesis.utils import array_class
+from genesis.utils.description import JointDescription
+from genesis.utils.misc import DeprecationError, tensor_to_array
 
 
 class RigidJoint(RBC):
@@ -15,34 +15,8 @@ class RigidJoint(RBC):
     Joint class for rigid body entities. Each RigidLink is connected to its parent link via a RigidJoint.
     """
 
-    def __init__(
-        self,
-        entity,
-        name,
-        idx,
-        link_idx,
-        q_start,
-        dof_start,
-        n_qs,
-        n_dofs,
-        type,
-        pos,
-        quat,
-        init_qpos,
-        sol_params,
-        dofs_motion_ang,
-        dofs_motion_vel,
-        dofs_limit,
-        dofs_invweight,
-        dofs_frictionloss,
-        dofs_stiffness,
-        dofs_damping,
-        dofs_armature,
-        dofs_act_gain,
-        dofs_act_bias,
-        dofs_force_range,
-    ):
-        self._name = name
+    def __init__(self, entity, idx, link_idx, q_start, dof_start, desc: JointDescription):
+        self.desc: JointDescription = desc
         self._entity = entity
         self._solver = entity.solver
 
@@ -51,25 +25,6 @@ class RigidJoint(RBC):
         self._link_idx = link_idx
         self._q_start = q_start
         self._dof_start = dof_start
-        self._n_qs = n_qs
-        self._n_dofs = n_dofs
-        self._type = type
-        self._pos = pos
-        self._quat = quat
-        self._init_qpos = init_qpos
-        self._sol_params = sol_params
-
-        self._dofs_motion_ang = dofs_motion_ang
-        self._dofs_motion_vel = dofs_motion_vel
-        self._dofs_limit = dofs_limit
-        self._dofs_invweight = dofs_invweight
-        self._dofs_frictionloss = dofs_frictionloss
-        self._dofs_stiffness = dofs_stiffness
-        self._dofs_damping = dofs_damping
-        self._dofs_armature = dofs_armature
-        self._dofs_act_gain = dofs_act_gain
-        self._dofs_act_bias = dofs_act_bias
-        self._dofs_force_range = dofs_force_range
 
     def __getattr__(self, name):
         # Must be implemented to throw deprecation warnings when accessing old properties, ignoring introspection
@@ -119,11 +74,7 @@ class RigidJoint(RBC):
         generalized coordinates corresponding to this joint (and all its ancestors in the kinematic tree). Physically,
         the anchor point is the "output" of the joint transmission, on which the child body is welded.
         """
-        tensor = torch.empty((self._solver._B, 3), dtype=gs.tc_float, device=gs.device)
-        _kernel_get_anchor_pos(self._idx, tensor, self._solver.dyn_state)
-        if self._solver.n_envs == 0:
-            tensor = tensor[0]
-        return tensor
+        return self._solver.get_joints_anchor_pos(self._idx)[..., 0, :]
 
     @gs.assert_built
     def get_anchor_axis(self):
@@ -132,11 +83,7 @@ class RigidJoint(RBC):
 
         See `RigidJoint.get_anchor_pos` documentation for details about the notion on anchor point.
         """
-        tensor = torch.empty((self._solver._B, 3), dtype=gs.tc_float, device=gs.device)
-        _kernel_get_anchor_axis(self._idx, tensor, self._solver.dyn_state)
-        if self._solver.n_envs == 0:
-            tensor = tensor[0]
-        return tensor
+        return self._solver.get_joints_anchor_axis(self._idx)[..., 0, :]
 
     def set_sol_params(self, sol_params):
         """
@@ -145,20 +92,18 @@ class RigidJoint(RBC):
         if self._solver.is_built:
             self._solver.set_sol_params(sol_params, joints_idx=self._idx, envs_idx=None)
         else:
-            self._sol_params = sol_params
-
-    @property
-    def sol_params(self):
-        """
-        Returns the solver parameters of the joint.
-        """
-        if self._solver.is_built:
-            return self._solver.get_sol_params(joints_idx=self._idx, envs_idx=None)[..., 0, :]
-        return self._sol_params
+            self.desc.sol_params = sol_params
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
     # ------------------------------------------------------------------------------------
+
+    @gs.assert_built
+    def get_sol_params(self):
+        """
+        Get the solver parameters the simulation is currently using for this joint.
+        """
+        return self._solver.get_sol_params(joints_idx=self._idx, envs_idx=None)[..., 0, :]
 
     @property
     def uid(self):
@@ -172,7 +117,7 @@ class RigidJoint(RBC):
         """
         Returns the name of the joint.
         """
-        return self._name
+        return self.desc.name
 
     @property
     def entity(self):
@@ -214,42 +159,42 @@ class RigidJoint(RBC):
         """
         Returns the initial joint position.
         """
-        return self._init_qpos
+        return self.desc.init_qpos
 
     @property
     def n_qs(self):
         """
         Returns the number of `q` (generalized coordinate) variables that the joint has.
         """
-        return self._n_qs
+        return self.desc.n_qs
 
     @property
     def n_dofs(self):
         """
         Returns the number of dofs that the joint has.
         """
-        return self._n_dofs
+        return self.desc.n_dofs
 
     @property
     def type(self):
         """
         Returns the type of the joint.
         """
-        return self._type
+        return self.desc.type
 
     @property
     def pos(self):
         """
         Returns the initial position of the joint in the world frame.
         """
-        return self._pos
+        return self.desc.pos
 
     @property
     def quat(self):
         """
         Returns the initial quaternion of the joint in the world frame.
         """
-        return self._quat
+        return self.desc.quat
 
     @property
     def q_start(self):
@@ -270,14 +215,14 @@ class RigidJoint(RBC):
         """
         Returns the ending index of the `q` variables of the joint in the rigid solver.
         """
-        return self._n_qs + self.q_start
+        return self.desc.n_qs + self.q_start
 
     @property
     def dof_end(self):
         """
         Returns the ending index of the dofs of the joint in the rigid solver.
         """
-        return self._n_dofs + self.dof_start
+        return self.desc.n_dofs + self.dof_start
 
     def _dof_idx(self):
         """
@@ -360,25 +305,11 @@ class RigidJoint(RBC):
 
     @property
     def dofs_motion_ang(self):
-        return self._dofs_motion_ang
+        return self.desc.dofs_motion_ang
 
     @property
     def dofs_motion_vel(self):
-        return self._dofs_motion_vel
-
-    @property
-    def dofs_limit(self):
-        """
-        Returns the range limit of the dofs of the joint.
-        """
-        return self._dofs_limit
-
-    @property
-    def dofs_invweight(self):
-        """
-        Returns the invweight of the dofs of the joint.
-        """
-        return self._dofs_invweight
+        return self.desc.dofs_motion_vel
 
     @property
     def dofs_length(self):
@@ -428,13 +359,13 @@ class RigidJoint(RBC):
         if self._solver._enable_mujoco_compatibility:
             # MuJoCo's dof_length: one body radius shared by every rotational dof, the largest geom bounding radius
             # plus its COM-to-geom-origin distance.
-            com = self.link.inertial_pos
+            com = self.link.desc.inertial_pos
             radii = [
                 np.linalg.norm(geom.init_verts, axis=1).max() + np.linalg.norm(com - geom.init_pos) for geom in geoms
             ]
             radius = body_radius(radii)
             for i_d in range(n_dofs):
-                if np.linalg.norm(self._dofs_motion_ang[i_d]) >= gs.EPS:  # rotational dof
+                if np.linalg.norm(self.desc.dofs_motion_ang[i_d]) >= gs.EPS:  # rotational dof
                     lengths[i_d] = radius
         else:
             # Per rotational dof, the largest perpendicular distance from its rotation axis (through the joint anchor)
@@ -445,7 +376,7 @@ class RigidJoint(RBC):
                 gu.transform_by_trans_quat(geom.init_verts, geom.init_pos, geom.init_quat) - anchor for geom in geoms
             ]
             for i_d in range(n_dofs):
-                axis = self._dofs_motion_ang[i_d]
+                axis = self.desc.dofs_motion_ang[i_d]
                 axis_norm = np.linalg.norm(axis)
                 if axis_norm < gs.EPS:
                     continue  # translational dof, length stays 1
@@ -453,55 +384,6 @@ class RigidJoint(RBC):
                 perp = [np.linalg.norm(v - np.outer(v @ axis, axis), axis=1).max() for v in verts]
                 lengths[i_d] = body_radius(perp)
         return lengths
-
-    @property
-    def dofs_frictionloss(self):
-        """
-        Returns the frictionloss of the dofs of the joint.
-        """
-        return self._dofs_frictionloss
-
-    @property
-    def dofs_stiffness(self):
-        """
-        Returns the stiffness of the dofs of the joint.
-        """
-        return self._dofs_stiffness
-
-    @property
-    def dofs_damping(self):
-        """
-        Returns the damping of the dofs of the joint.
-        """
-        return self._dofs_damping
-
-    @property
-    def dofs_armature(self):
-        """
-        Returns the armature of the dofs of the joint.
-        """
-        return self._dofs_armature
-
-    @property
-    def dofs_act_gain(self):
-        """
-        Returns the actuator gain of the dofs of the joint.
-        """
-        return self._dofs_act_gain
-
-    @property
-    def dofs_act_bias(self):
-        """
-        Returns the actuator bias [constant, pos_coeff, vel_coeff] of the dofs of the joint.
-        """
-        return self._dofs_act_bias
-
-    @property
-    def dofs_force_range(self):
-        """
-        Returns the force range of the dofs of the joint.
-        """
-        return self._dofs_force_range
 
     @property
     def is_built(self):
@@ -515,22 +397,4 @@ class RigidJoint(RBC):
     # ------------------------------------------------------------------------------------
 
     def _repr_brief(self):
-        return f"{(self.__repr_name__())}: {self._uid}, name: '{self._name}', idx: {self._idx}, type: {self._type}"
-
-
-@qd.kernel
-def _kernel_get_anchor_pos(joint_idx: qd.i32, tensor: qd.types.ndarray(), dyn_state: array_class.DynState):
-    _B = dyn_state.joints.xanchor.shape[1]
-    for i_b in range(_B):
-        xpos = dyn_state.joints.xanchor[joint_idx, i_b]
-        for i in qd.static(range(3)):
-            tensor[i_b, i] = xpos[i]
-
-
-@qd.kernel
-def _kernel_get_anchor_axis(joint_idx: qd.i32, tensor: qd.types.ndarray(), dyn_state: array_class.DynState):
-    _B = dyn_state.joints.xaxis.shape[1]
-    for i_b in range(_B):
-        xaxis = dyn_state.joints.xaxis[joint_idx, i_b]
-        for i in qd.static(range(3)):
-            tensor[i_b, i] = xaxis[i]
+        return f"{(self.__repr_name__())}: {self._uid}, name: '{self.name}', idx: {self._idx}, type: {self.type}"

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -10,12 +10,14 @@ from genesis.engine.mesh import InertialProperties
 from genesis.repr_base import RBC
 from genesis.typing import LaxPositiveFArrayType, Matrix3x3Type, UnitVec4FType, Vec3FType
 from genesis.utils import geom as gu
+from genesis.utils.description import GeomDescription, LinkDescription
 from genesis.utils.misc import DeprecationError, qd_to_torch
 
 from .rigid_geom import RigidGeom, RigidVisGeom
 
 if TYPE_CHECKING:
-    from genesis.engine.solvers.rigid.rigid_solver import RigidSolver
+    from genesis.engine.solvers.rigid import RigidSolver
+    from genesis.options.morphs import Morph
 
     from .rigid_entity import KinematicEntity, RigidEntity
     from .rigid_joint import RigidJoint
@@ -31,36 +33,37 @@ AABB_EPS = 0.002
 INERTIA_RATIO_MAX = 100.0
 
 
-def get_local_inertial_from_geom_info(g_info: dict, rho: float = 1.0) -> InertialProperties:
-    """Local inertial properties (mass, center of mass, inertia tensor) of a parsed geometry-info dict.
+def get_local_inertial_from_geom(
+    geom_type: gs.GEOM_TYPE, data: np.ndarray | None, mesh: "gs.Mesh | None", rho: float = 1.0
+) -> InertialProperties:
+    """Local inertial properties (mass, center of mass, inertia tensor) of one described geometry.
 
     Primitive types use the analytic formula on `data`; MESH defers to the mesh's cached unit-density mass properties
-    (`Mesh.get_inertial_info`) scaled by `rho`. This is the load-time computation available to kinematic and rigid
-    entities alike (it operates on the parsed info, not on a geom object), so the anchor it feeds matches the finalized
+    (`Mesh.inertial`) scaled by `rho`. This is the load-time computation available to kinematic and rigid
+    entities alike (it operates on the description, not on a geom object), so the anchor it feeds matches the finalized
     geom-derived inertia exactly.
     """
-    geom_type = g_info["type"]
     geom_com_local = np.zeros(3)
     if geom_type == gs.GEOM_TYPE.PLANE:
         geom_mass = 0.0
         geom_inertia_local = np.zeros(3, dtype=gs.np_float)
     elif geom_type == gs.GEOM_TYPE.SPHERE:
-        radius = g_info["data"][0]
+        radius = data[0]
         geom_mass = (4.0 / 3.0) * np.pi * radius**3 * rho
         I = (2.0 / 5.0) * geom_mass * radius**2
         geom_inertia_local = np.diag([I, I, I])
     elif geom_type == gs.GEOM_TYPE.ELLIPSOID:
-        hx, hy, hz = g_info["data"][:3]
+        hx, hy, hz = data[:3]
         geom_mass = (4.0 / 3.0) * np.pi * hx * hy * hz * rho
         geom_inertia_local = (geom_mass / 5.0) * np.diag([hy**2 + hz**2, hx**2 + hz**2, hx**2 + hy**2])
     elif geom_type == gs.GEOM_TYPE.CYLINDER:
-        radius, height = g_info["data"][:2]
+        radius, height = data[:2]
         geom_mass = np.pi * radius**2 * height * rho
         I_r = (geom_mass / 12.0) * (3.0 * radius**2 + height**2)
         I_z = 0.5 * geom_mass * radius**2
         geom_inertia_local = np.diag([I_r, I_r, I_z])
     elif geom_type == gs.GEOM_TYPE.CAPSULE:
-        radius, height = g_info["data"][:2]
+        radius, height = data[:2]
         m_cyl = np.pi * radius**2 * height * rho
         m_sph = (4.0 / 3.0) * np.pi * radius**3 * rho
         geom_mass = m_cyl + m_sph
@@ -70,18 +73,14 @@ def get_local_inertial_from_geom_info(g_info: dict, rho: float = 1.0) -> Inertia
         I_h = 0.5 * m_cyl * radius**2 + (2.0 / 5.0) * m_sph * radius**2
         geom_inertia_local = np.diag([I_r, I_r, I_h])
     elif geom_type == gs.GEOM_TYPE.BOX:
-        hx, hy, hz = g_info["data"][:3]
+        hx, hy, hz = data[:3]
         geom_mass = (hx * hy * hz) * rho
         geom_inertia_local = (geom_mass / 12.0) * np.diag([hy**2 + hz**2, hx**2 + hz**2, hx**2 + hy**2])
     else:
         # MESH type: reuse the mesh's cached unit-density mass properties; mass and inertia scale linearly with density.
-        inertial = g_info["mesh"].get_inertial_info().inertial
-        if inertial is None:
-            geom_mass, geom_inertia_local = 0.0, np.zeros((3, 3), dtype=gs.np_float)
-        else:
-            geom_mass = inertial.mass * rho
-            geom_com_local = inertial.com
-            geom_inertia_local = inertial.i * rho
+        geom_mass = mesh.inertial.mass * rho
+        geom_com_local = mesh.inertial.com
+        geom_inertia_local = mesh.inertial.i * rho
 
     return InertialProperties(geom_mass, geom_com_local, geom_inertia_local)
 
@@ -133,7 +132,7 @@ def compose_inertial_properties(geoms_inertial_info: Sequence[GeomInertialInfo])
     return InertialProperties(global_mass, global_com, global_inertia)
 
 
-def compose_inertial_from_g_infos(g_infos: Sequence[dict], rho: float) -> InertialProperties:
+def compose_inertial_from_geoms(g_descs: Sequence[GeomDescription], rho: float) -> InertialProperties:
     """
     Compose inertial properties (mass, center of mass, inertia tensor) from parsed geom infos.
 
@@ -143,21 +142,23 @@ def compose_inertial_from_g_infos(g_infos: Sequence[dict], rho: float) -> Inerti
 
     Parameters
     ----------
-    g_infos : list[dict]
-        Parsed geom infos to compute inertial from.
+    g_descs : list[GeomDescription]
+        Described geoms to compute inertial from.
     rho : float
         Material density (kg/m^3), used for every geom info without its own authored density.
     """
     geoms_inertial_info = tuple(
         GeomInertialInfo(
-            get_local_inertial_from_geom_info(
-                {"type": gs.GEOM_TYPE.MESH, "mesh": g_info["vmesh"]} if "vmesh" in g_info else g_info,
-                rho if g_info.get("density") is None else g_info["density"],
+            get_local_inertial_from_geom(
+                gs.GEOM_TYPE.MESH if g_desc.vmesh is not None else g_desc.type,
+                g_desc.data,
+                g_desc.vmesh if g_desc.vmesh is not None else g_desc.mesh,
+                rho if g_desc.density is None else g_desc.density,
             ),
-            np.asarray(g_info.get("pos", gu.zero_pos()), dtype=gs.np_float),
-            np.asarray(g_info.get("quat", gu.identity_quat()), dtype=gs.np_float),
+            np.asarray(g_desc.pos, dtype=gs.np_float),
+            np.asarray(g_desc.quat, dtype=gs.np_float),
         )
-        for g_info in g_infos
+        for g_desc in g_descs
     )
     return compose_inertial_properties(geoms_inertial_info)
 
@@ -172,6 +173,13 @@ class LinkInertial(NamedTuple):
     com: Vec3FType
     quat: UnitVec4FType
     inertia: Matrix3x3Type
+
+
+class LinkVariant(NamedTuple):
+    """One heterogeneous variant of a link: the morph it was loaded from, and what that asset described it with."""
+
+    morph: "Morph"
+    desc: LinkDescription
 
 
 class LinkInertialInfo(NamedTuple):
@@ -197,7 +205,7 @@ def finalize_inertial(
 
     Explicit values are used when given; otherwise the geometry estimate is used, and an explicit mass rescales a
     geometry-derived inertia. An omitted center of mass defaults to the link-frame origin when an explicit inertia
-    matrix is provided. The hint comes from the load-time inertial info ('compose_inertial_from_g_infos' over the
+    matrix is provided. The hint comes from the load-time inertial info ('compose_inertial_from_geoms' over the
     parsed geom infos, feeding both 'RigidLink._build' and the align anchor) - the single resolution path keeps the
     rigid dynamics inertia and the align anchor in lockstep.
 
@@ -236,20 +244,17 @@ class KinematicLink(RBC):
     def __init__(
         self,
         entity: "KinematicEntity",
-        name: str,
         idx: int,
+        parent_idx: int,
+        root_idx: int | None,
         joint_start: int,
         n_joints: int,
         vgeom_start: int,
         vvert_start: int,
         vface_start: int,
-        pos: "np.typing.ArrayLike",
-        quat: "np.typing.ArrayLike",
-        parent_idx: int,
-        root_idx: int | None,
-        aligned: bool = False,
+        desc: LinkDescription,
     ):
-        self._name: str = name
+        self.desc: LinkDescription = desc
         self._entity: "KinematicEntity" = entity
         self._solver: "RigidSolver" = entity.solver
         self._entity_idx_in_solver = entity._idx_in_solver
@@ -269,9 +274,7 @@ class KinematicLink(RBC):
             if link.parent_idx == -1:
                 break
             link = self.entity.links[link.parent_idx - self.entity.link_start]
-        if root_idx is None:
-            root_idx = link.idx
-        self._root_idx: int = root_idx
+        self._root_idx: int = link.idx if root_idx is None else root_idx
         self._is_fixed: bool = is_fixed
 
         self._joint_start: int = joint_start
@@ -280,14 +283,6 @@ class KinematicLink(RBC):
         self._vgeom_start: int = vgeom_start
         self._vvert_start: int = vvert_start
         self._vface_start: int = vface_start
-
-        # Link position & rotation at creation time:
-        self._pos: "np.typing.ArrayLike" = pos
-        self._quat: "np.typing.ArrayLike" = quat
-
-        # True when the link's frame is reframed to its center of mass and principal axes (the 'align' option). Affects
-        # the persistent geometry of any entity (kinematic or rigid), so it lives on the base class.
-        self._aligned: bool = aligned
 
         self._vgeoms: list[RigidVisGeom] = gs.List()
 
@@ -307,15 +302,13 @@ class KinematicLink(RBC):
         for vgeom in self._vgeoms:
             vgeom._build()
 
-    def _add_vgeom(self, vmesh, init_pos, init_quat):
+    def _add_vgeom(self, desc: GeomDescription):
         vgeom = RigidVisGeom(
             link=self,
             idx=self.n_vgeoms + self._vgeom_start,
             vvert_start=self.n_vverts + self._vvert_start,
             vface_start=self.n_vfaces + self._vface_start,
-            vmesh=vmesh,
-            init_pos=init_pos,
-            init_quat=init_quat,
+            desc=desc,
         )
         self._vgeoms.append(vgeom)
 
@@ -418,7 +411,7 @@ class KinematicLink(RBC):
         """
         The name of the link.
         """
-        return self._name
+        return self.desc.name
 
     @property
     def entity(self) -> "KinematicEntity":
@@ -543,46 +536,7 @@ class KinematicLink(RBC):
         enables - is applied only when the body is a single rigid body (a free root with no DOF-bearing descendant);
         callers relying on the diagonal mass must check that condition too, as the solver does.
         """
-        return self._aligned
-
-    @property
-    def invweight(self):
-        """Inverse weight of the link. Always zero for KinematicLink (infinite mass)."""
-        return np.zeros(2, dtype=gs.np_float)
-
-    @property
-    def pos(self) -> "np.typing.ArrayLike":
-        """
-        The initial position of the link. For real-time position, use `link.get_pos()`.
-        """
-        return self._pos
-
-    @property
-    def quat(self) -> "np.typing.ArrayLike":
-        """
-        The initial quaternion of the link. For real-time quaternion, use `link.get_quat()`.
-        """
-        return self._quat
-
-    @property
-    def inertial_pos(self):
-        """Initial position of the link's inertial frame. Zero for KinematicLink."""
-        return np.zeros(3, dtype=gs.np_float)
-
-    @property
-    def inertial_quat(self):
-        """Initial quaternion of the link's inertial frame. Identity for KinematicLink."""
-        return np.array([1.0, 0.0, 0.0, 0.0], dtype=gs.np_float)
-
-    @property
-    def inertial_mass(self):
-        """Mass of the link. Always 0.0 for KinematicLink."""
-        return 0.0
-
-    @property
-    def inertial_i(self):
-        """Inertia matrix of the link. Zero for KinematicLink."""
-        return np.zeros((3, 3), dtype=gs.np_float)
+        return self.desc.is_aligned
 
     @property
     def vgeoms(self) -> list[RigidVisGeom]:
@@ -653,7 +607,7 @@ class KinematicLink(RBC):
     # ------------------------------------------------------------------------------------
 
     def _repr_brief(self):
-        return f"{(self.__repr_name__())}: {self._uid}, name: '{self._name}', idx: {self._idx}"
+        return f"{(self.__repr_name__())}: {self._uid}, name: '{self.desc.name}', idx: {self._idx}"
 
 
 class RigidLink(KinematicLink):
@@ -665,8 +619,9 @@ class RigidLink(KinematicLink):
     def __init__(
         self,
         entity: "RigidEntity",
-        name: str,
         idx: int,
+        parent_idx: int,
+        root_idx: int | None,
         joint_start: int,
         n_joints: int,
         geom_start: int,
@@ -679,36 +634,12 @@ class RigidLink(KinematicLink):
         vgeom_start: int,
         vvert_start: int,
         vface_start: int,
-        pos: "np.typing.ArrayLike",
-        quat: "np.typing.ArrayLike",
-        inertial_pos: "np.typing.ArrayLike | None",
-        inertial_quat: "np.typing.ArrayLike | None",
-        inertial_i: "np.typing.ArrayLike | None",  # may be None, eg. for plane; NDArray is 3x3 matrix
-        inertial_mass: float | None,  # may be None, eg. for plane
-        parent_idx: int,
-        root_idx: int | None,
-        invweight: float | None,
         visualize_contact: bool,
-        is_robot: bool,
-        aligned: bool = False,
+        desc: LinkDescription,
     ):
         super().__init__(
-            entity,
-            name,
-            idx,
-            joint_start,
-            n_joints,
-            vgeom_start,
-            vvert_start,
-            vface_start,
-            pos,
-            quat,
-            parent_idx,
-            root_idx,
-            aligned,
+            entity, idx, parent_idx, root_idx, joint_start, n_joints, vgeom_start, vvert_start, vface_start, desc
         )
-
-        self._is_robot: bool = is_robot
 
         if self._is_fixed and not entity._batch_fixed_verts:
             verts_state_start = fixed_verts_state_start
@@ -722,20 +653,17 @@ class RigidLink(KinematicLink):
         self._edge_start: int = edge_start
         self._verts_state_start: int = verts_state_start
 
-        # Link's center-of-mass position & principal axes frame rotation at creation time:
-        if inertial_pos is not None:
-            inertial_pos = np.asarray(inertial_pos, dtype=gs.np_float)
-        self._inertial_pos: "np.typing.ArrayLike | None" = inertial_pos
-        if inertial_quat is None:
-            inertial_quat = (1.0, 0.0, 0.0, 0.0)
-        self._inertial_quat: "np.typing.ArrayLike" = np.asarray(inertial_quat, dtype=gs.np_float)
-        if inertial_mass is not None:
-            inertial_mass = float(inertial_mass)
-        self._inertial_mass: float | None = inertial_mass
-        if inertial_i is not None:
-            inertial_i = np.asarray(inertial_i, dtype=gs.np_float)
-        self._inertial_i: "np.typing.ArrayLike | None" = inertial_i
-        self._invweight: float | None = invweight
+        # Normalize the inertial values in the description the link reads them from: arrays for the offsets and the
+        # inertia, a float for the mass, and the identity quaternion for an orientation the asset leaves unset
+        if desc.inertial_pos is not None:
+            desc.inertial_pos = np.asarray(desc.inertial_pos, dtype=gs.np_float)
+        desc.inertial_quat = np.asarray(
+            (1.0, 0.0, 0.0, 0.0) if desc.inertial_quat is None else desc.inertial_quat, dtype=gs.np_float
+        )
+        if desc.mass is not None:
+            desc.mass = float(desc.mass)
+        if desc.inertia is not None:
+            desc.inertia = np.asarray(desc.inertia, dtype=gs.np_float)
 
         self._visualize_contact = visualize_contact
 
@@ -748,7 +676,7 @@ class RigidLink(KinematicLink):
         """Start tracking heterogeneous variants. Records first variant from current state."""
         super()._init_variant_tracking()
         self._variant_geom_ranges = [(self._geom_start, self._geom_start + self.n_geoms)]
-        self._variant_scene_inertial: list[tuple] | None = None
+        self._variant_sources: list[LinkVariant] | None = None
 
     def _record_variant_geom_range(self, n_new_geoms):
         """Record a new variant's geom range."""
@@ -762,7 +690,7 @@ class RigidLink(KinematicLink):
             geom._build()
 
         # Estimate the spatial inertia of the link. It will be used as a guess if not specified in morph, or as baseline
-        # to proof-check the provided values. The estimate was resolved at load from the parsed geom infos (primary
+        # to proof-check the provided values. The estimate was resolved at load from the described geoms (primary
         # variant), the only time their authored per-geom densities are available.
         hint_mass = 0.0
         hint_com = np.zeros(3, dtype=gs.np_float)
@@ -778,7 +706,7 @@ class RigidLink(KinematicLink):
             for geoms, is_visual in zip((self._geoms, self._vgeoms), (False, True)):
                 for geom in geoms:
                     verts = geom.init_vverts if is_visual else geom.init_verts
-                    verts = gu.transform_by_trans_quat(verts, geom._init_pos, geom._init_quat)
+                    verts = gu.transform_by_trans_quat(verts, geom.init_pos, geom.init_quat)
                     aabb_min = np.minimum(aabb_min, verts.min(axis=0))
                     aabb_max = np.maximum(aabb_max, verts.max(axis=0))
 
@@ -787,11 +715,11 @@ class RigidLink(KinematicLink):
         hint_mass_raw, hint_inertia_raw = hint_mass, np.array(hint_inertia)
 
         # Make sure that provided spatial inertia is consistent with the estimate from the geometries if not fixed
-        if (self._inertial_mass or hint_mass) > MASS_EPS and hint_mass > gs.EPS:
+        if (self.desc.mass or hint_mass) > MASS_EPS and hint_mass > gs.EPS:
             # An omitted center of mass is resolved to the link frame origin whenever the inertia tensor is authored
             # (see 'finalize_inertial'), so it must undergo the same consistency check as an authored one.
-            inertial_pos = self._inertial_pos
-            if inertial_pos is None and self._inertial_i is not None:
+            inertial_pos = self.desc.inertial_pos
+            if inertial_pos is None and self.desc.inertia is not None:
                 inertial_pos = gu.zero_pos()
             if inertial_pos is not None:
                 tol = (aabb_max - aabb_min) * AABB_EPS + AABB_EPS
@@ -802,21 +730,21 @@ class RigidLink(KinematicLink):
                         com_str.append(f"{name}={pos:0.3f}")
                         aabb_str.append(f"{name}=({axis_min:0.3f}, {axis_max:0.3f})")
                     gs.logger.warning(
-                        f"Link '{self._name}' has dubious center of mass [{', '.join(com_str)}] compared to the "
+                        f"Link '{self.desc.name}' has dubious center of mass [{', '.join(com_str)}] compared to the "
                         f"bounding box from geometry [{', '.join(aabb_str)}]."
                     )
 
-            if self._inertial_mass is not None:
-                if not (hint_mass / INERTIA_RATIO_MAX <= self._inertial_mass <= INERTIA_RATIO_MAX * hint_mass):
+            if self.desc.mass is not None:
+                if not (hint_mass / INERTIA_RATIO_MAX <= self.desc.mass <= INERTIA_RATIO_MAX * hint_mass):
                     gs.logger.warning(
-                        f"Link '{self._name}' has dubious mass {self._inertial_mass:0.3f} compared to the estimate "
+                        f"Link '{self.desc.name}' has dubious mass {self.desc.mass:0.3f} compared to the estimate "
                         f"from geometry {hint_mass:0.3f}."
                     )
-                hint_inertia *= self._inertial_mass / hint_mass
-                hint_mass = self._inertial_mass
+                hint_inertia *= self.desc.mass / hint_mass
+                hint_mass = self.desc.mass
 
-            if self._inertial_i is not None:
-                inertia_diag = np.diag(self._inertial_i)
+            if self.desc.inertia is not None:
+                inertia_diag = np.diag(self.desc.inertia)
                 hint_inertia_diag = np.diag(hint_inertia)
                 if not (
                     (hint_inertia_diag / INERTIA_RATIO_MAX <= inertia_diag)
@@ -827,43 +755,45 @@ class RigidLink(KinematicLink):
                         inertia_str = ",".join(f"{name}={val:0.3e}" for name, val in zip(("ixx", "iyy", "izz"), data))
                         inertias_str.append(inertia_str)
                     gs.logger.warning(
-                        f"Link '{self._name}' has dubious inertia [" + inertias_str[0] + "] compared to the estimate "
+                        f"Link '{self.desc.name}' has dubious inertia ["
+                        + inertias_str[0]
+                        + "] compared to the estimate "
                         "from geometry [" + inertias_str[1] + "]."
                     )
 
-        if self._inertial_mass is None or self._inertial_i is None:
+        if self.desc.mass is None or self.desc.inertia is None:
             if not self._is_fixed and self._vgeoms and not self._geoms:
                 gs.logger.info(
                     f"Mass is not specified and collision geoms can not be found for link '{self.name}'. "
                     f"Using visual geoms to compute inertial properties."
                 )
-            if self._inertial_pos is not None and self._inertial_i is None:
+            if self.desc.inertial_pos is not None and self.desc.inertia is None:
                 gs.logger.warning(
                     f"Ignoring center of mass of link '{self.name}' because inertia matrix is not specified."
                 )
-            self._invweight = None
+            self.desc.invweight = None
 
         # Resolve the final inertial from the explicit values and the geometry estimate, sharing finalize_inertial with
         # the load-time inertial info so the dynamics inertia and the align anchor stay in lockstep.
         inertial = finalize_inertial(
-            self._inertial_mass,
-            self._inertial_pos,
-            self._inertial_quat,
-            self._inertial_i,
+            self.desc.mass,
+            self.desc.inertial_pos,
+            self.desc.inertial_quat,
+            self.desc.inertia,
             hint_mass_raw,
             hint_com,
             hint_inertia_raw,
         )
-        self._inertial_mass, self._inertial_pos = inertial.mass, inertial.com
-        self._inertial_quat, self._inertial_i = inertial.quat, inertial.inertia
+        self.desc.mass, self.desc.inertial_pos = inertial.mass, inertial.com
+        self.desc.inertial_quat, self.desc.inertia = inertial.quat, inertial.inertia
 
         # Postpone computation of inverse weight if not specified
-        if self._invweight is None:
-            self._invweight = np.full((2,), fill_value=-1.0, dtype=gs.np_float)
+        if self.desc.invweight is None:
+            self.desc.invweight = np.full((2,), fill_value=-1.0, dtype=gs.np_float)
 
         # override invweight if fixed
         if self._is_fixed:
-            self._invweight = np.zeros((2,), dtype=gs.np_float)
+            self.desc.invweight = np.zeros((2,), dtype=gs.np_float)
 
         # Compute per-variant inertial for heterogeneous links
         if self._variant_geom_ranges is not None:
@@ -873,14 +803,14 @@ class RigidLink(KinematicLink):
                     # Primary variant: use the link's own parsed/computed inertial
                     self._variant_inertial.append(
                         LinkInertial(
-                            self._inertial_mass,
-                            np.asarray(self._inertial_pos, dtype=gs.np_float),
+                            self.desc.mass,
+                            np.asarray(self.desc.inertial_pos, dtype=gs.np_float),
                             (
-                                np.asarray(self._inertial_quat, dtype=gs.np_float)
-                                if self._inertial_quat is not None
+                                np.asarray(self.desc.inertial_quat, dtype=gs.np_float)
+                                if self.desc.inertial_quat is not None
                                 else gu.identity_quat()
                             ),
-                            np.asarray(self._inertial_i, dtype=gs.np_float),
+                            np.asarray(self.desc.inertia, dtype=gs.np_float),
                         )
                     )
                     continue
@@ -891,29 +821,17 @@ class RigidLink(KinematicLink):
                 # Primitive/Mesh variant has no parsed inertial, and 'recompute_inertia' discards it on purpose, so
                 # both fall back to the estimate alone.
                 v_mass, v_pos, v_quat, v_i = None, None, None, None
-                if self._variant_scene_inertial is not None:
-                    morph_v, v_mass, v_pos, v_quat, v_i = self._variant_scene_inertial[v - 1]
-                    if morph_v.recompute_inertia and not self._is_fixed:
-                        v_mass, v_pos, v_quat, v_i = None, None, None, None
+                if self._variant_sources is not None:
+                    variant = self._variant_sources[v - 1]
+                    if not (variant.morph.recompute_inertia and not self._is_fixed):
+                        v_mass = variant.desc.mass
+                        v_pos = variant.desc.inertial_pos
+                        v_quat = variant.desc.inertial_quat
+                        v_i = variant.desc.inertia
                 hint = self.entity._links_inertial_info[self.idx - self.entity._link_start][v].hint
                 self._variant_inertial.append(finalize_inertial(v_mass, v_pos, v_quat, v_i, *hint))
 
-    def _add_geom(
-        self,
-        mesh,
-        init_pos,
-        init_quat,
-        type,
-        friction,
-        friction_torsional,
-        friction_rolling,
-        sol_params,
-        center_init=None,
-        needs_coup=False,
-        contype=1,
-        conaffinity=1,
-        data=None,
-    ):
+    def _add_geom(self, desc: GeomDescription, center_init=None, needs_coup=False):
         geom = RigidGeom(
             link=self,
             idx=self.n_geoms + self._geom_start,
@@ -922,19 +840,9 @@ class RigidLink(KinematicLink):
             face_start=self.n_faces + self._face_start,
             edge_start=self.n_edges + self._edge_start,
             verts_state_start=self.n_verts + self._verts_state_start,
-            mesh=mesh,
-            init_pos=init_pos,
-            init_quat=init_quat,
-            type=type,
-            friction=friction,
-            friction_torsional=friction_torsional,
-            friction_rolling=friction_rolling,
-            sol_params=sol_params,
-            center_init=center_init,
             needs_coup=needs_coup,
-            contype=contype,
-            conaffinity=conaffinity,
-            data=data,
+            desc=desc,
+            center_init=center_init,
         )
         self._geoms.append(geom)
 
@@ -1161,41 +1069,6 @@ class RigidLink(KinematicLink):
         Whether to visualize the contact of the link.
         """
         return self._visualize_contact
-
-    @property
-    def invweight(self):
-        """
-        The build-time invweight of the link.
-        """
-        return self._invweight
-
-    @property
-    def inertial_pos(self) -> "np.typing.ArrayLike | None":
-        """
-        The build-time position of the link's inertial frame.
-        """
-        return self._inertial_pos
-
-    @property
-    def inertial_quat(self) -> "np.typing.ArrayLike | None":
-        """
-        The build-time quaternion of the link's inertial frame.
-        """
-        return self._inertial_quat
-
-    @property
-    def inertial_mass(self) -> float | None:
-        """
-        The build-time mass of the link.
-        """
-        return self._inertial_mass
-
-    @property
-    def inertial_i(self) -> "np.typing.ArrayLike | None":
-        """
-        The build-time inertia matrix of the link.
-        """
-        return self._inertial_i
 
     @property
     def geoms(self) -> list[RigidGeom]:

--- a/genesis/engine/mesh.py
+++ b/genesis/engine/mesh.py
@@ -26,14 +26,6 @@ class InertialProperties(NamedTuple):
     i: Matrix3x3Type
 
 
-class MeshInertialInfo(NamedTuple):
-    """A mesh's mass properties in its own frame at unit density: the volume and the corresponding intrinsic
-    'inertial', which is None for degenerate geometry that carries no well-defined mass distribution."""
-
-    volume: float
-    inertial: "InertialProperties | None"
-
-
 class Mesh(RBC):
     """
     Genesis's own triangle mesh object.
@@ -89,11 +81,11 @@ class Mesh(RBC):
         self._unique_edges: "np.ndarray | None" = None
         self._vert_adjacency: "tuple[np.ndarray, np.ndarray, np.ndarray] | None" = None
         self._is_convex: "bool | None" = None
-        self._inertial_info: "MeshInertialInfo | None" = None
+        self._inertial: "InertialProperties | None" = None
         # A mesh sharing another's processed geometry (a cached collision template) delegates its inertia query to that
         # source, so the (convex-hull) mass-property computation runs at most once per geometry and only when an entity
         # actually needs it - never eagerly for e.g. fixed or articulated assets whose link frames are not aligned.
-        self._inertial_info_source: "Mesh | None" = None
+        self._inertial_source: "Mesh | None" = None
 
         # By default, all meshes are considered zup, unless the "FileMorph.file_meshes_are_zup" option was set to False
         self._metadata.setdefault("imported_as_zup", True)
@@ -267,8 +259,8 @@ class Mesh(RBC):
         self._unique_edges = None
         self._vert_adjacency = None
         self._is_convex = None
-        self._inertial_info = None
-        self._inertial_info_source = None
+        self._inertial = None
+        self._inertial_source = None
 
     def get_unique_edges(self):
         """
@@ -285,22 +277,22 @@ class Mesh(RBC):
 
         return self._unique_edges
 
-    def get_inertial_info(self):
+    @property
+    def inertial(self):
         """
-        Get the mass properties of the geometry in its own frame as a MeshInertialInfo.
+        Mass, center of mass and inertia tensor of the geometry in its own frame, at unit density.
 
         Non-watertight geometry is closed by its convex hull first so the volume integral is well-defined; a degenerate
-        geometry reports a zero volume and no mass distribution. The result is memoized and shared by reference across
-        entities backed by the same geometry.
+        geometry weighs nothing, and composes as a geom of no mass at the origin. The result is memoized and shared by
+        reference across entities backed by the same geometry.
         """
-        if self._inertial_info_source is not None:
-            return self._inertial_info_source.get_inertial_info()
-        if self._inertial_info is None:
+        if self._inertial_source is not None:
+            return self._inertial_source.inertial
+        if self._inertial is None:
             # A degenerate geometry (zero / ill-defined volume) makes trimesh's mass-property integral divide by zero,
             # yielding a non-finite center of mass; a more degenerate one (fewer than 4 non-coplanar vertices) makes the
-            # convex-hull closure of a non-watertight mesh raise instead. Either way the geom carries no inertia: report
-            # a zero volume so the caller skips it, rather than crashing or letting NaNs propagate into the composed
-            # inertia (and emitting a warning).
+            # convex-hull closure of a non-watertight mesh raise instead. Either way the geom carries no inertia:
+            # report no mass, rather than crashing or letting NaNs propagate into the composed inertia.
             with np.errstate(invalid="ignore", divide="ignore"):
                 try:
                     tmesh = self._mesh
@@ -321,12 +313,10 @@ class Mesh(RBC):
                 except QhullError:
                     volume, center_mass = 0.0, None
                 if volume > 0.0 and np.all(np.isfinite(center_mass)):
-                    self._inertial_info = MeshInertialInfo(
-                        volume, InertialProperties(tmesh.mass, center_mass, tmesh.moment_inertia)
-                    )
+                    self._inertial = InertialProperties(tmesh.mass, center_mass, tmesh.moment_inertia)
                 else:
-                    self._inertial_info = MeshInertialInfo(0.0, None)
-        return self._inertial_info
+                    self._inertial = InertialProperties(0.0, np.zeros(3), np.zeros((3, 3)))
+        return self._inertial
 
     def get_vert_adjacency(self):
         """
@@ -633,6 +623,13 @@ class Mesh(RBC):
         Normals of the mesh.
         """
         return self._mesh.vertex_normals
+
+    @property
+    def color(self):
+        """
+        Color of the mesh, as red, green, blue and alpha.
+        """
+        return self._color
 
     @property
     def surface(self):

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -409,17 +409,17 @@ class KinematicSolver(Solver):
                     [(joint.link._entity_idx_in_solver,) * joint.n_dofs for joint in joints if joint.n_dofs],
                     dtype=gs.np_int,
                 ),
-                np.concatenate([joint.dofs_motion_ang for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_motion_vel for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_limit for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_invweight for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_stiffness for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_damping for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_frictionloss for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_armature for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_act_gain for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_act_bias for joint in joints], dtype=gs.np_float),
-                np.concatenate([joint.dofs_force_range for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_motion_ang for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_motion_vel for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_limit for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_invweight for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_stiffness for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_damping for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_frictionloss for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_armature for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_act_gain for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_act_bias for joint in joints], dtype=gs.np_float),
+                np.concatenate([joint.desc.dofs_force_range for joint in joints], dtype=gs.np_float),
                 self.dyn_state,
                 self.dyn_info,
                 self.rigid_info,
@@ -445,14 +445,14 @@ class KinematicSolver(Solver):
                 np.array([link.geom_end for link in links], dtype=gs.np_int),
                 np.array([link.vgeom_start for link in links], dtype=gs.np_int),
                 np.array([link.vgeom_end for link in links], dtype=gs.np_int),
-                np.array([link.invweight for link in links], dtype=gs.np_float),
+                np.array([link.desc.invweight for link in links], dtype=gs.np_float),
                 np.array([link.is_fixed for link in links], dtype=gs.np_bool),
-                np.array([link.pos for link in links], dtype=gs.np_float),
-                np.array([link.quat for link in links], dtype=gs.np_float),
-                np.array([link.inertial_pos for link in links], dtype=gs.np_float),
-                np.array([link.inertial_quat for link in links], dtype=gs.np_float),
-                np.array([link.inertial_i for link in links], dtype=gs.np_float),
-                np.array([link.inertial_mass for link in links], dtype=gs.np_float),
+                np.array([link.desc.pos for link in links], dtype=gs.np_float),
+                np.array([link.desc.quat for link in links], dtype=gs.np_float),
+                np.array([link.desc.inertial_pos for link in links], dtype=gs.np_float),
+                np.array([link.desc.inertial_quat for link in links], dtype=gs.np_float),
+                np.array([link.desc.inertia for link in links], dtype=gs.np_float),
+                np.array([link.desc.mass for link in links], dtype=gs.np_float),
                 self.dyn_state,
                 self.dyn_info,
                 self.rigid_info,
@@ -461,7 +461,7 @@ class KinematicSolver(Solver):
 
         if self.joints:
             joints = self.joints
-            joints_sol_params = np.array([joint.sol_params for joint in joints], dtype=gs.np_float)
+            joints_sol_params = np.array([joint.desc.sol_params for joint in joints], dtype=gs.np_float)
             joints_sol_params = self._sanitize_joint_sol_params(joints_sol_params)
 
             kernel_init_joint_fields(
@@ -496,8 +496,8 @@ class KinematicSolver(Solver):
             is_init_qpos_out_of_bounds = False
             for joint in self.joints:
                 if joint.type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC):
-                    is_init_qpos_out_of_bounds |= (joint.dofs_limit[0, 0] > init_qpos[joint.q_start]).any()
-                    is_init_qpos_out_of_bounds |= (init_qpos[joint.q_start] > joint.dofs_limit[0, 1]).any()
+                    is_init_qpos_out_of_bounds |= (joint.desc.dofs_limit[0, 0] > init_qpos[joint.q_start]).any()
+                    is_init_qpos_out_of_bounds |= (init_qpos[joint.q_start] > joint.desc.dofs_limit[0, 1]).any()
             if is_init_qpos_out_of_bounds:
                 gs.logger.warning("Neutral robot position (qpos0) exceeds joint limits.")
             self.qpos.from_numpy(init_qpos)
@@ -560,7 +560,7 @@ class KinematicSolver(Solver):
                 np.array([vgeom.vface_end for vgeom in vgeoms], dtype=gs.np_int),
                 np.array([vgeom.init_pos for vgeom in vgeoms], dtype=gs.np_float),
                 np.array([vgeom.init_quat for vgeom in vgeoms], dtype=gs.np_float),
-                np.array([vgeom._color for vgeom in vgeoms], dtype=gs.np_float),
+                np.array([vgeom.desc.vmesh.color for vgeom in vgeoms], dtype=gs.np_float),
                 self.dyn_info,
                 self.rigid_config,
             )
@@ -1123,6 +1123,14 @@ class KinematicSolver(Solver):
         if relative and self._links_offset_quat is not None:
             offset_quat = _select_links_offset(self._links_offset_quat, links_idx, envs_idx)
             tensor = gu.transform_quat_by_quat(gu.inv_quat(offset_quat), tensor)
+        return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_joints_anchor_pos(self, joints_idx=None, envs_idx=None):
+        tensor = qd_to_torch(self.dyn_state.joints.xanchor, envs_idx, joints_idx, transpose=True, copy=True)
+        return tensor[0] if self.n_envs == 0 else tensor
+
+    def get_joints_anchor_axis(self, joints_idx=None, envs_idx=None):
+        tensor = qd_to_torch(self.dyn_state.joints.xaxis, envs_idx, joints_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 else tensor
 
     def get_vgeoms_pos(self, vgeoms_idx=None, envs_idx=None, *, relative=False):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -874,50 +874,50 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 # their own anchors.
                 is_sole_joint = len(link.joints) == 1
                 if is_sole_joint:
-                    dist_com = {link.idx: np.linalg.norm(link.inertial_pos - anchor)}
+                    dist_com = {link.idx: np.linalg.norm(link.desc.inertial_pos - anchor)}
                 else:
-                    dist_com = {link.idx: np.linalg.norm(anchor) + np.linalg.norm(link.inertial_pos)}
+                    dist_com = {link.idx: np.linalg.norm(anchor) + np.linalg.norm(link.desc.inertial_pos)}
                 dist_origin = {link.idx: np.linalg.norm(anchor)}
                 sub, stack = [], [link]
                 while stack:
                     cur = stack.pop()
                     sub.append(cur)
                     for child in children.get(cur.idx, []):
-                        hop = np.linalg.norm(child.pos) + 2.0 * sum(np.linalg.norm(j.pos) for j in child.joints)
+                        hop = np.linalg.norm(child.desc.pos) + 2.0 * sum(np.linalg.norm(j.pos) for j in child.joints)
                         # A prismatic descendant carries the subtree outward by up to its full travel span (which
                         # covers the offset from any zero configuration within limits); an unlimited slide makes the
                         # upper bracket infinite and the gate enables.
-                        hop += sum(np.ptp(j.dofs_limit) for j in child.joints if j.type == gs.JOINT_TYPE.PRISMATIC)
+                        hop += sum(np.ptp(j.desc.dofs_limit) for j in child.joints if j.type == gs.JOINT_TYPE.PRISMATIC)
                         dist_origin[child.idx] = dist_origin[cur.idx] + hop
-                        dist_com[child.idx] = dist_origin[child.idx] + np.linalg.norm(child.inertial_pos)
+                        dist_com[child.idx] = dist_origin[child.idx] + np.linalg.norm(child.desc.inertial_pos)
                         stack.append(child)
-                sub_mass = sum(l.inertial_mass for l in sub)
-                eigvals = np.linalg.eigvalsh(link.inertial_i)
+                sub_mass = sum(l.desc.mass for l in sub)
+                eigvals = np.linalg.eigvalsh(link.desc.inertia)
                 rot_desc_upper = sum(
-                    np.linalg.eigvalsh(l.inertial_i)[-1] + l.inertial_mass * dist_com[l.idx] ** 2
+                    np.linalg.eigvalsh(l.desc.inertia)[-1] + l.desc.mass * dist_com[l.idx] ** 2
                     for l in sub
                     if l is not link
                 )
                 # Carrying link's inertia about the anchor: exact along a fixed axis, principal bracket otherwise.
                 if is_sole_joint:
-                    R_inertial = gu.quat_to_R(link.inertial_quat)
-                    inertia_com = R_inertial @ link.inertial_i @ R_inertial.T
-                    offset_com = link.inertial_pos - anchor
+                    R_inertial = gu.quat_to_R(link.desc.inertial_quat)
+                    inertia_com = R_inertial @ link.desc.inertia @ R_inertial.T
+                    offset_com = link.desc.inertial_pos - anchor
                     rot_self_lower = eigvals[0]
-                    rot_self_upper = eigvals[-1] + link.inertial_mass * np.dot(offset_com, offset_com)
+                    rot_self_upper = eigvals[-1] + link.desc.mass * np.dot(offset_com, offset_com)
                 else:
                     inertia_com = None
                     offset_com = None
                     rot_self_lower = eigvals[0]
-                    rot_self_upper = eigvals[-1] + link.inertial_mass * dist_com[link.idx] ** 2
-                for i_d, armature_d in enumerate(joint.dofs_armature):
+                    rot_self_upper = eigvals[-1] + link.desc.mass * dist_com[link.idx] ** 2
+                for i_d, armature_d in enumerate(joint.desc.dofs_armature):
                     if joint.type == gs.JOINT_TYPE.PRISMATIC or (joint.type == gs.JOINT_TYPE.FREE and i_d < 3):
                         lower.append(armature_d + sub_mass)
                         upper.append(armature_d + sub_mass)
                     elif joint.type == gs.JOINT_TYPE.REVOLUTE and is_sole_joint:
                         axis = joint.dofs_motion_ang[i_d]
                         lever = np.cross(axis, offset_com)
-                        rot_self = axis @ inertia_com @ axis + link.inertial_mass * np.dot(lever, lever)
+                        rot_self = axis @ inertia_com @ axis + link.desc.mass * np.dot(lever, lever)
                         lower.append(armature_d + rot_self)
                         upper.append(armature_d + rot_self + rot_desc_upper)
                     else:
@@ -1144,7 +1144,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
 
         if self.n_geoms > 0:
             geoms = self.geoms
-            geoms_sol_params = np.array([geom.sol_params for geom in geoms], dtype=gs.np_float)
+            geoms_sol_params = np.array([geom.desc.sol_params for geom in geoms], dtype=gs.np_float)
             # A geom keeps the time constant the model states; the floor lands on the value a contact mixes out of its
             # two geoms (see func_set_contact_data), the value the solver actually consumes. Flooring per geom would
             # raise the mix of a pair that is already above the floor, distorting the stated stiffness with no
@@ -1200,9 +1200,9 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 np.array(geoms_center, dtype=gs.np_float),
                 np.array([geom.init_quat for geom in geoms], dtype=gs.np_float),
                 np.array([geom.type for geom in geoms], dtype=gs.np_int),
-                np.array([geom.friction for geom in geoms], dtype=gs.np_float),
-                np.array([geom.friction_torsional for geom in geoms], dtype=gs.np_float),
-                np.array([geom.friction_rolling for geom in geoms], dtype=gs.np_float),
+                np.array([geom.desc.friction for geom in geoms], dtype=gs.np_float),
+                np.array([geom.desc.friction_torsional for geom in geoms], dtype=gs.np_float),
+                np.array([geom.desc.friction_rolling for geom in geoms], dtype=gs.np_float),
                 geoms_sol_params,
                 np.array([geom.data for geom in geoms], dtype=gs.np_float),
                 np.array([geom.is_convex for geom in geoms], dtype=gs.np_bool),
@@ -1243,7 +1243,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         if self.n_equalities > 0:
             equalities = self.equalities
 
-            equalities_sol_params = np.array([equality.sol_params for equality in equalities], dtype=gs.np_float)
+            equalities_sol_params = np.array([equality.desc.sol_params for equality in equalities], dtype=gs.np_float)
             _sanitize_sol_params(equalities_sol_params, self._sol_min_timeconst, self._sol_default_timeconst)
 
             kernel_init_equality_fields(
@@ -2368,7 +2368,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 links = (self.links[links_idx],)
             else:
                 links = [self.links[i_l] for i_l in links_idx]
-            if sum(0.0 if link.is_fixed else link.inertial_mass for link in links) <= gs.EPS:
+            if sum(0.0 if link.is_fixed else link.desc.mass for link in links) <= gs.EPS:
                 gs.raise_exception(
                     "None of the links being set holds a mass to spread out, so there is no mass to set."
                 )

--- a/genesis/ext/pyrender/overlay/types.py
+++ b/genesis/ext/pyrender/overlay/types.py
@@ -76,8 +76,8 @@ def build_entity_joint_data(entity: "RigidEntity", free_joint_pos_limit: float) 
             for i in range(joint.n_qs):
                 name = joint.name if joint.n_qs == 1 else f"{joint.name}[{i}]"
                 q_names.append(name)
-                lo = float(joint.dofs_limit[i, 0])
-                hi = float(joint.dofs_limit[i, 1])
+                lo = float(joint.desc.dofs_limit[i, 0])
+                hi = float(joint.desc.dofs_limit[i, 1])
                 if not np.isfinite(lo):
                     lo = -1e6
                 if not np.isfinite(hi):

--- a/genesis/options/solvers.py
+++ b/genesis/options/solvers.py
@@ -792,10 +792,10 @@ class SPHOptions(GravityMixin, TimeBasedMixin):
         if self.hash_grid_res is None:
             max_hash_grid_res = np.ceil(
                 (np.array(self.upper_bound) - np.array(self.lower_bound)) / self.hash_grid_cell_size
-            ).astype(gs.np_int)
-            self._hash_grid_res = np.minimum(max_hash_grid_res, np.array([150, 150, 150], dtype=gs.np_int))
+            )
+            self._hash_grid_res = np.minimum(max_hash_grid_res, 150).astype(int).tolist()
         else:
-            self._hash_grid_res = np.ceil(np.array(self.hash_grid_res) / self.hash_grid_cell_size).astype(gs.np_int)
+            self._hash_grid_res = np.ceil(np.array(self.hash_grid_res) / self.hash_grid_cell_size).astype(int).tolist()
 
 
 class PBDOptions(GravityMixin, TimeBasedMixin):
@@ -870,10 +870,10 @@ class PBDOptions(GravityMixin, TimeBasedMixin):
         if self.hash_grid_res is None:
             max_hash_grid_res = np.ceil(
                 (np.array(self.upper_bound) - np.array(self.lower_bound)) / self.hash_grid_cell_size
-            ).astype(gs.np_int)
-            self._hash_grid_res = np.minimum(max_hash_grid_res, np.array([150, 150, 150], dtype=gs.np_int))
+            )
+            self._hash_grid_res = np.minimum(max_hash_grid_res, 150).astype(int).tolist()
         else:
-            self._hash_grid_res = np.ceil(np.array(self.hash_grid_res) / self.hash_grid_cell_size).astype(gs.np_int)
+            self._hash_grid_res = np.ceil(np.array(self.hash_grid_res) / self.hash_grid_cell_size).astype(int).tolist()
 
 
 class FEMOptions(GravityMixin, TimeBasedMixin):

--- a/genesis/utils/description.py
+++ b/genesis/utils/description.py
@@ -1,0 +1,179 @@
+"""Describe a rigid entity as its asset authored it, before the entity is built.
+
+A parser fills these records in, and the entity builds itself from them. Each record resolves its own defaults on
+construction, so a consumer reads a field and applies no fallback of its own.
+
+A built link, joint, geom or equality constraint keeps its record as 'desc', where a quantity holds the value the
+build gave it. The matching 'get_*' accessor of that object returns the value the simulation currently uses.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+import genesis as gs
+from genesis.constants import EQUALITY_TYPE, GEOM_TYPE, JOINT_TYPE
+from genesis.utils import geom as gu
+
+
+# Generalized coordinates and degrees of freedom held by each joint type.
+JOINT_TYPE_SIZE = {
+    JOINT_TYPE.FIXED: (0, 0),
+    JOINT_TYPE.REVOLUTE: (1, 1),
+    JOINT_TYPE.PRISMATIC: (1, 1),
+    JOINT_TYPE.SPHERICAL: (4, 3),
+    JOINT_TYPE.FREE: (7, 6),
+}
+
+
+@dataclass
+class GeomDescription:
+    """Describe one geometry of a link, used for collision or for visualization.
+
+    A collision geom carries 'mesh', its shape 'type', and the 'data' that type reads. A visual geom carries 'vmesh'.
+    An unset field means the asset authored nothing: the density then falls back to the one the material states, and
+    the post-processing options to the ones the morph carries. 'prim_path' names the source prim of a geom parsed
+    from a USD stage, which the collision filtering of that format resolves its groups against.
+    """
+
+    contype: int
+    conaffinity: int
+    type: GEOM_TYPE | None = None
+    data: np.ndarray | None = None
+    pos: np.ndarray = field(default_factory=gu.zero_pos)
+    quat: np.ndarray = field(default_factory=gu.identity_quat)
+    mesh: "gs.Mesh | None" = None
+    vmesh: "gs.Mesh | None" = None
+    friction: float | None = None
+    friction_torsional: float | None = None
+    friction_rolling: float | None = None
+    group: int | None = None
+    sol_params: np.ndarray | None = None
+    density: float | None = None
+    convexify: bool | None = None
+    decimate: bool | None = None
+    decompose_error_threshold: float | None = None
+    prim_path: str | None = None
+
+    def __post_init__(self):
+        # Apply the default coefficients of the solver to a geom whose asset authored no friction, so that the
+        # record always carries the value the geom is built with
+        if self.friction is None:
+            self.friction = gu.default_friction()
+        if self.friction_torsional is None:
+            self.friction_torsional = gu.default_friction_torsional()
+        if self.friction_rolling is None:
+            self.friction_rolling = gu.default_friction_rolling()
+
+    @property
+    def is_collision(self) -> bool:
+        """
+        Get whether the geom takes part in collision detection.
+        """
+        return bool(self.contype or self.conaffinity)
+
+
+@dataclass
+class JointDescription:
+    """Describe one joint of a link, with its per-degree-of-freedom quantities.
+
+    The type gives the number of generalized coordinates and of degrees of freedom the joint holds, and construction
+    resolves every quantity the asset leaves unset from that number, including the motion axes of a free joint and
+    of a fixed one.
+    """
+
+    name: str
+    type: JOINT_TYPE
+    pos: np.ndarray = field(default_factory=gu.zero_pos)
+    quat: np.ndarray = field(default_factory=gu.identity_quat)
+    init_qpos: np.ndarray | None = None
+    sol_params: np.ndarray | None = None
+    dofs_motion_ang: np.ndarray | None = None
+    dofs_motion_vel: np.ndarray | None = None
+    dofs_limit: np.ndarray | None = None
+    dofs_invweight: np.ndarray | None = None
+    dofs_frictionloss: np.ndarray | None = None
+    dofs_stiffness: np.ndarray | None = None
+    dofs_damping: np.ndarray | None = None
+    dofs_armature: np.ndarray | None = None
+    dofs_act_gain: np.ndarray | None = None
+    dofs_act_bias: np.ndarray | None = None
+    dofs_force_range: np.ndarray | None = None
+
+    @property
+    def n_qs(self) -> int:
+        """
+        Get the number of generalized coordinates the joint holds.
+        """
+        return JOINT_TYPE_SIZE[self.type][0]
+
+    @property
+    def n_dofs(self) -> int:
+        """
+        Get the number of degrees of freedom the joint holds.
+        """
+        return JOINT_TYPE_SIZE[self.type][1]
+
+    def __post_init__(self):
+        if self.init_qpos is None:
+            self.init_qpos = np.zeros(self.n_dofs)
+        if self.sol_params is None:
+            self.sol_params = gu.default_solver_params()
+        # Resolve the motion axes of a free joint and of a fixed one, the two types whose axes follow from the
+        # number of degrees of freedom. A parser fills in the axes of every other type, here or afterwards
+        if self.n_dofs in (0, 6):
+            if self.dofs_motion_ang is None:
+                self.dofs_motion_ang = np.eye(6, 3, -3) if self.n_dofs == 6 else np.zeros((0, 3))
+            if self.dofs_motion_vel is None:
+                self.dofs_motion_vel = np.eye(6, 3) if self.n_dofs == 6 else np.zeros((0, 3))
+        if self.dofs_limit is None:
+            self.dofs_limit = np.tile([[-np.inf, np.inf]], [self.n_dofs, 1])
+        if self.dofs_force_range is None:
+            self.dofs_force_range = np.tile([[-np.inf, np.inf]], [self.n_dofs, 1])
+        if self.dofs_act_bias is None:
+            self.dofs_act_bias = np.zeros((self.n_dofs, 3))
+        if self.dofs_invweight is None:
+            self.dofs_invweight = np.zeros(self.n_dofs)
+        if self.dofs_frictionloss is None:
+            self.dofs_frictionloss = np.zeros(self.n_dofs)
+        if self.dofs_stiffness is None:
+            self.dofs_stiffness = np.zeros(self.n_dofs)
+        if self.dofs_damping is None:
+            self.dofs_damping = np.zeros(self.n_dofs)
+        if self.dofs_armature is None:
+            self.dofs_armature = np.zeros(self.n_dofs)
+        if self.dofs_act_gain is None:
+            self.dofs_act_gain = np.zeros(self.n_dofs)
+
+
+@dataclass
+class LinkDescription:
+    """Describe one link of an entity, beside the joints that move it and the geoms it holds.
+
+    The inertial quantities hold what the asset authored, and the build estimates each one left unset from the
+    geometry. 'is_aligned' records that the build moved the link frame onto the anchor its geoms share.
+    """
+
+    name: str
+    parent_idx: int | None = None
+    root_idx: int | None = None
+    pos: np.ndarray = field(default_factory=gu.zero_pos)
+    quat: np.ndarray = field(default_factory=gu.identity_quat)
+    inertial_pos: np.ndarray | None = None
+    inertial_quat: np.ndarray | None = None
+    inertia: np.ndarray | None = None
+    mass: float | None = None
+    invweight: np.ndarray | None = None
+    is_robot: bool = False
+    is_aligned: bool = False
+
+
+@dataclass
+class EqualityDescription:
+    """Describe one constraint tying two links or two joints of an entity together, named as the asset names them."""
+
+    name: str
+    type: EQUALITY_TYPE
+    objs_name: tuple[str, str]
+    data: np.ndarray
+    sol_params: np.ndarray

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -3,6 +3,7 @@ import marshal
 import math
 import os
 import pickle as pkl
+from dataclasses import replace
 from functools import lru_cache
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from PIL import Image
 import genesis as gs
 
 from . import geom as gu
+from .description import GeomDescription
 from .misc import (
     SizeCappedCache,
     get_assets_dir,
@@ -470,7 +472,7 @@ _COLLISION_GEOMS_CACHE = SizeCappedCache(max_bytes=512 * 1024 * 1024)
 
 
 def postprocess_collision_geoms(
-    g_infos,
+    g_descs: list[GeomDescription],
     decimate,
     decimate_face_num,
     decimate_aggressiveness,
@@ -484,9 +486,9 @@ def postprocess_collision_geoms(
     # entity. The result is memoized on the geometry of the input collision meshes and on every option / per-geom field
     # that can change the outcome. The processed meshes are immutable (their vertices are only read downstream,
     # alignment is folded into the link frame), so the cached ones are shared across entities, which also collapses
-    # their memory footprint. Only fresh g_info dicts are handed back so the caller can re-express the per-geom pose in
+    # their memory footprint. Only fresh g_desc dicts are handed back so the caller can re-express the per-geom pose in
     # place without corrupting the template.
-    if not g_infos:
+    if not g_descs:
         return []
 
     # Keyed on the vertices themselves rather than matched within a tolerance the way the on-disk caches are: one
@@ -502,30 +504,30 @@ def postprocess_collision_geoms(
         -1 if watertighten is None else int(watertighten),
         coacd_options.model_dump(),
     ]
-    for g_info in g_infos:
-        mesh = g_info["mesh"]
-        geom_type = g_info.get("type")
-        friction = g_info.get("friction")
-        density = g_info.get("density")
-        sol_params = g_info.get("sol_params")
+    for g_desc in g_descs:
+        mesh = g_desc.mesh
+        geom_type = g_desc.type
+        friction = g_desc.friction
+        density = g_desc.density
+        sol_params = g_desc.sol_params
         key_parts += [
             np.ascontiguousarray(mesh.verts),
             np.ascontiguousarray(mesh.faces),
             -1 if geom_type is None else int(geom_type),
-            int(g_info.get("contype", 0)),
-            int(g_info.get("conaffinity", 0)),
+            int(g_desc.contype),
+            int(g_desc.conaffinity),
             float("nan") if friction is None else float(friction),
             float("nan") if density is None else float(density),
             np.zeros(0) if sol_params is None else np.ascontiguousarray(sol_params, dtype=np.float64),
-            np.ascontiguousarray(g_info.get("pos", gu.zero_pos()), dtype=np.float64),
-            np.ascontiguousarray(g_info.get("quat", gu.identity_quat()), dtype=np.float64),
+            np.ascontiguousarray(g_desc.pos, dtype=np.float64),
+            np.ascontiguousarray(g_desc.quat, dtype=np.float64),
         ]
     key = get_hashkey(*key_parts)
 
     cached = _COLLISION_GEOMS_CACHE.get(key)
     if cached is None:
         cached = _postprocess_collision_geoms_impl(
-            g_infos,
+            g_descs,
             decimate,
             decimate_face_num,
             decimate_aggressiveness,
@@ -534,7 +536,7 @@ def postprocess_collision_geoms(
             coacd_options,
             watertighten,
         )
-        n_bytes = sum(g_info["mesh"].verts.nbytes + g_info["mesh"].faces.nbytes for g_info in cached)
+        n_bytes = sum(g_desc.mesh.verts.nbytes + g_desc.mesh.faces.nbytes for g_desc in cached)
         _COLLISION_GEOMS_CACHE.put(key, cached, n_bytes)
 
     # Hand back per-entity geoms that share the cached geometry and its derived data (edges, vertex adjacency, inertia)
@@ -543,8 +545,8 @@ def postprocess_collision_geoms(
     # shared. Edges and adjacency are always needed, so they are populated up front; inertia is queried lazily through
     # the template (only entities that align their link frame need it) to avoid eager convex-hull work.
     result = []
-    for g_info in cached:
-        template = g_info["mesh"]
+    for g_desc in cached:
+        template = g_desc.mesh
         template_tmesh = template.trimesh
         mesh = gs.Mesh(
             mesh=trimesh.Trimesh(vertices=template_tmesh.vertices, faces=template_tmesh.faces, process=False),
@@ -554,13 +556,13 @@ def postprocess_collision_geoms(
         )
         mesh._unique_edges = template.get_unique_edges()
         mesh._vert_adjacency = template.get_vert_adjacency()
-        mesh._inertial_info_source = template
-        result.append({**g_info, "mesh": mesh})
+        mesh._inertial_source = template
+        result.append(replace(g_desc, mesh=mesh))
     return result
 
 
 def _postprocess_collision_geoms_impl(
-    g_infos,
+    g_descs: list[GeomDescription],
     decimate,
     decimate_face_num,
     decimate_aggressiveness,
@@ -570,13 +572,13 @@ def _postprocess_collision_geoms_impl(
     watertighten,
 ):
     # Early return if there is no geometry to process
-    if not g_infos:
+    if not g_descs:
         return []
 
     # Check whether the geometries are authored, ie they are all watertight and convex, as a cheap proxy
     is_authored = all(
-        (tmesh := g_info["mesh"].trimesh).is_winding_consistent and tmesh.is_watertight and tmesh.is_convex
-        for g_info in g_infos
+        (tmesh := g_desc.mesh.trimesh).is_winding_consistent and tmesh.is_watertight and tmesh.is_convex
+        for g_desc in g_descs
     )
 
     # Weld coincident vertices of non-convex collision meshes onto a separate copy. Formats that store unshared
@@ -587,16 +589,16 @@ def _postprocess_collision_geoms_impl(
     # is swapped for the welded copy, leaving the visual vertices untouched. Already-shared meshes (OBJ, glTF) weld to
     # no fewer vertices and keep their original geom.
     if not is_authored and not convexify:
-        for g_info in g_infos:
-            if g_info["type"] != gs.GEOM_TYPE.MESH:
+        for g_desc in g_descs:
+            if g_desc.type != gs.GEOM_TYPE.MESH:
                 continue
-            welded = g_info["mesh"].trimesh.copy()
+            welded = g_desc.mesh.trimesh.copy()
             welded.merge_vertices()
-            if len(welded.vertices) < len(g_info["mesh"].trimesh.vertices):
-                g_info["mesh"] = gs.Mesh.from_trimesh(
+            if len(welded.vertices) < len(g_desc.mesh.trimesh.vertices):
+                g_desc.mesh = gs.Mesh.from_trimesh(
                     mesh=welded,
                     surface=gs.surfaces.Collision(),
-                    metadata=g_info["mesh"].metadata.copy(),
+                    metadata=g_desc.mesh.metadata.copy(),
                 )
 
     # Try the repair meshes that seems to be "broken" but not beyond repair.
@@ -604,10 +606,10 @@ def _postprocess_collision_geoms_impl(
     # repair, to avoid altering the original mesh without actual benefit. Moreover, only duplicate faces are removed,
     # which is less aggressive than `Trimesh.process(validate=True)`.
     if not is_authored:
-        for g_info in g_infos:
-            mesh = g_info["mesh"]
+        for g_desc in g_descs:
+            mesh = g_desc.mesh
             tmesh = mesh.trimesh
-            if g_info["type"] != gs.GEOM_TYPE.MESH:
+            if g_desc.type != gs.GEOM_TYPE.MESH:
                 continue
             if tmesh.is_winding_consistent and not tmesh.is_watertight:
                 tmesh_repaired = tmesh.copy()
@@ -626,15 +628,15 @@ def _postprocess_collision_geoms_impl(
                     tmesh.visual._cache.clear()
 
     # Check which geometries can be convexified without decomposition
-    geoms_must_decompose = [False] * len(g_infos)
+    geoms_must_decompose = [False] * len(g_descs)
     volume_err_max = 0.0
     if not is_authored and convexify:
-        for i_g, g_info in enumerate(g_infos):
-            mesh = g_info["mesh"]
+        for i_g, g_desc in enumerate(g_descs):
+            mesh = g_desc.mesh
             tmesh = mesh.trimesh
 
             # Skip geometries that do not corresponds to mesh or have no enclosed volume
-            if g_info["type"] != gs.GEOM_TYPE.MESH:
+            if g_desc.type != gs.GEOM_TYPE.MESH:
                 continue
             cmesh = trimesh.convex.convex_hull(tmesh)
             if abs(cmesh.volume) < gs.EPS:
@@ -669,22 +671,27 @@ def _postprocess_collision_geoms_impl(
     # scan and roughly one contact set per link instead of per geom. All geom types can be merged except planes and
     # terrains. On the nonconvex path, sub-groups are systematically fused unless watertightening is disabled; on the
     # convex path, only when one of their members requires decomposition.
-    geoms_is_fused = [False] * len(g_infos)
-    if len(g_infos) > 1 and ((not convexify and watertighten is not None) or (not is_authored and must_decompose)):
+    geoms_is_fused = [False] * len(g_descs)
+    if len(g_descs) > 1 and ((not convexify and watertighten is not None) or (not is_authored and must_decompose)):
         fusion_groups: list[list[int]] = []
-        for i, g_info in enumerate(g_infos):
+        for i, g_desc in enumerate(g_descs):
             # Join the first existing sub-group with a matching collision group and contact params, else open a new one.
-            if g_info["type"] not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN):
+            if g_desc.type not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN):
                 for fusion_group in fusion_groups:
-                    first_g_info = g_infos[fusion_group[0]]
+                    first_g_desc = g_descs[fusion_group[0]]
                     if (
-                        first_g_info["type"] not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN)
-                        and all(first_g_info.get(name) == g_info.get(name) for name in ("contype", "conaffinity"))
+                        first_g_desc.type not in (gs.GEOM_TYPE.PLANE, gs.GEOM_TYPE.TERRAIN)
+                        and (first_g_desc.contype, first_g_desc.conaffinity) == (g_desc.contype, g_desc.conaffinity)
+                        # A fused mesh carries a single density, so geoms with different authored densities must stay
+                        # separate for the density-weighted link inertial to survive fusion. What no geom of the pair
+                        # authored matches, since both fall back to the same value later on.
                         and all(
-                            np.allclose(first_g_info.get(name, np.nan), g_info.get(name, np.nan), equal_nan=True)
-                            # A fused mesh carries a single density, so geoms with different authored densities must
-                            # stay separate for the density-weighted link inertial to survive fusion.
-                            for name in ("friction", "sol_params", "density")
+                            (first is None) == (second is None) and (first is None or np.allclose(first, second))
+                            for first, second in (
+                                (first_g_desc.friction, g_desc.friction),
+                                (first_g_desc.sol_params, g_desc.sol_params),
+                                (first_g_desc.density, g_desc.density),
+                            )
                         )
                     ):
                         fusion_group.append(i)
@@ -694,26 +701,22 @@ def _postprocess_collision_geoms_impl(
             else:
                 fusion_groups.append([i])
 
-        fused_infos = []
+        fused_descs = []
         geoms_is_fused = []
         for fusion_group in fusion_groups:
             if len(fusion_group) == 1 or (convexify and not any(geoms_must_decompose[i] for i in fusion_group)):
-                fused_infos.extend(g_infos[i] for i in fusion_group)
+                fused_descs.extend(g_descs[i] for i in fusion_group)
                 geoms_is_fused.extend([False] * len(fusion_group))
                 continue
-            first_g_info = g_infos[fusion_group[0]]
-            T_first_inv = np.linalg.inv(
-                gu.trans_quat_to_T(first_g_info.get("pos", gu.zero_pos()), first_g_info.get("quat", gu.identity_quat()))
-            )
+            first_g_desc = g_descs[fusion_group[0]]
+            T_first_inv = np.linalg.inv(gu.trans_quat_to_T(first_g_desc.pos, first_g_desc.quat))
             tmeshes = []
-            metadata = set(first_g_info["mesh"].metadata.items())
+            metadata = set(first_g_desc.mesh.metadata.items())
             for i in fusion_group:
-                g_info = g_infos[i]
-                mesh = g_info["mesh"]
+                g_desc = g_descs[i]
+                mesh = g_desc.mesh
                 tmesh = mesh.trimesh
-                T_rel = T_first_inv @ gu.trans_quat_to_T(
-                    g_info.get("pos", gu.zero_pos()), g_info.get("quat", gu.identity_quat())
-                )
+                T_rel = T_first_inv @ gu.trans_quat_to_T(g_desc.pos, g_desc.quat)
                 if not np.allclose(T_rel, np.eye(4)):
                     tmesh = tmesh.copy()
                     tmesh.apply_transform(T_rel)
@@ -723,16 +726,16 @@ def _postprocess_collision_geoms_impl(
             mesh = gs.Mesh.from_trimesh(
                 mesh=tmesh, surface=gs.surfaces.Collision(), metadata=dict(metadata) | {"merged": True}
             )
-            fused_infos.append({**first_g_info, **dict(type=gs.GEOM_TYPE.MESH, data=None, mesh=mesh)})
+            fused_descs.append(replace(first_g_desc, type=gs.GEOM_TYPE.MESH, data=None, mesh=mesh))
             geoms_is_fused.append(True)
-        g_infos = fused_infos
+        g_descs = fused_descs
 
         # A genuinely fused mesh (a sub-group of more than one geom) re-enters the pipeline so its convex hull /
         # decomposition is recomputed on the union; requiring an actual merge stops infinite recursion once every
         # sub-group is either a singleton or accurate enough to skip decomposition.
         if convexify and any(geoms_is_fused):
             return _postprocess_collision_geoms_impl(
-                g_infos,
+                g_descs,
                 decimate,
                 decimate_face_num,
                 decimate_aggressiveness,
@@ -747,11 +750,11 @@ def _postprocess_collision_geoms_impl(
     if not convexify and watertighten is not None:
         from .watertighten import watertighten_mesh
 
-        for g_info, is_fused in zip(g_infos, geoms_is_fused):
+        for g_desc, is_fused in zip(g_descs, geoms_is_fused):
             # Fused geoms are always watertightened, as their sub-meshes may overlap while being individually
             # watertight. Other geoms are skipped if they are not generic meshes or already watertight or convex.
-            tmesh = g_info["mesh"].trimesh
-            if not is_fused and (g_info["type"] != gs.GEOM_TYPE.MESH or tmesh.is_watertight or tmesh.is_convex):
+            tmesh = g_desc.mesh.trimesh
+            if not is_fused and (g_desc.type != gs.GEOM_TYPE.MESH or tmesh.is_watertight or tmesh.is_convex):
                 continue
 
             # On-disk cache keyed by (vertices, faces, aggressiveness): a repeated build on the same geom is a file read
@@ -763,9 +766,9 @@ def _postprocess_collision_geoms_impl(
                 cache.save(cached_mesh)
             v_out, f_out = cached_mesh
             fused = trimesh.Trimesh(vertices=v_out, faces=f_out, process=False)
-            metadata = g_info["mesh"].metadata.copy()
+            metadata = g_desc.mesh.metadata.copy()
             metadata["watertightened"] = True
-            g_info["mesh"] = gs.Mesh.from_trimesh(mesh=fused, surface=gs.surfaces.Collision(), metadata=metadata)
+            g_desc.mesh = gs.Mesh.from_trimesh(mesh=fused, surface=gs.surfaces.Collision(), metadata=metadata)
 
     if not is_authored and must_decompose:
         if math.isinf(volume_err_max):
@@ -778,11 +781,11 @@ def _postprocess_collision_geoms_impl(
                 f"Convex hull is not accurate enough for collision detection ({volume_err_max:.3f}). Falling back to "
                 "more expensive convex decomposition (see FileMorph options)."
             )
-        _g_infos = []
-        for g_info in g_infos:
-            mesh = g_info["mesh"]
+        _g_descs = []
+        for g_desc in g_descs:
+            mesh = g_desc.mesh
             tmesh = mesh.trimesh
-            if g_info["type"] != gs.GEOM_TYPE.MESH:
+            if g_desc.type != gs.GEOM_TYPE.MESH:
                 volume_err = 0.0
             elif not tmesh.is_winding_consistent:
                 volume_err = float("inf")
@@ -799,15 +802,15 @@ def _postprocess_collision_geoms_impl(
                     )
                     for tmesh in tmeshes
                 ]
-                _g_infos += [{**g_info, **dict(mesh=mesh)} for mesh in meshes]
+                _g_descs += [replace(g_desc, mesh=mesh) for mesh in meshes]
             else:
-                _g_infos.append(g_info)
-        g_infos = _g_infos
+                _g_descs.append(g_desc)
+        g_descs = _g_descs
 
     # Process of meshes sequentially
-    _g_infos = []
-    for g_info in g_infos:
-        mesh = g_info["mesh"]
+    _g_descs = []
+    for g_desc in g_descs:
+        mesh = g_desc.mesh
         tmesh = mesh.trimesh
 
         num_faces = len(tmesh.faces)
@@ -840,9 +843,9 @@ def _postprocess_collision_geoms_impl(
             surface=gs.surfaces.Collision(),
             metadata=mesh.metadata.copy(),
         )
-        _g_infos.append({**g_info, **dict(mesh=mesh)})
+        _g_descs.append(replace(g_desc, mesh=mesh))
 
-    return _g_infos
+    return _g_descs
 
 
 @lru_cache(maxsize=32)

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -1,8 +1,9 @@
 import os
 import xml.etree.ElementTree as ET
-from pathlib import Path
-from itertools import chain
 from bisect import bisect_right
+from dataclasses import replace
+from itertools import chain
+from pathlib import Path
 
 # Note the importing mujoco with env var `MUJOCO_GL=EGL` forcibly defines `PYOPENGL_PLATFORM=egl`
 import mujoco
@@ -14,6 +15,7 @@ from PIL import Image
 
 import genesis as gs
 from genesis.ext import urdfpy
+from genesis.utils.description import EqualityDescription, GeomDescription, JointDescription, LinkDescription
 
 from . import geom as gu
 from . import urdf as uu
@@ -268,21 +270,21 @@ def parse_xml(morph, surface, rigid_options=None):
     )
 
     # We have another more informative warning later so we suppress this one
-    # gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_info['name']}`")
+    # gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_desc.name}`")
     # if mj.ntendon:
     #     gs.logger.warning("(MJCF) Tendon not supported")
 
     # Parse all geometries grouped by parent joint (or world)
-    links_g_infos = parse_geoms(mj, morph.scale, surface, morph.file)
+    links_g_descs = parse_geoms(mj, morph.scale, surface, morph.file)
 
     # Parse all bodies (links and joints)
-    l_infos, links_j_infos = parse_links(mj, morph.scale)
+    l_descs, links_j_descs = parse_links(mj, morph.scale)
 
     # Re-order kinematic tree info
-    l_infos, links_j_infos, links_g_infos, _ = uu.order_links_depth_first(l_infos, links_j_infos, links_g_infos)
+    l_descs, links_j_descs, links_g_descs, _ = uu.order_links_depth_first(l_descs, links_j_descs, links_g_descs)
 
     # Parsing all equality constraints
-    eqs_info = parse_equalities(mj, morph.scale)
+    eq_descs = parse_equalities(mj, morph.scale)
 
     # Friction features the model declares but the rigid options leave disabled parse to inert values; warn so their
     # absence in the simulation is no surprise. rigid_options is None on the secondary URDF parse, whose compiled
@@ -305,36 +307,32 @@ def parse_xml(morph, surface, rigid_options=None):
                 "'enable_rolling_friction' to honor the parsed coefficients."
             )
 
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    return l_descs, links_j_descs, links_g_descs, eq_descs
 
 
 def parse_link(mj, i_l, scale):
     # mj.body
-    l_info = dict()
-
     name_start = mj.name_bodyadr[i_l]
-    l_info["name"], *_ = mj.names[name_start:].decode("utf-8").split("\x00")
+    link_name, *_ = mj.names[name_start:].decode("utf-8").split("\x00")
 
-    l_info["pos"] = mj.body_pos[i_l]
-    l_info["quat"] = mj.body_quat[i_l]
-    l_info["inertial_pos"] = mj.body_ipos[i_l]
-    l_info["inertial_quat"] = mj.body_iquat[i_l]
-    l_info["inertial_i"] = np.diag(mj.body_inertia[i_l])
-    l_info["inertial_mass"] = float(mj.body_mass[i_l])
-    if mj.body_parentid[i_l] == i_l:
-        l_info["parent_idx"] = -1
-    else:
-        l_info["parent_idx"] = int(mj.body_parentid[i_l])
-    l_info["root_idx"] = int(mj.body_rootid[i_l])
-    l_info["invweight"] = mj.body_invweight0[i_l]
+    l_desc = LinkDescription(
+        name=link_name,
+        parent_idx=-1 if mj.body_parentid[i_l] == i_l else int(mj.body_parentid[i_l]),
+        pos=mj.body_pos[i_l],
+        quat=mj.body_quat[i_l],
+        root_idx=int(mj.body_rootid[i_l]),
+        inertial_pos=mj.body_ipos[i_l],
+        inertial_quat=mj.body_iquat[i_l],
+        inertia=np.diag(mj.body_inertia[i_l]),
+        mass=float(mj.body_mass[i_l]),
+        invweight=mj.body_invweight0[i_l],
+    )
 
     jnt_adr = mj.body_jntadr[i_l]
     jnt_num = mj.body_jntnum[i_l]
 
-    j_infos = []
+    j_descs = []
     for i_j in range(jnt_adr, jnt_adr + max(jnt_num, 1)):
-        j_info = dict()
-
         # Parsing joint type
         mj_type = mj.jnt_type[i_j] if i_j != -1 else None
         if mj_type is None:
@@ -354,82 +352,93 @@ def parse_link(mj, i_l, scale):
             n_qs, n_dofs = 4, 3
         else:
             gs.raise_exception(f"Unsupported MJCF joint type: {mj_type}")
-        j_info["type"], j_info["n_qs"], j_info["n_dofs"] = gs_type, n_qs, n_dofs
 
         # Parsing joint parameters that are type-agnostic
         mj_dof_offset = mj.jnt_dofadr[i_j] if i_j != -1 else 0
         mj_qpos_offset = mj.jnt_qposadr[i_j] if i_j != -1 else 0
         if i_j == -1:
-            j_info["name"] = l_info["name"]
-            j_info["pos"] = np.array([0.0, 0.0, 0.0])
+            joint_name = l_desc.name
+            joint_pos = np.array([0.0, 0.0, 0.0])
         else:
             name_start = mj.name_jntadr[i_j]
             joint_name, *_ = mj.names[name_start:].decode("utf-8").split("\x00")
             if not joint_name:
-                joint_name = l_info["name"]
-            j_info["name"] = joint_name
-            j_info["pos"] = mj.jnt_pos[i_j]
-        j_info["quat"] = np.array([1.0, 0.0, 0.0, 0.0])
-        j_info["init_qpos"] = np.array(mj.qpos0[mj_qpos_offset : (mj_qpos_offset + n_qs)])
-        j_info["dofs_damping"] = mj.dof_damping[mj_dof_offset : (mj_dof_offset + n_dofs)]
-        j_info["dofs_invweight"] = mj.dof_invweight0[mj_dof_offset : (mj_dof_offset + n_dofs)]
-        j_info["dofs_armature"] = mj.dof_armature[mj_dof_offset : (mj_dof_offset + n_dofs)]
-        j_info["dofs_frictionloss"] = mj.dof_frictionloss[mj_dof_offset : (mj_dof_offset + n_dofs)]
+                joint_name = l_desc.name
+            joint_pos = mj.jnt_pos[i_j]
+        joint_quat = np.array([1.0, 0.0, 0.0, 0.0])
+        init_qpos = np.array(mj.qpos0[mj_qpos_offset : (mj_qpos_offset + n_qs)])
+        dofs_damping = mj.dof_damping[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        dofs_invweight = mj.dof_invweight0[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        dofs_armature = mj.dof_armature[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        dofs_frictionloss = mj.dof_frictionloss[mj_dof_offset : (mj_dof_offset + n_dofs)]
         if mj.njnt > 0:
             mj_jnt_offset = i_j if i_j != -1 else 0
-            j_info["sol_params"] = np.concatenate((mj.jnt_solref[mj_jnt_offset], mj.jnt_solimp[mj_jnt_offset]))
+            sol_params = np.concatenate((mj.jnt_solref[mj_jnt_offset], mj.jnt_solimp[mj_jnt_offset]))
         else:
-            j_info["sol_params"] = gu.default_solver_params()  # Placeholder. It will not be used anyway.
+            sol_params = gu.default_solver_params()  # Placeholder. It will not be used anyway.
 
         # Parsing joint parameters that are type-specific
         mj_stiffness = mj.jnt_stiffness[i_j] if i_j != -1 else 0.0
         mj_is_limited = mj.jnt_limited[i_j] == 1 if i_j != -1 else False
         if gs_type == gs.JOINT_TYPE.FIXED:
-            j_info["dofs_motion_ang"] = np.zeros((0, 3))
-            j_info["dofs_motion_vel"] = np.zeros((0, 3))
-            j_info["dofs_limit"] = np.zeros((0, 2))
-            j_info["dofs_stiffness"] = np.zeros((0))
+            dofs_motion_ang = np.zeros((0, 3))
+            dofs_motion_vel = np.zeros((0, 3))
+            dofs_limit = np.zeros((0, 2))
+            dofs_stiffness = np.zeros((0))
         elif gs_type == gs.JOINT_TYPE.FREE:
             if mj_stiffness > 0.0:
                 gs.raise_exception("(MJCF) Joint stiffness not supported for free joints")
 
-            j_info["dofs_motion_ang"] = np.eye(6, 3, -3)
-            j_info["dofs_motion_vel"] = np.eye(6, 3)
-            j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (6, 1))
-            j_info["dofs_stiffness"] = np.zeros(6)
-            j_info["init_qpos"][:3] *= scale
+            dofs_motion_ang = np.eye(6, 3, -3)
+            dofs_motion_vel = np.eye(6, 3)
+            dofs_limit = np.tile([-np.inf, np.inf], (6, 1))
+            dofs_stiffness = np.zeros(6)
+            init_qpos[:3] *= scale
         elif gs_type == gs.JOINT_TYPE.SPHERICAL:
             if mj_is_limited:
                 gs.logger.warning("(MJCF) Joint limit ignored for ball joints")
 
-            j_info["dofs_motion_ang"] = np.eye(3)
-            j_info["dofs_motion_vel"] = np.zeros((3, 3))
-            j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (3, 1))
-            j_info["dofs_stiffness"] = np.full((3,), mj_stiffness)
+            dofs_motion_ang = np.eye(3)
+            dofs_motion_vel = np.zeros((3, 3))
+            dofs_limit = np.tile([-np.inf, np.inf], (3, 1))
+            dofs_stiffness = np.full((3,), mj_stiffness)
         else:
             mj_axis = mj.jnt_axis[i_j]
             mj_limit = mj.jnt_range[i_j] if mj_is_limited else np.array([-np.inf, np.inf])
 
             if gs_type == gs.JOINT_TYPE.REVOLUTE:
-                j_info["dofs_motion_ang"] = np.array([mj_axis])
-                j_info["dofs_motion_vel"] = np.zeros((1, 3))
-                j_info["dofs_limit"] = np.array([mj_limit])
-                j_info["dofs_stiffness"] = np.array([mj_stiffness])
+                dofs_motion_ang = np.array([mj_axis])
+                dofs_motion_vel = np.zeros((1, 3))
+                dofs_limit = np.array([mj_limit])
+                dofs_stiffness = np.array([mj_stiffness])
             else:  # gs_type == gs.JOINT_TYPE.PRISMATIC:
-                j_info["dofs_motion_ang"] = np.zeros((1, 3))
-                j_info["dofs_motion_vel"] = np.array([mj_axis])
-                j_info["dofs_limit"] = np.array([mj_limit]) * scale
-                j_info["dofs_stiffness"] = np.array([mj_stiffness])
-                j_info["init_qpos"] *= scale
+                dofs_motion_ang = np.zeros((1, 3))
+                dofs_motion_vel = np.array([mj_axis])
+                dofs_limit = np.array([mj_limit]) * scale
+                dofs_stiffness = np.array([mj_stiffness])
+                init_qpos *= scale
+
+        j_desc = JointDescription(
+            name=joint_name,
+            type=gs_type,
+            pos=joint_pos,
+            quat=joint_quat,
+            init_qpos=init_qpos,
+            sol_params=sol_params,
+            dofs_motion_ang=dofs_motion_ang,
+            dofs_motion_vel=dofs_motion_vel,
+            dofs_limit=dofs_limit,
+            dofs_invweight=dofs_invweight,
+            dofs_frictionloss=dofs_frictionloss,
+            dofs_stiffness=dofs_stiffness,
+            dofs_damping=dofs_damping,
+            dofs_armature=dofs_armature,
+        )
 
         # Parsing actuator parameters.
         # MuJoCo general actuator model (gaintype=FIXED, biastype=AFFINE):
         #   force = gainprm[0] * ctrl + biasprm[0] + biasprm[1] * pos + biasprm[2] * vel
         # See: https://mujoco.readthedocs.io/en/stable/XMLreference.html#actuator-general
-        j_info["dofs_act_gain"] = np.zeros((n_dofs,), dtype=gs.np_float)
-        j_info["dofs_act_bias"] = np.zeros((n_dofs, 3), dtype=gs.np_float)
-        j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (n_dofs, 1))
-
         i_a = -1
         try:
             actuator_mask_j = (mj.actuator_trnid[:, 0] == i_j) & (mj.actuator_trntype == mujoco.mjtTrn.mjTRN_JOINT)
@@ -445,9 +454,9 @@ def parse_link(mj, i_l, scale):
                             mj.actuator_trntype == mujoco.mjtTrn.mjTRN_TENDON
                         )
                         (i_a,) = np.nonzero(actuator_mask_t)[0]
-                        gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_info['name']}`")
+                        gs.logger.warning(f"(MJCF) Approximating tendon by joint actuator for `{j_desc.name}`")
         except ValueError:
-            gs.logger.warning(f"(MJCF) Failed to parse actuator for joint `{j_info['name']}`.")
+            gs.logger.warning(f"(MJCF) Failed to parse actuator for joint `{j_desc.name}`.")
 
         if i_a >= 0:
             if mj.actuator_dyntype[i_a] != mujoco.mjtDyn.mjDYN_NONE:
@@ -466,55 +475,55 @@ def parse_link(mj, i_l, scale):
             if biastype == mujoco.mjtBias.mjBIAS_NONE:
                 # Direct-drive (motor): force = gainprm[0] * ctrl
                 # FORCE mode handles this directly; store gainprm for model consistency.
-                j_info["dofs_act_gain"] = np.full(
+                j_desc.dofs_act_gain = np.full(
                     (n_dofs,), float(gear * mj.actuator_gainprm[i_a, 0] * scale**3), dtype=gs.np_float
                 )
             else:
                 # General actuator: force = gainprm[0] * ctrl + biasprm[0] + biasprm[1] * pos + biasprm[2] * vel
                 gainprm = mj.actuator_gainprm[i_a]
                 biasprm = mj.actuator_biasprm[i_a]
-                j_info["dofs_act_gain"] = np.full((n_dofs,), float(gear * gainprm[0] * scale**3), dtype=gs.np_float)
-                j_info["dofs_act_bias"] = np.tile(gear * biasprm[:3] * scale**3, (n_dofs, 1)).astype(gs.np_float)
+                j_desc.dofs_act_gain = np.full((n_dofs,), float(gear * gainprm[0] * scale**3), dtype=gs.np_float)
+                j_desc.dofs_act_bias = np.tile(gear * biasprm[:3] * scale**3, (n_dofs, 1)).astype(gs.np_float)
 
             if mj.actuator_forcelimited[i_a]:
-                j_info["dofs_force_range"] = np.tile(mj.actuator_forcerange[i_a], (n_dofs, 1))
+                j_desc.dofs_force_range = np.tile(mj.actuator_forcerange[i_a], (n_dofs, 1))
             if mj.actuator_ctrllimited[i_a] and biastype == mujoco.mjtBias.mjBIAS_NONE:
-                j_info["dofs_force_range"] = np.minimum(
-                    j_info["dofs_force_range"], np.tile(gear * mj.actuator_ctrlrange[i_a], (n_dofs, 1))
+                j_desc.dofs_force_range = np.minimum(
+                    j_desc.dofs_force_range, np.tile(gear * mj.actuator_ctrlrange[i_a], (n_dofs, 1))
                 )
         elif gs_type not in (gs.JOINT_TYPE.FIXED, gs.JOINT_TYPE.FREE):
-            gs.logger.debug(f"(MJCF) No actuator found for joint `{j_info['name']}`")
+            gs.logger.debug(f"(MJCF) No actuator found for joint `{j_desc.name}`")
 
-        j_infos.append(j_info)
+        j_descs.append(j_desc)
 
     # Applying scale if necessary.
     # Note that the mass matrix of a poly-articulated robot does not scale trivially as it is a copnfiguration-depends
     # mixing of s ** 3 factor for masses and s ** 5 factor for inertia tensors. As a result, it is much simpler to
     # consider invweight indefined, which will trigger recomputation at build time.
     if abs(1.0 - scale) > gs.EPS:
-        l_info["pos"] *= scale
-        l_info["inertial_pos"] *= scale
-        l_info["inertial_mass"] *= scale**3
-        l_info["inertial_i"] *= scale**5
-        l_info["invweight"][:] = -1.0
-        for j_info in j_infos:
-            j_info["pos"] *= scale
-            j_info["dofs_invweight"][:] = -1.0
+        l_desc.pos *= scale
+        l_desc.inertial_pos *= scale
+        l_desc.mass *= scale**3
+        l_desc.inertia *= scale**5
+        l_desc.invweight[:] = -1.0
+        for j_desc in j_descs:
+            j_desc.pos *= scale
+            j_desc.dofs_invweight[:] = -1.0
 
-    return l_info, j_infos
+    return l_desc, j_descs
 
 
 def parse_links(mj, scale):
-    l_infos = []
-    j_infos = []
+    l_descs = []
+    j_descs = []
 
     for i_l in range(mj.nbody):
-        l_info, j_info = parse_link(mj, i_l, scale)
+        l_desc, j_desc = parse_link(mj, i_l, scale)
 
-        l_infos.append(l_info)
-        j_infos.append(j_info)
+        l_descs.append(l_desc)
+        j_descs.append(j_desc)
 
-    return l_infos, j_infos
+    return l_descs, j_descs
 
 
 def parse_geom(mj, i_g, scale, surface, xml_path):
@@ -724,32 +733,28 @@ def parse_geom(mj, i_g, scale, surface, xml_path):
         tmesh, scale=scale, surface=gs.surfaces.Collision() if is_col else surface, metadata=metadata
     )
 
-    info = {
-        "type": gs_type,
-        "pos": mj_geom.pos * scale,
-        "quat": mj_geom.quat,
-        "contype": mj_geom.contype[0],
-        "conaffinity": mj_geom.conaffinity[0],
-        "group": mj_geom.group[0],
-        "data": geom_data,
-        "friction": mj_geom.friction[0],
+    return GeomDescription(
+        contype=mj_geom.contype[0],
+        conaffinity=mj_geom.conaffinity[0],
+        type=gs_type,
+        data=geom_data,
+        pos=mj_geom.pos * scale,
+        quat=mj_geom.quat,
+        mesh=mesh if is_col else None,
+        vmesh=None if is_col else mesh,
+        friction=mj_geom.friction[0],
         # MuJoCo only applies torsional friction from condim 4 and rolling friction from condim 6 onward, and the
         # friction vector carries its defaults on every geom regardless, so the coefficients of a lower-condim geom
         # must parse as inert or the geom would resist spin or rolling that MuJoCo leaves free.
-        "friction_torsional": mj_geom.friction[1] if mj_geom.condim[0] >= 4 else 0.0,
-        "friction_rolling": mj_geom.friction[2] if mj_geom.condim[0] >= 6 else 0.0,
-        "sol_params": np.concatenate((mj_geom.solref, mj_geom.solimp)),
-    }
-    if is_col:
-        info["mesh"] = mesh
-    else:
-        info["vmesh"] = mesh
-
-    return info
+        friction_torsional=mj_geom.friction[1] if mj_geom.condim[0] >= 4 else 0.0,
+        friction_rolling=mj_geom.friction[2] if mj_geom.condim[0] >= 6 else 0.0,
+        group=mj_geom.group[0],
+        sol_params=np.concatenate((mj_geom.solref, mj_geom.solimp)),
+    )
 
 
 def parse_geoms(mj, scale, surface, xml_path):
-    links_g_info = [[] for _ in range(mj.nbody)]
+    links_g_descs = [[] for _ in range(mj.nbody)]
 
     # Loop over all geometries sequentially
     is_any_col = False
@@ -758,35 +763,35 @@ def parse_geoms(mj, scale, surface, xml_path):
             continue
 
         # try parsing a given geometry
-        g_info = parse_geom(mj, i_g, scale, surface, xml_path)
-        if g_info is None:
+        g_desc = parse_geom(mj, i_g, scale, surface, xml_path)
+        if g_desc is None:
             continue
 
         # Ignore world when looking for collision geometries
         if mj.geom_bodyid[i_g] == 0:
-            is_any_col |= g_info["contype"] or g_info["conaffinity"]
+            is_any_col |= g_desc.contype or g_desc.conaffinity
 
         # assign geoms to link
         link_idx = mj.geom_bodyid[i_g]
-        links_g_info[link_idx].append(g_info)
+        links_g_descs[link_idx].append(g_desc)
 
     # Update contype and conaffinity to take into account any additional list of explicitly excluded collision pairs
     if mj.nexclude:
         # Extract the list of collision geometries
-        cg_infos = []
-        for g_info in chain.from_iterable(links_g_info):
-            if g_info["contype"] or g_info["conaffinity"]:
-                cg_infos.append(g_info)
+        cg_descs = []
+        for g_desc in chain.from_iterable(links_g_descs):
+            if g_desc.contype or g_desc.conaffinity:
+                cg_descs.append(g_desc)
 
         # Compute the original of all the excluded collision pairs
         invalid_set = set()
-        for i, g_info_1 in enumerate(cg_infos):
-            for j, g_info_2 in enumerate(cg_infos):
+        for i, g_desc_1 in enumerate(cg_descs):
+            for j, g_desc_2 in enumerate(cg_descs):
                 if i >= j:
                     continue
-                if g_info_1["contype"] & g_info_2["conaffinity"]:
+                if g_desc_1.contype & g_desc_2.conaffinity:
                     continue
-                if g_info_2["contype"] & g_info_1["conaffinity"]:
+                if g_desc_2.contype & g_desc_1.conaffinity:
                     continue
                 invalid_set.add(frozenset((i, j)))
 
@@ -797,9 +802,9 @@ def parse_geoms(mj, scale, surface, xml_path):
 
             geoms_1, geoms_2 = [], []
             for body_idx, geoms_idx in ((body_1, geoms_1), (body_2, geoms_2)):
-                for g_info in links_g_info[body_idx]:
-                    for geom_idx, cg_info in enumerate(cg_infos):
-                        if g_info is cg_info:
+                for g_desc in links_g_descs[body_idx]:
+                    for geom_idx, cg_desc in enumerate(cg_descs):
+                        if g_desc is cg_desc:
                             geoms_idx.append(geom_idx)
                             break
 
@@ -808,17 +813,17 @@ def parse_geoms(mj, scale, surface, xml_path):
                     invalid_set.add(frozenset((geom_1, geom_2)))
 
         # Compute updated contype and conaffinity from the complete list of invalid collision pairs
-        masks = solve_contype_conaffinity(len(cg_infos), invalid_set)
+        masks = solve_contype_conaffinity(len(cg_descs), invalid_set)
         if masks is None:
             gs.logger.warning(
                 "Compatible collision geometries cannot be described using bitmasks 'contype' and 'conaffinity'. "
                 "Using default values..."
             )
-            for g_info in cg_infos:
-                g_info["contype"], g_info["conaffinity"] = 1, 1
+            for g_desc in cg_descs:
+                g_desc.contype, g_desc.conaffinity = 1, 1
         else:
-            for g_info, (contype, conaffinity) in zip(cg_infos, masks):
-                g_info["contype"], g_info["conaffinity"] = contype, conaffinity
+            for g_desc, (contype, conaffinity) in zip(cg_descs, masks):
+                g_desc.contype, g_desc.conaffinity = contype, conaffinity
 
     # Inform the user that collision geometries are not displayed by default
     if is_any_col and surface.vis_mode != "collision":
@@ -828,37 +833,32 @@ def parse_geoms(mj, scale, surface, xml_path):
         )
 
     # Parse geometry group if available
-    for link_g_info in links_g_info:
-        for g_info in link_g_info.copy():
+    for link_g_descs in links_g_descs:
+        for g_desc in tuple(link_g_descs):
             # Skip visual geometries
-            if not (g_info["contype"] or g_info["conaffinity"]):
+            if not (g_desc.contype or g_desc.conaffinity):
                 continue
 
             # Duplicate collision geometries as visual in accordance with Mujoco logics:
             # If groups are defined, only create visual for geoms in visual groups (0, 1 or 2).
-            if g_info["group"] in (0, 1, 2):
-                g_info = g_info.copy()
-                mesh = g_info.pop("mesh")
+            if g_desc.group in (0, 1, 2):
                 vmesh = gs.Mesh.from_trimesh(
-                    mesh=mesh.trimesh,
+                    mesh=g_desc.mesh.trimesh,
                     surface=surface,
-                    metadata=mesh.metadata,
+                    metadata=g_desc.mesh.metadata,
                 )
-                g_info = {**g_info, "vmesh": vmesh, "contype": 0, "conaffinity": 0}
-                link_g_info.append(g_info)
+                link_g_descs.append(replace(g_desc, contype=0, conaffinity=0, mesh=None, vmesh=vmesh))
 
-    return links_g_info
+    return links_g_descs
 
 
 def parse_equalities(mj, scale):
-    eqs_info = []
+    eq_descs = []
     for i_e in range(mj.neq):
         mj_equality = mj.equality(i_e)
 
-        eq_info = dict()
-        eq_info["name"] = mj_equality.name
-        eq_info["data"] = mj.eq_data[i_e]
-        eq_info["sol_params"] = np.concatenate((mj.eq_solref[i_e], mj.eq_solimp[i_e]))
+        eq_data = mj.eq_data[i_e]
+        sol_params = np.concatenate((mj.eq_solref[i_e], mj.eq_solimp[i_e]))
 
         objs_idx = [mj.eq_obj1id[i_e], mj.eq_obj2id[i_e]]
         if mj.eq_objtype[i_e] == mujoco.mjtObj.mjOBJ_SITE:
@@ -870,10 +870,10 @@ def parse_equalities(mj, scale):
                 sites_pos.append(mj.site_pos[site_idx])
                 sites_quat.append(mj.site_quat[site_idx])
             if mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_WELD:
-                eq_info["data"][:3], eq_info["data"][3:6] = (sites_pos[1], sites_pos[0])
-                eq_info["data"][6:10] = gu.transform_quat_by_quat(sites_quat[0], gu.inv_quat(sites_quat[1]))
+                eq_data[:3], eq_data[3:6] = (sites_pos[1], sites_pos[0])
+                eq_data[6:10] = gu.transform_quat_by_quat(sites_quat[0], gu.inv_quat(sites_quat[1]))
             else:
-                eq_info["data"][:3], eq_info["data"][3:6] = (sites_pos[0], sites_pos[1])
+                eq_data[:3], eq_data[3:6] = (sites_pos[0], sites_pos[1])
         elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_JOINT:
             name_objadr = mj.name_jntadr
         elif mj.eq_objtype[i_e] == mujoco.mjtObj.mjOBJ_BODY:
@@ -882,14 +882,14 @@ def parse_equalities(mj, scale):
             gs.raise_exception(f"Unsupported MJCF equality object type: {mj.eq_objtype[i_e]}")
 
         if mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_CONNECT:
-            eq_info["type"] = gs.EQUALITY_TYPE.CONNECT
-            eq_info["data"][:6] *= scale
+            eq_type = gs.EQUALITY_TYPE.CONNECT
+            eq_data[:6] *= scale
         elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_WELD:
-            eq_info["type"] = gs.EQUALITY_TYPE.WELD
-            eq_info["data"][:6] *= scale
+            eq_type = gs.EQUALITY_TYPE.WELD
+            eq_data[:6] *= scale
         elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_JOINT:
             # y -y0 = a0 + a1 * (x-x0) + a2 * (x-x0)^2 + a3 * (x-x0)^3 + a4 * (x-x0)^4
-            eq_info["type"] = gs.EQUALITY_TYPE.JOINT
+            eq_type = gs.EQUALITY_TYPE.JOINT
         else:
             gs.raise_exception(f"Unsupported MJCF equality type: {mj.eq_type[i_e]}")
 
@@ -901,8 +901,14 @@ def parse_equalities(mj, scale):
                 name_start = name_objadr[obj_idx]
                 obj_name, *_ = mj.names[name_start:].decode("utf-8").split("\x00")
             objs_name.append(obj_name)
-        eq_info["objs_name"] = tuple(objs_name)
+        eq_descs.append(
+            EqualityDescription(
+                name=mj_equality.name,
+                type=eq_type,
+                objs_name=tuple(objs_name),
+                data=eq_data,
+                sol_params=sol_params,
+            )
+        )
 
-        eqs_info.append(eq_info)
-
-    return eqs_info
+    return eq_descs

--- a/genesis/utils/terrain.py
+++ b/genesis/utils/terrain.py
@@ -7,14 +7,19 @@ import fast_simplification
 import numpy as np
 import trimesh
 
+from typing import TYPE_CHECKING
+
 import genesis as gs
 from genesis.ext.isaacgym import terrain_utils as isaacgym_terrain_utils
-from genesis.options.morphs import Terrain
 
 from .mesh import get_gnd_path
 
 
-def parse_terrain(morph: Terrain, surface):
+if TYPE_CHECKING:
+    from genesis.options.morphs import Terrain
+
+
+def parse_terrain(morph: "Terrain", surface):
     """
     Generate mesh (and height field) according to configurations passed by morph.
 

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -10,6 +10,7 @@ import xacro
 import genesis as gs
 import genesis.utils.gltf as gltf_utils
 from genesis.ext import urdfpy
+from genesis.utils.description import EqualityDescription, GeomDescription, JointDescription, LinkDescription
 
 from . import geom as gu
 from .misc import get_assets_dir
@@ -88,14 +89,14 @@ def load_xacro(path, mappings):
     return robot
 
 
-def order_links_depth_first(l_infos, j_infos, links_g_infos=None):
+def order_links_depth_first(l_descs, j_descs, links_g_descs=None):
     # Re-order links depth-first so that each subtree occupies a contiguous range and parents precede their children.
-    n_links = len(l_infos)
+    n_links = len(l_descs)
     dict_child = {k: [] for k in range(n_links)}
     for lc in range(n_links):
-        if "parent_idx" not in l_infos[lc]:
-            l_infos[lc]["parent_idx"] = -1
-        lp = l_infos[lc]["parent_idx"]
+        if l_descs[lc].parent_idx is None:
+            l_descs[lc].parent_idx = -1
+        lp = l_descs[lc].parent_idx
         if lp != -1:
             dict_child[lp].append(lc)
 
@@ -104,7 +105,7 @@ def order_links_depth_first(l_infos, j_infos, links_g_infos=None):
     # their original relative order, and the result matches MuJoCo's body ordering. Contiguity lets the per-tree
     # mass-matrix factorization stay block-local instead of spanning the whole (possibly multi-body) entity.
     ordered_links_idx = []
-    stack_topology = [lc for lc in reversed(range(n_links)) if l_infos[lc]["parent_idx"] == -1]
+    stack_topology = [lc for lc in reversed(range(n_links)) if l_descs[lc].parent_idx == -1]
     while stack_topology:
         link = stack_topology.pop()
         ordered_links_idx.append(link)
@@ -115,19 +116,19 @@ def order_links_depth_first(l_infos, j_infos, links_g_infos=None):
         # avoid case with worldbody without any body (geom directly assigned to worldbody)
         return [], [], [], []
 
-    for l_info in l_infos:
-        if l_info["parent_idx"] >= 0:  # non-base link
-            l_info["parent_idx"] = ordered_links_idx.index(l_info["parent_idx"])
-        if "root_idx" in l_info:
-            l_info["root_idx"] = ordered_links_idx.index(l_info["root_idx"])
+    for l_desc in l_descs:
+        if l_desc.parent_idx >= 0:  # non-base link
+            l_desc.parent_idx = ordered_links_idx.index(l_desc.parent_idx)
+        if l_desc.root_idx is not None:
+            l_desc.root_idx = ordered_links_idx.index(l_desc.root_idx)
 
-    new_l_infos = [l_infos[i] for i in ordered_links_idx]
-    new_j_infos = [j_infos[i] for i in ordered_links_idx]
+    new_l_descs = [l_descs[i] for i in ordered_links_idx]
+    new_j_descs = [j_descs[i] for i in ordered_links_idx]
 
-    if links_g_infos is not None:
-        links_g_infos = [links_g_infos[i] for i in ordered_links_idx]
+    if links_g_descs is not None:
+        links_g_descs = [links_g_descs[i] for i in ordered_links_idx]
 
-    return new_l_infos, new_j_infos, links_g_infos, ordered_links_idx
+    return new_l_descs, new_j_descs, links_g_descs, ordered_links_idx
 
 
 def parse_urdf(morph, surface):
@@ -156,35 +157,34 @@ def parse_urdf(morph, surface):
     # Note that each link corresponds to one joint
     n_links = len(robot.links)
     assert n_links == len(robot.joints) + 1
-    l_infos = [dict() for _ in range(n_links)]
-    links_j_infos = [[] for _ in range(n_links)]
-    links_g_infos = [[] for _ in range(n_links)]
+    # A link has no parent and a neutral pose until the joint reaching it says otherwise, and its inverse weight is
+    # computed later, from the inertia the whole tree ends up with.
+    l_descs = [
+        LinkDescription(
+            name=link.name,
+            parent_idx=-1,
+            pos=gu.zero_pos(),
+            quat=gu.identity_quat(),
+            inertial_pos=None,
+            inertial_quat=gu.identity_quat(),
+            inertia=None,
+            mass=None,
+            invweight=np.full((2,), fill_value=-1.0),
+        )
+        for link in robot.links
+    ]
+    links_j_descs = [[] for _ in range(n_links)]
+    links_g_descs = [[] for _ in range(n_links)]
 
-    for link, l_info, link_g_infos in zip(robot.links, l_infos, links_g_infos):
-        l_info["name"] = link.name
-
-        # No parent by default. It will be overwritten latter on if appropriate.
-        l_info["parent_idx"] = -1
-
-        # Neutral pose by default. It will be overwritten latter on if necessary.
-        l_info["pos"] = gu.zero_pos()
-        l_info["quat"] = gu.identity_quat()
-
-        # we compute urdf's invweight later
-        l_info["invweight"] = np.full((2,), fill_value=-1.0)
-
-        l_info["inertial_pos"] = None
-        l_info["inertial_quat"] = gu.identity_quat()
-        l_info["inertial_i"] = None
-        l_info["inertial_mass"] = None
+    for link, l_desc, link_g_descs in zip(robot.links, l_descs, links_g_descs):
         if link.inertial is not None:
             if link.inertial.origin is not None:
-                l_info["inertial_pos"] = link.inertial.origin[:3, 3]
-                l_info["inertial_quat"] = gu.R_to_quat(link.inertial.origin[:3, :3])
+                l_desc.inertial_pos = link.inertial.origin[:3, 3]
+                l_desc.inertial_quat = gu.R_to_quat(link.inertial.origin[:3, :3])
             if link.inertial.inertia is not None:
-                l_info["inertial_i"] = link.inertial.inertia
+                l_desc.inertia = link.inertial.inertia
             if link.inertial.mass is not None:
-                l_info["inertial_mass"] = link.inertial.mass
+                l_desc.mass = link.inertial.mass
 
         for geom_prop in (*link.collisions, *link.visuals):
             geometry = geom_prop.geometry.geometry
@@ -272,49 +272,45 @@ def parse_urdf(morph, surface):
                 geom_meshes.append(mesh)
 
             for mesh in geom_meshes:
-                g_info = {
-                    "mesh" if geom_is_col else "vmesh": mesh,
-                    "type": geom_type,
-                    "data": geom_data,
-                    "pos": geom_prop.origin[:3, 3].copy(),
-                    "quat": gu.R_to_quat(geom_prop.origin[:3, :3]),
-                    "contype": 1 if geom_is_col else 0,
-                    "conaffinity": 1 if geom_is_col else 0,
-                    "friction": gu.default_friction(),
-                    "sol_params": gu.default_solver_params(),
-                }
-                link_g_infos.append(g_info)
+                link_g_descs.append(
+                    GeomDescription(
+                        contype=1 if geom_is_col else 0,
+                        conaffinity=1 if geom_is_col else 0,
+                        type=geom_type,
+                        data=geom_data,
+                        pos=geom_prop.origin[:3, 3].copy(),
+                        quat=gu.R_to_quat(geom_prop.origin[:3, :3]),
+                        mesh=mesh if geom_is_col else None,
+                        vmesh=None if geom_is_col else mesh,
+                        friction=gu.default_friction(),
+                        sol_params=gu.default_solver_params(),
+                    )
+                )
 
     #########################  non-base joints and links #########################
     for joint in robot.joints:
         idx = link_name_to_idx[joint.child]
-        l_info = l_infos[idx]
-        j_info = dict()
-        links_j_infos[idx].append(j_info)
+        l_desc = l_descs[idx]
 
-        j_info["name"] = joint.name
-        j_info["pos"] = gu.zero_pos()
-        j_info["quat"] = gu.identity_quat()
-
-        l_info["parent_idx"] = link_name_to_idx[joint.parent]
-        l_info["pos"] = joint.origin[:3, 3]
-        l_info["quat"] = gu.R_to_quat(joint.origin[:3, :3])
+        l_desc.parent_idx = link_name_to_idx[joint.parent]
+        l_desc.pos = joint.origin[:3, 3]
+        l_desc.quat = gu.R_to_quat(joint.origin[:3, :3])
 
         if joint.joint_type == "fixed":
-            j_info["dofs_motion_ang"] = np.zeros((0, 3))
-            j_info["dofs_motion_vel"] = np.zeros((0, 3))
-            j_info["dofs_limit"] = np.zeros((0, 2))
-            j_info["dofs_stiffness"] = np.zeros((0))
+            dofs_motion_ang = np.zeros((0, 3))
+            dofs_motion_vel = np.zeros((0, 3))
+            dofs_limit = np.zeros((0, 2))
+            dofs_stiffness = np.zeros((0))
 
-            j_info["type"] = gs.JOINT_TYPE.FIXED
-            j_info["n_qs"] = 0
-            j_info["n_dofs"] = 0
-            j_info["init_qpos"] = np.zeros(0)
+            joint_type = gs.JOINT_TYPE.FIXED
+            n_qs = 0
+            n_dofs = 0
+            init_qpos = np.zeros(0)
 
         elif joint.joint_type == "revolute":
-            j_info["dofs_motion_ang"] = np.array([joint.axis])
-            j_info["dofs_motion_vel"] = np.zeros((1, 3))
-            j_info["dofs_limit"] = np.array(
+            dofs_motion_ang = np.array([joint.axis])
+            dofs_motion_vel = np.zeros((1, 3))
+            dofs_limit = np.array(
                 [
                     [
                         joint.limit.lower if joint.limit.lower is not None else -np.inf,
@@ -322,26 +318,26 @@ def parse_urdf(morph, surface):
                     ]
                 ]
             )
-            j_info["dofs_stiffness"] = np.array([0.0])
+            dofs_stiffness = np.array([0.0])
 
-            j_info["type"] = gs.JOINT_TYPE.REVOLUTE
-            j_info["n_qs"] = 1
-            j_info["n_dofs"] = 1
-            j_info["init_qpos"] = np.zeros(1)
+            joint_type = gs.JOINT_TYPE.REVOLUTE
+            n_qs = 1
+            n_dofs = 1
+            init_qpos = np.zeros(1)
         elif joint.joint_type == "continuous":
-            j_info["dofs_motion_ang"] = np.array([joint.axis])
-            j_info["dofs_motion_vel"] = np.zeros((1, 3))
-            j_info["dofs_limit"] = np.array([[-np.inf, np.inf]])
-            j_info["dofs_stiffness"] = np.array([0.0])
+            dofs_motion_ang = np.array([joint.axis])
+            dofs_motion_vel = np.zeros((1, 3))
+            dofs_limit = np.array([[-np.inf, np.inf]])
+            dofs_stiffness = np.array([0.0])
 
-            j_info["type"] = gs.JOINT_TYPE.REVOLUTE
-            j_info["n_qs"] = 1
-            j_info["n_dofs"] = 1
-            j_info["init_qpos"] = np.zeros(1)
+            joint_type = gs.JOINT_TYPE.REVOLUTE
+            n_qs = 1
+            n_dofs = 1
+            init_qpos = np.zeros(1)
         elif joint.joint_type == "prismatic":
-            j_info["dofs_motion_ang"] = np.zeros((1, 3))
-            j_info["dofs_motion_vel"] = np.array([joint.axis])
-            j_info["dofs_limit"] = np.array(
+            dofs_motion_ang = np.zeros((1, 3))
+            dofs_motion_vel = np.array([joint.axis])
+            dofs_limit = np.array(
                 [
                     [
                         morph.scale * joint.limit.lower if joint.limit.lower is not None else -np.inf,
@@ -349,27 +345,27 @@ def parse_urdf(morph, surface):
                     ]
                 ]
             )
-            j_info["dofs_stiffness"] = np.array([0.0])
+            dofs_stiffness = np.array([0.0])
 
-            j_info["type"] = gs.JOINT_TYPE.PRISMATIC
-            j_info["n_qs"] = 1
-            j_info["n_dofs"] = 1
-            j_info["init_qpos"] = np.zeros(1)
+            joint_type = gs.JOINT_TYPE.PRISMATIC
+            n_qs = 1
+            n_dofs = 1
+            init_qpos = np.zeros(1)
         elif joint.joint_type == "floating":
-            j_info["dofs_motion_ang"] = np.eye(6, 3, -3)
-            j_info["dofs_motion_vel"] = np.eye(6, 3)
-            j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (6, 1))
-            j_info["dofs_stiffness"] = np.zeros(6)
+            dofs_motion_ang = np.eye(6, 3, -3)
+            dofs_motion_vel = np.eye(6, 3)
+            dofs_limit = np.tile([-np.inf, np.inf], (6, 1))
+            dofs_stiffness = np.zeros(6)
 
-            j_info["type"] = gs.JOINT_TYPE.FREE
-            j_info["n_qs"] = 7
-            j_info["n_dofs"] = 6
-            j_info["init_qpos"] = np.concatenate([gu.zero_pos(), gu.identity_quat()])
+            joint_type = gs.JOINT_TYPE.FREE
+            n_qs = 7
+            n_dofs = 6
+            init_qpos = np.concatenate([gu.zero_pos(), gu.identity_quat()])
         else:
             gs.raise_exception(f"Unsupported URDF joint type: {joint.joint_type}")
 
-        j_info["sol_params"] = gu.default_solver_params()
-        j_info["dofs_invweight"] = np.full((j_info["n_dofs"],), fill_value=-1.0)
+        sol_params = gu.default_solver_params()
+        dofs_invweight = np.full((n_dofs,), fill_value=-1.0)
 
         joint_friction, joint_damping = 0.0, 0.0
         if joint.dynamics is not None:
@@ -377,50 +373,72 @@ def parse_urdf(morph, surface):
                 joint_friction = joint.dynamics.friction
             if joint.dynamics.damping is not None:
                 joint_damping = joint.dynamics.damping
-        j_info["dofs_frictionloss"] = np.full(j_info["n_dofs"], joint_friction)
-        j_info["dofs_damping"] = np.full(j_info["n_dofs"], joint_damping)
-        j_info["dofs_armature"] = np.zeros(j_info["n_dofs"])
+        dofs_frictionloss = np.full(n_dofs, joint_friction)
+        dofs_damping = np.full(n_dofs, joint_damping)
+        dofs_armature = np.zeros(n_dofs)
         if joint.joint_type not in ("floating", "fixed") and morph.default_armature is not None:
-            j_info["dofs_armature"] = np.full((j_info["n_dofs"],), morph.default_armature)
+            dofs_armature = np.full((n_dofs,), morph.default_armature)
 
-        kp = gu.default_dofs_kp(j_info["n_dofs"])
-        kv = gu.default_dofs_kv(j_info["n_dofs"])
+        kp = gu.default_dofs_kp(n_dofs)
+        kv = gu.default_dofs_kv(n_dofs)
         if joint.safety_controller is not None:
             if joint.safety_controller.k_position is not None:
-                kp = np.tile(joint.safety_controller.k_position, j_info["n_dofs"])
+                kp = np.tile(joint.safety_controller.k_position, n_dofs)
             if joint.safety_controller.k_velocity is not None:
-                kv = np.tile(joint.safety_controller.k_velocity, j_info["n_dofs"])
-        j_info["dofs_act_gain"] = kp
-        j_info["dofs_act_bias"] = np.column_stack([np.zeros_like(kp), -kp, -kv])
+                kv = np.tile(joint.safety_controller.k_velocity, n_dofs)
+        dofs_act_gain = kp
+        dofs_act_bias = np.column_stack([np.zeros_like(kp), -kp, -kv])
 
-        j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (j_info["n_dofs"], 1))
+        dofs_force_range = np.tile([-np.inf, np.inf], (n_dofs, 1))
         if joint.limit is not None and joint.limit.effort is not None:
-            j_info["dofs_force_range"] = np.tile([-joint.limit.effort, joint.limit.effort], (j_info["n_dofs"], 1))
+            dofs_force_range = np.tile([-joint.limit.effort, joint.limit.effort], (n_dofs, 1))
+
+        links_j_descs[idx].append(
+            JointDescription(
+                name=joint.name,
+                type=joint_type,
+                pos=gu.zero_pos(),
+                quat=gu.identity_quat(),
+                init_qpos=init_qpos,
+                sol_params=sol_params,
+                dofs_motion_ang=dofs_motion_ang,
+                dofs_motion_vel=dofs_motion_vel,
+                dofs_limit=dofs_limit,
+                dofs_invweight=dofs_invweight,
+                dofs_frictionloss=dofs_frictionloss,
+                dofs_stiffness=dofs_stiffness,
+                dofs_damping=dofs_damping,
+                dofs_armature=dofs_armature,
+                dofs_act_gain=dofs_act_gain,
+                dofs_act_bias=dofs_act_bias,
+                dofs_force_range=dofs_force_range,
+            )
+        )
 
     # Apply scaling factor
-    for l_info, link_j_infos, link_g_infos in zip(l_infos, links_j_infos, links_g_infos):
-        l_info["pos"] *= morph.scale
-        if l_info["inertial_pos"] is not None:
-            l_info["inertial_pos"] *= morph.scale
-        if l_info["inertial_mass"] is not None:
-            l_info["inertial_mass"] *= morph.scale**3
-        if l_info["inertial_i"] is not None:
-            l_info["inertial_i"] *= morph.scale**5
-        for j_info in link_j_infos:
-            j_info["pos"] *= morph.scale
-        for g_info in link_g_infos:
-            g_info["pos"] *= morph.scale
+    for l_desc, link_j_descs, link_g_descs in zip(l_descs, links_j_descs, links_g_descs):
+        l_desc.pos *= morph.scale
+        if l_desc.inertial_pos is not None:
+            l_desc.inertial_pos *= morph.scale
+        if l_desc.mass is not None:
+            l_desc.mass *= morph.scale**3
+        if l_desc.inertia is not None:
+            l_desc.inertia *= morph.scale**5
+        for j_desc in link_j_descs:
+            j_desc.pos *= morph.scale
+        for g_desc in link_g_descs:
+            g_desc.pos *= morph.scale
 
     # Re-order kinematic tree info
-    l_infos, links_j_infos, links_g_infos, _ = order_links_depth_first(l_infos, links_j_infos, links_g_infos)
+    l_descs, links_j_descs, links_g_descs, _ = order_links_depth_first(l_descs, links_j_descs, links_g_descs)
 
-    eqs_info = parse_equalities(robot, morph)
+    eq_descs = parse_equalities(robot, morph)
 
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    return l_descs, links_j_descs, links_g_descs, eq_descs
 
 
 def parse_equalities(robot, morph):
-    eqs_info = []
+    eq_descs = []
 
     for joint in robot.joints:
         if joint.mimic:
@@ -428,20 +446,22 @@ def parse_equalities(robot, morph):
                 f"Joint '{joint.name}' mimics '{joint.mimic.joint}' with multiplier {joint.mimic.multiplier} and offset {joint.mimic.offset}"
             )
 
-            eq_info = dict()
-            eq_info["type"] = gs.EQUALITY_TYPE.JOINT
-            eq_info["name"] = f"mimic_{joint.name}_to_{joint.mimic.joint}"
-            eq_info["objs_name"] = (joint.name, joint.mimic.joint)
-            eq_info["sol_params"] = gu.default_solver_params()
+            eq_data = np.zeros([11])
+            eq_data[0] = joint.mimic.offset
+            eq_data[1] = joint.mimic.multiplier
+            eq_data[:6] *= morph.scale
 
-            eq_info["data"] = np.zeros([11])
-            eq_info["data"][0] = joint.mimic.offset
-            eq_info["data"][1] = joint.mimic.multiplier
-            eq_info["data"][:6] *= morph.scale
+            eq_descs.append(
+                EqualityDescription(
+                    name=f"mimic_{joint.name}_to_{joint.mimic.joint}",
+                    type=gs.EQUALITY_TYPE.JOINT,
+                    objs_name=(joint.name, joint.mimic.joint),
+                    data=eq_data,
+                    sol_params=gu.default_solver_params(),
+                )
+            )
 
-            eqs_info.append(eq_info)
-
-    return eqs_info
+    return eq_descs
 
 
 def merge_fixed_links(robot, links_to_keep):

--- a/genesis/utils/usd/usd_collision.py
+++ b/genesis/utils/usd/usd_collision.py
@@ -4,33 +4,34 @@ from pxr import Usd, UsdPhysics
 
 import genesis as gs
 from genesis.utils.collision import solve_contype_conaffinity
+from genesis.utils.description import GeomDescription
 
 
-def _geoms_under(cg_infos: list[dict], path: str) -> list[int]:
-    """Indices of collision g_infos whose source prim is `path` or a descendant of it."""
+def _geoms_under(cg_descs: list[GeomDescription], path: str) -> list[int]:
+    """Indices of collision g_descs whose source prim is `path` or a descendant of it."""
     prefix = path.rstrip("/") + "/"
-    return [i for i, g in enumerate(cg_infos) if g["prim_path"] == path or g["prim_path"].startswith(prefix)]
+    return [i for i, g in enumerate(cg_descs) if g.prim_path == path or g.prim_path.startswith(prefix)]
 
 
-def apply_collision_filtering(context, cg_infos: list[dict]):
+def apply_collision_filtering(context, cg_descs: list[GeomDescription]):
     """
-    Set contype/conaffinity on collision g_infos from USD collision filtering.
+    Set contype/conaffinity on collision g_descs from USD collision filtering.
 
     Honors ``UsdPhysics.CollisionGroup`` (collider membership + ``filteredGroups`` + ``mergeGroupName``)
-    and per-prim ``UsdPhysics.FilteredPairsAPI``, for the geoms in ``cg_infos`` (a single entity). The
+    and per-prim ``UsdPhysics.FilteredPairsAPI``, for the geoms in ``cg_descs`` (a single entity). The
     resulting "must not collide" pairs are realized as contype/conaffinity bitmasks by the shared
     solver; if they cannot be expressed as bitmasks, a warning is logged and defaults are kept.
 
     Filtering that spans entities is not expressible per entity, so it is detected against the stage's
     full collider set and reported once via ``context.note_unsupported_cross_entity_filtering()``.
 
-    ``cg_infos`` must each carry a ``prim_path``.
+    ``cg_descs`` must each carry a ``prim_path``.
     """
-    if not cg_infos:
+    if not cg_descs:
         return
 
     stage: Usd.Stage = context.stage
-    n = len(cg_infos)
+    n = len(cg_descs)
     invalid_pairs: set[frozenset[int]] = set()
 
     # Single stage sweep gathering all filtering-relevant prims. The full collider set (this entity's
@@ -46,7 +47,7 @@ def apply_collision_filtering(context, cg_infos: list[dict]):
             group_prims.append(prim)
         if prim.HasAPI(UsdPhysics.FilteredPairsAPI):
             filter_prims.append(prim)
-    entity_paths = {g["prim_path"] for g in cg_infos}
+    entity_paths = {g.prim_path for g in cg_descs}
     external_collider_paths = stage_collider_paths - entity_paths
     has_cross_entity_filtering = False
 
@@ -84,7 +85,7 @@ def apply_collision_filtering(context, cg_infos: list[dict]):
                 p for p in stage_collider_paths if query.IsPathIncluded(p)
             )
         geoms_canonicals = [
-            {canonical for canonical, members in group_members.items() if g["prim_path"] in members} for g in cg_infos
+            {canonical for canonical, members in group_members.items() if g.prim_path in members} for g in cg_descs
         ]
         for i in range(n):
             for j in range(i + 1, n):
@@ -103,12 +104,12 @@ def apply_collision_filtering(context, cg_infos: list[dict]):
 
     # 2) FilteredPairsAPI: explicit prim-subtree pairs that must not collide.
     for prim in filter_prims:
-        geoms_a = _geoms_under(cg_infos, str(prim.GetPath()))
+        geoms_a = _geoms_under(cg_descs, str(prim.GetPath()))
         if not geoms_a:
             continue
         for target in UsdPhysics.FilteredPairsAPI(prim).GetFilteredPairsRel().GetTargets():
             target_path = str(target)
-            target_geoms = _geoms_under(cg_infos, target_path)
+            target_geoms = _geoms_under(cg_descs, target_path)
             if not target_geoms:
                 # The target collider (or one below it) lives in another entity.
                 target_prefix = target_path.rstrip("/") + "/"
@@ -127,8 +128,8 @@ def apply_collision_filtering(context, cg_infos: list[dict]):
                 "Keeping default (all-colliding) values."
             )
         else:
-            for g_info, (contype, conaffinity) in zip(cg_infos, masks):
-                g_info["contype"], g_info["conaffinity"] = contype, conaffinity
+            for g_desc, (contype, conaffinity) in zip(cg_descs, masks):
+                g_desc.contype, g_desc.conaffinity = contype, conaffinity
 
     if has_cross_entity_filtering:
         context.note_unsupported_cross_entity_filtering()

--- a/genesis/utils/usd/usd_geometry.py
+++ b/genesis/utils/usd/usd_geometry.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import replace
 from typing import Dict, List
 
 import numpy as np
@@ -7,13 +8,14 @@ from pxr import Usd, UsdGeom, UsdPhysics
 
 import genesis as gs
 from genesis.utils import geom as gu
+from genesis.utils.description import GeomDescription
 
 from .usd_context import UsdContext
 from .usd_utils import AXES_T, AXES_VECTOR, usd_attr_array_to_numpy, usd_primvar_array_to_numpy
 
 
 # UsdPhysics.MeshCollisionAPI 'approximation' tokens -> per-geom collision post-processing overrides
-# consumed by RigidEntity._postprocess_geoms_info. 'boundingCube'/'boundingSphere' are handled
+# consumed by RigidEntity._postprocess_geoms. 'boundingCube'/'boundingSphere' are handled
 # separately by fitting a primitive geom in the parser.
 _APPROXIMATION_OVERRIDES = {
     "convexHull": {"convexify": True, "decompose_error_threshold": float("inf")},  # single hull, no decomposition
@@ -39,7 +41,7 @@ def parse_prim_geoms(
     context: UsdContext,
     prim: Usd.Prim,
     link_prim: Usd.Prim,
-    links_g_infos: List[List[Dict]],
+    links_g_descs: List[List[GeomDescription]],
     link_path_to_idx: Dict[str, int],
     morph: gs.morphs.USD,
     surface: gs.surfaces.Surface,
@@ -332,18 +334,18 @@ def parse_prim_geoms(
         is_visual = (is_visible and not is_guide) and (match_visual or not (match_collision or match_visual))
         is_collision = is_visible and (match_collision or not (match_collision or match_visual))
 
-        g_infos = links_g_infos[link_path_to_idx[str(link_prim.GetPath())]]
+        g_descs = links_g_descs[link_path_to_idx[str(link_prim.GetPath())]]
         if is_visual:
             for mesh in meshes:
-                g_infos.append(
-                    dict(
-                        vmesh=mesh,
-                        pos=geom_pos,
-                        quat=geom_quat,
+                g_descs.append(
+                    GeomDescription(
                         contype=0,
                         conaffinity=0,
                         type=gs_type,
                         data=geom_data,
+                        pos=geom_pos,
+                        quat=geom_quat,
+                        vmesh=mesh,
                     )
                 )
         if is_collision:
@@ -370,18 +372,18 @@ def parse_prim_geoms(
                 if approximation_attr.HasAuthoredValue():
                     approximation = approximation_attr.Get()
 
-            # 'prim_path' resolves collision-group membership (see usd_collision) and 'density' feeds
-            # the density-derived link mass; parse_usd_rigid_entity strips both once consumed.
-            collision_g_info = dict(
-                pos=geom_pos,
-                quat=geom_quat,
+            # 'prim_path' resolves collision-group membership (see usd_collision) and 'density' feeds the
+            # density-derived link mass.
+            collision_g_desc = GeomDescription(
                 contype=1,
                 conaffinity=1,
+                pos=geom_pos,
+                quat=geom_quat,
                 friction=geom_friction,
                 prim_path=str(prim.GetPath()),
             )
             if physics_material is not None and physics_material.density is not None:
-                collision_g_info["density"] = physics_material.density
+                collision_g_desc.density = physics_material.density
 
             if approximation in ("boundingCube", "boundingSphere") and meshes:
                 # Fit a single primitive to the collision vertices, replacing the mesh collider.
@@ -398,30 +400,30 @@ def parse_prim_geoms(
                     bv_tmesh = trimesh.creation.icosphere(radius=radius, subdivisions=2)
                     bv_type, bv_data = gs.GEOM_TYPE.SPHERE, np.array([radius])
                 bv_mesh = gs.Mesh.from_trimesh(bv_tmesh, surface=geom_surface, metadata={"name": geom_id})
-                g_infos.append(
-                    {
-                        **collision_g_info,
-                        "mesh": bv_mesh,
-                        "pos": prim_pos,
-                        "sol_params": gu.default_solver_params(),
-                        "type": bv_type,
-                        "data": bv_data,
+                g_descs.append(
+                    replace(
+                        collision_g_desc,
+                        type=bv_type,
+                        data=bv_data,
+                        pos=prim_pos,
+                        mesh=bv_mesh,
+                        sol_params=gu.default_solver_params(),
                         # Already a primitive: skip mesh convexify for this geom.
-                        "convexify": False,
-                    }
+                        convexify=False,
+                    )
                 )
             else:
                 approximation_overrides = _APPROXIMATION_OVERRIDES.get(approximation, {})
                 for mesh in meshes:
-                    g_infos.append(
-                        {
-                            **collision_g_info,
-                            "mesh": mesh,
-                            "sol_params": gu.default_solver_params(),
-                            "type": gs_type,
-                            "data": geom_data,
+                    g_descs.append(
+                        replace(
+                            collision_g_desc,
+                            type=gs_type,
+                            data=geom_data,
+                            mesh=mesh,
+                            sol_params=gu.default_solver_params(),
                             **approximation_overrides,
-                        }
+                        )
                     )
 
     predicate = Usd.TraverseInstanceProxies()
@@ -431,6 +433,6 @@ def parse_prim_geoms(
     next(iterator)
     for child in iterator:
         parse_prim_geoms(
-            context, child, link_prim, links_g_infos, link_path_to_idx, morph, surface, match_visual, match_collision
+            context, child, link_prim, links_g_descs, link_path_to_idx, morph, surface, match_visual, match_collision
         )
         iterator.PruneChildren()

--- a/genesis/utils/usd/usd_rigid_entity.py
+++ b/genesis/utils/usd/usd_rigid_entity.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Dict, List, NamedTuple, Tuple
 
 import numpy as np
@@ -6,6 +7,7 @@ from pxr import Usd, UsdPhysics
 import genesis as gs
 from genesis.utils import geom as gu
 from genesis.utils import urdf as urdf_utils
+from genesis.utils.description import GeomDescription, JointDescription, LinkDescription
 
 from .usd_context import (
     UsdContext,
@@ -169,9 +171,7 @@ def _parse_link(
     links: List[Usd.Prim],
     morph: gs.morphs.USD,
 ):
-    l_info = {}
-    l_info["name"] = str(link.GetPath())
-    l_info["invweight"] = np.full((2,), fill_value=-1.0)
+    l_desc = LinkDescription(name=str(link.GetPath()), invweight=np.full((2,), fill_value=-1.0))
 
     # parse link fixed state
     link_fixed = False
@@ -194,32 +194,32 @@ def _parse_link(
         mass_api = UsdPhysics.MassAPI(link)
 
         com_attr = mass_api.GetCenterOfMassAttr()
-        l_info["inertial_pos"] = usd_center_of_mass_to_numpy(com_attr.Get())
+        l_desc.inertial_pos = usd_center_of_mass_to_numpy(com_attr.Get())
         principal_axes_attr = mass_api.GetPrincipalAxesAttr()
-        l_info["inertial_quat"] = usd_principal_axes_to_numpy(principal_axes_attr.Get())
+        l_desc.inertial_quat = usd_principal_axes_to_numpy(principal_axes_attr.Get())
         inertia_attr = mass_api.GetDiagonalInertiaAttr()
-        l_info["inertial_i"] = usd_inertia_to_numpy(inertia_attr.Get())
+        l_desc.inertia = usd_inertia_to_numpy(inertia_attr.Get())
         mass_attr = mass_api.GetMassAttr()
-        l_info["inertial_mass"] = usd_mass_to_float(mass_attr.Get())
+        l_desc.mass = usd_mass_to_float(mass_attr.Get())
 
     # set link transform for pure rigid bodies (no joints)
     if not joints:
         Q, S = context.compute_gs_transform(link, None)
-        l_info["parent_idx"] = -1
-        l_info["pos"] = Q[:3, 3]
-        l_info["quat"] = gu.R_to_quat(Q[:3, :3])
+        l_desc.parent_idx = -1
+        l_desc.pos = Q[:3, 3]
+        l_desc.quat = gu.R_to_quat(Q[:3, :3])
 
-    j_infos = []
+    j_descs = []
     for joint_prim, parent_idx, is_body1, frame_path in joints:
-        if "parent_idx" not in l_info:
+        if l_desc.parent_idx is None:
             parent_link = None if parent_idx == -1 else links[parent_idx]
             Q, S = context.compute_gs_transform(link, parent_link)
-            l_info["parent_idx"] = parent_idx
-            l_info["pos"] = Q[:3, 3]
-            l_info["quat"] = gu.R_to_quat(Q[:3, :3])
+            l_desc.parent_idx = parent_idx
+            l_desc.pos = Q[:3, 3]
+            l_desc.quat = gu.R_to_quat(Q[:3, :3])
 
-        elif l_info["parent_idx"] != parent_idx:
-            gs.raise_exception(f"Link {link.GetPath()} has multiple parents: {l_info['parent_idx']} and {parent_idx}.")
+        elif l_desc.parent_idx != parent_idx:
+            gs.raise_exception(f"Link {link.GetPath()} has multiple parents: {l_desc.parent_idx} and {parent_idx}.")
 
         if joint_prim is not None:
             joint_type = gs.JOINT_TYPE.FIXED
@@ -266,26 +266,24 @@ def _parse_link(
                 n_dofs, n_qs = 6, 7
             joint = None
             joint_axis_str, joint_axis, joint_pos = None, None, gu.zero_pos()
-            joint_name = f"{l_info['name']}_joint"
+            joint_name = f"{l_desc.name}_joint"
 
-        j_info = {
-            "name": joint_name,
-            "sol_params": gu.default_solver_params(),
-            "n_qs": n_qs,
-            "n_dofs": n_dofs,
-            "type": joint_type,
-            "pos": joint_pos,
-            "dofs_invweight": np.full(n_dofs, -1.0, dtype=gs.np_float),
-        }
+        j_desc = JointDescription(
+            name=joint_name,
+            type=joint_type,
+            pos=joint_pos,
+            sol_params=gu.default_solver_params(),
+            dofs_invweight=np.full(n_dofs, -1.0, dtype=gs.np_float),
+        )
 
         if joint_type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC):
             # TODO: use attribute "state:<INSTANCE_NAME>:physics:positiion" to parse init_qpos (but it is IsaacSim specific)
-            j_info["init_qpos"] = np.zeros(n_qs, dtype=gs.np_float)
+            j_desc.init_qpos = np.zeros(n_qs, dtype=gs.np_float)
 
             if joint_type == gs.JOINT_TYPE.REVOLUTE:
-                j_info["dofs_motion_ang"] = joint_axis[None]
-                j_info["dofs_motion_vel"] = np.zeros((1, 3), dtype=gs.np_float)
-                j_info["dofs_stiffness"] = np.array(
+                j_desc.dofs_motion_ang = joint_axis[None]
+                j_desc.dofs_motion_vel = np.zeros((1, 3), dtype=gs.np_float)
+                j_desc.dofs_stiffness = np.array(
                     [
                         get_attr_value_by_candidates(
                             joint_prim,
@@ -296,7 +294,7 @@ def _parse_link(
                     ],
                     dtype=gs.np_float,
                 )
-                j_info["dofs_damping"] = np.array(
+                j_desc.dofs_damping = np.array(
                     [
                         get_attr_value_by_candidates(
                             joint_prim,
@@ -324,11 +322,11 @@ def _parse_link(
                     upper_limit_attr = joint.GetUpperLimitAttr()
                     lower_limit = np.deg2rad(lower_limit_attr.Get()) if lower_limit_attr.HasValue() else -np.inf
                     upper_limit = np.deg2rad(upper_limit_attr.Get()) if upper_limit_attr.HasValue() else np.inf
-                j_info["dofs_limit"] = np.asarray([[lower_limit, upper_limit]], dtype=gs.np_float)
+                j_desc.dofs_limit = np.asarray([[lower_limit, upper_limit]], dtype=gs.np_float)
             else:  # joint_type == gs.JOINT_TYPE.PRISMATIC
-                j_info["dofs_motion_ang"] = np.zeros((1, 3), dtype=gs.np_float)
-                j_info["dofs_motion_vel"] = joint_axis[None]
-                j_info["dofs_stiffness"] = np.array(
+                j_desc.dofs_motion_ang = np.zeros((1, 3), dtype=gs.np_float)
+                j_desc.dofs_motion_vel = joint_axis[None]
+                j_desc.dofs_stiffness = np.array(
                     [
                         get_attr_value_by_candidates(
                             joint_prim,
@@ -339,7 +337,7 @@ def _parse_link(
                     ],
                     dtype=gs.np_float,
                 )
-                j_info["dofs_damping"] = np.array(
+                j_desc.dofs_damping = np.array(
                     [
                         get_attr_value_by_candidates(
                             joint_prim,
@@ -366,17 +364,17 @@ def _parse_link(
                     upper_limit_attr = joint.GetUpperLimitAttr()
                     lower_limit = lower_limit_attr.Get() if lower_limit_attr.HasValue() else -np.inf
                     upper_limit = upper_limit_attr.Get() if upper_limit_attr.HasValue() else np.inf
-                j_info["dofs_limit"] = np.asarray([[lower_limit, upper_limit]], dtype=gs.np_float) * morph.scale
-                j_info["init_qpos"] *= morph.scale
+                j_desc.dofs_limit = np.asarray([[lower_limit, upper_limit]], dtype=gs.np_float) * morph.scale
+                j_desc.init_qpos *= morph.scale
 
         else:
-            j_info["dofs_stiffness"] = np.zeros(n_dofs, dtype=gs.np_float)
-            j_info["dofs_damping"] = np.zeros(n_dofs, dtype=gs.np_float)
+            j_desc.dofs_stiffness = np.zeros(n_dofs, dtype=gs.np_float)
+            j_desc.dofs_damping = np.zeros(n_dofs, dtype=gs.np_float)
 
             if joint_type == gs.JOINT_TYPE.SPHERICAL:
-                j_info["dofs_motion_ang"] = np.eye(3)
-                j_info["dofs_motion_vel"] = np.zeros((3, 3))
-                j_info["init_qpos"] = gu.identity_quat()
+                j_desc.dofs_motion_ang = np.eye(3)
+                j_desc.dofs_motion_vel = np.zeros((3, 3))
+                j_desc.init_qpos = gu.identity_quat()
                 # Native SphericalJoint uses cone limits (ConeAngle0/1), while generic PhysicsJoint
                 # (D6) uses per-axis pyramid limits via LimitAPI:rotX/rotY/rotZ. Neither is currently
                 # enforced by the Genesis solver for spherical joints.
@@ -391,21 +389,21 @@ def _parse_link(
                         dofs_limit.append([lo, hi])
                     else:
                         dofs_limit.append([-np.inf, np.inf])
-                j_info["dofs_limit"] = np.asarray(dofs_limit, dtype=gs.np_float)
+                j_desc.dofs_limit = np.asarray(dofs_limit, dtype=gs.np_float)
             elif joint_type == gs.JOINT_TYPE.FIXED:
-                j_info["dofs_motion_ang"] = np.zeros((0, 3))
-                j_info["dofs_motion_vel"] = np.zeros((0, 3))
-                j_info["dofs_limit"] = np.zeros((0, 2))
-                j_info["init_qpos"] = np.zeros(0)
+                j_desc.dofs_motion_ang = np.zeros((0, 3))
+                j_desc.dofs_motion_vel = np.zeros((0, 3))
+                j_desc.dofs_limit = np.zeros((0, 2))
+                j_desc.init_qpos = np.zeros(0)
             else:  # joint_type == gs.JOINT_TYPE.FREE
-                j_info["dofs_motion_ang"] = np.eye(6, 3, -3)
-                j_info["dofs_motion_vel"] = np.eye(6, 3)
-                j_info["dofs_limit"] = np.tile([-np.inf, np.inf], (6, 1))
-                j_info["init_qpos"] = np.concatenate([l_info["pos"] * morph.scale, l_info["quat"]])
+                j_desc.dofs_motion_ang = np.eye(6, 3, -3)
+                j_desc.dofs_motion_vel = np.eye(6, 3)
+                j_desc.dofs_limit = np.tile([-np.inf, np.inf], (6, 1))
+                j_desc.init_qpos = np.concatenate([l_desc.pos * morph.scale, l_desc.quat])
 
         # Only parse joint dynamics and drive API for non-fixed and non-free joints
         if joint_type not in (gs.JOINT_TYPE.FIXED, gs.JOINT_TYPE.FREE):
-            j_info["dofs_frictionloss"] = np.full(
+            j_desc.dofs_frictionloss = np.full(
                 (n_dofs,),
                 get_attr_value_by_candidates(
                     joint_prim,
@@ -415,7 +413,7 @@ def _parse_link(
                 ),
                 dtype=gs.np_float,
             )
-            j_info["dofs_armature"] = np.full(
+            j_desc.dofs_armature = np.full(
                 (n_dofs,),
                 get_attr_value_by_candidates(
                     joint_prim,
@@ -454,35 +452,35 @@ def _parse_link(
             # TODO: Implement target solving in rigid solver. (GetTargetPositionAttr())
             kp = np.asarray(dofs_kp, dtype=gs.np_float)
             kv = np.asarray(dofs_kv, dtype=gs.np_float)
-            j_info["dofs_act_gain"] = kp
-            j_info["dofs_act_bias"] = np.column_stack([np.zeros_like(kp), -kp, -kv])
-            j_info["dofs_force_range"] = np.asarray(dofs_force_range, dtype=gs.np_float)
+            j_desc.dofs_act_gain = kp
+            j_desc.dofs_act_bias = np.column_stack([np.zeros_like(kp), -kp, -kv])
+            j_desc.dofs_force_range = np.asarray(dofs_force_range, dtype=gs.np_float)
         else:
-            j_info["dofs_frictionloss"] = np.zeros(n_dofs, dtype=gs.np_float)
-            j_info["dofs_armature"] = np.zeros(n_dofs, dtype=gs.np_float)
-            j_info["dofs_act_gain"] = np.zeros(n_dofs, dtype=gs.np_float)
-            j_info["dofs_act_bias"] = np.zeros((n_dofs, 3), dtype=gs.np_float)
-            j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (n_dofs, 1))
+            j_desc.dofs_frictionloss = np.zeros(n_dofs, dtype=gs.np_float)
+            j_desc.dofs_armature = np.zeros(n_dofs, dtype=gs.np_float)
+            j_desc.dofs_act_gain = np.zeros(n_dofs, dtype=gs.np_float)
+            j_desc.dofs_act_bias = np.zeros((n_dofs, 3), dtype=gs.np_float)
+            j_desc.dofs_force_range = np.tile([-np.inf, np.inf], (n_dofs, 1))
 
-        j_infos.append(j_info)
+        j_descs.append(j_desc)
 
     if abs(1.0 - morph.scale) > gs.EPS:
-        l_info["pos"] *= morph.scale
-        if l_info.get("inertial_pos") is not None:
-            l_info["inertial_pos"] *= morph.scale
-        if l_info.get("inertial_mass") is not None:
-            l_info["inertial_mass"] *= morph.scale**3
-        if l_info.get("inertial_i") is not None:
-            l_info["inertial_i"] *= morph.scale**5
-        l_info["invweight"][:] = -1.0
-        for j_info in j_infos:
-            j_info["pos"] *= morph.scale
+        l_desc.pos *= morph.scale
+        if l_desc.inertial_pos is not None:
+            l_desc.inertial_pos *= morph.scale
+        if l_desc.mass is not None:
+            l_desc.mass *= morph.scale**3
+        if l_desc.inertia is not None:
+            l_desc.inertia *= morph.scale**5
+        l_desc.invweight[:] = -1.0
+        for j_desc in j_descs:
+            j_desc.pos *= morph.scale
             # TODO: parse actuator in USD articulation, now all joints are considered to have actuators
-            j_info["dofs_act_gain"] *= morph.scale**3
-            j_info["dofs_act_bias"] *= morph.scale**3
-            j_info["dofs_invweight"][:] = -1.0
+            j_desc.dofs_act_gain *= morph.scale**3
+            j_desc.dofs_act_bias *= morph.scale**3
+            j_desc.dofs_invweight[:] = -1.0
 
-    return l_info, j_infos
+    return l_desc, j_descs
 
 
 # Rigidbody requirements: https://docs.omniverse.nvidia.com/kit/docs/asset-requirements/latest/capabilities/physics_bodies/physics_rigid_bodies/capability-physics_rigid_bodies.html
@@ -563,9 +561,9 @@ def _parse_geoms(
     morph: gs.morphs.USD,
     surface: gs.surfaces.Surface,
 ) -> List[List[Dict]]:
-    links_g_infos = [[] for _ in range(len(link_path_to_idx))]
-    parse_prim_geoms(context, entity_prim, None, links_g_infos, link_path_to_idx, morph, surface)
-    return links_g_infos
+    links_g_descs = [[] for _ in range(len(link_path_to_idx))]
+    parse_prim_geoms(context, entity_prim, None, links_g_descs, link_path_to_idx, morph, surface)
+    return links_g_descs
 
 
 def _parse_links(
@@ -574,13 +572,13 @@ def _parse_links(
     link_joints: List[List[_LinkJoint]],
     morph: gs.morphs.USD,
 ) -> Tuple[List[Dict], List[List[Dict]]]:
-    l_infos = []
-    links_j_infos = []
+    l_descs = []
+    links_j_descs = []
     for link, joints in zip(links, link_joints):
-        l_info, link_j_info = _parse_link(context, link, joints, links, morph)
-        l_infos.append(l_info)
-        links_j_infos.append(link_j_info)
-    return l_infos, links_j_infos
+        l_desc, link_j_descs = _parse_link(context, link, joints, links, morph)
+        l_descs.append(l_desc)
+        links_j_descs.append(link_j_descs)
+    return l_descs, links_j_descs
 
 
 def _compute_joint_prim_paths(stage: Usd.Stage, entity_prim: Usd.Prim) -> List[str] | None:
@@ -661,13 +659,13 @@ def parse_usd_rigid_entity(morph: gs.morphs.USD, surface: gs.surfaces.Surface):
 
     Returns
     -------
-    l_infos : list
+    l_descs : list
         List of link info dictionaries.
-    links_j_infos : list
+    links_j_descs : list
         List of lists of joint info dictionaries.
-    links_g_infos : list
+    links_g_descs : list
         List of lists of geometry info dictionaries.
-    eqs_info : list
+    eq_descs : list
         List of equality constraint info dictionaries.
     """
     context: UsdContext = morph.usd_ctx
@@ -691,55 +689,46 @@ def parse_usd_rigid_entity(morph: gs.morphs.USD, surface: gs.surfaces.Surface):
     # Deduce joint prim paths for this entity and parse articulation structure (links + joints)
     joint_prims = _compute_joint_prim_paths(stage, entity_prim)
     links, link_joints, link_path_to_idx = _parse_articulation_structure(stage, entity_prim, joint_prims)
-    links_g_infos = _parse_geoms(context, entity_prim, link_path_to_idx, morph, surface)
+    links_g_descs = _parse_geoms(context, entity_prim, link_path_to_idx, morph, surface)
 
     # Visual fallback: duplicate collision geometry as visual when no visual geometry exists,
     # following the same pattern as MJCF (genesis/utils/mjcf.py).
     if surface.texture is None:
         surface = surface.model_copy()
         surface.update_texture()
-    for link_g_infos in links_g_infos:
-        has_visual = any("vmesh" in g for g in link_g_infos)
+    for link_g_descs in links_g_descs:
+        has_visual = any(g.vmesh is not None for g in link_g_descs)
         if has_visual:
             continue
-        collision_entries = [g for g in link_g_infos if g.get("contype") or g.get("conaffinity")]
+        collision_entries = [g for g in link_g_descs if g.is_collision]
         if collision_entries:
             gs.logger.warning(
                 "No visual geometry found for link. Falling back to using collision geometries as visual."
             )
-        for g_info in collision_entries:
-            g_info = g_info.copy()
-            mesh = g_info.pop("mesh")
-            mesh = gs.Mesh.from_trimesh(mesh=mesh.trimesh, surface=surface, metadata=mesh.metadata)
-            g_info = {**g_info, "vmesh": mesh, "contype": 0, "conaffinity": 0}
-            link_g_infos.append(g_info)
+        for g_desc in collision_entries:
+            mesh = gs.Mesh.from_trimesh(mesh=g_desc.mesh.trimesh, surface=surface, metadata=g_desc.mesh.metadata)
+            link_g_descs.append(replace(g_desc, contype=0, conaffinity=0, mesh=None, vmesh=mesh))
 
     # Apply USD collision filtering (CollisionGroup / FilteredPairsAPI) to this entity's collision geoms.
-    cg_infos = [g for link_g_infos in links_g_infos for g in link_g_infos if g.get("contype") or g.get("conaffinity")]
-    apply_collision_filtering(context, cg_infos)
+    cg_descs = [g for link_g_descs in links_g_descs for g in link_g_descs if g.is_collision]
+    apply_collision_filtering(context, cg_descs)
 
-    l_infos, links_j_infos = _parse_links(context, links, link_joints, morph)
+    l_descs, links_j_descs = _parse_links(context, links, link_joints, morph)
 
     # A density authored on the link's MassAPI overrides any per-geom physics-material density (USD
     # precedence); the per-geom densities then drive the rigid build's link inertial estimate wherever
     # no explicit mass is authored.
-    for link, link_g_infos in zip(links, links_g_infos):
+    for link, link_g_descs in zip(links, links_g_descs):
         if not link.HasAPI(UsdPhysics.MassAPI):
             continue
         link_density = usd_density_to_float(UsdPhysics.MassAPI(link).GetDensityAttr().Get())
         if link_density is None:
             continue
-        for g_info in link_g_infos:
-            if g_info.get("contype") or g_info.get("conaffinity"):
-                g_info["density"] = link_density
+        for g_desc in link_g_descs:
+            if g_desc.is_collision:
+                g_desc.density = link_density
 
-    # The prim paths are fully consumed at this point; strip them so they do not leak into the generic
-    # entity-building pipeline (including the visual copies of collision geoms).
-    for link_g_infos in links_g_infos:
-        for g_info in link_g_infos:
-            g_info.pop("prim_path", None)
+    l_descs, links_j_descs, links_g_descs, _ = urdf_utils.order_links_depth_first(l_descs, links_j_descs, links_g_descs)
+    eq_descs = []  # USD doesn't support equality constraints
 
-    l_infos, links_j_infos, links_g_infos, _ = urdf_utils.order_links_depth_first(l_infos, links_j_infos, links_g_infos)
-    eqs_info = []  # USD doesn't support equality constraints
-
-    return l_infos, links_j_infos, links_g_infos, eqs_info
+    return l_descs, links_j_descs, links_g_descs, eq_descs

--- a/genesis/vis/camera.py
+++ b/genesis/vis/camera.py
@@ -294,7 +294,7 @@ class Camera(RBC):
                 entity_pos = entity.get_pos(self._env_idx, relative=False).reshape((-1,))
             pos_rel = self._pos - entity_pos
         else:
-            pos_rel = self._initial_pos - torch.tensor(entity.base_link.pos, dtype=gs.tc_float, device=gs.device)
+            pos_rel = self._initial_pos - torch.tensor(entity.base_link.desc.pos, dtype=gs.tc_float, device=gs.device)
 
         if (pos_rel.abs() < gs.EPS).all():
             gs.raise_exception("Camera must not be co-located with base link of entity to which it is attached.")

--- a/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
+++ b/genesis/vis/viewer_plugins/plugins/mouse_interaction.py
@@ -130,7 +130,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
                 hit_env_idx = ray_hit.env_idx
                 # The mass a link was built with, which a setter may only ever bring to another valid mass, so the
                 # affordance costs no reading of the solver from the thread that draws it.
-                mass = link.inertial_mass
+                mass = link.desc.mass
 
                 # Validate mass is not too small to prevent numerical instability
                 if mass < MIN_PICKABLE_MASS:
@@ -278,7 +278,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
                 self._sim_running
                 and isinstance(link, RigidLink)
                 and not link.is_fixed
-                and link.inertial_mass >= MIN_PICKABLE_MASS
+                and link.desc.mass >= MIN_PICKABLE_MASS
             )
             if is_pickable:
                 arrow_T = gu.trans_R_to_T(closest_hit.position, gu.z_up_to_R(closest_hit.normal))
@@ -366,7 +366,7 @@ class MouseInteractionPlugin(RaycasterViewerPlugin):
         inertia_local = tensor_to_array(solver.get_links_inertia(self._held_link.idx, envs_idx_info))[..., 0, :, :]
         if envs_idx_info is not None:
             com_local, inertia_local = com_local[0], inertia_local[0]
-        inertial_quat = tensor_to_array(self._held_link.inertial_quat)
+        inertial_quat = tensor_to_array(self._held_link.desc.inertial_quat)
         world_principal_quat = gu.transform_quat_by_quat(inertial_quat, link_quat)
 
         # Compute arm from COM to held point in world frame

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -264,8 +264,8 @@ def test_franka_panda_grasp_fem_entity(primitive_type, show_viewer):
     # Only allow finger contact to accelerate
     for geom in franka.geoms:
         if "finger" not in geom.link.name:
-            geom._contype = 0
-            geom._conaffinity = 0
+            geom.desc.contype = 0
+            geom.desc.conaffinity = 0
     if primitive_type == "sphere":
         obj = scene.add_entity(
             morph=gs.morphs.Sphere(

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -224,8 +224,8 @@ def compare_links(compared_links, usd_links, tol):
         err_msg = f"Properties mismatched for link {link_name}"
 
         # Compare link properties
-        assert_allclose(compared_link.pos, usd_link.pos, tol=tol, err_msg=err_msg)
-        assert_allclose(compared_link.quat, usd_link.quat, tol=tol, err_msg=err_msg)
+        assert_allclose(compared_link.desc.pos, usd_link.desc.pos, tol=tol, err_msg=err_msg)
+        assert_allclose(compared_link.desc.quat, usd_link.desc.quat, tol=tol, err_msg=err_msg)
         assert compared_link.is_fixed == usd_link.is_fixed, err_msg
         assert len(compared_link.geoms) == len(usd_link.geoms), err_msg
         assert compared_link.n_joints == usd_link.n_joints, err_msg
@@ -245,13 +245,13 @@ def compare_links(compared_links, usd_links, tol):
         assert compared_parent_name == usd_parent_name, err_msg
 
         # Compare inertial properties if available
-        assert_allclose(compared_link.inertial_pos, usd_link.inertial_pos, tol=tol, err_msg=err_msg)
-        assert_allclose(compared_link.inertial_quat, usd_link.inertial_quat, tol=tol, err_msg=err_msg)
+        assert_allclose(compared_link.desc.inertial_pos, usd_link.desc.inertial_pos, tol=tol, err_msg=err_msg)
+        assert_allclose(compared_link.desc.inertial_quat, usd_link.desc.inertial_quat, tol=tol, err_msg=err_msg)
 
         # Skip mass and inertia checks for fixed links - they're not used in simulation
         if not compared_link.is_fixed:
-            assert_allclose(compared_link.inertial_mass, usd_link.inertial_mass, atol=tol, err_msg=err_msg)
-            assert_allclose(compared_link.inertial_i, usd_link.inertial_i, atol=tol, err_msg=err_msg)
+            assert_allclose(compared_link.desc.mass, usd_link.desc.mass, atol=tol, err_msg=err_msg)
+            assert_allclose(compared_link.desc.inertia, usd_link.desc.inertia, atol=tol, err_msg=err_msg)
 
 
 def compare_joints(compared_joints, usd_joints):
@@ -289,20 +289,20 @@ def compare_joints(compared_joints, usd_joints):
         # Skip mass/inertia-dependent property checks for fixed joints - they're not used in simulation
         if compared_joint.type != gs.JOINT_TYPE.FIXED:
             # Compare dof limits
-            assert_joint_allclose(compared_joint.dofs_limit, usd_joint.dofs_limit)
+            assert_joint_allclose(compared_joint.desc.dofs_limit, usd_joint.desc.dofs_limit)
 
             # Compare dof motion properties
             assert_joint_allclose(compared_joint.dofs_motion_ang, usd_joint.dofs_motion_ang)
             assert_joint_allclose(compared_joint.dofs_motion_vel, usd_joint.dofs_motion_vel)
-            assert_joint_allclose(compared_joint.dofs_frictionloss, usd_joint.dofs_frictionloss)
-            assert_joint_allclose(compared_joint.dofs_stiffness, usd_joint.dofs_stiffness)
-            assert_joint_allclose(compared_joint.dofs_force_range, usd_joint.dofs_force_range)
-            assert_joint_allclose(compared_joint.dofs_damping, usd_joint.dofs_damping)
-            assert_joint_allclose(compared_joint.dofs_armature, usd_joint.dofs_armature)
+            assert_joint_allclose(compared_joint.desc.dofs_frictionloss, usd_joint.desc.dofs_frictionloss)
+            assert_joint_allclose(compared_joint.desc.dofs_stiffness, usd_joint.desc.dofs_stiffness)
+            assert_joint_allclose(compared_joint.desc.dofs_force_range, usd_joint.desc.dofs_force_range)
+            assert_joint_allclose(compared_joint.desc.dofs_damping, usd_joint.desc.dofs_damping)
+            assert_joint_allclose(compared_joint.desc.dofs_armature, usd_joint.desc.dofs_armature)
 
             # Compare dof control properties
-            assert_joint_allclose(compared_joint.dofs_act_gain, usd_joint.dofs_act_gain)
-            assert_joint_allclose(compared_joint.dofs_act_bias, usd_joint.dofs_act_bias)
+            assert_joint_allclose(compared_joint.desc.dofs_act_gain, usd_joint.desc.dofs_act_gain)
+            assert_joint_allclose(compared_joint.desc.dofs_act_bias, usd_joint.desc.dofs_act_bias)
 
 
 def compare_geoms(compared_geoms, usd_geoms, tol):
@@ -332,10 +332,13 @@ def compare_vgeoms(compared_vgeoms, usd_vgeoms, tol):
 
     for compared_vgeom, usd_vgeom in zip(compared_vgeoms_sorted, usd_vgeoms_sorted):
         compared_vgeom_pos, compared_vgeom_quat = gu.transform_pos_quat_by_trans_quat(
-            compared_vgeom.init_pos, compared_vgeom.init_quat, compared_vgeom.link.pos, compared_vgeom.link.quat
+            compared_vgeom.init_pos,
+            compared_vgeom.init_quat,
+            compared_vgeom.link.desc.pos,
+            compared_vgeom.link.desc.quat,
         )
         usd_vgeom_pos, usd_vgeom_quat = gu.transform_pos_quat_by_trans_quat(
-            usd_vgeom.init_pos, usd_vgeom.init_quat, usd_vgeom.link.pos, usd_vgeom.link.quat
+            usd_vgeom.init_pos, usd_vgeom.init_quat, usd_vgeom.link.desc.pos, usd_vgeom.link.desc.quat
         )
         compared_vgeom_T = gu.trans_quat_to_T(compared_vgeom_pos, compared_vgeom_quat)
         usd_vgeom_T = gu.trans_quat_to_T(usd_vgeom_pos, usd_vgeom_quat)

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -89,14 +89,14 @@ def test_morph_scale(scale, mesh_file, mesh_urdf):
         vgeom_orig = obj_orig.vgeoms[i_vg]
         mesh_orig = vgeom_orig.vmesh.trimesh.copy()
         w_pos_orig, w_quat_orig = gu.transform_pos_quat_by_trans_quat(
-            vgeom_orig.init_pos, vgeom_orig.init_quat, obj_orig.base_link.pos, obj_orig.base_link.quat
+            vgeom_orig.init_pos, vgeom_orig.init_quat, obj_orig.base_link.desc.pos, obj_orig.base_link.desc.quat
         )
         mesh_orig.apply_transform(gu.trans_quat_to_T(w_pos_orig, w_quat_orig))
 
         vgeom_scaled = obj_scaled.vgeoms[i_vg]
         mesh_scaled = vgeom_scaled.vmesh.trimesh.copy()
         w_pos_scaled, w_quat_scaled = gu.transform_pos_quat_by_trans_quat(
-            vgeom_scaled.init_pos, vgeom_scaled.init_quat, obj_scaled.base_link.pos, obj_scaled.base_link.quat
+            vgeom_scaled.init_pos, vgeom_scaled.init_quat, obj_scaled.base_link.desc.pos, obj_scaled.base_link.desc.quat
         )
         mesh_scaled.apply_transform(gu.trans_quat_to_T(w_pos_scaled, w_quat_scaled))
         assert_allclose(mesh_orig.vertices, mesh_scaled.vertices, tol=gs.EPS)
@@ -105,7 +105,10 @@ def test_morph_scale(scale, mesh_file, mesh_urdf):
             vgeom_robot = robot_scaled.vgeoms[i_vg]
             mesh_robot_scaled = vgeom_robot.vmesh.trimesh.copy()
             w_pos_robot, w_quat_robot = gu.transform_pos_quat_by_trans_quat(
-                vgeom_robot.init_pos, vgeom_robot.init_quat, robot_scaled.base_link.pos, robot_scaled.base_link.quat
+                vgeom_robot.init_pos,
+                vgeom_robot.init_quat,
+                robot_scaled.base_link.desc.pos,
+                robot_scaled.base_link.desc.quat,
             )
             mesh_robot_scaled.apply_transform(gu.trans_quat_to_T(w_pos_robot, w_quat_robot))
             assert_allclose(mesh_robot_scaled.vertices, mesh_scaled.vertices, tol=gs.EPS)
@@ -213,7 +216,7 @@ def test_mesh_yup(show_viewer):
         for vgeom in entity.vgeoms:
             tmesh = vgeom.vmesh.trimesh.copy()
             w_pos, w_quat = gu.transform_pos_quat_by_trans_quat(
-                vgeom.init_pos, vgeom.init_quat, vgeom.link.pos, vgeom.link.quat
+                vgeom.init_pos, vgeom.init_quat, vgeom.link.desc.pos, vgeom.link.desc.quat
             )
             tmesh.apply_transform(gu.trans_quat_to_T(w_pos, w_quat))
             tmeshes.append(tmesh)
@@ -246,7 +249,7 @@ def test_urdf_yup(file_meshes_are_zup, mesh_urdf, show_viewer):
     tmeshes = []
     for vgeom in robot.vgeoms:
         tmesh = vgeom.vmesh.trimesh.copy()
-        tmesh.apply_transform(gu.trans_quat_to_T(vgeom.link.pos, vgeom.link.quat))
+        tmesh.apply_transform(gu.trans_quat_to_T(vgeom.link.desc.pos, vgeom.link.desc.quat))
         tmeshes.append(tmesh)
     combined = trimesh.util.concatenate(tmeshes)
     assert_allclose(combined.center_mass, (-0.012, -0.142, 0.397), tol=0.002)

--- a/tests/parsers/test_usd.py
+++ b/tests/parsers/test_usd.py
@@ -341,9 +341,9 @@ def test_physics_material_friction_and_density(usd_scene, physics_material_usd):
     entities = {entity.links[0].name: entity for entity in usd_scene.entities}
 
     # Dynamic friction (0.6) is preferred over static (0.8); restitution (0.4) is dropped.
-    assert_allclose(entities["/root/material_body"].geoms[0].friction, 0.6, tol=5e-8)
+    assert_allclose(entities["/root/material_body"].geoms[0].desc.friction, 0.6, tol=5e-8)
     # An explicitly authored dynamic_friction = 0 is honored (frictionless collider).
-    assert_allclose(entities["/root/frictionless_body"].geoms[0].friction, 0.0, tol=gs.EPS)
+    assert_allclose(entities["/root/frictionless_body"].geoms[0].desc.friction, 0.0, tol=gs.EPS)
 
     # The explicitly set entity material density (rho=1000 in build_usd_scene) overrides the authored
     # per-geom densities, as material friction does for authored frictions: unit cubes weigh 1000 kg.
@@ -390,7 +390,7 @@ def test_align_anchor_with_geom_densities(density_align_usd):
     # for the rigid body and its kinematic ghost.
     assert_allclose(body.get_mass(), 400.0, tol=gs.EPS)
     assert_allclose(body.base_link.get_pos(relative=False), (0.25, 0.0, 0.0), tol=gs.EPS)
-    assert_allclose(body.base_link.inertial_pos, 0.0, tol=gs.EPS)
+    assert_allclose(body.base_link.desc.inertial_pos, 0.0, tol=gs.EPS)
     assert_allclose(ghost.base_link.get_pos(relative=False), (0.25, 0.0, 0.0), tol=gs.EPS)
 
 
@@ -544,7 +544,7 @@ def test_oriented_capsule(oriented_capsule_usd, show_viewer, tol):
     assert capsule.n_geoms >= 1
     assert capsule.n_vgeoms >= 1
     for vgeom, geom in zip(capsule.vgeoms, capsule.geoms):
-        assert_allclose(vgeom._init_quat, geom._init_quat, tol=gs.EPS)
+        assert_allclose(vgeom.init_quat, geom.init_quat, tol=gs.EPS)
         # Capsule with axis=X has identity quat — axis rotation not composed into geom_Q.
         with pytest.raises(AssertionError):
             assert_allclose(geom.get_quat(), (1.0, 0.0, 0.0, 0.0), atol=tol)

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -270,20 +270,20 @@ def test_urdf_parsing_inertia_defaults(
         ),
     )
 
-    assert entity_with_implicit_origin.base_link.inertial_pos is None
+    assert entity_with_implicit_origin.base_link.desc.inertial_pos is None
 
     with caplog.at_level("WARNING"):
         scene.build()
 
     # An omitted inertial origin places the center of mass at the link frame, whereas a link without any inertial
     # element derives it from the geometry.
-    assert_allclose(entity_without_inertia.base_link.inertial_pos, GEOM_POS, tol=tol)
-    assert_allclose(entity_with_implicit_origin.base_link.inertial_pos, 0.0, tol=gs.EPS)
-    assert_allclose(entity_with_implicit_origin.base_link.inertial_mass, 2.5, tol=gs.EPS)
+    assert_allclose(entity_without_inertia.base_link.desc.inertial_pos, GEOM_POS, tol=tol)
+    assert_allclose(entity_with_implicit_origin.base_link.desc.inertial_pos, 0.0, tol=gs.EPS)
+    assert_allclose(entity_with_implicit_origin.base_link.desc.mass, 2.5, tol=gs.EPS)
     # The tensor is stored in its principal frame, whose parsed quaternion is markedly less accurate than the tensor
     # itself, so compare the rotation-invariant principal moments rather than the tensor rotated back.
     assert_allclose(
-        np.linalg.eigvalsh(entity_with_implicit_origin.base_link.inertial_i),
+        np.linalg.eigvalsh(entity_with_implicit_origin.base_link.desc.inertia),
         np.linalg.eigvalsh(INERTIA),
         tol=tol,
     )
@@ -298,8 +298,8 @@ def test_urdf_parsing_inertia_defaults(
     # code paths, so their agreement is bounded by that cross-path floor rather than by the storage precision.
     assert_allclose(entity_chain_unmerged.get_mass(), entity_chain_merged.get_mass(), rtol=5e-7)
     assert_allclose(
-        np.linalg.eigvalsh(entity_chain_unmerged.base_link.inertial_i),
-        np.linalg.eigvalsh(entity_chain_merged.base_link.inertial_i),
+        np.linalg.eigvalsh(entity_chain_unmerged.base_link.desc.inertia),
+        np.linalg.eigvalsh(entity_chain_merged.base_link.desc.inertia),
         rtol=5e-7,
     )
 
@@ -483,10 +483,10 @@ def test_urdf_joint_dynamics(joint_damping, joint_friction, xml_path):
     scene.build()
     expected_damping = 0.0 if joint_damping is None else joint_damping
     expected_frictionloss = 0.0 if joint_friction is None else joint_friction
-    assert_allclose(robot.joints[0].dofs_damping, 0.0, tol=gs.EPS)
-    assert_allclose(robot.joints[1].dofs_damping, expected_damping, tol=gs.EPS)
-    assert_allclose(robot.joints[0].dofs_frictionloss, 0.0, tol=gs.EPS)
-    assert_allclose(robot.joints[1].dofs_frictionloss, expected_frictionloss, tol=gs.EPS)
+    assert_allclose(robot.joints[0].desc.dofs_damping, 0.0, tol=gs.EPS)
+    assert_allclose(robot.joints[1].desc.dofs_damping, expected_damping, tol=gs.EPS)
+    assert_allclose(robot.joints[0].desc.dofs_frictionloss, 0.0, tol=gs.EPS)
+    assert_allclose(robot.joints[1].desc.dofs_frictionloss, expected_frictionloss, tol=gs.EPS)
 
 
 @pytest.mark.slow  # ~200s
@@ -742,7 +742,7 @@ def test_robot_scale_and_dofs_armature(xml_path, tol):
         attr_orig.setdefault("mass", mass)
         assert_allclose(mass, attr_orig["mass"], tol=tol)
 
-        inertia = np.stack([link.inertial_i for link in robot.links], axis=0) / scale**5
+        inertia = np.stack([link.desc.inertia for link in robot.links], axis=0) / scale**5
         attr_orig.setdefault("inertia", inertia)
         assert_allclose(inertia, attr_orig["inertia"], tol=tol)
 

--- a/tests/rigid/test_collision_nonconvex.py
+++ b/tests/rigid/test_collision_nonconvex.py
@@ -346,7 +346,7 @@ def test_overlap(show_viewer):
     # Constraint stabilization alone resolves the overlap, so it cannot separate the apples faster than
     # overlap / timeconst; a spurious deep contact catapults them an order of magnitude above that ceiling.
     # Contact impulses being internal to the pair, its total momentum must stay zero.
-    v_sep_max = apples_overlap / float(geom.sol_params[0])
+    v_sep_max = apples_overlap / float(geom.desc.sol_params[0])
     assert np.linalg.norm(tensor_to_array(apples[1].get_vel() - apples[0].get_vel())) < v_sep_max
     assert_allclose(apples[0].get_vel() + apples[1].get_vel(), 0, atol=1e-6)
     # The apples must separate by at least the overlap, but no more than the stabilization drift accumulates

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -42,7 +42,7 @@ def test_equality_link(gs_sim, mj_sim, gs_solver, xml_path):
     TIME_CONSTANT = 0.02
     for entity in gs_sim.entities:
         for equality in entity.equalities:
-            equality.set_sol_params((TIME_CONSTANT, *tensor_to_array(equality.sol_params)[1:]))
+            equality.set_sol_params((TIME_CONSTANT, *tensor_to_array(equality.desc.sol_params)[1:]))
     mj_sim.model.eq_solref[:, 0] = TIME_CONSTANT
 
     # Randomize the initial condition for force convergence of the constraints
@@ -285,9 +285,9 @@ def test_set_sol_params(n_envs, batched, tol):
 
     for objs, batched in ((robot.joints, batched), (robot.geoms, False), (robot.equalities, True)):
         for obj in objs:
-            sol_params = obj.sol_params + 1.0
+            sol_params = obj.get_sol_params() + 1.0
             obj.set_sol_params(sol_params)
             with pytest.raises(AssertionError):
-                assert_allclose(obj.sol_params, sol_params, tol=tol)
+                assert_allclose(obj.get_sol_params(), sol_params, tol=tol)
             obj.set_sol_params([0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0])
-            assert_allclose(obj.sol_params, [2.0e-02, 0.5, 1e-4, 1e-4, 0.0, 1e-4, 1.0], tol=tol)
+            assert_allclose(obj.get_sol_params(), [2.0e-02, 0.5, 1e-4, 1e-4, 0.0, 1e-4, 1.0], tol=tol)

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -268,7 +268,7 @@ def test_apply_external_wrench(xml_path, show_viewer):
         elif step == 800:
             assert_allclose(ee_pos, (-0.8 / math.sqrt(2), 0.8 / math.sqrt(2), 0.02), tol=0.02)
         assert_allclose(duck_pos, duck_init_link_pos, tol=1e-3)
-        assert_allclose(duck_quat, duck.base_link.quat, tol=1e-3)
+        assert_allclose(duck_quat, duck.base_link.desc.quat, tol=1e-3)
 
         if step >= 600:
             force = [-4.0, 4.0, 0.0]
@@ -302,8 +302,9 @@ def test_apply_external_wrench(xml_path, show_viewer):
     # A local force and a local application point are both expressed in the frame that 'ref' designates, which only
     # shows on a link whose inertial frame is rotated with respect to its own frame.
     base_link = robot.get_link("base")
-    assert not np.allclose(base_link.inertial_quat, gu.identity_quat())
-    base_inertial_quat = torch.as_tensor(base_link.inertial_quat, device=gs.device)
+    with pytest.raises(AssertionError):
+        assert_allclose(base_link.desc.inertial_quat, gu.identity_quat(), tol=gs.EPS)
+    base_inertial_quat = torch.as_tensor(base_link.desc.inertial_quat, device=gs.device)
     base_link_pos = rigid_solver.get_links_pos(base_link.idx)
     base_link_quat = rigid_solver.get_links_quat(base_link.idx)
     base_link_COM = rigid_solver.get_links_pos(base_link.idx, ref=gs.link_ref_frame.link_COM)

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -259,7 +259,7 @@ def test_static_friction(mode, friction, n_boxes, solver, scale, mesh_boxes, sho
     # Start every box at its static equilibrium instead of dropping it onto the stack, since the landing transient
     # proves nothing that the holding phase does not. The rest force of a contact is f(d) = k * imp(d)^2 * d / ((1 -
     # imp(d)) * inv_w) with the translation-only inverse weight, and friction still bootstraps at the first step.
-    timeconst, dampratio, dmin, dmax, width, mid, power = tensor_to_array(floating_boxes[0].geoms[0].sol_params)
+    timeconst, dampratio, dmin, dmax, width, mid, power = tensor_to_array(floating_boxes[0].geoms[0].get_sol_params())
     k_stiff = 1.0 / (dmax * dmax * timeconst * timeconst * dampratio * dampratio)
     push = -SAFETY_FACTOR * force_x
     inv_mass = [1.0 / masses[k] + (1.0 / masses[k - 1] if k > 0 else 0.0) for k in range(n_boxes)]
@@ -440,8 +440,8 @@ def test_static_hold_unaffected_by_press_on_separate_body(show_viewer):
     assert_allclose(geom.get_friction(), scene.rigid_solver.get_geoms_friction(geom.idx), tol=gs.EPS)
     assert_allclose(geom.get_friction(), 0.37, tol=gs.EPS)
     assert_allclose(geom.get_friction_rolling(), 0.02, tol=gs.EPS)
-    assert_allclose(geom.friction, FRICTION, tol=gs.EPS)
-    assert_allclose(geom.sol_params, scene.rigid_solver.get_sol_params(geoms_idx=geom.idx)[0], tol=gs.EPS)
+    assert_allclose(geom.desc.friction, FRICTION, tol=gs.EPS)
+    assert_allclose(geom.get_sol_params(), scene.rigid_solver.get_sol_params(geoms_idx=geom.idx)[0], tol=gs.EPS)
 
 
 @pytest.mark.required

--- a/tests/utils/mujoco_parity.py
+++ b/tests/utils/mujoco_parity.py
@@ -7,7 +7,7 @@ import pytest
 
 import genesis as gs
 import genesis.utils.geom as gu
-from genesis.utils.misc import qd_to_numpy
+from genesis.utils.misc import qd_to_numpy, tensor_to_array
 
 from .assertions import assert_allclose
 
@@ -378,13 +378,18 @@ def check_mujoco_model_consistency(
     mj_dof_dof_frictionloss = mj_sim.model.dof_frictionloss
     assert_allclose(gs_dof_dof_frictionloss[gs_dofs_idx], mj_dof_dof_frictionloss[mj_dofs_idx], tol=tol)
 
-    gs_joint_solparams = np.array([joint.sol_params.cpu() for entity in gs_sim.entities for joint in entity.joints])
+    # Solver parameters carry an environment axis wherever the joint info is batched, while the model states one
+    # value per joint, so compare the first environment against it.
+    joints_idx = range(gs_sim.rigid_solver.n_joints)
+    gs_joints_solparams = tensor_to_array(gs_sim.rigid_solver.get_sol_params(joints_idx=joints_idx))
+    gs_joint_solparams = gs_joints_solparams[0] if gs_joints_solparams.ndim == 3 else gs_joints_solparams
     mj_joint_solparams = np.concatenate((mj_sim.model.jnt_solref, mj_sim.model.jnt_solimp), axis=-1)
     _sanitize_sol_params(
         mj_joint_solparams, gs_sim.rigid_solver._sol_min_timeconst, gs_sim.rigid_solver._sol_default_timeconst
     )
     assert_allclose(gs_joint_solparams[gs_joints_idx], mj_joint_solparams[mj_joints_idx], tol=tol)
-    gs_geom_solparams = np.array([geom.sol_params.cpu() for entity in gs_sim.entities for geom in entity.geoms])
+    gs_geoms_solparams = tensor_to_array(gs_sim.rigid_solver.get_sol_params(geoms_idx=None))
+    gs_geom_solparams = gs_geoms_solparams[0] if gs_geoms_solparams.ndim == 3 else gs_geoms_solparams
     mj_geom_solparams = np.concatenate((mj_sim.model.geom_solref, mj_sim.model.geom_solimp), axis=-1)
     # Geom time constants are compared as the model states them: a contact mixes the two geoms' values and the floor is
     # applied to that mix, so flooring per geom here would expect a value neither engine stores.
@@ -397,7 +402,7 @@ def check_mujoco_model_consistency(
     assert_allclose(gs_geom_solparams[gs_geoms_idx], mj_geom_solparams[mj_geoms_idx], tol=tol)
     # FIXME: Masking geometries and equality constraints is not supported for now
     gs_eq_solparams = np.array(
-        [equality.sol_params.cpu() for entity in gs_sim.entities for equality in entity.equalities]
+        [tensor_to_array(equality.get_sol_params()) for entity in gs_sim.entities for equality in entity.equalities]
     ).reshape((-1, 7))
     mj_eq_solparams = np.concatenate((mj_sim.model.eq_solref, mj_sim.model.eq_solimp), axis=-1)
     _sanitize_sol_params(

--- a/tests/utils/simulators.py
+++ b/tests/utils/simulators.py
@@ -172,13 +172,13 @@ def build_genesis_sim(
 
     # Force recomputation of invweights to make sure it works fine
     for link in scene.rigid_solver.links:
-        link.invweight[:] = -1
+        link.desc.invweight[:] = -1
     for joint in scene.rigid_solver.joints:
-        joint.dofs_invweight[:] = -1
+        joint.desc.dofs_invweight[:] = -1
 
     # Canonicalize mesh center-of-mass dust to zero: see the matching body_ipos normalization in build_mujoco_sim.
     for link in scene.rigid_solver.links:
-        link.inertial_pos[np.abs(link.inertial_pos) < 1e-12] = 0.0
+        link.desc.inertial_pos[np.abs(link.desc.inertial_pos) < 1e-12] = 0.0
 
     scene.build()
 


### PR DESCRIPTION
## Description

Every rigid parser (MJCF, URDF, USD, primitive, mesh, terrain) now fills typed records - `LinkDescription`, `JointDescription`, `GeomDescription`, `EqualityDescription` - instead of dictionaries of untyped keys, and each record resolves its own defaults, so no consumer applies a fallback of its own. A built link, joint, geom or equality constraint keeps its record as `desc` rather than copying its fields.

The properties reporting a value the simulation can change are removed: `link.pos`, `link.quat`, `link.inertial_pos`, `link.inertial_quat`, `link.inertial_mass`, `link.inertial_i`, `link.invweight`, `geom.friction`, `geom.friction_torsional`, `geom.friction_rolling`, `sol_params` on geom, joint and equality, and every `joint.dofs_*` a setter writes. Read `link.desc.mass` for the value the build gave, `link.get_mass()` for the value the solver uses. `get_sol_params()` is new on geom, joint and equality, which had a setter and no getter. The description names each quantity as its accessor does, so `inertial_mass` and `inertial_i` become `mass` and `inertia`.

`SPHOptions` and `PBDOptions` resolved their hash-grid resolution through `gs.np_int`, so instantiating either before `gs.init` raised. The resolution is a count of cells and no longer carries a runtime dtype, which is what lets every solver option be created before a backend is chosen.

## Motivation and Context

An entity was both the description of what an asset says and a view of the solver arrays, so a build-time copy and a runtime value could disagree while both were reachable through similarly-named attributes. Reading `geom.friction` after `set_friction` returned the value the geom was built with, which is a plausible way to measure the wrong thing.

## How Has This Been / Can This Be Tested?

`tests/parsers` compares parsed models field by field through the descriptions, and the rigid, integration and coupling suites exercise the build end to end. A scene of a plane, a box, a sphere, a mesh, an MJCF robot and a URDF robot builds to identical link, joint, dof and geom counts, identical per-link mass, and an identical trajectory.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.


