### PR TITLE
[BUG FIX] Fix buggy hibernation on GPU and correctly report resting force.

### DIFF
--- a/genesis/engine/solvers/rigid/abd/accessor.py
+++ b/genesis/engine/solvers/rigid/abd/accessor.py
@@ -340,7 +340,9 @@ def kernel_wake_up_entities_on_new_contact(
     _B = collider_state.n_contacts.shape[0]
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
-        for i_c in range(collider_state.n_contacts[i_b]):
+        # The kept contacts are read through the permutation, see has_prunable_contacts in array_class.py.
+        for i_c_ in range(collider_state.n_contacts[i_b]):
+            i_c = collider_state.contact_sort_idx[i_c_, i_b]
             i_la = collider_state.contact_data.link_a[i_c, i_b]
             i_lb = collider_state.contact_data.link_b[i_c, i_b]
             I_la = [i_la, i_b] if qd.static(rigid_config.batch_links_info) else i_la

--- a/genesis/engine/solvers/rigid/abd/forward_kinematics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_kinematics.py
@@ -1062,13 +1062,18 @@ def func_aggregate_awake_entities(
 def func_hibernate_link_and_zero_dof_velocities(
     i_l: int, i_b: int, dyn_state: array_class.DynState, dyn_info: array_class.DynInfo, rigid_config: qd.template()
 ):
-    """Mark a link, its DOFs, and its geoms as hibernated, and zero out the DOF velocities and accelerations."""
+    """Mark a link, its DOFs, and its geoms as hibernated, and zero out the DOF velocities and accelerations.
+
+    The next-velocity buffer is zeroed too: the integration copy runs over every dof, so a stale value there would be
+    restored as the sleeper's velocity on the following substep.
+    """
     dyn_state.links.is_hibernated[i_l, i_b] = True
 
     link_I = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
     for i_d in range(dyn_info.links.dof_start[link_I], dyn_info.links.dof_end[link_I]):
         dyn_state.dofs.is_hibernated[i_d, i_b] = True
         dyn_state.dofs.vel[i_d, i_b] = 0.0
+        dyn_state.dofs.vel_next[i_d, i_b] = 0.0
         dyn_state.dofs.acc[i_d, i_b] = 0.0
 
     for i_g in range(dyn_info.links.geom_start[link_I], dyn_info.links.geom_end[link_I]):

--- a/genesis/engine/solvers/rigid/collider/broadphase.py
+++ b/genesis/engine/solvers/rigid/collider/broadphase.py
@@ -10,6 +10,7 @@ import quadrants as qd
 import genesis as gs
 import genesis.utils.array_class as array_class
 
+from .contact import func_collider_clear_env
 from .utils import func_is_geom_aabbs_overlap
 
 
@@ -63,63 +64,7 @@ def func_collision_clear(
 
     qd.loop_config(name="collision_clear", serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
     for i_b in range(_B):
-        if qd.static(rigid_config.use_hibernation):
-            collider_state.n_contacts_hibernated[i_b] = 0
-
-            # Advect hibernated contacts
-            for i_c in range(collider_state.n_contacts[i_b]):
-                i_la = collider_state.contact_data.link_a[i_c, i_b]
-                i_lb = collider_state.contact_data.link_b[i_c, i_b]
-                I_la = [i_la, i_b] if qd.static(rigid_config.batch_links_info) else i_la
-                I_lb = [i_lb, i_b] if qd.static(rigid_config.batch_links_info) else i_lb
-
-                # Pair of hibernated-fixed links -> hibernated contact
-                # TODO: we should also include hibernated-hibernated links and wake up the whole contact island
-                # once a new collision is detected
-                if (dyn_state.links.is_hibernated[i_la, i_b] and dyn_info.links.is_fixed[I_lb]) or (
-                    dyn_state.links.is_hibernated[i_lb, i_b] and dyn_info.links.is_fixed[I_la]
-                ):
-                    i_c_hibernated = collider_state.n_contacts_hibernated[i_b]
-                    if i_c != i_c_hibernated:
-                        # Copying all fields of class ContactData individually
-                        # (fields mode doesn't support struct-level copy operations):
-                        # fmt: off
-                        collider_state.contact_data.geom_a[i_c_hibernated, i_b] = collider_state.contact_data.geom_a[i_c, i_b]
-                        collider_state.contact_data.geom_b[i_c_hibernated, i_b] = collider_state.contact_data.geom_b[i_c, i_b]
-                        collider_state.contact_data.penetration[i_c_hibernated, i_b] = collider_state.contact_data.penetration[i_c, i_b]
-                        collider_state.contact_data.normal[i_c_hibernated, i_b] = collider_state.contact_data.normal[i_c, i_b]
-                        collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
-                        collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
-                        collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
-                        collider_state.contact_data.friction_rolling[i_c_hibernated, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
-                        collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
-                        collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
-                        collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]
-                        collider_state.contact_data.link_b[i_c_hibernated, i_b] = collider_state.contact_data.link_b[i_c, i_b]
-                        # fmt: on
-                    collider_state.n_contacts_hibernated[i_b] = i_c_hibernated + 1
-
-        # Clear contacts: when hibernation is enabled, only clear non-hibernated contacts.
-        # The hibernated contacts (positions 0 to n_contacts_hibernated-1) were just advected and should be preserved.
-        for i_c in range(collider_state.n_contacts[i_b]):
-            should_clear = True
-            if qd.static(rigid_config.use_hibernation):
-                # Only clear if this is not a hibernated contact
-                should_clear = i_c >= collider_state.n_contacts_hibernated[i_b]
-            if should_clear:
-                collider_state.contact_data.link_a[i_c, i_b] = -1
-                collider_state.contact_data.link_b[i_c, i_b] = -1
-                collider_state.contact_data.geom_a[i_c, i_b] = -1
-                collider_state.contact_data.geom_b[i_c, i_b] = -1
-                collider_state.contact_data.penetration[i_c, i_b] = 0.0
-                collider_state.contact_data.pos[i_c, i_b] = qd.Vector.zero(gs.qd_float, 3)
-                collider_state.contact_data.normal[i_c, i_b] = qd.Vector.zero(gs.qd_float, 3)
-                collider_state.contact_data.force[i_c, i_b] = qd.Vector.zero(gs.qd_float, 3)
-
-        if qd.static(rigid_config.use_hibernation):
-            collider_state.n_contacts[i_b] = collider_state.n_contacts_hibernated[i_b]
-        else:
-            collider_state.n_contacts[i_b] = 0
+        func_collider_clear_env(i_b, dyn_state, collider_state, dyn_info, rigid_config)
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/collider/contact.py
+++ b/genesis/engine/solvers/rigid/collider/contact.py
@@ -185,36 +185,46 @@ def func_collider_clear_env(
     rigid_config: qd.template(),
 ):
     if qd.static(rigid_config.use_hibernation):
-        collider_state.n_contacts_hibernated[i_b] = 0
-
-        for i_c in range(collider_state.n_contacts[i_b]):
+        # Advect the contacts of the sleepers: a hibernated-fixed pair stays where it is, so its contact is kept at the
+        # front of the buffer with the force of the last solve it took part in. The kept contacts are read through the
+        # permutation (see has_prunable_contacts in array_class.py), so they are first flagged on their raw slot, in
+        # the sort key the narrowphase rewrites before reading it, then compacted in raw order: every slot written to
+        # was already read, so no kept contact is overwritten.
+        n_raw = 0
+        for i_c_ in range(collider_state.n_contacts[i_b]):
+            n_raw = qd.max(n_raw, collider_state.contact_sort_idx[i_c_, i_b] + 1)
+        for i_c in range(n_raw):
+            collider_state.contact_sort_key[i_c, i_b] = 0.0
+        for i_c_ in range(collider_state.n_contacts[i_b]):
+            i_c = collider_state.contact_sort_idx[i_c_, i_b]
             i_la = collider_state.contact_data.link_a[i_c, i_b]
             i_lb = collider_state.contact_data.link_b[i_c, i_b]
-
             I_la = [i_la, i_b] if qd.static(rigid_config.batch_links_info) else i_la
             I_lb = [i_lb, i_b] if qd.static(rigid_config.batch_links_info) else i_lb
-
             if (dyn_state.links.is_hibernated[i_la, i_b] and dyn_info.links.is_fixed[I_lb]) or (
                 dyn_state.links.is_hibernated[i_lb, i_b] and dyn_info.links.is_fixed[I_la]
             ):
-                i_c_hibernated = collider_state.n_contacts_hibernated[i_b]
-                if i_c != i_c_hibernated:
+                collider_state.contact_sort_key[i_c, i_b] = 1.0
+        n_hib = 0
+        for i_c in range(n_raw):
+            if collider_state.contact_sort_key[i_c, i_b] > 0.0:
+                if i_c != n_hib:
                     # fmt: off
-                    collider_state.contact_data.geom_a[i_c_hibernated, i_b] = collider_state.contact_data.geom_a[i_c, i_b]
-                    collider_state.contact_data.geom_b[i_c_hibernated, i_b] = collider_state.contact_data.geom_b[i_c, i_b]
-                    collider_state.contact_data.penetration[i_c_hibernated, i_b] = collider_state.contact_data.penetration[i_c, i_b]
-                    collider_state.contact_data.normal[i_c_hibernated, i_b] = collider_state.contact_data.normal[i_c, i_b]
-                    collider_state.contact_data.pos[i_c_hibernated, i_b] = collider_state.contact_data.pos[i_c, i_b]
-                    collider_state.contact_data.friction[i_c_hibernated, i_b] = collider_state.contact_data.friction[i_c, i_b]
-                    collider_state.contact_data.friction_torsional[i_c_hibernated, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
-                    collider_state.contact_data.friction_rolling[i_c_hibernated, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
-                    collider_state.contact_data.sol_params[i_c_hibernated, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
-                    collider_state.contact_data.force[i_c_hibernated, i_b] = collider_state.contact_data.force[i_c, i_b]
-                    collider_state.contact_data.link_a[i_c_hibernated, i_b] = collider_state.contact_data.link_a[i_c, i_b]
-                    collider_state.contact_data.link_b[i_c_hibernated, i_b] = collider_state.contact_data.link_b[i_c, i_b]
+                    collider_state.contact_data.geom_a[n_hib, i_b] = collider_state.contact_data.geom_a[i_c, i_b]
+                    collider_state.contact_data.geom_b[n_hib, i_b] = collider_state.contact_data.geom_b[i_c, i_b]
+                    collider_state.contact_data.penetration[n_hib, i_b] = collider_state.contact_data.penetration[i_c, i_b]
+                    collider_state.contact_data.normal[n_hib, i_b] = collider_state.contact_data.normal[i_c, i_b]
+                    collider_state.contact_data.pos[n_hib, i_b] = collider_state.contact_data.pos[i_c, i_b]
+                    collider_state.contact_data.friction[n_hib, i_b] = collider_state.contact_data.friction[i_c, i_b]
+                    collider_state.contact_data.friction_torsional[n_hib, i_b] = collider_state.contact_data.friction_torsional[i_c, i_b]
+                    collider_state.contact_data.friction_rolling[n_hib, i_b] = collider_state.contact_data.friction_rolling[i_c, i_b]
+                    collider_state.contact_data.sol_params[n_hib, i_b] = collider_state.contact_data.sol_params[i_c, i_b]
+                    collider_state.contact_data.force[n_hib, i_b] = collider_state.contact_data.force[i_c, i_b]
+                    collider_state.contact_data.link_a[n_hib, i_b] = collider_state.contact_data.link_a[i_c, i_b]
+                    collider_state.contact_data.link_b[n_hib, i_b] = collider_state.contact_data.link_b[i_c, i_b]
                     # fmt: on
-
-                collider_state.n_contacts_hibernated[i_b] = i_c_hibernated + 1
+                n_hib = n_hib + 1
+        collider_state.n_contacts_hibernated[i_b] = n_hib
 
     for i_c in range(collider_state.n_contacts[i_b]):
         should_clear = True

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -303,7 +303,11 @@ class ConstraintSolver:
             self.noslip()
 
         func_update_contact_force(
-            self._solver.dyn_state, self._collider._collider_state, self.constraint_state, self._solver.rigid_config
+            self._solver.dyn_state,
+            self._collider._collider_state,
+            self.constraint_state,
+            self._solver.dyn_info,
+            self._solver.rigid_config,
         )
 
     def noslip(self):
@@ -7141,6 +7145,7 @@ def func_update_contact_force(
     dyn_state: array_class.DynState,
     collider_state: array_class.ColliderState,
     constraint_state: array_class.ConstraintState,
+    dyn_info: array_class.DynInfo,
     rigid_config: qd.template(),
 ):
     n_links = dyn_state.links.contact_force.shape[0]
@@ -7188,6 +7193,11 @@ def func_update_contact_force(
                             * constraint_state.efc_force[i_c * rows_per_contact + i_dir + const_start, i_b]
                         )
 
+            # An inert contact keeps the force of the last solve it took part in, so a resting sleeper keeps reporting
+            # the support force it is at rest under.
+            if qd.static(rigid_config.use_hibernation):
+                if _is_contact_inert(contact_data_link_a, contact_data_link_b, i_b, dyn_state, dyn_info, rigid_config):
+                    force = collider_state.contact_data.force[i_col, i_b]
             collider_state.contact_data.force[i_col, i_b] = force
 
             dyn_state.links.contact_force[contact_data_link_a, i_b] = (

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -655,6 +655,58 @@ def _func_contact_row_direction(
 
 
 @qd.func
+def _is_contact_inert(
+    link_a,
+    link_b,
+    i_b,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+) -> bool:
+    """Whether a contact carries no constraint because neither endpoint is an awake dynamic body.
+
+    A sleeper struck by an awake body is revived before the constraints are assembled
+    (kernel_wake_up_entities_on_new_contact), so only hibernated-fixed pairs reach this state.
+    """
+    link_a_maybe_batch = [link_a, i_b] if qd.static(rigid_config.batch_links_info) else link_a
+    link_b_maybe_batch = [link_b, i_b] if qd.static(rigid_config.batch_links_info) else link_b
+    is_a_awake = not (dyn_info.links.is_fixed[link_a_maybe_batch] or dyn_state.links.is_hibernated[link_a, i_b])
+    is_b_awake = link_b >= 0 and not (
+        dyn_info.links.is_fixed[link_b_maybe_batch] or dyn_state.links.is_hibernated[link_b, i_b]
+    )
+    return not is_a_awake and not is_b_awake
+
+
+@qd.func
+def _clear_inert_collision_row(n_con, i_b, constraint_state: array_class.ConstraintState, rigid_config: qd.template()):
+    """Write an inert (force-free) collision row in slot n_con.
+
+    The slots are reused by index across steps, so a contact that carries no constraint must actively clear its
+    slots and mark them inert: leaving the stale jacobian of a prior step (when those dofs were awake and in contact)
+    would leak that contact force into the qfrc_constraint of a since-woken body that now shares the slot. The dof
+    support is emptied too, so every sparse consumer (jv products, island resolve, noslip) skips the row.
+    """
+    if qd.static(rigid_config.sparse_solve):
+        for i_d_ in range(constraint_state.jac_n_dofs[n_con, i_b]):
+            i_d = constraint_state.jac_dofs_idx[n_con, i_d_, i_b]
+            constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
+    else:
+        for i_d in range(constraint_state.jac.shape[1]):
+            constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
+    constraint_state.jac_n_dofs[n_con, i_b] = 0
+    constraint_state.diag[n_con, i_b] = gs.qd_float(1.0)
+    constraint_state.aref[n_con, i_b] = gs.qd_float(0.0)
+    # The elliptic cone reads efc_D as con_mu = friction * sqrt(d0 / d1). A zero would give sqrt(0 / 0) = NaN that the
+    # cleared jacobian cannot mask (0 * NaN = NaN), poisoning the solve. A finite efc_D = 1 / diag keeps con_mu finite,
+    # so the zero residuals classify this inert row as inactive. The pyramidal path is unaffected by efc_D once its
+    # jacobian is zero, so it keeps 0.
+    if qd.static(rigid_config.enable_elliptic_friction):
+        constraint_state.efc_D[n_con, i_b] = 1.0
+    else:
+        constraint_state.efc_D[n_con, i_b] = 0.0
+
+
+@qd.func
 def _add_friction_constraint(
     i_b,
     i_col_,
@@ -857,9 +909,27 @@ def _add_collision_constraints_per_friction(
         i_col_ = slot // rows_per_contact
         i_friction = slot % rows_per_contact
         if i_col_ < collider_state.n_contacts[i_b]:
-            _add_friction_constraint(
-                i_b, i_col_, i_friction, dyn_state, collider_state, constraint_state, dyn_info, rigid_info, rigid_config
-            )
+            is_inert = False
+            if qd.static(rigid_config.use_hibernation):
+                i_col = collider_state.contact_sort_idx[i_col_, i_b]
+                link_a = collider_state.contact_data.link_a[i_col, i_b]
+                link_b = collider_state.contact_data.link_b[i_col, i_b]
+                is_inert = _is_contact_inert(link_a, link_b, i_b, dyn_state, dyn_info, rigid_config)
+            if is_inert:
+                n_con = constraint_state.n_constraints[i_b] + i_col_ * rows_per_contact + i_friction
+                _clear_inert_collision_row(n_con, i_b, constraint_state, rigid_config)
+            else:
+                _add_friction_constraint(
+                    i_b,
+                    i_col_,
+                    i_friction,
+                    dyn_state,
+                    collider_state,
+                    constraint_state,
+                    dyn_info,
+                    rigid_info,
+                    rigid_config,
+                )
 
 
 @qd.func
@@ -902,45 +972,16 @@ def _add_collision_constraints_per_contact(
             link_a_maybe_batch = [link_a, i_b] if qd.static(rigid_config.batch_links_info) else link_a
             link_b_maybe_batch = [link_b, i_b] if qd.static(rigid_config.batch_links_info) else link_b
 
+            if qd.static(rigid_config.use_hibernation):
+                if _is_contact_inert(link_a, link_b, i_b, dyn_state, dyn_info, rigid_config):
+                    for i_friction in range(rows_per_contact):
+                        n_con = collision_con_start + i_col_ * rows_per_contact + i_friction
+                        _clear_inert_collision_row(n_con, i_b, constraint_state, rigid_config)
+                    continue
+
             dyn_state.links.is_constrained[link_a, i_b] = True
             if link_b > -1:
                 dyn_state.links.is_constrained[link_b, i_b] = True
-
-            # A contact needs a constraint only when at least one endpoint is an awake dynamic body; if both are
-            # hibernated or fixed, no awake dof is acted upon and the contact carries no constraint. A sleeper struck
-            # by an awake body was already revived in the broad phase, so it does not reach this branch. The slots are
-            # reused by index across steps, so a skipped contact must actively clear its slots and mark them inert:
-            # leaving the stale jacobian of a prior step (when those dofs were awake and in contact) would leak that
-            # contact force into the qfrc_constraint of a since-woken body that now shares the slot.
-            if qd.static(rigid_config.use_hibernation):
-                is_a_awake = not (
-                    dyn_info.links.is_fixed[link_a_maybe_batch] or dyn_state.links.is_hibernated[link_a, i_b]
-                )
-                is_b_awake = link_b >= 0 and not (
-                    dyn_info.links.is_fixed[link_b_maybe_batch] or dyn_state.links.is_hibernated[link_b, i_b]
-                )
-                if not is_a_awake and not is_b_awake:
-                    for i_friction in range(rows_per_contact):
-                        n_con = collision_con_start + i_col_ * rows_per_contact + i_friction
-                        if qd.static(rigid_config.sparse_solve):
-                            for i_d_ in range(constraint_state.jac_n_dofs[n_con, i_b]):
-                                i_d = constraint_state.jac_dofs_idx[n_con, i_d_, i_b]
-                                constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
-                            constraint_state.jac_n_dofs[n_con, i_b] = 0
-                        else:
-                            for i_d in range(n_dofs):
-                                constraint_state.jac[n_con, i_d, i_b] = gs.qd_float(0.0)
-                        constraint_state.diag[n_con, i_b] = gs.qd_float(1.0)
-                        constraint_state.aref[n_con, i_b] = gs.qd_float(0.0)
-                        # The elliptic cone reads efc_D as con_mu = friction * sqrt(d0 / d1); a zero would give
-                        # sqrt(0 / 0) = NaN that the cleared jacobian cannot mask (0 * NaN = NaN), poisoning the solve.
-                        # A finite efc_D = 1 / diag keeps con_mu finite, so the zero residuals classify this inert row
-                        # as inactive. The pyramidal path is unaffected by efc_D once its jacobian is zero, so it keeps 0.
-                        if qd.static(rigid_config.enable_elliptic_friction):
-                            constraint_state.efc_D[n_con, i_b] = 1.0
-                        else:
-                            constraint_state.efc_D[n_con, i_b] = 0.0
-                    continue
 
             # FIXME: The reference engine anchors the tangent frame of a plane-capsule contact to the capsule axis,
             # while this frame comes from the normal alone, so the friction rows of plane-capsule pairs do not match
@@ -2985,6 +3026,18 @@ def func_island_tiled_factor_solve_all(
                         TileCls,
                         write_L,
                     )
+                elif qd.static(rigid_config.use_hibernation):
+                    # The line search and the iterate update run over every dof of the env, so a hibernated island,
+                    # whose factor and solve are skipped, must carry a zero gradient and search direction: a stale
+                    # direction would otherwise step its dofs every iteration, drifting them without bound and feeding
+                    # that drift into the env-wide step length of the awake islands. The gradient is zeroed where it
+                    # is computed (func_update_gradient_no_solve, func_update_gradient_batch).
+                    dof_start = constraint_state.island.dof_slices.start[i_island, i_b]
+                    i_d_ = tid
+                    while i_d_ < constraint_state.island.dof_slices.n[i_island, i_b]:
+                        i_d = constraint_state.island.dof_id[dof_start + i_d_, i_b]
+                        constraint_state.Mgrad[i_d, i_b] = gs.qd_float(0.0)
+                        i_d_ = i_d_ + T
             # Fence the shared tile before this block reuses it for its next work item.
             qd.simt.block.sync()
             i_work = i_work + N_BLOCKS
@@ -6266,6 +6319,15 @@ def func_update_gradient_batch(
             constraint_state.Ma[i_d, i_b] - dyn_state.dofs.force[i_d, i_b] - constraint_state.qfrc_constraint[i_d, i_b]
         )
 
+    # A dof of a hibernated island carries no gradient and no search direction; see func_island_tiled_factor_solve_all.
+    # The solves below skip that island, so Mgrad is cleared here.
+    if qd.static(rigid_config.use_hibernation):
+        for i_d in range(n_dofs):
+            i_island = constraint_state.island.dofs_island_idx[i_d, i_b]
+            if i_island >= 0 and constraint_state.island.is_hibernated[i_island, i_b]:
+                constraint_state.grad[i_d, i_b] = gs.qd_float(0.0)
+                constraint_state.Mgrad[i_d, i_b] = gs.qd_float(0.0)
+
     if qd.static(rigid_config.solver_type == gs.constraint_solver.CG):
         func_solve_mass_batch(
             i_b, constraint_state.grad, constraint_state.Mgrad, dyn_state, dyn_info, rigid_info, rigid_config
@@ -6310,6 +6372,11 @@ def func_update_gradient_no_solve(
                 - dyn_state.dofs.force[i_d, i_b]
                 - constraint_state.qfrc_constraint[i_d, i_b]
             )
+            # A dof of a hibernated island carries no gradient; see func_island_tiled_factor_solve_all.
+            if qd.static(rigid_config.use_hibernation):
+                i_island = constraint_state.island.dofs_island_idx[i_d, i_b]
+                if i_island >= 0 and constraint_state.island.is_hibernated[i_island, i_b]:
+                    constraint_state.grad[i_d, i_b] = gs.qd_float(0.0)
 
 
 @qd.func
@@ -7143,6 +7210,10 @@ def func_update_qacc(
 
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.PARTIAL)
     for i_d, i_b in qd.ndrange(n_dofs, _B):
+        # A hibernated dof is left out of the solve, so its zero acceleration and last awake forces stand.
+        if qd.static(rigid_config.use_hibernation):
+            if dyn_state.dofs.is_hibernated[i_d, i_b]:
+                continue
         dyn_state.dofs.acc[i_d, i_b] = constraint_state.qacc[i_d, i_b]
         dyn_state.dofs.qf_constraint[i_d, i_b] = constraint_state.qfrc_constraint[i_d, i_b]
         dyn_state.dofs.force[i_d, i_b] = dyn_state.dofs.qf_smooth[i_d, i_b] + constraint_state.qfrc_constraint[i_d, i_b]

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -800,6 +800,9 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
     # hibernated-fixed pairs exactly like SAP, and the hibernated-vs-hibernated pairs it traverses instead of skipping
     # are inert (both bodies frozen).
     scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            gravity=(0.0, 0.0, -9.81),
+        ),
         rigid_options=gs.options.RigidOptions(
             use_contact_island=True,
             use_hibernation=True,
@@ -855,7 +858,8 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
     assert all(link_asleep(link) for link in multibody_bases[:-1])
     assert not link_asleep(late)
     # The sleepers stay frozen while the env keeps solving the body still falling: zero velocity, and forces held at
-    # their values from the moment they fell asleep, since their island is left out of the solve.
+    # their values from the moment they fell asleep, since their island is left out of the solve. A sleeper resting on
+    # the ground keeps reporting the support force balancing its weight.
     sleepers_force = [box.get_dofs_force() for box in (box_rest, box_hit)]
     sleepers_contact_force = [box.get_links_net_contact_force() for box in (box_rest, box_hit)]
     for _ in range(40):
@@ -864,6 +868,7 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
         assert_equal(box.get_dofs_velocity(), 0.0)
         assert_equal(box.get_dofs_force(), force)
         assert_equal(box.get_links_net_contact_force(), contact_force)
+        assert_allclose(contact_force[..., 0, 2], 9.81 * box.get_mass(), tol=1e-2)
     rest_x0 = box_rest.get_pos()[..., 0]
 
     box_hit.set_dofs_velocity([-2.0, 0.0, 0.0, 0.0, 0.0, 0.0])

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -854,8 +854,16 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
     # The bodies that landed first sleep while the one still falling does not.
     assert all(link_asleep(link) for link in multibody_bases[:-1])
     assert not link_asleep(late)
+    # The sleepers stay frozen while the env keeps solving the body still falling: zero velocity, and forces held at
+    # their values from the moment they fell asleep, since their island is left out of the solve.
+    sleepers_force = [box.get_dofs_force() for box in (box_rest, box_hit)]
+    sleepers_contact_force = [box.get_links_net_contact_force() for box in (box_rest, box_hit)]
     for _ in range(40):
         scene.step()
+    for box, force, contact_force in zip((box_rest, box_hit), sleepers_force, sleepers_contact_force):
+        assert_equal(box.get_dofs_velocity(), 0.0)
+        assert_equal(box.get_dofs_force(), force)
+        assert_equal(box.get_links_net_contact_force(), contact_force)
     rest_x0 = box_rest.get_pos()[..., 0]
 
     box_hit.set_dofs_velocity([-2.0, 0.0, 0.0, 0.0, 0.0, 0.0])

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -492,7 +492,7 @@ def test_hibernation_with_pruning(show_viewer, n_envs):
     for duck, z in zip(ducks, z_rest):
         assert_allclose(duck.get_pos()[..., 2], z, atol=1e-5)
         # A sleeper resting on the ground keeps reporting the support force balancing its weight.
-        assert_allclose(duck.get_links_net_contact_force()[..., 0, 2], -GRAVITY * duck.get_mass(), tol=1e-2)
+        assert_allclose(duck.get_links_net_contact_force()[..., 0, 2], -GRAVITY * duck.get_mass(), tol=2e-3)
 
     # Resetting wakes every body: the restored state is a discontinuity, so a body left hibernated would stay frozen
     # and never be resimulated. After reset the ducks are awake again, with their flags cleared and awake counter zeroed.
@@ -873,7 +873,7 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
         assert_equal(box.get_dofs_velocity(), 0.0)
         assert_equal(box.get_dofs_force(), force)
         assert_equal(box.get_links_net_contact_force(), contact_force)
-        assert_allclose(contact_force[..., 0, 2], -GRAVITY * box.get_mass(), tol=1e-2)
+        assert_allclose(contact_force[..., 0, 2], -GRAVITY * box.get_mass(), tol=2e-3)
     rest_x0 = box_rest.get_pos()[..., 0]
 
     box_hit.set_dofs_velocity([-2.0, 0.0, 0.0, 0.0, 0.0, 0.0])

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -447,9 +447,11 @@ def test_hibernation_with_pruning(show_viewer, n_envs):
     # hibernation all run together. contact_pruning_tolerance is set explicitly to keep pruning on alongside islands.
     # Two separated ducks give two islands (hibernation does not keep a single-island scene partitioned). Each duck
     # must reach the plane without tunnelling, hibernate, and then stay frozen in place.
+    GRAVITY = -9.81
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=1.0 / 100.0,
+            gravity=(0.0, 0.0, GRAVITY),
         ),
         rigid_options=gs.options.RigidOptions(
             contact_pruning_tolerance=0.02,
@@ -490,7 +492,7 @@ def test_hibernation_with_pruning(show_viewer, n_envs):
     for duck, z in zip(ducks, z_rest):
         assert_allclose(duck.get_pos()[..., 2], z, atol=1e-5)
         # A sleeper resting on the ground keeps reporting the support force balancing its weight.
-        assert_allclose(duck.get_links_net_contact_force()[..., 0, 2], 9.81 * duck.get_mass(), tol=1e-2)
+        assert_allclose(duck.get_links_net_contact_force()[..., 0, 2], -GRAVITY * duck.get_mass(), tol=1e-2)
 
     # Resetting wakes every body: the restored state is a discontinuity, so a body left hibernated would stay frozen
     # and never be resimulated. After reset the ducks are awake again, with their flags cleared and awake counter zeroed.
@@ -801,9 +803,10 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
     # rather than per entity. ALL_VS_ALL exercises hibernation under the non-default traversal: it advects and skips
     # hibernated-fixed pairs exactly like SAP, and the hibernated-vs-hibernated pairs it traverses instead of skipping
     # are inert (both bodies frozen).
+    GRAVITY = -9.81
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
-            gravity=(0.0, 0.0, -9.81),
+            gravity=(0.0, 0.0, GRAVITY),
         ),
         rigid_options=gs.options.RigidOptions(
             use_contact_island=True,
@@ -870,7 +873,7 @@ def test_hibernation_wakes_on_collision(show_viewer, n_envs, broadphase_traversa
         assert_equal(box.get_dofs_velocity(), 0.0)
         assert_equal(box.get_dofs_force(), force)
         assert_equal(box.get_links_net_contact_force(), contact_force)
-        assert_allclose(contact_force[..., 0, 2], 9.81 * box.get_mass(), tol=1e-2)
+        assert_allclose(contact_force[..., 0, 2], -GRAVITY * box.get_mass(), tol=1e-2)
     rest_x0 = box_rest.get_pos()[..., 0]
 
     box_hit.set_dofs_velocity([-2.0, 0.0, 0.0, 0.0, 0.0, 0.0])

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -489,6 +489,8 @@ def test_hibernation_with_pruning(show_viewer, n_envs):
     assert asleep()
     for duck, z in zip(ducks, z_rest):
         assert_allclose(duck.get_pos()[..., 2], z, atol=1e-5)
+        # A sleeper resting on the ground keeps reporting the support force balancing its weight.
+        assert_allclose(duck.get_links_net_contact_force()[..., 0, 2], 9.81 * duck.get_mass(), tol=1e-2)
 
     # Resetting wakes every body: the restored state is a discontinuity, so a body left hibernated would stay frozen
     # and never be resimulated. After reset the ducks are awake again, with their flags cleared and awake counter zeroed.


### PR DESCRIPTION
## Description
On GPU, a sleeping body kept receiving constraint forces: the cooperative collision-row assembly had no hibernation branch, so its resting contacts stayed live rows, and the env-wide Newton passes kept stepping its dofs along a stale search direction while the per-island factor skipped its island. Under contact pruning, the wake-on-contact pass also read raw contact slots instead of the kept ones, delaying the wake of a struck sleeper. Both assembly paths now write inert rows through shared helpers, both GPU arms zero the gradient and search direction of hibernated islands, the wake pass and the advection of a sleeper's contacts read contacts through `contact_sort_idx`, a sleeping dof keeps zero velocity and acceleration, and a resting sleeper keeps reporting the support force it is at rest under.

## Related Issue
Resolves https://github.com/Genesis-Embodied-AI/genesis-world/issues/3293

## How Has This Been / Can This Be Tested?
`test_hibernation_wakes_on_collision` now asserts that sleepers keep zero velocity and forces frozen at their weight while an awake body is simulated in the same env, which the previous code fails on GPU, and `test_hibernation_with_pruning` asserts the same weight for sleepers whose contacts are pruned. The script from the issue runs to completion.

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
