### PR TITLE
[MISC] Fix inverted --pile-type condition in the pyramid collision example.

### DIFF
--- a/examples/collision/pyramid.py
+++ b/examples/collision/pyramid.py
@@ -41,7 +41,7 @@ def main():
 
     # create pyramid of boxes
     box_size = 0.25
-    box_spacing = (1.0 - 1e-3 + 0.1 * (args.pile_type == "static")) * box_size
+    box_spacing = (1.0 - 1e-3 + 0.1 * (args.pile_type == "falling")) * box_size
     box_pos_offset = (-0.5, 1, 0.0) + 0.5 * np.array([box_size, box_size, box_size])
     boxes = {}
     for i in range(args.num_cubes):

--- a/examples/collision/pyramid.py
+++ b/examples/collision/pyramid.py
@@ -8,7 +8,7 @@ def main():
     parser.add_argument(
         "--pile-type",
         type=str,
-        default="falling",
+        default="static",
         choices=("static", "falling"),
         help="Whether the pile starts settled or falls into place",
     )


### PR DESCRIPTION
## Description

`examples/collision/pyramid.py` compares `--pile-type` against the wrong value, so each option produces the behavior of the other one.

```python
box_spacing = (1.0 - 1e-3 + 0.1 * (args.pile_type == "static")) * box_size
```

With `box_size = 0.25`:

| `--pile-type` | `box_spacing` | gap between adjacent boxes |
| --- | --- | --- |
| `static` | 0.27475 | +0.02475 — detached, falls into place |
| `falling` | 0.24975 | -0.00025 — in contact, already settled |

The `- 1e-3` term seeds contacts at `t = 0`, i.e. builds the settled pile, so the extra `0.1` spacing belongs to the `falling` branch. This changes the comparison to `"falling"`.

## Related Issue

Resolves #3285

## Motivation and Context

As written, `--pile-type static` drops the pyramid into place and `--pile-type falling` starts it fully settled, contradicting both the option names and the help string ("Whether the pile starts settled or falls into place"). The default is also switched from `"falling"` to `"static"`, so that running the example with no arguments keeps producing the settled pyramid it did before.

Example script only — no library API or solver behavior is touched.

## How Has This Been / Can This Be Tested?

```bash
python examples/collision/pyramid.py --pile-type static --vis
python examples/collision/pyramid.py --pile-type falling --vis
```

`static` now stays at rest; `falling` now drops into place.

`tests/test_examples.py` runs this script with no arguments and only asserts a zero exit code, so the examples CI job passes either way:

```bash
pytest -v -m examples tests/test_examples.py -k pyramid
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.