### PR TITLE
[FEATURE] Allow stepping the scene without updating sensors.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1078,9 +1078,23 @@ class Scene(RBC):
         self._pre_step_callbacks.append(callback)
 
     @gs.assert_built
-    def step(self, update_visualizer=True, refresh_visualizer=True):
+    def step(self, update_visualizer=True, refresh_visualizer=True, update_sensors=True):
         """
         Runs a simulation step forward in time.
+
+        Parameters
+        ----------
+        update_visualizer : bool
+            Whether the visualizer is updated after the step. Defaults to True.
+        refresh_visualizer : bool
+            Whether the visualizer window is refreshed on that update. Defaults to True.
+        update_sensors : bool
+            Whether the sensors observe this step. When False, the physics advances while every sensor keeps the reading
+            and the internal state of the last observed step, so `read()` and `read_sensors()` return the same values
+            as before the call and sensor responses with memory (filters, hysteresis) integrate only over observed
+            steps. Use it to run several physics steps per control step and pay the sensor update once. Requires every
+            sensor to have `delay=0`, `jitter=0` and `history_length=0`, since those reads address past steps.
+            Defaults to True.
         """
         # Run pre-step callbacks on the stepping thread. A callback may perform deferred work and veto this
         # frame's advance by returning True. The scene treats them opaquely, without knowing what they do or who
@@ -1091,7 +1105,7 @@ class Scene(RBC):
         if advance:
             if not self._forward_ready:
                 gs.raise_exception("Forward simulation not allowed after backward pass. Please reset scene state.")
-            self._sim.step()
+            self._sim.step(update_sensors=update_sensors)
 
         if update_visualizer:
             # Force the refresh when the sim did not advance (e.g. paused) so edits made off the step loop -

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -137,7 +137,9 @@ class SharedSensorContext(ABC):
 
     @abstractmethod
     def update(self) -> None:
-        """Refresh the resource for the current step; manager-driven once per step. Must no-op when inactive."""
+        """Refresh the resource for the current step; manager-driven once per step. Must no-op when inactive. Runs only
+        on the steps that update sensors, so it rebuilds from the live scene state and may span several physics
+        steps."""
 
     @abstractmethod
     def reset(self, envs_idx) -> None:

--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -145,8 +145,6 @@ class RasterizerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorM
     sensors: Optional[List["RasterizerCameraSensor"]] = None
     # {sensor_idx: np.ndarray with shape (B, H, W, 3)}
     image_cache: Optional[Dict[int, np.ndarray]] = None
-    # Track when rasterizer cameras were last updated
-    last_render_timestep: int = -1
 
     def destroy(self):
         super().destroy()
@@ -174,8 +172,6 @@ class RaytracerCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSensorMe
     sensors: Optional[List["RaytracerCameraSensor"]] = None
     # {sensor_idx: np.ndarray with shape (B, H, W, 3)}
     image_cache: Optional[Dict[int, np.ndarray]] = None
-    # Track when raytracer cameras were last updated
-    last_render_timestep: int = -1
 
     def destroy(self):
         super().destroy()
@@ -197,8 +193,6 @@ class BatchRendererCameraSharedMetadata(KinematicSensorMetadataMixin, SharedSens
     sensors: Optional[List["BatchRendererCameraSensor"]] = None
     # {sensor_idx: np.ndarray with shape (B, H, W, 3)}
     image_cache: Optional[Dict[int, np.ndarray]] = None
-    # Track when batch was last rendered
-    last_render_timestep: int = -1
     # MinimalVisualizerWrapper instance
     visualizer_wrapper: Optional["MinimalVisualizerWrapper"] = None
 
@@ -220,7 +214,7 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
 
     This class centralizes:
     - Attachment handling via KinematicSensorMixin
-    - The _stale flag used for auto-render-on-read
+    - The _stale flag driving render-on-read: raised when the manager observes a step or resets, cleared by a render
     - Common Sensor cache integration (shape/dtype)
     - Shared read() method returning torch tensors
     """
@@ -259,17 +253,20 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         measured_data_timeline: "TensorRingBuffer | None",
         intermediate_cache: torch.Tensor,
     ):
-        # No per-step cache update for cameras (handled lazily on read()). `BaseCameraSensor` declares
-        # `uses_ring_pipeline = False`, so the manager passes both timeline rings as ``None`` here.
-        pass
+        # Cameras render lazily on `read()`, so observing a step marks the frames rendered before it as stale.
+        # `BaseCameraSensor` declares `uses_ring_pipeline = False`, so the manager passes both timeline rings as
+        # ``None``.
+        for sensor in shared_metadata.sensors:
+            sensor._stale = True
 
     @classmethod
     def reset(cls, shared_metadata: SharedSensorMetadata, shared_ground_truth_cache: torch.Tensor, envs_idx):
         super().reset(shared_metadata, shared_ground_truth_cache, envs_idx)
-        # Reset can restore a different state at the last rendered timestep, so force the next read to rerender.
-        # FIXME: the frame cache keys on a single timestep for the whole batch, so a partial-env reset invalidates
-        # every environment. Extend the caching mechanism to be env-aware so envs_idx only refreshes the reset envs.
-        shared_metadata.last_render_timestep = -1
+        # Reset can restore a different state, so force the next read to rerender.
+        # FIXME: the frame cache is invalidated for the whole batch, so a partial-env reset rerenders every environment.
+        # Extend the caching mechanism to be env-aware so envs_idx only refreshes the reset envs.
+        for sensor in shared_metadata.sensors:
+            sensor._stale = True
 
     def _draw_debug(self, context: "RasterizerContext"):
         """No debug drawing for cameras."""
@@ -320,19 +317,9 @@ class BaseCameraSensor(KinematicSensorMixin, Sensor[OptionsT, None, SharedSensor
         return self._shared_metadata.image_cache[self._idx]
 
     def _ensure_rendered_for_current_state(self):
-        """Ensure this camera has an up-to-date render before reading.
-        Base handles staleness and timestamps; subclasses implement _render_current_state().
+        """Render this camera if the manager observed a step or a reset since its last render.
+        Base handles staleness; subclasses implement _render_current_state().
         """
-        scene = self._manager._sim.scene
-
-        # If the scene time advanced, mark all cameras as stale
-        if self._shared_metadata.last_render_timestep != scene.sim.cur_step_global:
-            if self._shared_metadata.sensors is not None:
-                for sensor in self._shared_metadata.sensors:
-                    sensor._stale = True
-            self._shared_metadata.last_render_timestep = scene.sim.cur_step_global
-
-        # If this camera is not stale, cache is considered fresh
         if not self._stale:
             return
 
@@ -780,7 +767,6 @@ class BatchRendererCameraSensor(
             self._shared_metadata.sensors = []
             self._shared_metadata.lights = gs.List()
             self._shared_metadata.image_cache = {}
-            self._shared_metadata.last_render_timestep = -1
 
             all_sensors = self._manager._sensors_by_type[type(self)]
             resolutions = [s._options.res for s in all_sensors]
@@ -843,8 +829,6 @@ class BatchRendererCameraSensor(
         for sensor, rgb_arr in zip(sensors, rgb_arrs):
             sensor._shared_metadata.image_cache[sensor._idx][:] = rgb_arr
             sensor._stale = False
-
-        self._shared_metadata.last_render_timestep = self._manager._sim.cur_step_global
 
     def _apply_camera_transform(self, camera_T: torch.Tensor):
         """Update batch renderer camera from a world transform."""

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -317,17 +317,17 @@ class SensorManager:
                 self._sensors_metadata[sensor_cls], self._ground_truth_intermediate_cache[dtype][cache_slice], envs_idx
             )
 
+    @property
+    def has_past_step_reads(self) -> bool:
+        """Whether a sensor samples past steps through a delay or a history. Such reads address the return-space rings
+        by step age, so every physics step must be observed for them to stay aligned."""
+        return self._has_past_step_reads
+
     def step(self, update_sensors=True):
+        # An unobserved step leaves slot 0 of every ring at the last observed step and the shared contexts on that
+        # step's geometry, which they rebuild from on the next update (see `SharedSensorContext.update`). The simulator
+        # refuses unobserved steps whenever `has_past_step_reads` holds.
         if not update_sensors:
-            # Delay sampling and history reads address the return-space rings by step age, so a ring left untouched for
-            # a step would shift every such read by one step. Otherwise slot 0 of every ring stays the last observed
-            # step, and the shared contexts rebuild from the live geometry on the next update (see
-            # `SharedSensorContext.update`).
-            if self._has_past_step_reads:
-                gs.raise_exception(
-                    "Stepping without updating sensors requires every sensor to have delay=0, jitter=0 and "
-                    "history_length=0, since delayed and history reads address past steps."
-                )
             return
 
         # Timeline rings must rotate before `_update_shared_cache` because `_apply_transform` mutates `at(0)` of the

--- a/genesis/engine/sensors/sensor_manager.py
+++ b/genesis/engine/sensors/sensor_manager.py
@@ -56,6 +56,9 @@ class SensorManager:
         # (sensor class, entity_idx) -> slice within the class cache. entity_idx == -1 means static sensors.
         self._entity_slice_in_class: dict[type["Sensor"], dict[int, slice]] = {}
         self._max_history_by_class: dict[type["Sensor"], int] = {}
+        # Whether any sensor samples past steps (delay or history), which binds the manager to one update per physics
+        # step: see `step`.
+        self._has_past_step_reads = False
 
     def create_sensor(self, sensor_options: "SensorOptions") -> "Sensor":
         sensor_options.validate_scene(self._sim.scene)
@@ -149,6 +152,7 @@ class SensorManager:
         return_dtype_by_class: dict[type["Sensor"], torch.dtype] = {}
         # Deepest return-space slot delay sampling can reach, plus one.
         delay_depth_by_class: dict[type["Sensor"], int] = {}
+        self._has_past_step_reads = False
         for sensor_cls, sensors in self._sensors_by_type.items():
             intermediate_dtype = sensor_cls._get_intermediate_dtype()
             return_dtype = sensor_cls._get_cache_dtype()
@@ -168,6 +172,8 @@ class SensorManager:
                 # time; without that slot, `at()` wraps modulo the depth and returns the newest frame as the oldest.
                 cls_delay_depth = max(cls_delay_depth, sensor._delay_ts + (2 if sensor._options.delay > 0.0 else 1))
                 hist = sensor._options.history_length
+                if sensor._options.delay > 0.0 or hist > 0:
+                    self._has_past_step_reads = True
                 if hist > 0:
                     max_history_per_dtype[intermediate_dtype] = max(
                         max_history_per_dtype.get(intermediate_dtype, 0), hist
@@ -311,7 +317,19 @@ class SensorManager:
                 self._sensors_metadata[sensor_cls], self._ground_truth_intermediate_cache[dtype][cache_slice], envs_idx
             )
 
-    def step(self):
+    def step(self, update_sensors=True):
+        if not update_sensors:
+            # Delay sampling and history reads address the return-space rings by step age, so a ring left untouched for
+            # a step would shift every such read by one step. Otherwise slot 0 of every ring stays the last observed
+            # step, and the shared contexts rebuild from the live geometry on the next update (see
+            # `SharedSensorContext.update`).
+            if self._has_past_step_reads:
+                gs.raise_exception(
+                    "Stepping without updating sensors requires every sensor to have delay=0, jitter=0 and "
+                    "history_length=0, since delayed and history reads address past steps."
+                )
+            return
+
         # Timeline rings must rotate before `_update_shared_cache` because `_apply_transform` mutates `at(0)` of the
         # timeline ring and needs a fresh write slot. Return-space rings, by contrast, are read during `_post_process`
         # (past post-output values) and written afterward; their rotation is deferred to inside the per-class loop so

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -327,7 +327,7 @@ class Simulator(RBC):
     # ------------------------------------ stepping --------------------------------------
     # ------------------------------------------------------------------------------------
 
-    def step(self, in_backward=False):
+    def step(self, in_backward=False, update_sensors=True):
         # Check errno at the very beginning of the step.
         # This will trigger GPU sync, but it is not a big deal at the point, since we are going to enqueue very large
         # kernel right away. Moreover, if computations are still not done at this point, then the queue will just
@@ -356,7 +356,7 @@ class Simulator(RBC):
         if self.rigid_solver.is_active:
             self.rigid_solver.clear_external_force()
 
-        self._sensor_manager.step()
+        self._sensor_manager.step(update_sensors=update_sensors)
 
     def _step_grad(self):
         self._steps -= 1

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -328,6 +328,13 @@ class Simulator(RBC):
     # ------------------------------------------------------------------------------------
 
     def step(self, in_backward=False, update_sensors=True):
+        # Refused before any state moves, so a rejected call leaves the physics and the sensor timelines in agreement.
+        if not update_sensors and self._sensor_manager.has_past_step_reads:
+            gs.raise_exception(
+                "Stepping without updating sensors requires every sensor to have delay=0, jitter=0 and "
+                "history_length=0, since delayed and history reads address past steps."
+            )
+
         # Check errno at the very beginning of the step.
         # This will trigger GPU sync, but it is not a big deal at the point, since we are going to enqueue very large
         # kernel right away. Moreover, if computations are still not done at this point, then the queue will just

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -549,6 +549,9 @@ def test_sensor_history_length_contact_and_imu(show_viewer, tol, n_envs):
 
     scene.build(n_envs=n_envs)
 
+    with pytest.raises(gs.GenesisException, match="history_length=0"):
+        scene.step(update_sensors=False)
+
     def _expected_shape_with_history(shape: tuple[int, ...]):
         return (HISTORY_LEN, *shape) if n_envs == 0 else (n_envs, HISTORY_LEN, *shape)
 
@@ -778,3 +781,16 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
         for env_idx in range(n_envs):
             assert_equal(scene.read_sensors()[gs.sensors.types.IMU][env_idx, 0:3], imu_a1.read().lin_acc[env_idx])
             assert_equal(scene.read_sensors()[gs.sensors.types.Contact][env_idx, 0:1], contact_a.read()[env_idx])
+
+    # Unobserved steps advance the physics only: the boxes land (bottom face 0.15 m above the plane, touching down after
+    # sqrt(2 * 0.15 / 10) = 0.17 s, i.e. 18 steps) while every reading stays at the last observed step, and the next
+    # observed step picks the contact up.
+    frozen_data = scene.read_sensors()
+    for _ in range(20):
+        scene.step(update_sensors=False)
+    assert (np.atleast_1d(tensor_to_array(box_a.get_pos()))[..., 2] < 0.06).all()
+    for type_tag, tensor in scene.read_sensors().items():
+        assert_equal(tensor, frozen_data[type_tag])
+    assert not contact_a.read().any()
+    scene.step()
+    assert contact_a.read().all()

--- a/tests/sensors/test_api.py
+++ b/tests/sensors/test_api.py
@@ -549,8 +549,11 @@ def test_sensor_history_length_contact_and_imu(show_viewer, tol, n_envs):
 
     scene.build(n_envs=n_envs)
 
+    # A refused unobserved step leaves the physics untouched.
+    pos_before = box.get_pos()
     with pytest.raises(gs.GenesisException, match="history_length=0"):
         scene.step(update_sensors=False)
+    assert_equal(box.get_pos(), pos_before)
 
     def _expected_shape_with_history(shape: tuple[int, ...]):
         return (HISTORY_LEN, *shape) if n_envs == 0 else (n_envs, HISTORY_LEN, *shape)
@@ -786,11 +789,15 @@ def test_read_sensors_bulk_api(show_viewer, n_envs):
     # sqrt(2 * 0.15 / 10) = 0.17 s, i.e. 18 steps) while every reading stays at the last observed step, and the next
     # observed step picks the contact up.
     frozen_data = scene.read_sensors()
+    frozen_frame = static_cam.read().rgb.clone()
     for _ in range(20):
         scene.step(update_sensors=False)
     assert (np.atleast_1d(tensor_to_array(box_a.get_pos()))[..., 2] < 0.06).all()
     for type_tag, tensor in scene.read_sensors().items():
         assert_equal(tensor, frozen_data[type_tag])
+    # The camera renders lazily on read, so it must serve the frame of the last observed step as well.
+    assert_equal(static_cam.read().rgb, frozen_frame)
     assert not contact_a.read().any()
     scene.step()
     assert contact_a.read().all()
+    assert (static_cam.read().rgb != frozen_frame).any()


### PR DESCRIPTION
## Description

`Scene.step` gains an `update_sensors` flag (default `True`), threaded through `Simulator.step` to `SensorManager.step`. When `False`, the physics advances while every sensor keeps the reading and the internal state of the last observed step: the timeline rings stay in place, the shared contexts are left untouched, and no per-type update, post-processing or delay sampling runs. `read()`, `read_ground_truth()` and `read_sensors()` then return the values of the last observed step, and sensor responses with memory (filters, hysteresis) integrate only over observed steps.

Sensors that sample past steps (`delay > 0` or `history_length > 0`) address the return-space rings by step age, so leaving a ring untouched for a step would shift every such read. `Simulator.step` refuses the call in that case, before any state moves, instead of producing a silently wrong timeline. Camera sensors render lazily on `read()`; they now go stale only when the manager observes a step or resets, so a read after an unobserved step serves the frame of the last observed step without rendering. The `SharedSensorContext.update` contract now states that it runs only on observed steps and rebuilds from the live scene state.

## Related Issue

No open issue. The need surfaced in a downstream RL harness that steps the physics several times per control step and only reads sensors at control rate; the only way to get that today is to clear the manager's private dispatch table from outside.

## Motivation and Context

Control loops that run `decimation` physics steps per action pay the full sensor update on every intermediate step, although only the last reading is ever consumed. For raycast-heavy scenes the shared-context rebuild dominates the step, and skipping it on intermediate steps gives roughly a 2x speedup. `update_sensors=False` makes that a supported, explicit choice, mirroring the existing `update_visualizer` flag.

## How Has This Been / Can This Be Tested?

- `tests/sensors/test_api.py::test_read_sensors_bulk_api` now snapshots every bulk reading, runs 20 unobserved steps during which the boxes land (bottom face 0.15 m above the plane, touchdown after `sqrt(2 * 0.15 / 10) = 0.17 s`, i.e. 18 steps), asserts that the boxes are resting (`z < 0.06`) while every reading equals its snapshot and the contact sensor still reads `False`, then observes one step and asserts the contact is picked up. The static camera frame is asserted unchanged across the unobserved steps and changed after the observed one.
- `tests/sensors/test_api.py::test_sensor_history_length_contact_and_imu` asserts that `scene.step(update_sensors=False)` raises `GenesisException` when a sensor declares `history_length > 0`, and that the refused call leaves the box pose unchanged.
- Both checks were broken on purpose: dropping the early return makes the frozen-reading assertion fail once the boxes land, and never setting the past-step flag makes the `pytest.raises` fail.
- Full `tests/sensors` passed (70 passed, 4 raytracer skips) with `-n 4` in a fresh `uv sync --extra dev` environment (quadrants 1.3.0, torch 2.14.0+cu126, RTX 3080); the madrona `test_batch_renderer` tests passed when run alone with `-n 0`.
- `pre-commit` (ruff check + format) passed on every changed file.

```bash
uv run pytest -q tests/sensors/test_api.py -k "read_sensors_bulk_api or history_length" -n 0
uv run pytest -q tests/sensors -n 4
```

## Screenshots (if appropriate):

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTVtpR7Mj64cDZQshjJu4b
