### PR TITLE
[BUG FIX] Keep the authored mass and inertia of fixed links on aligned free bodies.

### DIFF
--- a/genesis/__init__.py
+++ b/genesis/__init__.py
@@ -50,6 +50,7 @@ backend: _gs_backend | None = None
 use_ndarray: bool | None = None
 use_zerocopy: bool | None = None
 use_deterministic_algorithms: bool | None = None
+debug: bool | None = None
 EPS: float | None = None
 
 
@@ -165,6 +166,7 @@ def init(
     # Reproducing a rollout means settling the runtime-measured choices the simulation would otherwise keep revisiting
     # (see prefer_decomposed_solver in rigid_solver.py), at the cost of the throughput they were buying, hence opt-in.
     globals()["use_deterministic_algorithms"] = use_deterministic_algorithms
+    globals()["debug"] = debug
 
     # Define the right dtypes in accordance with selected backend and precision
     global qd_float, np_float, tc_float

--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -43,7 +43,6 @@ from .inertial import (
     RHO_OBJECT,
     RHO_ROBOT,
     GeomInertialInfo,
-    LinkInertial,
     LinkInertialInfo,
     compose_inertial_from_g_infos,
     compose_inertial_properties,
@@ -1085,21 +1084,20 @@ class KinematicEntityDescription(EntityDescription):
                 )
                 subtree.append(i_l)
             if is_articulated:
+                root.is_aligned = False
                 continue
 
             # Each variant anchors on its own resolved inertia and geoms, which kinematic and rigid entities both
             # have. The anchor composes the fixed subtree's inertia and moves the body frame to its center of mass
-            # and principal axes. It re-expresses the variant's geoms, so the world geometry stays put. The composite
-            # folds into the variant's dynamics inertia (rigid only) and into its offset and init_qpos.
+            # and principal axes. It re-expresses the variant geoms, so the geometry keeps its world pose, and folds
+            # into the variant offset and init_qpos.
             for i_v in range(len(resolution.links_inertial_info[i_root])):
                 inertial_info = []
                 explicit_mass_flags = set()
-                composite_locals = []
                 for i_l in subtree:
                     props, is_mass_explicit, _ = resolution.links_inertial_info[i_l][i_v]
                     if props.mass < gs.EPS:
                         continue
-                    composite_locals.append(i_l)
                     explicit_mass_flags.add(is_mass_explicit)
                     rot = gu.quat_to_R(props.quat)
                     inertia_in_link = rot @ props.inertia @ rot.T
@@ -1125,14 +1123,16 @@ class KinematicEntityDescription(EntityDescription):
                         "densities) and geometry-estimated link masses. Specify the mass or density of all of its "
                         "links or none of them."
                     )
+                # A body without inertia gets no anchor and keeps its frame, like the articulated body above. The solver
+                # and the setters then read it as unaligned (see 'func_midpoint_is_aligned' and '_init_mass_mat').
                 if not inertial_info:
+                    root.is_aligned = False
                     continue
                 mass_total, com_root, inertia_root = compose_inertial_properties(inertial_info)
                 if mass_total <= gs.EPS:
+                    root.is_aligned = False
                     continue
-                principal_R = uu.principal_axes_rot(inertia_root)
-                principal_quat = gu.R_to_quat(principal_R)
-                inertia_diag = principal_R.T @ inertia_root @ principal_R
+                principal_quat = gu.R_to_quat(uu.principal_axes_rot(inertia_root))
 
                 # Re-express the variant's geoms across the subtree so the body frame can move to (com_root, principal
                 # axes) while the world geometry stays fixed. The static link poses are shared across heterogeneous
@@ -1151,29 +1151,15 @@ class KinematicEntityDescription(EntityDescription):
                     for geom in geoms:
                         geom.pos, geom.quat = gu.transform_pos_quat_by_trans_quat(geom.pos, geom.quat, pos, quat)
 
-                # Fold the composite (diagonal, COM-centered) into the dynamics inertia.
-                # Rescale the unit-density estimate to the link masses.
+                # Every link keeps its own mass and inertia. The inertial frame moves with the geoms into the anchored
+                # frame: getters and wrenches read it as 'link_COM', and the inverse weight derives from it. The solver
+                # composes the body from its links each step, so the composite is diagonal there (see '_init_mass_mat').
                 if isinstance(root, RigidLinkDescription):
-                    # Sum the dynamics masses of exactly the links that contributed to 'mass_total'; the massless
-                    # links skipped above (a geometry-less link carries only the 'gs.EPS' placeholder) must not
-                    # inflate the composite.
-                    real_total = sum(
-                        (links[i_l] if i_v == 0 else variants[i_v].links[i_l]).mass for i_l in composite_locals
-                    )
-                    scale = real_total / mass_total
                     for i_l in subtree:
                         desc = links[i_l] if i_v == 0 else variants[i_v].links[i_l]
-                        if i_l == i_root:
-                            props = LinkInertial(real_total, gu.zero_pos(), gu.identity_quat(), scale * inertia_diag)
-                        else:
-                            # A fixed child keeps its authored inertial frame, re-expressed like its geoms: it is the
-                            # public 'link_COM' reference of the getters and external wrenches, and the inverse weight
-                            # of the link derives from it. Only its mass and inertia fold into the composite.
-                            pos, quat = gu.transform_pos_quat_by_trans_quat(
-                                desc.inertial_pos, desc.inertial_quat, *alignment_inv_in_link[i_l]
-                            )
-                            props = LinkInertial(gs.EPS, pos, quat, np.zeros((3, 3), dtype=gs.np_float))
-                        desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia = props
+                        desc.inertial_pos, desc.inertial_quat = gu.transform_pos_quat_by_trans_quat(
+                            desc.inertial_pos, desc.inertial_quat, *alignment_inv_in_link[i_l]
+                        )
 
                 # Fold the anchoring into the offset (relative getters keep reporting the authored frame) and the root
                 # free-joint init_qpos (the body frame moves to old_pose o (com_root, principal), keeping the

--- a/genesis/engine/entities/rigid_entity/rigid_link.py
+++ b/genesis/engine/entities/rigid_entity/rigid_link.py
@@ -327,10 +327,9 @@ class KinematicLink(RBC):
     @property
     def aligned(self) -> bool:
         """
-        Whether the link opts into center-of-mass / principal-axis reframing (the 'align' option, set for a free body
-        that opts in or is a primitive). The reframing - and the resulting exactly-diagonal joint-space mass block it
-        enables - is applied only when the body is a single rigid body (a free root with no DOF-bearing descendant);
-        callers relying on the diagonal mass must check that condition too, as the solver does.
+        Whether the build anchored the link frame on the center of mass and principal axes of its body (the 'align'
+        option, on a free body that opts in or is a primitive). Only a single rigid body gets the anchor: a free root
+        with an inertia and no DOF-bearing descendant. Its joint-space mass block is then exactly diagonal.
         """
         return self.desc.is_aligned
 

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -1811,12 +1811,6 @@ def func_update_force(
                         func_add_safe_backward(I_p, dyn_state.links.cfrc_vel[i_l, i_b], dyn_state.links.cfrc_vel, BW)
                         func_add_safe_backward(I_p, dyn_state.links.cfrc_ang[i_l, i_b], dyn_state.links.cfrc_ang, BW)
 
-    # Clear coupling forces after use
-    qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.PARTIAL)
-    for I in qd.grouped(qd.ndrange(*dyn_state.links.cfrc_coupling_ang.shape)):
-        dyn_state.links.cfrc_coupling_ang[I] = qd.Vector.zero(gs.qd_float, 3)
-        dyn_state.links.cfrc_coupling_vel[I] = qd.Vector.zero(gs.qd_float, 3)
-
 
 @qd.func
 def func_actuation(self):
@@ -2225,6 +2219,13 @@ def func_integrate(
                             dyn_state.dofs.vel_next[i_d, i_b] = (
                                 2.0 * dyn_state.dofs.vel_next[i_d, i_b] - dyn_state.dofs.vel[i_d, i_b]
                             )
+
+    # The coupling wrench of this substep is consumed: the bias force read it during forward dynamics and the midpoint
+    # pass above read it last. The coupler accumulates the next one after the substep.
+    qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.PARTIAL)
+    for I in qd.grouped(qd.ndrange(*dyn_state.links.cfrc_coupling_ang.shape)):
+        dyn_state.links.cfrc_coupling_ang[I] = qd.Vector.zero(gs.qd_float, 3)
+        dyn_state.links.cfrc_coupling_vel[I] = qd.Vector.zero(gs.qd_float, 3)
 
 
 @qd.kernel

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -1907,28 +1907,35 @@ def func_midpoint_eligible(
     i_b,
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """Whether the link is a standalone free body eligible for midpoint integration this step.
+    """Whether the link is a free rigid body eligible for midpoint integration this step.
 
-    Eligible: a 6-DOF free-joint link that is its own whole kinematic tree (no parent, and no descendant
-    contributing mass, detected as crb equal to the link's own spatial inertia), and unconstrained this step (no
-    contact touching it and no connect/weld equality involving it, per the assembly-written involvement flag; see
-    is_constrained in array_class.py). The flag covers dynamically registered welds; entities merged at build time
-    via attach are excluded by the tree tests. A constrained body must keep the standard update: the constraint
-    impulse is resolved by the solver at the current configuration and would double-count inside the discrete free
-    rigid-body equation.
+    Eligible: a 6-DOF free-joint link that is its own whole kinematic tree (no parent, and no DOF-bearing descendant, so
+    its mass block holds its own DOFs alone, see dofs_mass_block_start in array_class.py), and unconstrained this step
+    (no contact touching the body, fixed children included, and no connect/weld equality involving it, per the
+    assembly-written involvement flag; see is_constrained in array_class.py). The flag covers dynamically registered
+    welds; entities merged at build time via attach are excluded by the tree tests. A constrained body must keep the
+    standard update: the constraint impulse is resolved by the solver at the current configuration and would
+    double-count inside the discrete free rigid-body equation.
     """
     I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
     is_eligible = False
     if dyn_info.links.n_dofs[I_l] == 6 and dyn_info.links.parent_idx[I_l] == -1:
         i_j = dyn_info.links.joint_start[I_l]
         I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+        dof_start = dyn_info.links.dof_start[I_l]
         is_eligible = (
             dyn_info.joints.type[I_j] == gs.JOINT_TYPE.FREE
-            and dyn_state.links.crb_mass[i_l, i_b] == dyn_state.links.cinr_mass[i_l, i_b]
-            and not dyn_state.links.is_constrained[i_l, i_b]
+            and rigid_info.dofs_mass_block_end[dof_start] <= dyn_info.links.dof_end[I_l]
         )
+        if is_eligible:
+            # The assembly marks the link a constraint acts on, a fixed child included, so the whole body is scanned.
+            for j_l in range(i_l, rigid_info.links_tree_end[i_l]):
+                J_l = [j_l, i_b] if qd.static(rigid_config.batch_links_info) else j_l
+                if dyn_info.links.root_idx[J_l] == i_l and dyn_state.links.is_constrained[j_l, i_b]:
+                    is_eligible = False
         if is_eligible:
             # A position/velocity servo folds its stabilizing gain into the implicit velocity update; treating it
             # explicitly inside the midpoint solve diverges at practical gains, so a servoed body keeps the
@@ -1940,6 +1947,50 @@ def func_midpoint_eligible(
 
 
 @qd.func
+def func_midpoint_has_fixed_children(
+    i_l,
+    i_b,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+):
+    """Whether the body of the free root holds links other than the root itself."""
+    has_fixed_children = False
+    for j_l in range(i_l + 1, rigid_info.links_tree_end[i_l]):
+        J_l = [j_l, i_b] if qd.static(rigid_config.batch_links_info) else j_l
+        if dyn_info.links.root_idx[J_l] == i_l:
+            has_fixed_children = True
+    return has_fixed_children
+
+
+@qd.func
+def func_midpoint_is_aligned(
+    i_l,
+    i_b,
+    dyn_state: array_class.DynState,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+):
+    """Whether the center of mass of the free body sits at its joint origin.
+
+    Alignment moves the frame of an aligned free body onto its center of mass at load, and the build shrinks the mass
+    block of such a body to single DOFs, which no other body gets. A body made of one link reads its own inertial
+    position. Such a body keeps the standard translation update, so the position update and the velocity recovery
+    both read this (see func_midpoint_free_body).
+    """
+    I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+    dof_start = dyn_info.links.dof_start[I_l]
+    is_aligned = False
+    if rigid_info.dofs_mass_block_end[dof_start] == dof_start + 1:
+        is_aligned = True
+    elif not func_midpoint_has_fixed_children(i_l, i_b, dyn_info, rigid_info, rigid_config):
+        ipos = dyn_info.links.inertial_pos[I_l]
+        is_aligned = ipos[0] == 0.0 and ipos[1] == 0.0 and ipos[2] == 0.0
+    return is_aligned
+
+
+@qd.func
 def func_midpoint_free_body(
     i_l,
     i_b,
@@ -1948,15 +1999,15 @@ def func_midpoint_free_body(
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """Advance one standalone free body with the implicit midpoint rule (matching MuJoCo's midpoint integration).
+    """Advance one free rigid body with the implicit midpoint rule (matching MuJoCo's midpoint integration).
 
     Solves the free rigid-body equation I * (w_new - w) / h = tau - w_mid x (I * w_mid) for the midpoint angular
-    velocity w_mid = (w + w_new) / 2 by Newton iteration with backtracking, in the link's inertial
-    (center-of-mass) frame where I is constant. The midpoint rule preserves the quadratic invariants of torque-free
-    tumbling (kinetic energy, squared angular momentum), which the velocity-implicit integrators lose because they
-    omit the gyroscopic derivative. When the center of mass coincides with the joint origin the translation keeps
-    its standard update; otherwise the coupled midpoint center-of-mass velocity has a closed-form solution, with
-    gravity applied in the accelerating frame.
+    velocity w_mid = (w + w_new) / 2 by Newton iteration with backtracking, in a frame attached to the body where the
+    inertia I is constant: the inertial frame of a lone link, or the link frame of a composite. The midpoint rule
+    preserves the quadratic invariants of torque-free tumbling (kinetic energy, squared angular momentum), which the
+    velocity-implicit integrators lose because they omit the gyroscopic derivative. When the center of mass coincides
+    with the joint origin the translation keeps its standard update; otherwise the coupled midpoint center-of-mass
+    velocity has a closed-form solution, with gravity applied in the accelerating frame.
 
     Writes acc[dofs] = (new - old) / h and vel_next[dofs] = (new + old) / 2: the position update integrates with
     the midpoint velocity, and the caller recovers the true next velocity from it afterwards.
@@ -1971,19 +2022,34 @@ def func_midpoint_free_body(
     dof_start = dyn_info.links.dof_start[I_l]
 
     iquat = dyn_info.links.inertial_quat[I_l]
-    inv_iquat = gu.qd_inv_quat(iquat)
     ipos = dyn_info.links.inertial_pos[I_l]
     inertia = dyn_info.links.inertial_i[I_l]
     mass = dyn_info.links.inertial_mass[I_l]
     xquat = dyn_state.links.quat[i_l, i_b]
 
+    # Fixed children make the link a composite. The composite inertia is constant in the link frame, so it replaces the
+    # own inertial for the integration.
+    if func_midpoint_has_fixed_children(i_l, i_b, dyn_info, rigid_info, rigid_config):
+        rot_x = gu.qd_quat_to_R(xquat, EPS)
+        iquat = gu.qd_identity_quat()
+        ipos = rot_x.transpose() @ (dyn_state.links.root_COM[i_l, i_b] - dyn_state.links.pos[i_l, i_b])
+        inertia = rot_x.transpose() @ dyn_state.links.crb_inertial[i_l, i_b] @ rot_x
+        mass = dyn_state.links.crb_mass[i_l, i_b]
+    inv_iquat = gu.qd_inv_quat(iquat)
+    rot_x2i = gu.qd_quat_mul(inv_iquat, gu.qd_inv_quat(xquat))
+
     # Angular velocity and total torque (applied + passive + constraint + external link loads) in the inertial frame.
-    # The stored bias force is re-added to make the gyroscopic and gravity terms explicit, but it also carries the
-    # external link and coupling loads (see func_bias_force): those are stripped back out so they keep their
-    # standard-path sign, leaving the midpoint equation and its accelerating-frame gravity term to regenerate only
-    # the velocity products and gravity. The free joint's angular DOFs are body-frame.
-    ext_ang = dyn_state.links.cfrc_applied_ang[i_l, i_b] + dyn_state.links.cfrc_coupling_ang[i_l, i_b]
-    ext_vel = dyn_state.links.cfrc_applied_vel[i_l, i_b] + dyn_state.links.cfrc_coupling_vel[i_l, i_b]
+    # The free joint's angular DOFs are body-frame. The stored bias force is re-added to make the gyroscopic and gravity
+    # terms explicit. It also carries the external link and coupling loads of every link of the tree (see
+    # func_bias_force), which are stripped back out so they keep their standard-path sign: the midpoint equation and its
+    # accelerating-frame gravity term regenerate only the velocity products and gravity.
+    ext_ang = qd.Vector.zero(gs.qd_float, 3)
+    ext_vel = qd.Vector.zero(gs.qd_float, 3)
+    for j_l in range(i_l, rigid_info.links_tree_end[i_l]):
+        J_l = [j_l, i_b] if qd.static(rigid_config.batch_links_info) else j_l
+        if dyn_info.links.root_idx[J_l] == i_l:
+            ext_ang += dyn_state.links.cfrc_applied_ang[j_l, i_b] + dyn_state.links.cfrc_coupling_ang[j_l, i_b]
+            ext_vel += dyn_state.links.cfrc_applied_vel[j_l, i_b] + dyn_state.links.cfrc_coupling_vel[j_l, i_b]
     w_body = gs.qd_vec3(
         [
             dyn_state.dofs.vel[dof_start + 3, i_b],
@@ -2000,9 +2066,8 @@ def func_midpoint_free_body(
     tau_com = gu.qd_transform_by_quat(tau_body, inv_iquat)
 
     # A center of mass at the joint origin decouples rotation from translation
-    is_aligned = ipos[0] == 0.0 and ipos[1] == 0.0 and ipos[2] == 0.0
+    is_aligned = func_midpoint_is_aligned(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config)
 
-    rot_x2i = gu.qd_quat_mul(inv_iquat, gu.qd_inv_quat(xquat))
     force = qd.Vector.zero(gs.qd_float, 3)
     r_com = qd.Vector.zero(gs.qd_float, 3)
     if not is_aligned:
@@ -2115,7 +2180,7 @@ def func_integrate(
             ):
                 if func_check_index_range(i_1, 0, rigid_info.n_awake_links[i_b], rigid_config.use_hibernation):
                     i_l = rigid_info.awake_links[i_1, i_b] if qd.static(rigid_config.use_hibernation) else i_0
-                    if func_midpoint_eligible(i_l, i_b, dyn_state, dyn_info, rigid_config):
+                    if func_midpoint_eligible(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config):
                         func_midpoint_free_body(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config)
 
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
@@ -2206,13 +2271,12 @@ def func_integrate(
             ):
                 if func_check_index_range(i_1, 0, rigid_info.n_awake_links[i_b], rigid_config.use_hibernation):
                     i_l = rigid_info.awake_links[i_1, i_b] if qd.static(rigid_config.use_hibernation) else i_0
-                    if func_midpoint_eligible(i_l, i_b, dyn_state, dyn_info, rigid_config):
+                    if func_midpoint_eligible(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config):
                         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
                         # Linear DOFs are midpoint-integrated only when the center of mass is off the joint origin
                         # (see func_midpoint_free_body)
-                        ipos = dyn_info.links.inertial_pos[I_l]
                         j_start = 3
-                        if not (ipos[0] == 0.0 and ipos[1] == 0.0 and ipos[2] == 0.0):
+                        if not func_midpoint_is_aligned(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config):
                             j_start = 0
                         for j in range(j_start, 6):
                             i_d = dyn_info.links.dof_start[I_l] + j

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -1914,11 +1914,11 @@ def func_midpoint_eligible(
 
     Eligible: a 6-DOF free-joint link that is its own whole kinematic tree (no parent, and no DOF-bearing descendant, so
     its mass block holds its own DOFs alone, see dofs_mass_block_start in array_class.py), and unconstrained this step
-    (no contact touching the body, fixed children included, and no connect/weld equality involving it, per the
-    assembly-written involvement flag; see is_constrained in array_class.py). The flag covers dynamically registered
-    welds; entities merged at build time via attach are excluded by the tree tests. A constrained body must keep the
-    standard update: the constraint impulse is resolved by the solver at the current configuration and would
-    double-count inside the discrete free rigid-body equation.
+    (no contact on the body, fixed children included, and no connect/weld equality, per the involvement flag the
+    assembly writes, see is_constrained in array_class.py). The flag covers dynamically registered welds, and entities
+    merged at build time via attach fail the tree tests. A constrained body keeps the standard update: the solver
+    resolves the constraint impulse at the current configuration, and the discrete free rigid-body equation would count
+    it again. In the MuJoCo compatibility mode, the body is the link alone, without fixed children.
     """
     I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
     is_eligible = False
@@ -1936,13 +1936,10 @@ def func_midpoint_eligible(
                 J_l = [j_l, i_b] if qd.static(rigid_config.batch_links_info) else j_l
                 if dyn_info.links.root_idx[J_l] == i_l and dyn_state.links.is_constrained[j_l, i_b]:
                     is_eligible = False
-        if is_eligible:
-            # A position/velocity servo folds its stabilizing gain into the implicit velocity update; treating it
-            # explicitly inside the midpoint solve diverges at practical gains, so a servoed body keeps the
-            # standard update.
-            for i_d in range(dyn_info.links.dof_start[I_l], dyn_info.links.dof_end[I_l]):
-                if dyn_state.dofs.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
-                    is_eligible = False
+        # MuJoCo integrates a lone body only, so its compatibility mode leaves a composite on the standard update.
+        if qd.static(rigid_config.enable_mujoco_compatibility):
+            if is_eligible and func_midpoint_has_fixed_children(i_l, i_b, dyn_info, rigid_info, rigid_config):
+                is_eligible = False
     return is_eligible
 
 
@@ -1999,15 +1996,17 @@ def func_midpoint_free_body(
     rigid_info: array_class.RigidInfo,
     rigid_config: qd.template(),
 ):
-    """Advance one free rigid body with the implicit midpoint rule (matching MuJoCo's midpoint integration).
+    """Integrate the velocities of a free rigid body over one substep with the implicit midpoint rule, so that a
+    tumbling body keeps its kinetic energy and angular momentum.
 
     Solves the free rigid-body equation I * (w_new - w) / h = tau - w_mid x (I * w_mid) for the midpoint angular
-    velocity w_mid = (w + w_new) / 2 by Newton iteration with backtracking, in a frame attached to the body where the
-    inertia I is constant: the inertial frame of a lone link, or the link frame of a composite. The midpoint rule
-    preserves the quadratic invariants of torque-free tumbling (kinetic energy, squared angular momentum), which the
-    velocity-implicit integrators lose because they omit the gyroscopic derivative. When the center of mass coincides
-    with the joint origin the translation keeps its standard update; otherwise the coupled midpoint center-of-mass
-    velocity has a closed-form solution, with gravity applied in the accelerating frame.
+    velocity w_mid = (w + w_new) / 2 by Newton iteration with backtracking, in a body frame where I is constant: the
+    inertial frame of a lone link, or the link frame of a composite. Outside the MuJoCo compatibility mode, armature,
+    damping and servo gains add to the derivative terms only, along the link axes for the angular DOFs and the world
+    axes for the linear ones. The midpoint rule preserves the quadratic invariants of torque-free tumbling (kinetic
+    energy, squared angular momentum). A center of mass at the joint origin keeps the standard translation update.
+    Otherwise the coupled midpoint center-of-mass velocity has a closed form, with gravity applied in the accelerating
+    frame, and a linear augmentation couples the rotation to it through the origin.
 
     Writes acc[dofs] = (new - old) / h and vel_next[dofs] = (new + old) / 2: the position update integrates with
     the midpoint velocity, and the caller recovers the true next velocity from it afterwards.
@@ -2037,6 +2036,26 @@ def func_midpoint_free_body(
         mass = dyn_state.links.crb_mass[i_l, i_b]
     inv_iquat = gu.qd_inv_quat(iquat)
     rot_x2i = gu.qd_quat_mul(inv_iquat, gu.qd_inv_quat(xquat))
+
+    # Each DOF adds to the joint-space mass its armature and the first-order damping and servo terms of the implicit
+    # update (see func_mass_mat_implicit_damping). The angular ones sit along the link axes and add to the inertia in
+    # the inertial frame, where both are constant. The linear ones sit along the world axes. MuJoCo integrates the
+    # inertia of the links alone here, so its compatibility mode leaves them out.
+    aug_ang = qd.Matrix.zero(gs.qd_float, 3, 3)
+    aug_vel = qd.Vector.zero(gs.qd_float, 3)
+    if qd.static(not rigid_config.enable_mujoco_compatibility):
+        for j in qd.static(range(6)):
+            i_d = dof_start + j
+            I_d = [i_d, i_b] if qd.static(rigid_config.batch_dofs_info) else i_d
+            augmentation = dyn_info.dofs.armature[I_d] + dyn_info.dofs.damping[I_d] * h
+            if dyn_state.dofs.ctrl_mode[i_d, i_b] <= gs.CTRL_MODE.VELOCITY:
+                augmentation -= dyn_info.dofs.act_bias[I_d][2] * h
+            if qd.static(j < 3):
+                aug_vel[j] = augmentation
+            else:
+                aug_ang[j - 3, j - 3] = augmentation
+    rot_i = gu.qd_quat_to_R(iquat, EPS)
+    inertia_aug = inertia + rot_i.transpose() @ aug_ang @ rot_i
 
     # Angular velocity and total torque (applied + passive + constraint + external link loads) in the inertial frame.
     # The free joint's angular DOFs are body-frame. The stored bias force is re-added to make the gyroscopic and gravity
@@ -2080,28 +2099,69 @@ def func_midpoint_free_body(
         r_com = gu.qd_transform_by_quat(ipos, inv_iquat)
         tau_com = tau_com - r_com.cross(force)
 
-    # Newton iteration with backtracking line search on the residual
-    # f(w_mid) = 2/h * I * (w_mid - w) + w_mid x (I * w_mid) - tau
+    # A linear augmentation on a body whose center of mass is off the joint origin couples the rotation to the
+    # translation (see the residual below). Diagonal along the world axes, it is expressed in the inertial frame.
+    gravity = qd.Vector.zero(gs.qd_float, 3)
+    aug_vel_mat = qd.Matrix.zero(gs.qd_float, 3, 3)
+    mass_inv_mat = qd.Matrix.zero(gs.qd_float, 3, 3)
+    is_coupled = False
+    if not is_aligned:
+        i_e = dyn_info.links.entity_idx[I_l]
+        gravity = rigid_info.gravity[i_b] * (1.0 - dyn_info.entities.gravity_compensation[i_e])
+        gravity = gu.qd_transform_by_quat(gravity, rot_x2i)
+        is_coupled = aug_vel[0] > 0.0 or aug_vel[1] > 0.0 or aug_vel[2] > 0.0
+        if is_coupled:
+            rot_x2i_mat = gu.qd_quat_to_R(rot_x2i, EPS)
+            for j in qd.static(range(3)):
+                aug_vel_mat[j, j] = aug_vel[j]
+                mass_inv_mat[j, j] = 1.0 / (mass + aug_vel[j])
+            aug_vel_mat = rot_x2i_mat @ aug_vel_mat @ rot_x2i_mat.transpose()
+            mass_inv_mat = rot_x2i_mat @ mass_inv_mat @ rot_x2i_mat.transpose()
+    skew_r = qd.Matrix([[0.0, -r_com[2], r_com[1]], [r_com[2], 0.0, -r_com[0]], [-r_com[1], r_com[0], 0.0]])
+    identity = qd.Matrix.identity(gs.qd_float, 3)
+
+    # Newton iteration with backtracking line search on the residual of the rotational midpoint equation. The residual
+    # is f(w_mid) = 2/h * (I + E) * (w_mid - w) + w_mid x (I * w_mid) - tau - r_com x (E_lin * a_origin). The last term
+    # is the moment of the linear augmentation E_lin. The translation midpoint gives a_origin = a_com - u, with (m * Id
+    # + E_lin) @ a_com = f + m * g + E_lin @ u and u = alpha x r_com + w_mid x (w_mid x r_com). Each candidate is
+    # evaluated once. An accepted one takes a Newton step, a rejected one halves the step.
     w_mid = w
-    for _i_newton in range(100):
-        Iw = inertia @ w_mid
-        f = i2h * (inertia @ (w_mid - w)) + w_mid.cross(Iw) - tau_com
-        f_norm = f.norm()
-        if f_norm < tol * (1.0 + i2h * Iw.norm()):
-            break
-        # J = 2/h * I + d(w x Iw)/dw, with d(w x Iw)/dw = skew(w_mid) @ I - skew(I @ w_mid)
-        skew_w = qd.Matrix([[0.0, -w_mid[2], w_mid[1]], [w_mid[2], 0.0, -w_mid[0]], [-w_mid[1], w_mid[0], 0.0]])
-        skew_Iw = qd.Matrix([[0.0, -Iw[2], Iw[1]], [Iw[2], 0.0, -Iw[0]], [-Iw[1], Iw[0], 0.0]])
-        J = i2h * inertia + skew_w @ inertia - skew_Iw
-        delta = J.inverse() @ (-f)
-        step = gs.qd_float(1.0)
-        for _i_ls in range(20):
-            w_try = w_mid + step * delta
-            f_try = i2h * (inertia @ (w_try - w)) + w_try.cross(inertia @ w_try) - tau_com
-            if f_try.norm() < f_norm:
-                w_mid = w_try
+    w_try = w
+    delta = qd.Vector.zero(gs.qd_float, 3)
+    step = gs.qd_float(1.0)
+    f_norm = gs.qd_float(-1.0)
+    n_newton = 0
+    n_backtracks = 0
+    while n_newton < 100 and n_backtracks < 20:
+        Iw = inertia @ w_try
+        f = i2h * (inertia_aug @ (w_try - w)) + w_try.cross(Iw) - tau_com
+        if is_coupled:
+            alpha = i2h * (w_try - w)
+            u = alpha.cross(r_com) + w_try.cross(w_try.cross(r_com))
+            a_origin = mass_inv_mat @ (force + mass * gravity + aug_vel_mat @ u) - u
+            f = f - r_com.cross(aug_vel_mat @ a_origin)
+        if f_norm < 0.0 or f.norm() < f_norm:
+            w_mid = w_try
+            f_norm = f.norm()
+            if f_norm < tol * (1.0 + i2h * Iw.norm()):
                 break
+            # J = 2/h * (I + E) + d(w x Iw)/dw, with d(w x Iw)/dw = skew(w_mid) @ I - skew(I @ w_mid)
+            skew_w = qd.Matrix([[0.0, -w_mid[2], w_mid[1]], [w_mid[2], 0.0, -w_mid[0]], [-w_mid[1], w_mid[0], 0.0]])
+            skew_Iw = qd.Matrix([[0.0, -Iw[2], Iw[1]], [Iw[2], 0.0, -Iw[0]], [-Iw[1], Iw[0], 0.0]])
+            J = i2h * inertia_aug + skew_w @ inertia - skew_Iw
+            if is_coupled:
+                # d(a_origin)/dw = (M^-1 @ E - Id) @ du/dw with du/dw = -2/h * skew(r_com) + d(w x (w x r_com))/dw
+                du_dw = -i2h * skew_r + w_mid.outer_product(r_com) + w_mid.dot(r_com) * identity
+                du_dw = du_dw - 2.0 * r_com.outer_product(w_mid)
+                J = J - skew_r @ aug_vel_mat @ ((mass_inv_mat @ aug_vel_mat - identity) @ du_dw)
+            delta = J.inverse() @ (-f)
+            step = gs.qd_float(1.0)
+            n_newton += 1
+            n_backtracks = 0
+        else:
             step = 0.5 * step
+            n_backtracks += 1
+        w_try = w_mid + step * delta
 
     # Next angular velocity in the body frame; positions integrate with the midpoint velocity
     w_new = 2.0 * w_mid - w
@@ -2121,9 +2181,12 @@ def func_midpoint_free_body(
         )
         v = gu.qd_transform_by_quat(v_world, rot_x2i)
         vcom = v + w.cross(r_com)
-        i_e = dyn_info.links.entity_idx[I_l]
-        gravity = rigid_info.gravity[i_b] * (1.0 - dyn_info.entities.gravity_compensation[i_e])
-        b = force / mass + i2h * vcom + gu.qd_transform_by_quat(gravity, rot_x2i)
+        a_com = force / mass + gravity
+        if is_coupled:
+            alpha = i2h * (w_mid - w)
+            u = alpha.cross(r_com) + w_mid.cross(w_mid.cross(r_com))
+            a_com = mass_inv_mat @ (force + mass * gravity + aug_vel_mat @ u)
+        b = a_com + i2h * vcom
         denom = i2h * i2h + w_mid.dot(w_mid)
         vcom_mid = (i2h * b + (w_mid.dot(b) / i2h) * w_mid - w_mid.cross(b)) / denom
         v_mid = vcom_mid - w_mid.cross(r_com)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -2254,6 +2254,19 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         # tensor of one number repeated: no inertia of any body.
         if shape and np.shape(values)[-len(shape) :] != shape:
             gs.raise_exception(f"{name} is {shape} per link, and {np.shape(values)} cannot be read as that.")
+        # The anchor check below reads the written indices as given, in any form the sanitizer accepts. A tensor on a
+        # GPU device is read back in debug mode only, since that stalls the GPU.
+        links_idx_ = None
+        if links_idx is None:
+            links_idx_ = range(self.n_links)
+        elif not isinstance(links_idx, torch.Tensor) or gs.debug or links_idx.device.type == "cpu":
+            (links_idx_,) = indices_to_mask(links_idx, keepdim=False, to_torch=False, boolean_mask=False)
+            if isinstance(links_idx_, slice):
+                links_idx_ = range(*links_idx_.indices(self.n_links))
+            elif isinstance(links_idx_, torch.Tensor):
+                links_idx_ = tensor_to_array(links_idx_)
+            if np.ndim(links_idx_) == 0:
+                links_idx_ = (links_idx_,)
         values, links_idx, envs_idx = self._sanitize_io_variables(
             values,
             links_idx,
@@ -2264,24 +2277,45 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             batched=self._options.batch_links_info,
             skip_allocation=True,
         )
-        if name != "mass":
-            # TODO: An aligned link is anchored on its own center of mass and principal axes, which is what makes its
-            # mass block diagonal (see _init_mass_mat), so writing either one leaves the anchoring behind. Following
-            # the value instead means moving the frame, which shifts the local pose of every geom of the fixed subtree
-            # ('GeomsInfo.pos' / 'quat', one entry per geom, shared by all environments), so a per-environment value
-            # has no frame to go to. It also moves 'qpos', which is quoted in the anchored frame, and the origin a
-            # fixed child reports. Lifting this takes geom info batched per environment.
-            aligned_idx = next((i_l for i_l in tensor_to_array(links_idx) if self.links[i_l].aligned), None)
-            if aligned_idx is not None:
-                link = self.links[aligned_idx]
+        if links_idx_ is not None:
+            # TODO: the anchor of an aligned root keeps its mass block diagonal (see _init_mass_mat). A center of mass
+            # or an inertia written on any link of the body moves the anchor. A mass write keeps it only as one rescale
+            # of every link of the body, inertia included. A frame move shifts the local pose of every geom
+            # ('GeomsInfo.pos' / 'quat', one entry per geom for all environments). It also shifts 'qpos', quoted in the
+            # anchored frame, and the origin a fixed child reports. A per-environment value has no frame to go to, so
+            # the guard stays until 'GeomsInfo' gets a batch dimension.
+            links_anchor = []
+            for link in self.links:
+                anchor = link
+                while anchor.parent_idx != -1 and all(joint.type == gs.JOINT_TYPE.FIXED for joint in anchor.joints):
+                    anchor = self.links[anchor.parent_idx]
+                links_anchor.append(anchor if anchor.aligned else None)
+            values_idx_by_link = {i_l: i_col for i_col, i_l in enumerate(links_idx_)}
+            for i_l in values_idx_by_link:
+                anchor = links_anchor[i_l]
+                if anchor is None:
+                    continue
+                links_idx_body = [link.idx for link in self.links if links_anchor[link.idx] is anchor]
+                if name == "mass" and len(links_idx_body) == 1:
+                    continue
+                if name == "mass" and scale_inertia and all(i_b in values_idx_by_link for i_b in links_idx_body):
+                    # The rescale check reads the values back and stalls the GPU, so it runs in debug mode only.
+                    if not gs.debug:
+                        continue
+                    ratios = values[..., [values_idx_by_link[i_b] for i_b in links_idx_body]]
+                    ratios = ratios / self.get_links_mass(links_idx_body, envs_idx)
+                    if torch.allclose(ratios, ratios[..., :1], rtol=gs.EPS, atol=gs.EPS):
+                        continue
+                link = self.links[i_l]
                 remedy = (
                     "Load the entity with 'align=False' to write inertial properties at runtime."
                     if isinstance(link.entity.main_morph, gs.options.morphs.FileMorph)
                     else "Writing the inertial properties of a primitive morph is not supported yet."
                 )
+                what = {"mass": "mass", "COM": "center of mass", "inertia": "inertia"}[name]
                 gs.raise_exception(
-                    f"Cannot set the {'center of mass' if name == 'COM' else 'inertia'} of link '{link.name}': its "
-                    f"frame is anchored on the center of mass and principal axes of its body. {remedy}"
+                    f"Cannot set the {what} of link '{link.name}': the frame of its body is anchored on the center of "
+                    f"mass and principal axes of all its links. Set the mass of the whole entity instead. {remedy}"
                 )
 
         envs_idx = envs_idx if self._options.batch_links_info else self._scene._envs_idx

--- a/tests/coupling/test_sph_rigid.py
+++ b/tests/coupling/test_sph_rigid.py
@@ -1,6 +1,8 @@
 import pytest
+import torch
 
 import genesis as gs
+import genesis.utils.geom as gu
 from genesis.utils.misc import qd_to_numpy
 
 
@@ -64,10 +66,23 @@ def test_rigid_flotation_follows_density_ratio(n_envs, pressure_solver, show_vie
             rho=1500.0,
         ),
     )
+    raft = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 0.12, 0.25),
+            size=(0.1, 0.1, 0.04),
+            euler=(30.0, 0.0, 0.0),
+        ),
+        material=gs.materials.Rigid(
+            rho=200.0,
+        ),
+    )
     scene.build(n_envs=n_envs)
 
+    raft_rolls = []
     for _ in range(50):
         scene.step()
+        raft_rolls.append(gu.quat_to_xyz(raft.get_quat(), rpy=True, degrees=True)[..., 0])
+    raft_rolls = torch.stack(raft_rolls)
 
     # The static fluid pressure must push the light ball (rho well below the fluid rest density) up toward the
     # surface, while the heavy ball (rho well above) must keep sinking: flotation discriminates on the density
@@ -76,6 +91,9 @@ def test_rigid_flotation_follows_density_ratio(n_envs, pressure_solver, show_vie
     heavy_z = heavy_ball.get_pos()[..., 2]
     assert (light_z > 0.28).all(), f"Light ball must rise under buoyancy, got z={light_z}"
     assert (heavy_z < 0.22).all(), f"Heavy ball must sink, got z={heavy_z}"
+    # The pressure on the tilted raft acts off its center of mass, so the buoyancy torque rocks it about its roll
+    # axis. That torque reaches the rigid body through the coupling wrench alone.
+    assert (raft_rolls.amax(dim=0) - raft_rolls.amin(dim=0) > 2.0).all(), f"Raft must rock, got rolls={raft_rolls}"
 
 
 @pytest.mark.required

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -865,7 +865,9 @@ def test_normalized_quat(show_viewer, tol):
 
 
 @pytest.mark.required
-def test_inertial_property_setters(sliding_ball_pair, free_bodies_in_one_model, show_viewer, tol):
+def test_inertial_property_setters(
+    sliding_ball_pair, free_bodies_in_one_model, implicit_inertial_origin_chain, show_viewer, tol
+):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=0.01,
@@ -907,6 +909,13 @@ def test_inertial_property_setters(sliding_ball_pair, free_bodies_in_one_model, 
             file=free_bodies_in_one_model,
             pos=(0.0, 10.0, 8.0),
             align=False,
+        ),
+    )
+    chain = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=implicit_inertial_origin_chain,
+            pos=(0.0, -3.0, 0.5),
+            merge_fixed_links=False,
         ),
     )
     scene.build(n_envs=4)
@@ -1014,6 +1023,22 @@ def test_inertial_property_setters(sliding_ball_pair, free_bodies_in_one_model, 
         solver.set_links_COM([OFFSET, 0.0, 0.0], links_idx=free_bodies.links[0].idx)
     with pytest.raises(gs.GenesisException, match="not supported yet"):
         solver.set_links_inertia(SKEWED_INERTIA, links_idx=het_link.idx)
+    # The anchor covers fixed children too, so the setters hold their center of mass and inertia like the root's. A mass
+    # written on one link alone moves the anchor, so the setter rejects it. A mass set on the whole entity keeps the
+    # anchor and the mass ratios.
+    root, child = chain.links
+    with pytest.raises(gs.GenesisException, match="align=False"):
+        child.set_COM([OFFSET, 0.0, 0.0])
+    with pytest.raises(gs.GenesisException, match="align=False"):
+        child.set_inertia(SKEWED_INERTIA)
+    with pytest.raises(gs.GenesisException, match="align=False"):
+        child.set_mass(1.0)
+    with pytest.raises(gs.GenesisException, match="align=False"):
+        root.set_mass(1.0)
+    with pytest.raises(gs.GenesisException, match="align=False"):
+        chain.set_links_mass([1.0, 1.0])
+    chain.set_mass(2.0)
+    assert_allclose(chain.get_links_mass(), [[1.25, 0.75]] * 4, tol=tol)
 
     # An inertial property belongs to the model, so a reset restores the configuration the scene was built at and
     # leaves the mass it now runs with alone.

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -275,6 +275,21 @@ def test_urdf_parsing_inertia_defaults(
             pos=(1.6, 0.0, 0.5),
         ),
     )
+    entity_chain_unmerged_unaligned = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=implicit_inertial_origin_chain,
+            pos=(0.8, 1.0, 0.5),
+            align=False,
+            merge_fixed_links=False,
+        ),
+    )
+    entity_chain_merged_unaligned = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=implicit_inertial_origin_chain,
+            pos=(1.6, 1.0, 0.5),
+            align=False,
+        ),
+    )
     # The asset states no inertial for its base link. Attachment makes that base movable, so Genesis computes its
     # mass from geometry at robot density, the same value the free-standing copy gets.
     carrier = scene.add_entity(
@@ -377,15 +392,39 @@ def test_urdf_parsing_inertia_defaults(
     dubious_com_records = [record for record in caplog.records if "dubious center of mass" in record.getMessage()]
     assert len(dubious_com_records) == 1
 
-    # Folding a fixed-jointed subtree into its parent must not change the composite rigid-body inertia, which the
-    # merging path normalizes the omitted origin for on its own. The two composites are accumulated by independent
-    # code paths, so their agreement is bounded by that cross-path floor rather than by the storage precision.
+    # Every link of an aligned free body keeps its own mass, so each link reads its authored mass. The two totals are
+    # accumulated by independent code paths, so their agreement is bounded by that cross-path floor rather than by the
+    # storage precision.
+    assert_allclose(entity_chain_unmerged.get_links_mass(), (2.5, 1.5), tol=gs.EPS)
     assert_allclose(entity_chain_unmerged.get_mass(), entity_chain_merged.get_mass(), rtol=5e-7)
-    assert_allclose(
-        np.linalg.eigvalsh(entity_chain_unmerged.base_link.desc.inertia),
-        np.linalg.eigvalsh(entity_chain_merged.base_link.desc.inertia),
-        rtol=5e-7,
-    )
+
+    # Merged and unmerged copies are the same rigid body, so one step from rest under the same wrench gives both the
+    # same motion. This holds with the frame anchored on the center of mass and with the frame at the link origin. The
+    # wrench acts on the last link, the fixed child when kept, at one world point above the base.
+    for entity_chain in (
+        entity_chain_unmerged,
+        entity_chain_merged,
+        entity_chain_unmerged_unaligned,
+        entity_chain_merged_unaligned,
+    ):
+        entity_chain.apply_links_external_wrench(
+            force=(3.0, 0.0, 0.0),
+            torque=(0.4, -0.2, 0.1),
+            links_idx_local=entity_chain.n_links - 1,
+            pos=(*entity_chain.morph.pos[:2], 0.8),
+        )
+    scene.step()
+    for entity_chain, entity_chain_ref in (
+        (entity_chain_unmerged, entity_chain_merged),
+        (entity_chain_unmerged_unaligned, entity_chain_merged_unaligned),
+    ):
+        assert_allclose(entity_chain.get_dofs_velocity(), entity_chain_ref.get_dofs_velocity(), tol=1e-6)
+        assert_allclose(entity_chain.get_quat(), entity_chain_ref.get_quat(), tol=1e-6)
+        assert_allclose(
+            entity_chain.get_pos() - torch.tensor(entity_chain.morph.pos),
+            entity_chain_ref.get_pos() - torch.tensor(entity_chain_ref.morph.pos),
+            tol=1e-6,
+        )
 
     # Attachment resolves the base like any movable link, so its mass matches the same asset added free. Both
     # collision and visual geometry feed the computation.
@@ -1501,7 +1540,7 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
         material=gs.materials.Rigid(),
     )
     # Free bodies whose root link is empty and whose mass lives on a fixed child (merge_fixed_links=False keeps the
-    # wrapper). Alignment folds the child's mass onto the root; the subsumed child keeps only the gs.EPS placeholder.
+    # wrapper). The empty root reads the gs.EPS placeholder and the child its authored mass.
     WRAP_MASS_A, WRAP_MASS_B = 0.5, 0.25
     wrapped_morph = (
         gs.morphs.URDF(
@@ -1637,15 +1676,12 @@ def test_align_heterogeneous_inertial(show_viewer, tol):
     with pytest.raises(AssertionError):
         assert_allclose(inertial_i[0, 0], inertial_i[2, 0], tol=tol)
 
-    # Empty-free-root wrapping a fixed massive child: alignment folds the composite mass onto the root (link 0),
-    # leaving the subsumed child (link 1) with only the gs.EPS placeholder. The root must carry exactly the child's
-    # mass; a prior bug summed the root's own gs.EPS placeholder into the composite, inflating it by one gs.EPS
-    # (hence the sub-EPS tolerance below). Envs are dispatched as [A, A, B, B].
-    wrapped_idx = slice(free_wrapped.link_start, free_wrapped.link_end)
-    wrapped_mass = qd_to_numpy(scene.rigid_solver.dyn_info.links.inertial_mass, None, wrapped_idx, transpose=True)
-    assert_allclose(wrapped_mass[[0, 1], 0], WRAP_MASS_A, atol=gs.EPS * 0.5)
-    assert_allclose(wrapped_mass[[2, 3], 0], WRAP_MASS_B, atol=gs.EPS * 0.5)
-    assert_allclose(wrapped_mass[:, 1], gs.EPS, atol=gs.EPS * 1e-3)
+    # The root (link 0) reads the gs.EPS placeholder of a geometry-free link, the child (link 1) its authored mass. The
+    # environments hold [A, A, B, B].
+    wrapped_mass = free_wrapped.get_links_mass()
+    assert_allclose(wrapped_mass[:, 0], gs.EPS, tol=gs.EPS)
+    assert_allclose(wrapped_mass[[0, 1], 1], WRAP_MASS_A, tol=gs.EPS)
+    assert_allclose(wrapped_mass[[2, 3], 1], WRAP_MASS_B, tol=gs.EPS)
 
     # Check contacts
     for i in range(4):

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -236,8 +236,13 @@ def test_urdf_parsing_inertia_defaults(
         (0.01, 0.22, 0.03),
         (0.02, 0.03, 0.30),
     )
+    GRAVITY = (0.0, 0.0, -9.81)
 
     scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=0.01,
+            gravity=GRAVITY,
+        ),
         viewer_options=gs.options.ViewerOptions(
             camera_pos=(0.5, 0.5, 0.5),
             camera_lookat=(0.0, 0.0, 0.0),
@@ -393,37 +398,72 @@ def test_urdf_parsing_inertia_defaults(
     assert len(dubious_com_records) == 1
 
     # Every link of an aligned free body keeps its own mass, so each link reads its authored mass. The two totals are
-    # accumulated by independent code paths, so their agreement is bounded by that cross-path floor rather than by the
-    # storage precision.
+    # accumulated by independent code paths, so their agreement is bounded by that cross-path floor.
     assert_allclose(entity_chain_unmerged.get_links_mass(), (2.5, 1.5), tol=gs.EPS)
     assert_allclose(entity_chain_unmerged.get_mass(), entity_chain_merged.get_mass(), rtol=5e-7)
 
     # Merged and unmerged copies are the same rigid body, so one step from rest under the same wrench gives both the
     # same motion. This holds with the frame anchored on the center of mass and with the frame at the link origin. The
-    # wrench acts on the last link, the fixed child when kept, at one world point above the base.
+    # wrench acts on the last link, the fixed child when kept, at one world point above the base. Armature, damping and
+    # a velocity servo sit on every free-joint DOF.
+    ARMATURE = (0.5, 0.4, 0.3, 0.01, 0.02, 0.015)
+    DAMPING = (2.0, 1.0, 3.0, 0.05, 0.1, 0.02)
+    KV = (4.0, 3.0, 5.0, 0.2, 0.3, 0.1)
+    VEL_TARGET = (0.5, -0.2, 0.3, 1.0, -2.0, 0.5)
+    FORCE, TORQUE = (3.0, 0.0, 0.0), (0.4, -0.2, 0.1)
     for entity_chain in (
         entity_chain_unmerged,
         entity_chain_merged,
         entity_chain_unmerged_unaligned,
         entity_chain_merged_unaligned,
     ):
+        entity_chain.set_dofs_armature(ARMATURE)
+        entity_chain.set_dofs_damping(DAMPING)
+        entity_chain.set_dofs_kv(KV)
+        entity_chain.control_dofs_velocity(VEL_TARGET)
         entity_chain.apply_links_external_wrench(
-            force=(3.0, 0.0, 0.0),
-            torque=(0.4, -0.2, 0.1),
+            force=FORCE,
+            torque=TORQUE,
             links_idx_local=entity_chain.n_links - 1,
             pos=(*entity_chain.morph.pos[:2], 0.8),
         )
+    # From rest, one implicit step solves the augmented mass matrix against the generalized force. Both are written in
+    # the coordinates of the free joint: origin velocity along the world axes, angular velocity along the link axes. The
+    # single unaligned link is the case with every coupling in it.
+    desc = entity_chain_merged_unaligned.base_link.desc
+    link_R = gu.quat_to_R(tensor_to_array(entity_chain_merged_unaligned.get_quat()))
+    com = link_R @ desc.inertial_pos
+    inertia = link_R @ gu.quat_to_R(desc.inertial_quat) @ desc.inertia @ gu.quat_to_R(desc.inertial_quat).T @ link_R.T
+    com_skew = np.array([[0.0, -com[2], com[1]], [com[2], 0.0, -com[0]], [-com[1], com[0], 0.0]])
+    mass_mat = np.block(
+        [
+            [desc.mass * np.eye(3), -desc.mass * com_skew @ link_R],
+            [desc.mass * link_R.T @ com_skew, link_R.T @ (inertia - desc.mass * com_skew @ com_skew) @ link_R],
+        ]
+    )
+    mass_mat += np.diag(ARMATURE) + scene.dt * np.diag(np.add(DAMPING, KV))
+    origin = tensor_to_array(entity_chain_merged_unaligned.get_pos())
+    arm = np.array((*entity_chain_merged_unaligned.morph.pos[:2], 0.8)) - origin
+    force = np.concatenate([FORCE + desc.mass * np.array(GRAVITY), link_R.T @ (TORQUE + np.cross(arm, FORCE))])
+    force += np.multiply(KV, VEL_TARGET)
     scene.step()
+    # The midpoint rule takes the velocity products at the midpoint velocity, the implicit update at the initial one.
+    # From rest the two differ by h * |dv|^2 / 4, the tolerance here.
+    assert_allclose(
+        entity_chain_merged_unaligned.get_dofs_velocity(), scene.dt * np.linalg.solve(mass_mat, force), tol=1e-5
+    )
+    # The two copies compose the same body through independent code paths, so their agreement is bounded by that
+    # cross-path floor, or by the working precision when coarser.
     for entity_chain, entity_chain_ref in (
         (entity_chain_unmerged, entity_chain_merged),
         (entity_chain_unmerged_unaligned, entity_chain_merged_unaligned),
     ):
-        assert_allclose(entity_chain.get_dofs_velocity(), entity_chain_ref.get_dofs_velocity(), tol=1e-6)
-        assert_allclose(entity_chain.get_quat(), entity_chain_ref.get_quat(), tol=1e-6)
+        assert_allclose(entity_chain.get_dofs_velocity(), entity_chain_ref.get_dofs_velocity(), tol=max(tol, 5e-7))
+        assert_allclose(entity_chain.get_quat(), entity_chain_ref.get_quat(), tol=max(tol, 5e-7))
         assert_allclose(
             entity_chain.get_pos() - torch.tensor(entity_chain.morph.pos),
             entity_chain_ref.get_pos() - torch.tensor(entity_chain_ref.morph.pos),
-            tol=1e-6,
+            tol=max(tol, 5e-7),
         )
 
     # Attachment resolves the base like any movable link, so its mass matches the same asset added free. Both

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -209,7 +209,7 @@ def test_many_boxes_dynamics(box_box_detection, gjk_collision, dynamics, show_vi
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 @pytest.mark.parametrize("model_name", ["double_ball_pendulum"])
-def test_apply_external_wrench(xml_path, show_viewer):
+def test_apply_external_wrench(xml_path, show_viewer, tol):
     GRAVITY = 2.0
 
     scene = gs.Scene(
@@ -359,10 +359,25 @@ def test_apply_external_wrench(xml_path, show_viewer):
     with pytest.raises(gs.GenesisException, match="'pos' requires 'force'"):
         rigid_solver.apply_links_external_wrench(torque=(0, 0, 0), links_idx=duck_link_idx, pos=lever_arm)
 
+    # Armature on a free joint adds to the inertia the solver turns the body with. A torque from rest spins the body up
+    # by that augmented inertia under the implicit integrators too. The torque is given in the inertial frame, which
+    # holds the inertia tensor, and the angular velocity is read in the link frame.
+    ARMATURE, TORQUE = 0.002, (0.02, -0.01, 0.015)
+    duck_inertia = duck.base_link.desc.inertia + ARMATURE * np.eye(3)
+    duck_inertial_R = gu.quat_to_R(duck.base_link.desc.inertial_quat)
+    duck_ang = duck.get_dofs_velocity()[3:]
+    duck.set_dofs_armature(ARMATURE, dofs_idx_local=[3, 4, 5])
+    duck.base_link.apply_external_torque(TORQUE, ref=gs.link_ref_frame.link_COM, local=True)
+    scene.step()
+    duck_spin = duck_inertial_R @ np.linalg.solve(duck_inertia, np.array(TORQUE) * scene.dt)
+    assert_allclose(duck.get_dofs_velocity()[3:] - duck_ang, duck_spin, tol=1e-4)
+
 
 @pytest.mark.required
 @pytest.mark.parametrize("integrator", [gs.integrator.Euler, gs.integrator.approximate_implicitfast])
-def test_energy_analytical_and_conservation(spring_double_pendulum, show_viewer, tol, integrator):
+def test_energy_analytical_and_conservation(
+    spring_double_pendulum, implicit_inertial_origin_chain, show_viewer, tol, integrator
+):
     g = 9.81
     dt = 0.001
     h0 = 0.5
@@ -402,9 +417,25 @@ def test_energy_analytical_and_conservation(spring_double_pendulum, show_viewer,
             file=spring_double_pendulum,
         ),
     )
+    # Three copies of a tumbling free body, high enough to fall for the whole horizon: one link, a root with a fixed
+    # child, and one link with armature on its angular DOFs.
+    tumblers = [
+        scene.add_entity(
+            gs.morphs.URDF(
+                file=implicit_inertial_origin_chain,
+                pos=(x, 1.0, 2.0),
+                merge_fixed_links=merge_fixed_links,
+            ),
+        )
+        for x, merge_fixed_links in ((1.0, True), (1.6, False), (2.2, True))
+    ]
     scene.build()
 
     arm.set_dofs_position([0.5, -0.8])
+    ARMATURE = 0.05
+    for tumbler in tumblers:
+        tumbler.set_dofs_velocity([0.0, 0.0, 0.0, 3.0, 1.0, 2.0])
+    tumblers[2].set_dofs_armature(ARMATURE, dofs_idx_local=[3, 4, 5])
 
     # Nearly undamped contact for sphere_a: small dampratio gives very stiff elastic spring with minimal damping.
     # Contact sol_params are averaged: 0.5*(geom_a + geom_b), so both geoms must share the same params.
@@ -414,11 +445,12 @@ def test_energy_analytical_and_conservation(spring_double_pendulum, show_viewer,
     mass = sphere_a.get_links_mass()
     te_initial = sphere_a.get_total_energy()
 
-    ke_a, pe_a, ke_b, pe_b, te_arm = [], [], [], [], []
+    ke_a, pe_a, ke_b, pe_b, te_arm, ke_tumblers = [], [], [], [], [], []
     impact_step = -1
     for i in range(n_steps):
         scene.step()
         te_arm.append(arm.get_total_energy())
+        ke_tumblers.append(torch.stack([tumbler.get_kinetic_energy() for tumbler in tumblers]))
         ke_a.append(sphere_a.get_kinetic_energy())
         pe_a.append(sphere_a.get_potential_energy())
         ke_b.append(sphere_b.get_kinetic_energy())
@@ -452,6 +484,15 @@ def test_energy_analytical_and_conservation(spring_double_pendulum, show_viewer,
     # The springs must carry a real share of that energy, otherwise the check above would hold with no spring term
     spring_energy = 0.5 * torch.sum(arm.get_dofs_stiffness() * arm.get_dofs_position() ** 2)
     assert spring_energy > 0.1 * te_arm[-1]
+
+    # Gravity exerts no torque about the center of mass, so the rotational energy of a tumbling body is a constant of
+    # its motion. The midpoint rule keeps it, with armature the augmented energy w^T (I + A) w / 2. Each Newton solve
+    # leaves a residual at the working precision, and the horizon accumulates them.
+    tumblers_mass = torch.stack([tumbler.get_mass() for tumbler in tumblers])
+    steps = torch.arange(1, n_steps + 1, dtype=gs.tc_float, device=gs.device)
+    ke_rot = torch.stack(ke_tumblers) - 0.5 * tumblers_mass * (steps[:, None] * g * dt) ** 2
+    if integrator != gs.integrator.Euler:
+        assert_allclose(ke_rot, ke_rot[0], tol=10.0 * tol)
 
 
 @pytest.mark.slow  # ~250s


### PR DESCRIPTION
## Description

- Every link of an aligned free body keeps its own mass, center of mass and inertia. Alignment moves the body frame to the center of mass and principal axes of the composite and re-expresses each inertial frame there, like the geoms. The midpoint integrator reads the composite inertia from the solver when fixed children carry mass, gathers constraint involvement and external loads over the whole body, and recognizes an aligned root by its single-DOF mass block. A body without inertia gets no anchor and is described as unaligned.
- The inertial setters hold the anchor of the whole body: the center of mass and inertia of a fixed child are rejected like the root's own, and a mass write must rescale every link of the body by one factor, inertia included, which `set_mass` on the entity does. The check runs on the indices as given; a tensor on a GPU device and the values of a rescale are read back in debug mode only, through the new `gs.debug` flag.
- The pending coupling wrench is consumed at the end of integration. Forward dynamics cleared it before the midpoint pass read it, which cancelled the torque of every coupling force on a free body under the implicit integrators.
- Armature, damping and servo gains of the free joint enter the midpoint solve on the derivative terms, along the link axes for the angular DOFs and the world axes for the linear ones. Off the center of mass, the linear terms couple the rotation to the translation through the origin acceleration, which the rotational residual carries.

## Motivation and Context

With `merge_fixed_links=False`, a fixed child of an aligned free body read a mass of `gs.EPS` and a zero inertia through the per-link API, since alignment folded the composite onto the root link.

## How Has This Been / Can This Be Tested?

- `tests/rigid/test_asset_loading.py::test_urdf_parsing_inertia_defaults`: per-link masses of an unmerged chain, one step of merged and unmerged copies under the same wrench, and one implicit step of an unaligned body with armature, damping and a velocity servo on every DOF against the augmented mass matrix.
- `tests/rigid/test_asset_loading.py::test_align_heterogeneous_inertial`: per-link masses of an empty free root wrapping a fixed child.
- `tests/rigid/test_api.py::test_inertial_property_setters`: rejected and accepted writes on an aligned body with a fixed child.
- `tests/rigid/test_dynamics.py::test_apply_external_wrench`: spin-up of a free body with free-joint armature under a torque.
- `tests/rigid/test_dynamics.py::test_energy_analytical_and_conservation`: rotational energy of a tumbling body, one link, a composite, or with angular armature, held over the horizon.
- `tests/coupling/test_sph_rigid.py::test_rigid_flotation_follows_density_ratio`: a tilted floating box rocked by the buoyancy torque.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
