### PR TITLE
[BUG FIX] Support offscreen rendering with OSMesa.

### DIFF
--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -4,6 +4,7 @@ Author: Matthew Matl
 """
 
 import os
+import sys
 
 from OpenGL.GL import *
 
@@ -17,41 +18,17 @@ class OffscreenRenderer(object):
 
     Parameters
     ----------
-    viewport_width : int
-        The width of the main viewport, in pixels.
-    viewport_height : int
-        The height of the main viewport, in pixels.
     point_size : float
         The size of screen-space points in pixels.
     """
 
-    def __init__(self, point_size=1.0, pyopengl_platform="pyglet", seg_node_map=None):
+    def __init__(self, point_size=1.0, seg_node_map=None):
         self.point_size = point_size
         self._platform = None
         self._is_software = False
         self._has_valid_context = False
-        self._create(pyopengl_platform)
+        self._create()
         self._seg_node_map = seg_node_map
-
-    @property
-    def viewport_width(self):
-        """int : The width of the main viewport, in pixels."""
-        return 32
-        # return self._viewport_width
-
-    @viewport_width.setter
-    def viewport_width(self, value):
-        self._viewport_width = int(value)
-
-    @property
-    def viewport_height(self):
-        """int : The height of the main viewport, in pixels."""
-        return 32
-        # return self._viewport_height
-
-    @viewport_height.setter
-    def viewport_height(self, value):
-        self._viewport_height = int(value)
 
     @property
     def point_size(self):
@@ -70,19 +47,6 @@ class OffscreenRenderer(object):
             )
 
         self._platform.make_current()
-
-        # If platform does not support dynamically-resizing framebuffers, destroy it and restart it
-        if (
-            self._platform.viewport_height != self.viewport_height
-            or self._platform.viewport_width != self.viewport_width
-        ):
-            if not self._platform.supports_framebuffers():
-                self.delete()
-                self._create()
-
-                # Only needs to happen if the context was deleted and created
-                self._platform.make_current()
-
         self._has_valid_context = True
 
     def make_uncurrent(self):
@@ -172,30 +136,9 @@ class OffscreenRenderer(object):
 
         first_pass_done = False
         if rgb or depth or seg:
-            if self._platform.supports_framebuffers():
-                flags |= RenderFlags.OFFSCREEN
-                retval = renderer.render(scene, flags, seg_node_map)
-                assert retval is not None
-            else:
-                if flags & RenderFlags.ENV_SEPARATE:
-                    gs.raise_exception("'env_separate_rigid=True' not supported on this platform.")
-                result = renderer.render(scene, flags, seg_node_map)
-                assert result is not None
-                glBindFramebuffer(GL_READ_FRAMEBUFFER, 0)
-                glReadBuffer(GL_FRONT)
-                if depth:
-                    z_near = scene.main_camera_node.camera.znear
-                    z_far = scene.main_camera_node.camera.zfar
-                    if z_far is None:
-                        z_far = -1.0
-                    depth_arr = renderer.jit.read_depth_buf(self.viewport_height, self.viewport_width, z_near, z_far)
-                    depth_arr = renderer._resize_image(depth_arr, antialias=not seg)
-                if flags & RenderFlags.DEPTH_ONLY:
-                    retval = (depth_arr,)
-                else:
-                    color_arr = renderer.jit.read_color_buf(self.viewport_height, self.viewport_width, rgba=False)
-                    color_arr = renderer._resize_image(color_arr, antialias=not seg)
-                    retval = (color_arr, depth_arr) if depth else (color_arr,)
+            flags |= RenderFlags.OFFSCREEN
+            retval = renderer.render(scene, flags, seg_node_map)
+            assert retval is not None
             first_pass_done = True
         else:
             retval = ()
@@ -211,17 +154,7 @@ class OffscreenRenderer(object):
                 flags |= RenderFlags.SKIP_MARKERS
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
 
-            if self._platform.supports_framebuffers():
-                normal_arr, *_ = renderer.render(
-                    scene, flags, is_first_pass=not first_pass_done, force_skip_shadows=True
-                )
-            else:
-                glBindFramebuffer(GL_READ_FRAMEBUFFER, 0)
-                glReadBuffer(GL_FRONT)
-                renderer.render(scene, flags, is_first_pass=not first_pass_done, force_skip_shadows=True)
-                normal_arr = renderer.jit.read_color_buf(self.viewport_height, self.viewport_width, rgba=False)
-                normal_arr = renderer._resize_image(normal_arr, antialias=not seg)
-
+            normal_arr, *_ = renderer.render(scene, flags, is_first_pass=not first_pass_done, force_skip_shadows=True)
             retval = (*retval, normal_arr)
 
             renderer._program_cache = old_cache
@@ -241,11 +174,20 @@ class OffscreenRenderer(object):
         del self._platform
         self._platform = None
 
-    def _create(self, platform):
+    def _create(self):
+        # The PyOpenGL platform requested through PYOPENGL_PLATFORM, defaulting to the window-less one of the operating
+        # system.
+        platform = os.environ.get("PYOPENGL_PLATFORM", {"linux": "egl", "darwin": "cgl"}.get(sys.platform, "pyglet"))
+        if platform not in ("osmesa", "pyglet", "egl", "cgl"):
+            gs.logger.warning(f"PYOPENGL_PLATFORM='{platform}' not supported. Falling back to 'pyglet'.")
+            platform = "pyglet"
+        if sys.platform != "darwin" and platform == "cgl":
+            gs.raise_exception("PYOPENGL_PLATFORM='cgl' is only supported on MacOS.")
+
         if platform == "pyglet":
             from .platforms.pyglet_platform import PygletPlatform
 
-            self._platform = PygletPlatform(self.viewport_width, self.viewport_height)
+            self._platform = PygletPlatform()
         elif platform == "egl":
             from .platforms import egl
 
@@ -253,17 +195,15 @@ class OffscreenRenderer(object):
                 device_id = int(os.environ["EGL_DEVICE_ID"])
             else:
                 device_id = None
-            self._platform = egl.EGLPlatform(self.viewport_width, self.viewport_height, device_id)
+            self._platform = egl.EGLPlatform(device_id)
         elif platform == "osmesa":
             from .platforms.osmesa import OSMesaPlatform
 
-            self._platform = OSMesaPlatform(self.viewport_width, self.viewport_height)
-        elif platform == "cgl":
+            self._platform = OSMesaPlatform()
+        else:
             from .platforms.cgl import CGLPlatform
 
-            self._platform = CGLPlatform(self.viewport_width, self.viewport_height)
-        else:
-            raise ValueError("Unsupported PyOpenGL platform: {}".format(platform))
+            self._platform = CGLPlatform()
         self._platform.init_context()
 
         self._platform.make_current()

--- a/genesis/ext/pyrender/platforms/base.py
+++ b/genesis/ext/pyrender/platforms/base.py
@@ -5,35 +5,9 @@ from abc import ABCMeta
 class Platform(metaclass=ABCMeta):
     """Base class for all OpenGL platforms.
 
-    Parameters
-    ----------
-    viewport_width : int
-        The width of the main viewport, in pixels.
-    viewport_height : int
-        The height of the main viewport, in pixels
+    Rendering targets framebuffer objects allocated by the renderer itself, so a platform only has to provide a current
+    OpenGL context, whatever the size of its default framebuffer.
     """
-
-    def __init__(self, viewport_width, viewport_height):
-        self.viewport_width = viewport_width
-        self.viewport_height = viewport_height
-
-    @property
-    def viewport_width(self):
-        """int : The width of the main viewport, in pixels."""
-        return self._viewport_width
-
-    @viewport_width.setter
-    def viewport_width(self, value):
-        self._viewport_width = value
-
-    @property
-    def viewport_height(self):
-        """int : The height of the main viewport, in pixels."""
-        return self._viewport_height
-
-    @viewport_height.setter
-    def viewport_height(self, value):
-        self._viewport_height = value
 
     @abc.abstractmethod
     def init_context(self):
@@ -64,11 +38,6 @@ class Platform(metaclass=ABCMeta):
     @abc.abstractmethod
     def delete_context(self):
         """Delete the OpenGL context."""
-        pass
-
-    @abc.abstractmethod
-    def supports_framebuffers(self):
-        """Returns True if the method supports framebuffer rendering."""
         pass
 
     def __del__(self):

--- a/genesis/ext/pyrender/platforms/cgl.py
+++ b/genesis/ext/pyrender/platforms/cgl.py
@@ -60,8 +60,7 @@ class CGLPlatform(Platform):
     a virtual machine exposing no screen at all.
     """
 
-    def __init__(self, viewport_width, viewport_height):
-        super().__init__(viewport_width, viewport_height)
+    def __init__(self):
         self._pixel_format = None
         self._context = None
 
@@ -126,9 +125,6 @@ class CGLPlatform(Platform):
         if self._pixel_format is not None:
             _CGLDestroyPixelFormat(self._pixel_format)
             self._pixel_format = None
-
-    def supports_framebuffers(self):
-        return True
 
 
 __all__ = ["CGLPlatform"]

--- a/genesis/ext/pyrender/platforms/egl.py
+++ b/genesis/ext/pyrender/platforms/egl.py
@@ -129,8 +129,7 @@ class EGLDevice:
 class EGLPlatform(Platform):
     """Renders using EGL."""
 
-    def __init__(self, viewport_width, viewport_height, device_id: int | None = None):
-        super().__init__(viewport_width, viewport_height)
+    def __init__(self, device_id: int | None = None):
         if _eglQueryDevicesEXT is None and device_id not in (0, None):
             raise RuntimeError("EGL platform plugin is not available. Enforcing specific EGL device not supported.")
         self._egl_device_id = device_id
@@ -309,9 +308,6 @@ class EGLPlatform(Platform):
             # driver does not support terminate/re-initialize cycles on the same
             # device (returns EGL_BAD_ACCESS), which breaks multi-scene workflows.
             self._egl_display = None
-
-    def supports_framebuffers(self):
-        return True
 
 
 __all__ = ["EGLPlatform"]

--- a/genesis/ext/pyrender/platforms/osmesa.py
+++ b/genesis/ext/pyrender/platforms/osmesa.py
@@ -1,32 +1,56 @@
+import ctypes
+import functools
+
+import OpenGL.platform
+import OpenGL.platform.osmesa
+
+import genesis as gs
+
 from .base import Platform
+
+
+# PyOpenGL commits to the OSMesa library at import time (see 'OSMesaPlatform'), so the bindings below only exist when
+# it was selected upfront.
+if not isinstance(OpenGL.platform.PLATFORM, OpenGL.platform.osmesa.OSMesaPlatform):
+    gs.raise_exception("PYOPENGL_PLATFORM='osmesa' must be set before importing genesis.")
+from OpenGL import GL as gl
+from OpenGL import arrays
+from OpenGL.osmesa import (
+    OSMESA_CONTEXT_MAJOR_VERSION,
+    OSMESA_CONTEXT_MINOR_VERSION,
+    OSMESA_CORE_PROFILE,
+    OSMESA_DEPTH_BITS,
+    OSMESA_FORMAT,
+    OSMESA_PROFILE,
+    OSMESA_RGBA,
+    OSMesaCreateContextAttribs,
+    OSMesaDestroyContext,
+    OSMesaGetColorBuffer,
+    OSMesaGetCurrentContext,
+    OSMesaMakeCurrent,
+)
 
 
 __all__ = ["OSMesaPlatform"]
 
 
 class OSMesaPlatform(Platform):
-    """Renders into a software buffer using OSMesa. Requires special versions
-    of OSMesa to be installed, plus PyOpenGL upgrade.
+    """Renders offscreen using OSMesa, the window-system-independent software rasterizer of Mesa.
+
+    OSMesa is a self-contained copy of Mesa, and PyOpenGL binds every OpenGL function to the library of the platform
+    selected when it is first imported. The platform is therefore committed for the whole process: PYOPENGL_PLATFORM
+    must be set to 'osmesa' before importing genesis, and every OpenGL context of the process is then an OSMesa one.
+    Genesis selects it by itself on a headless Linux machine lacking EGL (see rasterizer.py).
+
+    Making the context current requires a color buffer serving as default framebuffer. A 1x1 buffer suffices, like the
+    hidden 1x1 window of the pyglet platform, since rendering targets framebuffer objects (see Platform).
     """
 
-    def __init__(self, viewport_width, viewport_height):
-        super().__init__(viewport_width, viewport_height)
+    def __init__(self):
         self._context = None
         self._buffer = None
 
     def init_context(self):
-        from OpenGL import arrays
-        from OpenGL.osmesa import (
-            OSMesaCreateContextAttribs,
-            OSMESA_FORMAT,
-            OSMESA_RGBA,
-            OSMESA_PROFILE,
-            OSMESA_CORE_PROFILE,
-            OSMESA_CONTEXT_MAJOR_VERSION,
-            OSMESA_CONTEXT_MINOR_VERSION,
-            OSMESA_DEPTH_BITS,
-        )
-
         attrs = arrays.GLintArray.asArray(
             [
                 OSMESA_FORMAT,
@@ -43,26 +67,33 @@ class OSMesaPlatform(Platform):
             ]
         )
         self._context = OSMesaCreateContextAttribs(attrs, None)
-        self._buffer = arrays.GLubyteArray.zeros((self.viewport_height, self.viewport_width, 4))
+        self._buffer = arrays.GLubyteArray.zeros((1, 1, 4))
 
     def make_current(self):
-        from OpenGL import GL as gl
-        from OpenGL.osmesa import OSMesaMakeCurrent
-
-        assert OSMesaMakeCurrent(
-            self._context, self._buffer, gl.GL_UNSIGNED_BYTE, self.viewport_width, self.viewport_height
-        )
+        assert OSMesaMakeCurrent(self._context, self._buffer, gl.GL_UNSIGNED_BYTE, 1, 1)
 
     def make_uncurrent(self):
-        """Make the OpenGL context uncurrent."""
-        pass
+        OSMesaMakeCurrent(None, None, gl.GL_UNSIGNED_BYTE, 0, 0)
+
+    def save_current_context(self):
+        # 'make_uncurrent' releases the context and every render path ends there, so this platform's own context is
+        # never the one captured here, only an external one (e.g. another renderer mid-render) or none. A context is
+        # made current together with its color buffer, which is queried back from the context to restore both.
+        context = OSMesaGetCurrentContext()
+        if not context:
+            return None
+        width, height, _, buffer = OSMesaGetColorBuffer(context)
+        return functools.partial(OSMesaMakeCurrent, context, buffer, gl.GL_UNSIGNED_BYTE, width, height)
 
     def delete_context(self):
-        from OpenGL.osmesa import OSMesaDestroyContext
-
-        OSMesaDestroyContext(self._context)
-        self._context = None
-        self._buffer = None
-
-    def supports_framebuffers(self):
-        return False
+        if self._context is not None:
+            # The current context is process-global and shared across renderers, so release it only when it is ours,
+            # otherwise a renderer that is mid-render would be stranded. Handles are compared by address since PyOpenGL
+            # returns a fresh pointer object on every query.
+            current_addr = ctypes.cast(OSMesaGetCurrentContext(), ctypes.c_void_p).value
+            own_addr = ctypes.cast(self._context, ctypes.c_void_p).value
+            if current_addr == own_addr:
+                self.make_uncurrent()
+            OSMesaDestroyContext(self._context)
+            self._context = None
+            self._buffer = None

--- a/genesis/ext/pyrender/platforms/pyglet_platform.py
+++ b/genesis/ext/pyrender/platforms/pyglet_platform.py
@@ -13,8 +13,7 @@ class PygletPlatform(Platform):
     an OpenGL context.
     """
 
-    def __init__(self, viewport_width, viewport_height):
-        super().__init__(viewport_width, viewport_height)
+    def __init__(self):
         self._window = None
 
     def init_context(self):
@@ -102,6 +101,3 @@ class PygletPlatform(Platform):
             self._window = None
             OpenGL.contextdata.cleanupContext(cid)
             del cid
-
-    def supports_framebuffers(self):
-        return True

--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -1,3 +1,4 @@
+import ctypes.util
 import os
 import sys
 
@@ -7,6 +8,16 @@ import OpenGL
 
 import genesis as gs
 from genesis.repr_base import RBC
+from genesis.utils.misc import has_display
+
+
+# PyOpenGL binds every OpenGL function to the library of the platform selected when pyrender is first imported (see
+# OSMesaPlatform), so the platform must be settled here. Offscreen rendering on Linux goes through EGL, and a headless
+# machine lacking it can still render through OSMesa, a self-contained software rasterizer: select it upfront, leaving
+# an explicit choice untouched. A machine with a display keeps its window-system platform, which the viewer relies on.
+if sys.platform == "linux" and "PYOPENGL_PLATFORM" not in os.environ:
+    if ctypes.util.find_library("EGL") is None and ctypes.util.find_library("OSMesa") and not has_display():
+        os.environ["PYOPENGL_PLATFORM"] = "osmesa"
 from genesis.ext import pyrender
 from genesis.vis.camera import Camera
 
@@ -26,22 +37,7 @@ class Rasterizer(RBC):
             return
 
         if self._offscreen:
-            # Select PyOpenGL backend for `pyrender.OffscreenRenderer`.
-            # If env variable is set, use specified platform if supported, otherwise some platform-specific default.
-            default_platform = {"linux": "egl", "darwin": "cgl"}.get(sys.platform, "pyglet")
-            platform = os.environ.get("PYOPENGL_PLATFORM", default_platform)
-            if platform not in ("osmesa", "pyglet", "egl", "cgl"):
-                gs.logger.warning(f"PYOPENGL_PLATFORM='{platform}' not supported. Falling back to 'pyglet'.")
-                platform = "pyglet"
-            if sys.platform == "win32" and platform == "osmesa":
-                gs.raise_exception("PYOPENGL_PLATFORM='osmesa' not supported on Windows OS.")
-            if sys.platform != "darwin" and platform == "cgl":
-                gs.raise_exception("PYOPENGL_PLATFORM='cgl' is only supported on MacOS.")
-
-            # Start the viewer
-            self._renderer = pyrender.OffscreenRenderer(
-                pyopengl_platform=platform, seg_node_map=self._context.seg_node_map
-            )
+            self._renderer = pyrender.OffscreenRenderer(seg_node_map=self._context.seg_node_map)
 
         self.visualizer = self._context.visualizer
 

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -96,25 +96,30 @@ class Viewer(RBC):
             self._is_built = True
             return
 
-        # Try all candidate onscreen OpenGL "platforms" if none is specifically requested
+        # Try all candidate onscreen OpenGL "platforms" if none is specifically requested. OSMesa is ruled out for the
+        # viewer: it binds PyOpenGL to its own private copy of Mesa for the whole process (see OSMesaPlatform), which
+        # the window-system context of the viewer cannot be driven through.
         opengl_platform_orig = os.environ.get("PYOPENGL_PLATFORM")
+        if opengl_platform_orig == "osmesa":
+            gs.raise_exception(
+                "PYOPENGL_PLATFORM='osmesa' only supports offscreen rendering. Unset it or disable the interactive "
+                "viewer."
+            )
         if opengl_platform_orig is None:
             if sys.platform == "win32":
                 all_opengl_platforms = ("wgl",)  # same as "native"
             elif sys.platform == "linux":
                 if pyglet.options.get("headless"):
                     # pyglet's headless windowing creates an EGL pbuffer context, so only the matching PyOpenGL EGL
-                    # platform can share it; native/glx/osmesa query a different context and fail with "no valid
-                    # context", churning GL state on the way out.
+                    # platform can share it; native/glx query a different context and fail with "no valid context",
+                    # churning GL state on the way out.
                     all_opengl_platforms = ("egl",)
                 else:
                     # "native" is platform-specific ("egl" or "glx")
-                    all_opengl_platforms = ("native", "egl", "glx", "osmesa")
+                    all_opengl_platforms = ("native", "egl", "glx")
             else:
                 all_opengl_platforms = ("native",)
         else:
-            if opengl_platform_orig == "osmesa" and sys.platform != "linux":
-                gs.raise_exception("PYOPENGL_PLATFORM='osmesa' is only supported on Linux OS for now.")
             all_opengl_platforms = (opengl_platform_orig,)
 
         for i, platform in enumerate(all_opengl_platforms):


### PR DESCRIPTION
## Description

OSMesa contexts render into framebuffer objects like every other offscreen platform. The separate default-framebuffer path, the offscreen viewport hardcoded to 32x32 pixels and the `supports_framebuffers` hook are removed.

PyOpenGL commits to the OSMesa library when it is first imported, for the whole process. The OSMesa platform now checks that it was selected upfront, releases and restores its current context like the EGL platform does, and the interactive viewer rejects `PYOPENGL_PLATFORM='osmesa'` with a clear message, since a window-system context cannot be driven through OSMesa.

OSMesa is selected automatically on a headless Linux machine lacking EGL, where offscreen rendering would otherwise fail, and it is accepted on every operating system: Mesa builds for Windows ship it up to version 25.0.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3292

## Motivation and Context

Every camera render with `PYOPENGL_PLATFORM=osmesa` failed on an assertion: the OSMesa branch of the offscreen renderer never requested an offscreen pass, so the renderer returned nothing. Removing the assertion would have produced 32x32 images regardless of the camera resolution.

## How Has This Been / Can This Be Tested?

Run the script of the issue with `PYOPENGL_PLATFORM=osmesa` set before importing genesis: it renders at the camera resolution, and its RGB, depth and segmentation match the EGL platform pixel for pixel, both running the same software rasterizer. Enabling the viewer with that variable set raises the new exception.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
