### PR TITLE
[BREAKING][BUG FIX] Restore the whole simulation state from a checkpoint.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -9,10 +9,9 @@ from typing import TYPE_CHECKING, Callable, Iterable, Literal, overload
 
 import numpy as np
 import torch
-import quadrants as qd
-from quadrants.lang import impl
 
 import genesis as gs
+import genesis.utils.array_class as array_class
 import genesis.utils.geom as gu
 import genesis.utils.mesh as mu
 from genesis.engine.force_fields import ForceField
@@ -1521,26 +1520,17 @@ class Scene(RBC):
         self._backward_ready = False
         self._forward_ready = False
 
-    def dump_ckpt_to_numpy(self) -> dict[str, np.ndarray]:
+    def _array_roots(self):
+        """Return the holders of every array the scene holds, each paired with its key prefix.
+
+        The coupler belongs to a pair of solvers and to neither of them, and it owns the state of their exchange (the
+        link each particle is attached to, and the contact normals of the last exchange).
         """
-        Collect every Quadrants field in the **scene and its active solvers** and
-        return them as a flat ``{key: ndarray}`` dictionary.
-
-        Returns
-        -------
-        dict[str, np.ndarray]
-            Mapping ``"Class.attr[.member]" -> array`` with raw field data.
-        """
-        arrays: dict[str, np.ndarray] = {}
-
-        for name, value in self.__dict__.items():
-            if isinstance(value, (qd.Tensor, qd.Field, qd.Ndarray)):
-                arrays[".".join((self.__class__.__name__, name))] = value.to_numpy()
-
+        coupler = self._sim.coupler
+        roots = [(self.__class__.__name__, self), (type(coupler).__name__, coupler)]
         for solver in self.active_solvers:
-            arrays.update(solver.dump_ckpt_to_numpy())
-
-        return arrays
+            roots.extend(solver._array_roots())
+        return tuple(roots)
 
     @gs.assert_built
     def save_checkpoint(self, path: str | os.PathLike) -> None:
@@ -1555,8 +1545,8 @@ class Scene(RBC):
         state = {
             "timestamp": time.time(),
             "step_index": self._sim.cur_step_global,
-            "steps": tensor_to_array(self._sim._steps),
-            "arrays": self.dump_ckpt_to_numpy(),
+            "steps": self._sim._steps,
+            "arrays": array_class.dump_arrays(self._array_roots()),
         }
         with open(path, "wb") as f:
             pickle.dump(state, f, protocol=pickle.HIGHEST_PROTOCOL)
@@ -1574,21 +1564,14 @@ class Scene(RBC):
         with open(path, "rb") as f:
             state = pickle.load(f)
 
-        arrays = state["arrays"]
-
-        for name, value in self.__dict__.items():
-            if isinstance(value, (qd.Tensor, qd.Field, qd.Ndarray)):
-                key = ".".join((self.__class__.__name__, name))
-                if key in arrays:
-                    value.from_numpy(arrays[key])
-
-        for solver in self.active_solvers:
-            solver.load_ckpt_from_numpy(arrays)
+        array_class.load_arrays(self._array_roots(), state["arrays"])
+        if gs.use_zerocopy and gs.backend == gs.metal:
+            torch.mps.synchronize()
 
         # Two clocks, and neither stands for the other: the tape is indexed by how many times the host called step,
         # while what each environment has simulated is its own and survives a reset of its neighbours.
         self._sim._cur_substep_global = state["step_index"] * self._sim.substeps
-        self._sim._steps[:] = torch.as_tensor(state["steps"], device=gs.device)
+        self._sim._steps[:] = state["steps"].to(gs.device)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- utilities --------------------------------------

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -1,4 +1,3 @@
-import dataclasses
 import enum
 import functools
 import inspect
@@ -356,76 +355,17 @@ class Solver(RBC):
     def build(self):
         self._B = self._sim._B
 
-    def _iter_data_manager_tensors(self):
-        """Yield (store name, tensor) for every tensor reachable from the data manager, descending through the
-        nested per-component dataclasses."""
+    def _array_roots(self):
+        """Return the holders of the arrays this solver owns, each paired with its key prefix.
 
-        def walk(prefix, struct):
-            if dataclasses.is_dataclass(struct):
-                for field in dataclasses.fields(struct):
-                    yield from walk(f"{prefix}.{field.name}", getattr(struct, field.name))
-            elif isinstance(struct, (qd.Tensor, qd.Field, qd.Ndarray)):
-                yield prefix, struct
-
-        for attr_name, struct in self.data_manager.__dict__.items():
-            yield from walk(f"{self.__class__.__name__}.data_manager.{attr_name}", struct)
-
-    def dump_ckpt_to_numpy(self) -> dict[str, np.ndarray]:
-        arrays: dict[str, np.ndarray] = {}
-
-        for attr_name, value in self.__dict__.items():
-            if not isinstance(value, (qd.Tensor, qd.Field, qd.Ndarray)):
-                continue
-
-            key_base = ".".join((self.__class__.__name__, attr_name))
-            data = value.to_numpy()
-
-            # StructField -> data is a dict: flatten each member
-            if isinstance(data, dict):
-                for sub_name, sub_arr in data.items():
-                    arrays[f"{key_base}.{sub_name}"] = sub_arr
-            else:
-                arrays[key_base] = data
-
+        Each holder is named here because an array is reachable through several attributes, and a walk that follows
+        every reference reaches the simulator and from there the state of another solver.
+        """
+        name = self.__class__.__name__
+        roots = ((name, self),)
         if self.data_manager is not None:
-            for store_name, sub_arr in self._iter_data_manager_tensors():
-                arrays[store_name] = sub_arr.to_numpy()
-
-        return arrays
-
-    def load_ckpt_from_numpy(self, arr_dict: dict[str, np.ndarray]) -> None:
-        for attr_name, value in self.__dict__.items():
-            if not isinstance(value, (qd.Tensor, qd.Field, qd.Ndarray)):
-                continue
-
-            key_base = ".".join((self.__class__.__name__, attr_name))
-            member_prefix = key_base + "."
-
-            # ---- StructField: gather its members -----------------------------
-            member_items = {}
-            for saved_key, saved_arr in arr_dict.items():
-                if saved_key.startswith(member_prefix):
-                    sub_name = saved_key[len(member_prefix) :]
-                    member_items[sub_name] = saved_arr
-
-            if member_items:  # we found at least one sub-member
-                value.from_numpy(member_items)
-                continue
-
-            # ---- Ordinary field ---------------------------------------------
-            if key_base not in arr_dict:
-                continue  # nothing saved for this attribute
-
-            arr = arr_dict[key_base]
-            value.from_numpy(arr)
-
-        # if it has data_manager, add it to the arrays
-        if self.data_manager is not None:
-            for store_name, sub_arr in self._iter_data_manager_tensors():
-                if store_name in arr_dict:
-                    sub_arr.from_numpy(arr_dict[store_name])
-                else:
-                    gs.logger.warning(f"Failed to load {store_name}. Not found in stored arrays.")
+            roots = (*roots, (f"{name}.data_manager", self.data_manager))
+        return roots
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1368,7 +1368,8 @@ class KinematicSolver(Solver):
         if n_links > n_tgts:
             gs.raise_exception(f"Cannot solve for {n_links} targets. Raise 'IK_max_targets' above {n_tgts}.")
 
-        ik_state, ik_fk, targets = self.data_manager.ik_scratch
+        scratch = self.data_manager.ik_scratch
+        ik_state, ik_fk, targets = scratch.state, scratch.fk, scratch.targets
 
         # Only the leading rows each buffer holds for this solve are written, and the kernel reads no further.
         if gs.use_zerocopy:

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2909,6 +2909,17 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         tensor = qd_to_torch(self.dyn_info.links.inertial_pos, envs_idx, links_idx, transpose=True, copy=True)
         return tensor[0] if self.n_envs == 0 and self._options.batch_links_info else tensor
 
+    def _array_roots(self):
+        # The collider and the constraint solver own the contacts and the warm start, which a scene resumed from a
+        # checkpoint carries over for its next step to match the step that followed the state it was saved at.
+        name = self.__class__.__name__
+        roots = super()._array_roots()
+        if self.collider is not None:
+            roots = (*roots, (f"{name}.collider", self.collider))
+        if self.constraint_solver is not None:
+            roots = (*roots, (f"{name}.constraint_solver", self.constraint_solver))
+        return roots
+
     @property
     def is_links_info_batched(self) -> bool:
         """Whether the inertial properties of a link are stored per environment rather than shared by the batch."""

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1,7 +1,6 @@
 import dataclasses
 import math
 from enum import IntEnum
-from typing import NamedTuple
 
 import quadrants as qd
 from typing_extensions import dataclass_transform  # Made it into standard lib from Python 3.12
@@ -9,6 +8,7 @@ import numpy as np
 import torch
 
 import genesis as gs
+from genesis.utils.misc import qd_to_torch
 
 
 def _tensor_backend():
@@ -75,6 +75,59 @@ def V_SCALAR_FROM(dtype, value):
     data = V(dtype=dtype, shape=())
     data.fill(value)
     return data
+
+
+def _iter_struct_arrays(prefix, struct):
+    if dataclasses.is_dataclass(struct):
+        for field in dataclasses.fields(struct):
+            yield from _iter_struct_arrays(f"{prefix}.{field.name}", getattr(struct, field.name))
+    elif isinstance(struct, qd.StructField):
+        # Each member of a struct field is a field of its own, under either memory layout
+        for member_name in struct.keys:
+            yield from _iter_struct_arrays(f"{prefix}.{member_name}", getattr(struct, member_name))
+    elif isinstance(struct, (qd.Tensor, qd.Field, qd.Ndarray)):
+        yield prefix, struct
+
+
+def iter_arrays(roots):
+    """Yield (dotted name, array) for every array the given roots hold, each root a (name, holder) pair.
+
+    A holder contributes the attributes of its own '__dict__', each followed through nested dataclasses, so the walk
+    covers what the holder owns and stops at any other kind of object. Only attributes already present are read, so a
+    structure a holder creates on demand joins the walk from the moment it exists.
+    """
+    for prefix, root in roots:
+        for attr_name, struct in root.__dict__.items():
+            yield from _iter_struct_arrays(f"{prefix}.{attr_name}", struct)
+
+
+def dump_arrays(roots) -> dict[str, torch.Tensor]:
+    """Read every array the given roots hold into a flat {dotted name: tensor} mapping.
+
+    Each tensor windows onto the buffer it was read from wherever zero-copy allows, so the mapping holds the state
+    the scene is in at the call and follows it from the next step on.
+    """
+    return {key: qd_to_torch(value) for key, value in iter_arrays(roots)}
+
+
+def load_arrays(roots, arrays) -> None:
+    """Refill every array the given roots hold from a mapping 'dump_arrays' produced, warning about each one it misses.
+
+    Metal leaves the writes on the torch stream, so a caller launching a kernel over these buffers synchronizes first.
+    """
+    for key, value in iter_arrays(roots):
+        saved = arrays.get(key)
+        if saved is None:
+            gs.logger.warning(f"Failed to load {key}. Not found in stored arrays.")
+            continue
+
+        if gs.use_zerocopy:
+            view = qd_to_torch(value, copy=False)
+            if tuple(view.shape) != tuple(saved.shape):
+                gs.raise_exception(f"Shape {tuple(saved.shape)} stored for {key}, which holds {tuple(view.shape)}.")
+            view.copy_(saved)
+        else:
+            value.from_torch(saved)
 
 
 # =========================================== ErrorCode ===========================================
@@ -551,7 +604,8 @@ def get_kinematics_scratch(solver):
     )
 
 
-class WeightScratch(NamedTuple):
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class WeightScratch:
     """Buffers used to compute the constraint inverse weights of one solver.
 
     One weight needs one row of a link Jacobian and the mass-matrix solve against that row, which is what these two
@@ -569,7 +623,8 @@ def get_weight_scratch(solver):
     )
 
 
-class IKScratch(NamedTuple):
+@dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
+class IKScratch:
     """The three solve-time buffers an inverse-kinematics call needs, shared by every entity of one solver.
 
     Sized by the largest entity the solver holds and by the target cap, so each solve writes the leading rows its own

--- a/tests/particles/test_pbd.py
+++ b/tests/particles/test_pbd.py
@@ -179,7 +179,7 @@ def test_cloth_attach_fixed_point(n_envs, material_type, show_viewer, tol):
 
 
 @pytest.mark.required
-def test_cloth_attach_rigid_link(show_viewer):
+def test_cloth_attach_rigid_link(tmp_path, show_viewer):
     particle_size = 0.01
     box_height = 2.25
 
@@ -253,6 +253,9 @@ def test_cloth_attach_rigid_link(show_viewer):
     link_pos1 = scene.rigid_solver.links[box_link_idx].get_pos().clone()
     assert_allclose((cloth_pos1 - cloth_pos0).movedim(0, -2), link_pos1 - link_pos0, atol=2e-5)
 
+    ckpt_path = tmp_path / "attached.pkl"
+    scene.save_checkpoint(ckpt_path)
+
     # Release cloth and restore box's speed
     box.set_dofs_velocity(vel, dofs_idx_local=[0, 1, 2])
     cloth.release_particle(particles_idx)
@@ -265,3 +268,15 @@ def test_cloth_attach_rigid_link(show_viewer):
     link_disp = link_pos2 - link_pos1
     cloth_disp = cloth_pos2 - cloth_pos1
     assert ((cloth_disp.movedim(0, -2) - link_disp).norm(dim=-1) > 0.2).all()
+
+    # The coupling owns the link a particle is attached to, so a checkpoint taken while the cloth is attached
+    # restores the attachment and the cloth travels with the link again.
+    scene.load_checkpoint(ckpt_path)
+    box.set_dofs_velocity(vel, dofs_idx_local=[0, 1, 2])
+    cloth_pos3 = cloth.get_particles_pos()[:, particles_idx].clone()
+    link_pos3 = scene.rigid_solver.links[box_link_idx].get_pos().clone()
+    for _ in range(10):
+        scene.step()
+    cloth_pos4 = cloth.get_particles_pos()[:, particles_idx]
+    link_pos4 = scene.rigid_solver.links[box_link_idx].get_pos()
+    assert_allclose((cloth_pos4 - cloth_pos3).movedim(0, -2), link_pos4 - link_pos3, atol=2e-5)

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -1231,6 +1231,18 @@ def test_scene_saver_franka(tmp_path, show_viewer, tol):
             file="xml/franka_emika_panda/panda.xml",
         ),
     )
+    scene1.add_entity(
+        gs.morphs.Plane(),
+    )
+    boxes1 = [
+        scene1.add_entity(
+            gs.morphs.Box(
+                pos=(0.6, 0.0, 0.1 + 0.21 * i),
+                size=(0.2, 0.2, 0.2),
+            ),
+        )
+        for i in range(3)
+    ]
     scene1.build()
 
     dof_idx = [j.dofs_idx_local[0] for j in franka1.joints]
@@ -1255,6 +1267,16 @@ def test_scene_saver_franka(tmp_path, show_viewer, tol):
             file="xml/franka_emika_panda/panda.xml",
         ),
     )
+    scene2.add_entity(
+        gs.morphs.Plane(),
+    )
+    for i in range(3):
+        scene2.add_entity(
+            gs.morphs.Box(
+                pos=(0.6, 0.0, 0.1 + 0.21 * i),
+                size=(0.2, 0.2, 0.2),
+            ),
+        )
     scene2.build()
     scene2.load_checkpoint(ckpt_path)
 
@@ -1266,6 +1288,17 @@ def test_scene_saver_franka(tmp_path, show_viewer, tol):
     # A checkpoint carries how long each environment had simulated, so the loaded scene reports the time of the pose
     # it restored rather than the one it had reached on its own.
     assert_allclose(scene1.get_time(), scene2.get_time(), tol=gs.EPS)
+
+    # A checkpoint restores every array the solver owns, contacts and warm start included, so a scene resumed from
+    # one steps exactly as it stepped from the state it was saved at.
+    resumed = []
+    for _ in range(10):
+        scene1.step()
+        resumed.append(torch.stack([box.get_pos() for box in boxes1]))
+    scene1.load_checkpoint(ckpt_path)
+    for reference in resumed:
+        scene1.step()
+        assert_equal(torch.stack([box.get_pos() for box in boxes1]), reference)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

`Solver.dump_ckpt_to_numpy` read the arrays of the data manager and nothing else, so everything a solver's components own was left out of the file: the contacts and contact cache the collider holds, and the constraint state and warm start the constraint solver holds. `Scene.dump_ckpt_to_numpy` read the arrays the scene declares itself, so what the coupler holds was left out too - including which particle is attached to which link, which is the state of the coupling and belongs to no solver.

What holds arrays is now enumerated as `_array_roots`, on the scene and on each solver, each root paired with the name its keys start from. `RigidSolver` adds its collider and its constraint solver, and the scene adds its coupler. Roots are named rather than discovered because an array is reachable through several attributes and a walk that follows every reference leaves the solver entirely, through the simulator and into the state of another one.

`WeightScratch` and `IKScratch` were declared `NamedTuple` while every sibling structure in `array_class.py` is a frozen dataclass, and the walk descends dataclasses, so the buffers an inverse-kinematics solve allocates were invisible to it. Both are dataclasses now, which is also what the rest of the module's tooling expects of a structure holding arrays.

Reading and refilling a set of roots is one implementation, `array_class.dump_arrays` and `array_class.load_arrays`, used by the scene and by every solver, where the scene and the solver each had their own copy of the loop and its struct-field handling. An array a root only allocates on demand is walked once it exists, and the walk never brings it into being.

## Motivation and Context

A scene loaded from a checkpoint resumed from a state that was part the file's and part its own, and neither the save nor the load said so. It shows up as a resumed run that diverges from the run the checkpoint was taken on, and as a cloth that comes back detached from the link it was attached to when the file was written.

## How Has This Been / Can This Be Tested?

`test_scene_saver_franka` now stacks three boxes on a plane, so contacts and warm start exist, and asserts that a scene reloaded from a checkpoint replays the following steps identically rather than merely landing near the saved pose. `test_cloth_attach_rigid_link` takes a checkpoint while the cloth is attached, releases the particles, reloads, and asserts the cloth travels with the link again.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
