### PR TITLE
[BUG FIX] Report a zero velocity for a body that fell asleep.

### DIFF
--- a/genesis/engine/solvers/rigid/abd/forward_kinematics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_kinematics.py
@@ -1062,12 +1062,17 @@ def func_aggregate_awake_entities(
 def func_hibernate_link_and_zero_dof_velocities(
     i_l: int, i_b: int, dyn_state: array_class.DynState, dyn_info: array_class.DynInfo, rigid_config: qd.template()
 ):
-    """Mark a link, its DOFs, and its geoms as hibernated, and zero out the DOF velocities and accelerations.
+    """Mark a link, its DOFs, and its geoms as hibernated, and zero out the DOF and link velocities and accelerations.
 
     The next-velocity buffer is zeroed too: the integration copy runs over every dof, so a stale value there would be
-    restored as the sleeper's velocity on the following substep.
+    restored as the sleeper's velocity on the following substep. The link Cartesian velocity is zeroed as well: the
+    velocity pass skips a sleeping link (see func_forward_velocity_entity), so the value it holds at the transition is
+    what every velocity getter reports for as long as the link sleeps, and a restored state recomputes it from the
+    zeroed dof velocities.
     """
     dyn_state.links.is_hibernated[i_l, i_b] = True
+    dyn_state.links.cd_vel[i_l, i_b] = qd.Vector.zero(gs.qd_float, 3)
+    dyn_state.links.cd_ang[i_l, i_b] = qd.Vector.zero(gs.qd_float, 3)
 
     link_I = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
     for i_d in range(dyn_info.links.dof_start[link_I], dyn_info.links.dof_end[link_I]):


### PR DESCRIPTION
## Description

When an island falls asleep, the transition now zeroes the link Cartesian velocity of every link it puts to sleep, together with the dof velocities it already zeroed.

The velocity pass skips a sleeping link, so whatever its Cartesian velocity buffers held at the transition was what every velocity getter reported for as long as the link slept. A state captured while asleep and restored again recomputes those buffers from the zeroed dof velocities, so the same getter read a different value before and after the restore.

## Motivation and Context

`tests/rigid/test_api.py::test_reset[pyramidal-None-True-False]` compares every velocity getter of a body captured asleep against its value after the state is restored, and the link velocity getters disagreed by the last awake velocity of the body.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_api.py::test_reset` with hibernation enabled asserts that every getter reads the same before and after restoring a state captured while the bodies sleep. `tests/rigid/test_islands.py` covers the sleep and wake transitions.