### PR TITLE
[BUG FIX] Keep scalar arrays intact in exported scenes and make copied options picklable.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1428,7 +1428,8 @@ class Scene(RBC):
         omitted_kinds.update(type(recorder).__name__ for recorder in self._recorder_manager.recorders)
         if self._visualizer is not None:
             omitted_kinds.update(type(camera).__name__ for camera in self._visualizer.cameras)
-        omitted_kinds["pre_step_callback"] += len(self._pre_step_callbacks)
+        if self._pre_step_callbacks:
+            omitted_kinds["pre_step_callback"] += len(self._pre_step_callbacks)
         surfaces = [entity.surface for entity in self.entities]
         if isinstance(self.options.renderer, gs.renderers.RayTracer) and self.options.renderer.env_surface is not None:
             surfaces.append(self.options.renderer.env_surface)

--- a/genesis/utils/serialization.py
+++ b/genesis/utils/serialization.py
@@ -326,7 +326,7 @@ def _store_array(value, exported: "Exported") -> int:
     file as they share it in memory. Two views onto one buffer read the same bytes, so the memory a view reads keys
     the lookup rather than the view itself, and every keyed array is held until the export ends so no address is
     reused meanwhile. The copy is made contiguous in row order, so the file holds the same bytes however numpy laid
-    the values out.
+    the values out, and keeps the shape it was given: an array holding one value and no axis loads back as such.
     """
     layout = value.__array_interface__
     key = (layout["data"][0], layout["shape"], layout["strides"], layout["typestr"])
@@ -335,7 +335,7 @@ def _store_array(value, exported: "Exported") -> int:
         slot = len(exported.values)
         exported.slots[key] = slot
         exported.stored.append(value)
-        exported.values.append(np.ascontiguousarray(value))
+        exported.values.append(np.require(value, requirements="C"))
     return slot
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "psutil",
     "quadrants==1.3.0",
-    "pydantic>=2.11.0",
+    # * 2.13.0 sets the private state of a model built by 'model_construct', which pickling reads.
+    "pydantic>=2.13.0",
     "numpy>=1.26.4",
     "frozendict",
     # * 4.8.2 fixed linear/sRGB color conversion in `to_color()`.

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -1,4 +1,5 @@
 import json
+import pickle
 import xml.etree.ElementTree as ET
 import zipfile
 from copy import deepcopy
@@ -355,7 +356,7 @@ def test_export_and_load_rigid(
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
-def test_export_before_build(n_envs, tmp_path, show_viewer):
+def test_export_before_build(n_envs, tmp_path, show_viewer, caplog):
     scene = gs.Scene(
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(1.5, 1.0, 1.0),
@@ -372,9 +373,15 @@ def test_export_before_build(n_envs, tmp_path, show_viewer):
             size=(0.2, 0.2, 0.2),
         ),
     )
-    # Adding an entity resolves its description, so a scene is written before its build as readily as after
+    # Adding an entity resolves its description, so a scene is written before its build as readily as after. The scene
+    # holds nothing a file leaves out, so the export warns of nothing.
     exported = tmp_path / f"authored{SCENE_FORMAT}"
-    scene.export(exported)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        scene.export(exported)
+    assert not caplog.records
+    # The options of a scene are merged copies of the ones given, and pickle as any option does
+    assert pickle.loads(pickle.dumps(scene.options.rigid)) == scene.options.rigid
     scene.build(n_envs=n_envs)
 
     # A file states no environment layout, so whoever opens one builds it with the layout they ask for


### PR DESCRIPTION
## Description

- `Scene.export` writes an array holding one value and no axis with the shape it was given, so it loads back as a scalar array instead of a one-element vector.
- An `Options` instance made by `model_copy_from` pickles: pydantic 2.13 fixes `model_construct` leaving the private state unset on a class declaring `model_post_init` (pydantic/pydantic#12813), so the requirement moves to `pydantic>=2.13.0`.
- The warning of `Scene.export` names pre-step callbacks only when the scene holds some.

## Motivation and Context

Both defects surface as soon as a scene is pickled or exported with such values, which the upcoming scene checkpoint and trajectory log do at every save.

## How Has This Been / Can This Be Tested?

`test_export_before_build` now asserts that exporting a scene holding nothing a file leaves out warns of nothing, and that the options of a scene pickle. Both fail on `main`, the second with pydantic 2.12. The scalar array shape has no test: no description reaches the array store with a 0-d array today.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
