### PR TITLE
[BUG FIX] Support MJCF joint equalities without joint2 in the rigid solver.

### DIFF
--- a/genesis/engine/couplers/sap_coupler.py
+++ b/genesis/engine/couplers/sap_coupler.py
@@ -223,6 +223,10 @@ class SAPCoupler(RBC):
         self._enable_rigid_fem_contact &= self.rigid_solver.is_active and self.fem_solver.is_active
         self._enable_fem_self_tet_contact &= self.fem_solver.is_active
 
+        for equality in self.rigid_solver.equalities:
+            if equality.type == gs.EQUALITY_TYPE.JOINT and equality.eq_obj2id < 0:
+                gs.raise_exception("SAPCoupler does not support JOINT equality constraints without `joint2`.")
+
         init_tet_tables = False
 
         if self.fem_solver.is_active:

--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -198,11 +198,11 @@ class RigidLinkDescription(KinematicLinkDescription):
 
 @dataclass
 class RigidEqualityDescription:
-    """Describe one constraint tying two links or two joints of an entity together, named as the asset names them."""
+    """Describe a constraint between two links, two joints, or one joint and a constant, using their asset names."""
 
     name: str
     type: EQUALITY_TYPE
-    objs_name: tuple[str, str]
+    objs_name: tuple[str, str | None]
     data: np.ndarray
     sol_params: np.ndarray
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -1969,7 +1969,7 @@ class RigidEntity(KinematicEntity):
             case gs.EQUALITY_TYPE.CONNECT | gs.EQUALITY_TYPE.WELD:
                 objs_id = [self.get_link(obj_name).idx for obj_name in desc.objs_name]
             case gs.EQUALITY_TYPE.JOINT:
-                objs_id = [self.get_joint(obj_name).idx for obj_name in desc.objs_name]
+                objs_id = [self.get_joint(obj_name).idx if obj_name is not None else -1 for obj_name in desc.objs_name]
             case _:
                 gs.raise_exception(
                     f"Equality type {desc.type} not supported. Only CONNECT, JOINT, and WELD are supported."

--- a/genesis/engine/entities/rigid_entity/rigid_equality.py
+++ b/genesis/engine/entities/rigid_entity/rigid_equality.py
@@ -105,7 +105,7 @@ class RigidEquality(RBC):
     @property
     def eq_obj2id(self):
         """
-        Returns the index of the second object (joint for EQUALITY_TYPE.JOINT, link otherwise)
+        Returns the index of the second object, or -1 for a JOINT equality that fixes one joint to a constant.
         """
         return self._eq_obj2id
 

--- a/genesis/engine/solvers/rigid/constraint/backward.py
+++ b/genesis/engine/solvers/rigid/constraint/backward.py
@@ -825,15 +825,15 @@ def kernel_manual_add_equality_constraints_bw(
 ):
     """Manual reverse of `add_equality_constraints` (JOINT + CONNECT + WELD).
 
-    * JOINT   - couples two scalar dofs via a quartic polynomial (1 row).
+    * JOINT   - constrains one scalar dof, optionally against another via a quartic polynomial (1 row).
     * CONNECT - 3 rows pinning `global_anchor1` to `global_anchor2` in world.
     * WELD    - 6 rows: 3 position + 3 orientation, all sharing a single
                 combined `pos_imp = ||all_error||` (6D).
 
     Accumulates into kinematic-state grads only (conservative):
         JOINT:
-            rigid_info.qpos.grad[i_qpos1], qpos.grad[i_qpos2]
-            dyn_state.dofs.vel.grad[i_dof1], vel.grad[i_dof2]
+            rigid_info.qpos.grad[i_qpos1], and qpos.grad[i_qpos2] when joint2 exists
+            dyn_state.dofs.vel.grad[i_dof1], and vel.grad[i_dof2] when joint2 exists
         CONNECT / WELD:
             dyn_state.links.{pos, quat, root_COM, cd_ang, cd_vel}.grad[link1 / link2]
             dyn_state.dofs.{cdof_ang, cdof_vel, cdofd_ang, cdofd_vel, vel}.grad over each link chain
@@ -841,13 +841,13 @@ def kernel_manual_add_equality_constraints_bw(
     `dyn_info.links.invweight`) are not differentiated.
 
     Forward recap (per equality of type JOINT):
-        diff = qpos[i_qpos2] - qpos0[i_qpos2]
+        diff = qpos[i_qpos2] - qpos0[i_qpos2], or 0 when joint2 is omitted
         pos_poly = a0 + a1 * diff + a2 * diff^2 + a3 * diff^3 + a4 * diff^4
         pos = qpos[i_qpos1] - qpos0[i_qpos1] - pos_poly
         deriv = d(pos_poly)/d(diff) = a1 + 2 * a2 * diff + 3 * a3 * diff^2 + 4 * a4 * diff^3
         jac[n_con, i_dof1] = 1.0
-        jac[n_con, i_dof2] = -deriv
-        jac_qvel = vel[i_dof1] - deriv * vel[i_dof2]
+        jac[n_con, i_dof2] = -deriv, when joint2 exists
+        jac_qvel = vel[i_dof1] - deriv * vel[i_dof2], with the second term omitted when joint2 is omitted
         imp, aref = imp_aref(sol_params, -|pos|, jac_qvel, pos)
             aref = -b * jac_qvel - k * imp * pos
         diag = max(invweight * (1 - imp) / imp, EPS); efc_D = 1/diag
@@ -874,22 +874,21 @@ def kernel_manual_add_equality_constraints_bw(
                     if qd.static(rigid_config.batch_joints_info)
                     else dyn_info.equalities.eq_obj1id[i_e, i_b]
                 )
-                I_joint2 = (
-                    [dyn_info.equalities.eq_obj2id[i_e, i_b], i_b]
-                    if qd.static(rigid_config.batch_joints_info)
-                    else dyn_info.equalities.eq_obj2id[i_e, i_b]
-                )
                 i_qpos1 = dyn_info.joints.q_start[I_joint1]
-                i_qpos2 = dyn_info.joints.q_start[I_joint2]
                 i_dof1 = dyn_info.joints.dof_start[I_joint1]
-                i_dof2 = dyn_info.joints.dof_start[I_joint2]
                 I_dof1 = [i_dof1, i_b] if qd.static(rigid_config.batch_dofs_info) else i_dof1
-                I_dof2 = [i_dof2, i_b] if qd.static(rigid_config.batch_dofs_info) else i_dof2
 
                 pos1 = rigid_info.qpos[i_qpos1, i_b]
-                pos2 = rigid_info.qpos[i_qpos2, i_b]
                 ref1 = rigid_info.qpos0[i_qpos1, i_b]
-                ref2 = rigid_info.qpos0[i_qpos2, i_b]
+                i_joint2 = dyn_info.equalities.eq_obj2id[i_e, i_b]
+                i_qpos2 = -1
+                i_dof2 = -1
+                diff = gs.qd_float(0.0)
+                if i_joint2 >= 0:
+                    I_joint2 = [i_joint2, i_b] if qd.static(rigid_config.batch_joints_info) else i_joint2
+                    i_qpos2 = dyn_info.joints.q_start[I_joint2]
+                    i_dof2 = dyn_info.joints.dof_start[I_joint2]
+                    diff = rigid_info.qpos[i_qpos2, i_b] - rigid_info.qpos0[i_qpos2, i_b]
 
                 a0 = dyn_info.equalities.eq_data[i_e, i_b][0]
                 a1 = dyn_info.equalities.eq_data[i_e, i_b][1]
@@ -897,7 +896,6 @@ def kernel_manual_add_equality_constraints_bw(
                 a3 = dyn_info.equalities.eq_data[i_e, i_b][3]
                 a4 = dyn_info.equalities.eq_data[i_e, i_b][4]
 
-                diff = pos2 - ref2
                 diff2 = diff * diff
                 diff3 = diff2 * diff
                 diff4 = diff3 * diff
@@ -906,11 +904,17 @@ def kernel_manual_add_equality_constraints_bw(
                 d_deriv_d_diff = 2.0 * a2 + 6.0 * a3 * diff + 12.0 * a4 * diff2
 
                 jac1 = gs.qd_float(1.0)
-                jac2 = -deriv
+                jac2 = gs.qd_float(0.0)
                 vel1 = dyn_state.dofs.vel[i_dof1, i_b]
-                vel2 = dyn_state.dofs.vel[i_dof2, i_b]
-                jac_qvel = jac1 * vel1 + jac2 * vel2
-                invweight = dyn_info.dofs.invweight[I_dof1] + dyn_info.dofs.invweight[I_dof2]
+                vel2 = gs.qd_float(0.0)
+                jac_qvel = jac1 * vel1
+                invweight = dyn_info.dofs.invweight[I_dof1]
+                if i_joint2 >= 0:
+                    I_dof2 = [i_dof2, i_b] if qd.static(rigid_config.batch_dofs_info) else i_dof2
+                    jac2 = -deriv
+                    vel2 = dyn_state.dofs.vel[i_dof2, i_b]
+                    jac_qvel = jac_qvel + jac2 * vel2
+                    invweight = invweight + dyn_info.dofs.invweight[I_dof2]
 
                 sol_params = dyn_info.equalities.sol_params[i_e, i_b]
                 imp, b_coef, k_coef, d_imp_d_imp_x = gu.imp_aref_grad(sol_params, pos)
@@ -923,7 +927,9 @@ def kernel_manual_add_equality_constraints_bw(
                 g_aref = constraint_state.dL_daref[n_con, i_b]
                 g_efc_D = constraint_state.dL_defc_D[n_con, i_b]
                 # jac[dof1] = 1.0 (constant) => no chain through dL_djac[n_con, i_dof1].
-                g_jac2 = constraint_state.dL_djac[n_con, i_dof2, i_b]
+                g_jac2 = gs.qd_float(0.0)
+                if i_joint2 >= 0:
+                    g_jac2 = constraint_state.dL_djac[n_con, i_dof2, i_b]
 
                 # ---- Partials ----
                 # aref = -b * jac_qvel - k * imp * pos
@@ -952,11 +958,12 @@ def kernel_manual_add_equality_constraints_bw(
 
                 # ---- Propagate ----
                 dyn_state.dofs.vel.grad[i_dof1, i_b] += dL_d_jac_qvel * jac1
-                dyn_state.dofs.vel.grad[i_dof2, i_b] += dL_d_jac_qvel * jac2
                 # qpos1 enters only via pos (d_pos/d_pos1 = 1).
                 rigid_info.qpos.grad[i_qpos1, i_b] += dL_d_pos
-                # qpos2 enters via pos (d_pos/d_pos2 = -deriv) and deriv (d_deriv/d_diff).
-                rigid_info.qpos.grad[i_qpos2, i_b] += dL_d_pos * (-deriv) + dL_d_deriv * d_deriv_d_diff
+                if i_joint2 >= 0:
+                    dyn_state.dofs.vel.grad[i_dof2, i_b] += dL_d_jac_qvel * jac2
+                    # qpos2 enters via pos (d_pos/d_pos2 = -deriv) and deriv (d_deriv/d_diff).
+                    rigid_info.qpos.grad[i_qpos2, i_b] += dL_d_pos * (-deriv) + dL_d_deriv * d_deriv_d_diff
             elif dyn_info.equalities.eq_type[i_e, i_b] == gs.EQUALITY_TYPE.CONNECT:
                 # ----------------------------------------------------------
                 # CONNECT: 3 rows pin global_anchor1 == global_anchor2.

--- a/genesis/engine/solvers/rigid/constraint/backward.py
+++ b/genesis/engine/solvers/rigid/constraint/backward.py
@@ -847,7 +847,7 @@ def kernel_manual_add_equality_constraints_bw(
         deriv = d(pos_poly)/d(diff) = a1 + 2 * a2 * diff + 3 * a3 * diff^2 + 4 * a4 * diff^3
         jac[n_con, i_dof1] = 1.0
         jac[n_con, i_dof2] = -deriv, when joint2 exists
-        jac_qvel = vel[i_dof1] - deriv * vel[i_dof2], with the second term omitted when joint2 is omitted
+        jac_qvel = vel[i_dof1] - deriv * vel[i_dof2], the second term only when joint2 exists
         imp, aref = imp_aref(sol_params, -|pos|, jac_qvel, pos)
             aref = -b * jac_qvel - k * imp * pos
         diag = max(invweight * (1 - imp) / imp, EPS); efc_D = 1/diag

--- a/genesis/engine/solvers/rigid/constraint/island.py
+++ b/genesis/engine/solvers/rigid/constraint/island.py
@@ -64,7 +64,8 @@ def func_equality_links(i_eq, i_b, n_links, dyn_info: array_class.DynInfo, rigid
     lb = -1
     if eq_type == gs.EQUALITY_TYPE.JOINT:
         la = func_joint_link(obj1, i_b, n_links, dyn_info, rigid_config)
-        lb = func_joint_link(obj2, i_b, n_links, dyn_info, rigid_config)
+        if obj2 >= 0:
+            lb = func_joint_link(obj2, i_b, n_links, dyn_info, rigid_config)
     else:
         la = obj1
         lb = obj2

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1337,17 +1337,18 @@ def func_equality_joint(
         if qd.static(rigid_config.batch_joints_info)
         else dyn_info.equalities.eq_obj1id[i_e, i_b]
     )
-    I_joint2 = (
-        [dyn_info.equalities.eq_obj2id[i_e, i_b], i_b]
-        if qd.static(rigid_config.batch_joints_info)
-        else dyn_info.equalities.eq_obj2id[i_e, i_b]
-    )
     i_qpos1 = dyn_info.joints.q_start[I_joint1]
-    i_qpos2 = dyn_info.joints.q_start[I_joint2]
     i_dof1 = dyn_info.joints.dof_start[I_joint1]
-    i_dof2 = dyn_info.joints.dof_start[I_joint2]
     I_dof1 = [i_dof1, i_b] if qd.static(rigid_config.batch_dofs_info) else i_dof1
-    I_dof2 = [i_dof2, i_b] if qd.static(rigid_config.batch_dofs_info) else i_dof2
+
+    i_joint2 = dyn_info.equalities.eq_obj2id[i_e, i_b]
+    i_dof2 = -1
+    diff = gs.qd_float(0.0)
+    if i_joint2 >= 0:
+        I_joint2 = [i_joint2, i_b] if qd.static(rigid_config.batch_joints_info) else i_joint2
+        i_qpos2 = dyn_info.joints.q_start[I_joint2]
+        i_dof2 = dyn_info.joints.dof_start[I_joint2]
+        diff = rigid_info.qpos[i_qpos2, i_b] - rigid_info.qpos0[i_qpos2, i_b]
 
     n_con = qd.atomic_add(constraint_state.n_constraints[i_b], 1)
     qd.atomic_add(constraint_state.n_constraints_equality[i_b], 1)
@@ -1361,12 +1362,8 @@ def func_equality_joint(
             constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
 
     pos1 = rigid_info.qpos[i_qpos1, i_b]
-    pos2 = rigid_info.qpos[i_qpos2, i_b]
     ref1 = rigid_info.qpos0[i_qpos1, i_b]
-    ref2 = rigid_info.qpos0[i_qpos2, i_b]
 
-    # TODO: zero objid2
-    diff = pos2 - ref2
     pos = pos1 - ref1
     deriv = gs.qd_float(0.0)
 
@@ -1378,12 +1375,13 @@ def func_equality_joint(
             deriv = deriv + dyn_info.equalities.eq_data[i_e, i_b][i_5 + 1] * diff_power * (i_5 + 1)
 
     constraint_state.jac[n_con, i_dof1, i_b] = gs.qd_float(1.0)
-    constraint_state.jac[n_con, i_dof2, i_b] = -deriv
-    jac_qvel = (
-        constraint_state.jac[n_con, i_dof1, i_b] * dyn_state.dofs.vel[i_dof1, i_b]
-        + constraint_state.jac[n_con, i_dof2, i_b] * dyn_state.dofs.vel[i_dof2, i_b]
-    )
-    invweight = dyn_info.dofs.invweight[I_dof1] + dyn_info.dofs.invweight[I_dof2]
+    jac_qvel = dyn_state.dofs.vel[i_dof1, i_b]
+    invweight = dyn_info.dofs.invweight[I_dof1]
+    if i_joint2 >= 0:
+        I_dof2 = [i_dof2, i_b] if qd.static(rigid_config.batch_dofs_info) else i_dof2
+        constraint_state.jac[n_con, i_dof2, i_b] = -deriv
+        jac_qvel = jac_qvel - deriv * dyn_state.dofs.vel[i_dof2, i_b]
+        invweight = invweight + dyn_info.dofs.invweight[I_dof2]
 
     imp, aref = gu.imp_aref(sol_params, -qd.abs(pos), jac_qvel, pos)
 
@@ -1398,7 +1396,7 @@ def func_equality_joint(
     con_n_dofs = 0
     constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_dof1
     con_n_dofs += 1
-    if i_dof2 != i_dof1:
+    if i_joint2 >= 0 and i_dof2 != i_dof1:
         constraint_state.jac_dofs_idx[n_con, con_n_dofs, i_b] = i_dof2
         con_n_dofs += 1
     constraint_state.jac_n_dofs[n_con, i_b] = con_n_dofs

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -509,8 +509,9 @@ class FileMorph(Morph):
 
     Parameters
     ----------
-    file : str
-        The path to the file.
+    file : str or xml.etree.ElementTree.Element
+        The path to the file. An MJCF or URDF description built in memory is accepted as XML content in place of
+        the path, either as a string or as an element tree.
     scale : float or tuple, optional
         The scaling factor for the size of the entity. If a float, it scales uniformly.
         If a 3-tuple, it scales along each axis. Defaults to 1.0.
@@ -631,6 +632,12 @@ class FileMorph(Morph):
                 if not os.path.exists(abs_file):
                     gs.raise_exception(f"File not found in either current directory or assets directory: '{file}'.")
                 data["file"] = abs_file
+        elif isinstance(file, (ET.Element, ET.ElementTree)):
+            # An element tree is XML content by construction, so it is serialized to the inline string form the loaders
+            # read without the parse round-trip above.
+            if isinstance(file, ET.ElementTree):
+                file = file.getroot()
+            data["file"] = ET.tostring(file, encoding="unicode")
 
         return data
 
@@ -895,8 +902,8 @@ class MJCF(FileMorph):
 
     Parameters
     ----------
-    file : str
-        The path to the file.
+    file : str or xml.etree.ElementTree.Element
+        The path to the MJCF file, or the MJCF content itself as a string or an element tree.
     scale : float or tuple, optional
         The scaling factor for the size of the entity. If a float, it scales uniformly.
         If a 3-tuple, it scales along each axis. Defaults to 1.0.
@@ -1033,8 +1040,8 @@ class URDF(FileMorph):
 
     Parameters
     ----------
-    file : str
-        The path to the file.
+    file : str or xml.etree.ElementTree.Element
+        The path to the URDF file, or the URDF content itself as a string or an element tree.
     scale : float or tuple, optional
         The scaling factor for the size of the entity. If a float, it scales uniformly.
         If a 3-tuple, it scales along each axis. Defaults to 1.0.

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -883,7 +883,9 @@ def parse_equalities(mj, scale):
         elif mj.eq_type[i_e] == mujoco.mjtEq.mjEQ_JOINT:
             eq_info["type"] = gs.EQUALITY_TYPE.JOINT
             follower_scale = scale if mj.jnt_type[objs_idx[0]] == mujoco.mjtJoint.mjJNT_SLIDE else 1.0
-            driver_scale = scale if mj.jnt_type[objs_idx[1]] == mujoco.mjtJoint.mjJNT_SLIDE else 1.0
+            driver_scale = (
+                scale if objs_idx[1] >= 0 and mj.jnt_type[objs_idx[1]] == mujoco.mjtJoint.mjJNT_SLIDE else 1.0
+            )
 
             # eq_data[0:5] stores a0..a4 in q_follower - q_follower0 = sum(a_k * (q_driver - q_driver0)^k).
             # A model scale transforms a_k to s_f * a_k / s_d**k, where s_f and s_d are scale for prismatic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,13 +11,12 @@ from enum import Enum
 from io import BytesIO
 from pathlib import Path
 
-import pytest
-
-from _pytest.mark import Expression, MarkMatcher
-from PIL import Image
+import setproctitle
 import psutil
 import pyglet
-import setproctitle
+import pytest
+from _pytest.mark import Expression, MarkMatcher
+from PIL import Image
 from syrupy.extensions.image import PNGImageSnapshotExtension
 
 from tests.gpu_info import detect_gpu_backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,16 @@ import shutil
 import subprocess
 import sys
 import warnings
+import xml.etree.ElementTree as ET
 from argparse import SUPPRESS
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
 
-import setproctitle
 import psutil
 import pyglet
 import pytest
+import setproctitle
 from _pytest.mark import Expression, MarkMatcher
 from PIL import Image
 from syrupy.extensions.image import PNGImageSnapshotExtension
@@ -70,6 +71,19 @@ IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or has_egl
 
 TOL_SINGLE = 5e-5
 TOL_DOUBLE = 1e-9
+
+
+@pytest.fixture(scope="session")
+def single_joint_equality():
+    mjcf = ET.Element("mujoco", model="single_joint_equality")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    for name, pos in (("target", "0 0 0"), ("unrelated", "0 0.25 0")):
+        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=pos)
+        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
+        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
+    equality = ET.SubElement(mjcf, "equality")
+    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
+    return mjcf
 
 
 # Canonical skip reason registry.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,18 +6,18 @@ import shutil
 import subprocess
 import sys
 import warnings
-import xml.etree.ElementTree as ET
 from argparse import SUPPRESS
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
 
-import psutil
-import pyglet
 import pytest
-import setproctitle
+
 from _pytest.mark import Expression, MarkMatcher
 from PIL import Image
+import psutil
+import pyglet
+import setproctitle
 from syrupy.extensions.image import PNGImageSnapshotExtension
 
 from tests.gpu_info import detect_gpu_backend
@@ -71,19 +71,6 @@ IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or has_egl
 
 TOL_SINGLE = 5e-5
 TOL_DOUBLE = 1e-9
-
-
-@pytest.fixture(scope="session")
-def single_joint_equality():
-    mjcf = ET.Element("mujoco", model="single_joint_equality")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    for name, pos in (("target", "0 0 0"), ("unrelated", "0 0.25 0")):
-        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=pos)
-        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
-        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
-    equality = ET.SubElement(mjcf, "equality")
-    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
-    return mjcf
 
 
 # Canonical skip reason registry.

--- a/tests/grad/conftest.py
+++ b/tests/grad/conftest.py
@@ -151,6 +151,17 @@ def grad_hinge_pair_joint_eq_quadratic():
 
 
 @pytest.fixture(scope="session")
+def grad_hinge_joint_eq_constant():
+    mjcf = ET.Element("mujoco", model="hinge_joint_eq_constant")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    _add_hinge_arm(worldbody, "arm1", "0 0 0", name="j1")
+    _add_hinge_arm(worldbody, "arm2", "0.4 0 0", name="j2")
+    equality = ET.SubElement(mjcf, "equality")
+    ET.SubElement(equality, "joint", joint1="j1", polycoef="0.25 1 0 0 0", solimp="0.95 0.99 0.001", solref="0.005 1")
+    return ET.tostring(mjcf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
 def grad_connect_loop():
     # arm2 hangs off arm1 and the connect closes the loop within one kinematic tree: the constraint rows then share
     # arm1's dof across both chains (dedup path) and both anchors move with the chain (velocity-product bias).

--- a/tests/grad/test_rigid_constraints.py
+++ b/tests/grad/test_rigid_constraints.py
@@ -184,6 +184,7 @@ def test_frictionloss_grad_matches_fd(grad_revolute_frictionloss, precision, sho
     [
         ("grad_hinge_pair_joint_eq_linear", 1),
         ("grad_hinge_pair_joint_eq_quadratic", 1),
+        ("grad_hinge_joint_eq_constant", 1),
         ("grad_connect_loop", 3),
         ("grad_weld_pair", 6),
     ],

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -232,6 +232,19 @@ def mimic_hinges():
 
 
 @pytest.fixture(scope="session")
+def single_joint_equality():
+    mjcf = ET.Element("mujoco", model="single_joint_equality")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    for name, pos in (("target", "0 0 0"), ("unrelated", "0 0.25 0")):
+        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=pos)
+        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
+        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
+    equality = ET.SubElement(mjcf, "equality")
+    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
+    return mjcf
+
+
+@pytest.fixture(scope="session")
 def scaled_mjcf_joint_equalities(single_joint_equality):
     mjcf = ET.Element("mujoco", model="scaled_mjcf_joint_equalities")
     worldbody = ET.SubElement(mjcf, "worldbody")
@@ -259,7 +272,7 @@ def scaled_mjcf_joint_equalities(single_joint_equality):
         )
     worldbody.extend(single_joint_equality.find("worldbody"))
     equality.extend(single_joint_equality.find("equality"))
-    return ET.tostring(mjcf, encoding="unicode")
+    return mjcf
 
 
 @pytest.fixture(scope="session")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -232,21 +232,21 @@ def mimic_hinges():
 
 
 @pytest.fixture(scope="session")
-def scaled_mjcf_joint_equalities():
+def scaled_mjcf_joint_equalities(single_joint_equality):
     mjcf = ET.Element("mujoco", model="scaled_mjcf_joint_equalities")
     worldbody = ET.SubElement(mjcf, "worldbody")
     equality = ET.SubElement(mjcf, "equality")
-    for driver_type, follower_type in (
-        ("hinge", "hinge"),
-        ("slide", "slide"),
-        ("slide", "hinge"),
-        ("hinge", "slide"),
+    for driver_type, follower_type, position_y in (
+        ("hinge", "hinge", -0.25),
+        ("slide", "slide", -0.5),
+        ("slide", "hinge", -0.75),
+        ("hinge", "slide", -1.0),
     ):
         pair_name = f"{driver_type}_{follower_type}"
-        driver_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_driver_body")
+        driver_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_driver_body", pos=f"0 {position_y} 0")
         ET.SubElement(driver_body, "joint", name=f"{pair_name}_driver", type=driver_type, axis="1 0 0")
         ET.SubElement(driver_body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
-        follower_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_follower_body")
+        follower_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_follower_body", pos=f"0.15 {position_y} 0")
         ET.SubElement(follower_body, "joint", name=f"{pair_name}_follower", type=follower_type, axis="1 0 0")
         ET.SubElement(follower_body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
         ET.SubElement(
@@ -257,6 +257,8 @@ def scaled_mjcf_joint_equalities():
             joint2=f"{pair_name}_driver",
             polycoef="0.2 0.4 -0.3 0.2 -0.1",
         )
+    worldbody.extend(single_joint_equality.find("worldbody"))
+    equality.extend(single_joint_equality.find("equality"))
     return ET.tostring(mjcf, encoding="unicode")
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -232,20 +232,7 @@ def mimic_hinges():
 
 
 @pytest.fixture(scope="session")
-def single_joint_equality():
-    mjcf = ET.Element("mujoco", model="single_joint_equality")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    for name, pos in (("target", "0 0 0"), ("unrelated", "0 0.25 0")):
-        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=pos)
-        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
-        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
-    equality = ET.SubElement(mjcf, "equality")
-    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
-    return mjcf
-
-
-@pytest.fixture(scope="session")
-def scaled_mjcf_joint_equalities(single_joint_equality):
+def scaled_mjcf_joint_equalities():
     mjcf = ET.Element("mujoco", model="scaled_mjcf_joint_equalities")
     worldbody = ET.SubElement(mjcf, "worldbody")
     equality = ET.SubElement(mjcf, "equality")
@@ -270,8 +257,11 @@ def scaled_mjcf_joint_equalities(single_joint_equality):
             joint2=f"{pair_name}_driver",
             polycoef="0.2 0.4 -0.3 0.2 -0.1",
         )
-    worldbody.extend(single_joint_equality.find("worldbody"))
-    equality.extend(single_joint_equality.find("equality"))
+    for name, position_y in (("target", 0.0), ("unrelated", 0.25)):
+        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=f"0 {position_y} 0")
+        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
+        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
+    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
     return mjcf
 
 

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -29,14 +29,17 @@ def test_equality_joint(gs_sim, mj_sim, gs_solver, tol):
 
 
 @pytest.mark.required
-def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, tol):
+@pytest.mark.parametrize("n_envs, is_batched", [(0, False), (2, True)])
+def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, n_envs, is_batched, tol):
     scene = gs.Scene(
-        sim_options=gs.options.SimOptions(
-            gravity=(0.0, 0.0, 0.0),
-        ),
         rigid_options=gs.options.RigidOptions(
-            enable_collision=False,
-            enable_joint_limit=False,
+            batch_joints_info=is_batched,
+            batch_dofs_info=is_batched,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.0, -0.75, 4.0),
+            camera_lookat=(1.0, -0.75, 0.0),
+            camera_up=(0.0, 1.0, 0.0),
         ),
         show_viewer=show_viewer,
     )
@@ -47,7 +50,7 @@ def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, tol):
             scale=SCALE,
         ),
     )
-    scene.build()
+    scene.build(n_envs=n_envs)
 
     COEFFICIENTS = (0.2, 0.4, -0.3, 0.2, -0.1)
     DRIVER_POSITION = 0.5
@@ -64,22 +67,28 @@ def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, tol):
         ("slide_hinge", "slide", "hinge"),
         ("hinge_slide", "hinge", "slide"),
     )
+    TARGET_POSITION = 0.25
+    UNRELATED_POSITION = 1.0
     qpos = entity.get_qpos()
     for name, driver_type, follower_type in JOINT_PAIRS:
-        (driver_idx,) = entity.get_joint(f"{name}_driver").qs_idx_local
-        (follower_idx,) = entity.get_joint(f"{name}_follower").qs_idx_local
-        qpos[..., driver_idx] = DRIVER_POSITION * (SCALE if driver_type == "slide" else 1.0)
-        qpos[..., follower_idx] = FOLLOWER_POSITION * (SCALE if follower_type == "slide" else 1.0)
+        (i_driver_q,) = entity.get_joint(f"{name}_driver").qs_idx_local
+        (i_follower_q,) = entity.get_joint(f"{name}_follower").qs_idx_local
+        qpos[..., i_driver_q] = DRIVER_POSITION * (SCALE if driver_type == "slide" else 1.0)
+        qpos[..., i_follower_q] = FOLLOWER_POSITION * (SCALE if follower_type == "slide" else 1.0)
+    (i_target_q,) = entity.get_joint("target").qs_idx_local
+    (i_unrelated_q,) = entity.get_joint("unrelated").qs_idx_local
+    qpos[..., i_target_q] = TARGET_POSITION * SCALE
+    qpos[..., i_unrelated_q] = UNRELATED_POSITION * SCALE
     entity.set_qpos(qpos)
     scene.step()
 
     qpos = entity.get_qpos()
     for name, driver_type, follower_type in JOINT_PAIRS:
-        (driver_idx,) = entity.get_joint(f"{name}_driver").qs_idx_local
-        (follower_idx,) = entity.get_joint(f"{name}_follower").qs_idx_local
+        (i_driver_q,) = entity.get_joint(f"{name}_driver").qs_idx_local
+        (i_follower_q,) = entity.get_joint(f"{name}_follower").qs_idx_local
         driver_scale = SCALE if driver_type == "slide" else 1.0
         follower_scale = SCALE if follower_type == "slide" else 1.0
-        driver_position = qpos[..., driver_idx] / driver_scale
+        driver_position = qpos[..., i_driver_q] / driver_scale
         expected_follower_position = (
             COEFFICIENTS[0]
             + COEFFICIENTS[1] * driver_position
@@ -87,7 +96,10 @@ def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, tol):
             + COEFFICIENTS[3] * driver_position**3
             + COEFFICIENTS[4] * driver_position**4
         )
-        assert_allclose(qpos[..., follower_idx] / follower_scale, expected_follower_position, tol=tol)
+        assert_allclose(qpos[..., i_follower_q] / follower_scale, expected_follower_position, tol=tol)
+
+    assert_allclose(qpos[..., i_target_q] / SCALE, TARGET_POSITION, tol=tol)
+    assert_allclose(qpos[..., i_unrelated_q] / SCALE, UNRELATED_POSITION, tol=tol)
 
 
 @pytest.mark.required

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -1,34 +1,12 @@
-import xml.etree.ElementTree as ET
-
 import numpy as np
 import pytest
 import torch
-
-import mujoco
 
 import genesis as gs
 import genesis.utils.geom as gu
 from genesis.utils.misc import tensor_to_array
 
 from ..utils.assertions import assert_allclose, assert_equal
-from ..utils.mujoco_parity import simulate_and_check_mujoco_consistency
-
-
-@pytest.mark.parametrize("model_name", ["mimic_hinges"])
-@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
-@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
-@pytest.mark.parametrize("backend", [gs.cpu])
-def test_equality_joint(gs_sim, mj_sim, gs_solver, tol):
-    # there is an equality constraint
-    assert gs_sim.rigid_solver.n_equalities == 1
-
-    qpos = np.array((0.0, -1.0))
-    qvel = np.array((1.0, -0.3))
-    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, tol=tol)
-
-    # check if the two joints are equal
-    gs_qpos = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]
-    assert_allclose(gs_qpos[0], gs_qpos[1], tol=tol)
 
 
 @pytest.mark.required
@@ -49,7 +27,7 @@ def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, n_env
     SCALE = 2.0
     entity = scene.add_entity(
         morph=gs.morphs.MJCF(
-            file=ET.tostring(scaled_mjcf_joint_equalities, encoding="unicode"),
+            file=scaled_mjcf_joint_equalities,
             scale=SCALE,
         ),
     )
@@ -103,37 +81,6 @@ def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, n_env
 
     assert_allclose(qpos[..., i_target_q] / SCALE, TARGET_POSITION, tol=tol)
     assert_allclose(qpos[..., i_unrelated_q] / SCALE, UNRELATED_POSITION, tol=tol)
-
-
-@pytest.mark.required
-@pytest.mark.parametrize("xml_path", ["xml/four_bar_linkage_weld.xml", "weld.xml", "connect.xml"])
-@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.Newton])
-@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
-@pytest.mark.parametrize("backend", [gs.cpu])
-def test_equality_link(gs_sim, mj_sim, gs_solver, xml_path):
-    # Must disable self-collision caused by closing the kinematic chain (adjacent link filtering is not enough)
-    gs_sim.rigid_solver._enable_collision = False
-    mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
-
-    # Must the time constant of the constraints to improve numerical stability
-    TIME_CONSTANT = 0.02
-    for entity in gs_sim.entities:
-        for equality in entity.equalities:
-            equality.set_sol_params((TIME_CONSTANT, *tensor_to_array(equality.desc.sol_params)[1:]))
-    mj_sim.model.eq_solref[:, 0] = TIME_CONSTANT
-
-    # Randomize the initial condition for force convergence of the constraints
-    np.random.seed(0)
-    qpos = np.random.rand(gs_sim.rigid_solver.n_qs) * 0.1
-
-    # Note that the world frame in which weld constraint is computed is different between Mujoco and Genesis for sites.
-    # Mujoco is using site 1, whereas Genesis is using parent link frame of site 1 since it has no notion of site.
-    ignore_constraints = np.any(
-        (mj_sim.model.eq_objtype == mujoco.mjtObj.mjOBJ_SITE) & (mj_sim.model.eq_type == mujoco.mjtEq.mjEQ_WELD)
-    )
-    simulate_and_check_mujoco_consistency(
-        gs_sim, mj_sim, qpos, num_steps=300, tol=1e-7, ignore_constraints=ignore_constraints
-    )
 
 
 @pytest.mark.slow  # ~250s

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -32,16 +32,16 @@ def test_equality_joint(gs_sim, mj_sim, gs_solver, tol):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("n_envs, is_batched", [(0, False), (2, True)])
-def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, n_envs, is_batched, tol):
+@pytest.mark.parametrize("n_envs, batched", [(0, False), (2, True)])
+def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, n_envs, batched, tol):
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
-            batch_joints_info=is_batched,
-            batch_dofs_info=is_batched,
+            batch_joints_info=batched,
+            batch_dofs_info=batched,
         ),
         viewer_options=gs.options.ViewerOptions(
-            camera_pos=(1.0, -0.75, 4.0),
-            camera_lookat=(1.0, -0.75, 0.0),
+            camera_pos=(0.15, -0.75, 4.0),
+            camera_lookat=(0.15, -0.75, 0.0),
             camera_up=(0.0, 1.0, 0.0),
         ),
         show_viewer=show_viewer,

--- a/tests/rigid/test_constraints.py
+++ b/tests/rigid/test_constraints.py
@@ -1,7 +1,10 @@
-import mujoco
+import xml.etree.ElementTree as ET
+
 import numpy as np
 import pytest
 import torch
+
+import mujoco
 
 import genesis as gs
 import genesis.utils.geom as gu
@@ -46,7 +49,7 @@ def test_equality_joint_scaling(show_viewer, scaled_mjcf_joint_equalities, n_env
     SCALE = 2.0
     entity = scene.add_entity(
         morph=gs.morphs.MJCF(
-            file=scaled_mjcf_joint_equalities,
+            file=ET.tostring(scaled_mjcf_joint_equalities, encoding="unicode"),
             scale=SCALE,
         ),
     )

--- a/tests/rigid/test_friction.py
+++ b/tests/rigid/test_friction.py
@@ -10,21 +10,6 @@ from genesis.utils.misc import tensor_to_array
 
 from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.assets import get_hf_dataset
-from ..utils.mujoco_parity import simulate_and_check_mujoco_consistency
-
-
-@pytest.mark.required
-@pytest.mark.parametrize("model_name", ["hinge_slide"])
-@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
-@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
-@pytest.mark.parametrize("backend", [gs.cpu])
-def test_frictionloss(gs_sim, mj_sim, tol):
-    qvel = np.array([0.7, -0.9])
-    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qvel=qvel, num_steps=2000, tol=tol)
-
-    # Check that final velocity is almost zero
-    gs_qvel = gs_sim.rigid_solver.dyn_state.dofs.vel.to_numpy()
-    assert_allclose(gs_qvel, 0.0, tol=1e-2)
 
 
 @pytest.mark.required

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -17,11 +17,15 @@ from ..utils.mujoco_parity import (
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("model_name", ["single_joint_equality"])
+@pytest.mark.parametrize("model_name", ["scaled_mjcf_joint_equalities"])
 @pytest.mark.parametrize("gs_solver, gs_integrator", [(gs.constraint_solver.Newton, gs.integrator.implicitfast)])
 @pytest.mark.parametrize("backend", [gs.cpu])
-def test_equality_joint_constant(gs_sim, mj_sim, tol):
-    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=(0.0, 1.0), num_steps=50, tol=tol)
+def test_equality_joint(gs_sim, mj_sim, tol):
+    (entity,) = gs_sim.entities
+    qpos = entity.get_qpos()
+    (i_unrelated_q,) = entity.get_joint("unrelated").qs_idx_local
+    qpos[i_unrelated_q] = 1.0
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=qpos, num_steps=50, tol=tol)
 
 
 @pytest.mark.required

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -17,6 +17,14 @@ from ..utils.mujoco_parity import (
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("model_name", ["single_joint_equality"])
+@pytest.mark.parametrize("gs_solver, gs_integrator", [(gs.constraint_solver.Newton, gs.integrator.implicitfast)])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_equality_joint_constant(gs_sim, mj_sim, tol):
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=(0.0, 1.0), num_steps=50, tol=tol)
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("model_name", ["box_plan"])
 @pytest.mark.parametrize(
     "gs_solver, gs_integrator",

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -5,6 +5,7 @@ import torch
 
 import genesis as gs
 import genesis.utils.geom as gu
+from genesis.utils.misc import tensor_to_array
 
 from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.mujoco_parity import (
@@ -26,6 +27,53 @@ def test_equality_joint(gs_sim, mj_sim, tol):
     (i_unrelated_q,) = entity.get_joint("unrelated").qs_idx_local
     qpos[i_unrelated_q] = 1.0
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos=qpos, num_steps=50, tol=tol)
+
+
+@pytest.mark.parametrize("model_name", ["mimic_hinges"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_equality_joint_mimic(gs_sim, mj_sim, tol):
+    assert gs_sim.rigid_solver.n_equalities == 1
+
+    qpos = np.array((0.0, -1.0))
+    qvel = np.array((1.0, -0.3))
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qpos, qvel, num_steps=300, tol=tol)
+
+    (entity,) = gs_sim.entities
+    qpos = entity.get_qpos()
+    assert_allclose(qpos[0], qpos[1], tol=tol)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("xml_path", ["xml/four_bar_linkage_weld.xml", "weld.xml", "connect.xml"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_equality_link(gs_sim, mj_sim):
+    # Must disable self-collision caused by closing the kinematic chain (adjacent link filtering is not enough)
+    gs_sim.rigid_solver._enable_collision = False
+    mj_sim.model.opt.disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
+
+    # Set the time constant of the constraints on both engines to improve numerical stability
+    TIME_CONSTANT = 0.02
+    for entity in gs_sim.entities:
+        for equality in entity.equalities:
+            equality.set_sol_params((TIME_CONSTANT, *tensor_to_array(equality.desc.sol_params)[1:]))
+    mj_sim.model.eq_solref[:, 0] = TIME_CONSTANT
+
+    # Randomize the initial condition for force convergence of the constraints
+    np.random.seed(0)
+    qpos = np.random.rand(gs_sim.rigid_solver.n_qs) * 0.1
+
+    # Note that the world frame in which weld constraint is computed is different between Mujoco and Genesis for sites.
+    # Mujoco is using site 1, whereas Genesis is using parent link frame of site 1 since it has no notion of site.
+    ignore_constraints = np.any(
+        (mj_sim.model.eq_objtype == mujoco.mjtObj.mjOBJ_SITE) & (mj_sim.model.eq_type == mujoco.mjtEq.mjEQ_WELD)
+    )
+    simulate_and_check_mujoco_consistency(
+        gs_sim, mj_sim, qpos, num_steps=300, tol=1e-7, ignore_constraints=ignore_constraints
+    )
 
 
 @pytest.mark.required
@@ -82,6 +130,19 @@ def test_scene_aggregates_hold_across_entities(gs_sim, mj_sim, tol):
         gs_sim, mj_sim, armature_ratio=3.0, mass_ratio=0.5, inertia_ratio=2.0, com_offset=(0.01, -0.02, 0.03)
     )
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=10, tol=tol)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("model_name", ["hinge_slide"])
+@pytest.mark.parametrize("gs_solver", [gs.constraint_solver.CG, gs.constraint_solver.Newton])
+@pytest.mark.parametrize("gs_integrator", [gs.integrator.implicitfast, gs.integrator.Euler])
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_frictionloss(gs_sim, mj_sim, tol):
+    qvel = np.array([0.7, -0.9])
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, qvel=qvel, num_steps=2000, tol=tol)
+
+    (entity,) = gs_sim.entities
+    assert_allclose(entity.get_dofs_velocity(), 0.0, tol=1e-2)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

Support MJCF joint equalities without `joint2` in the rigid solver, including model scaling and gradients. The constrained joint follows the specified constant while unrelated joints remain unaffected. SAP retains its build-time rejection for this unsupported case.

## Related Issue

Resolves #3289

## How Has This Been / Can This Be Tested?

9 targeted cases passed in this test-only revision: the 50-step CPU parity test using the comprehensive equality model, one-step scaling checks in both batching configurations on CPU fp64 and RTX 5090 fp32, and adjacent CPU joint-equality checks. The previous revision also passed all five CPU equality-gradient cases, which are unchanged. MuJoCo 3.10.0 was used. The expanded parity test still exposes the missing-joint setup error on the unfixed base `b3c6c73a`. Ruff 0.14.11 lint and format checks passed. The full suite and compatibility with newer main commits were not tested in this revision.

```sh
PYTHONPATH="$PWD" QD_OFFLINE_CACHE=0 pytest -n 0 tests/rigid/test_mujoco_parity.py::test_equality_joint tests/rigid/test_constraints.py::test_equality_joint_scaling tests/rigid/test_constraints.py::test_equality_joint --backend cpu
PYTHONPATH="$PWD" QD_OFFLINE_CACHE=0 pytest -n 0 tests/rigid/test_constraints.py::test_equality_joint_scaling --backend gpu
```
