### PR TITLE
[BUG FIX] Apply MeshSet member poses to sampled particles.

### DIFF
--- a/genesis/engine/entities/particle_entity.py
+++ b/genesis/engine/entities/particle_entity.py
@@ -242,30 +242,13 @@ class ParticleEntity(Entity):
 
         if isinstance(self._morph, gs.options.morphs.MeshSet):
             particles = []
-            mesh_data = self._morph.model_dump()
-            del mesh_data["files"], mesh_data["poss"], mesh_data["eulers"], mesh_data["quat"]
-            for i, file in enumerate(self._morph.files):
-                mesh_data.update(file=file, pos=self._morph.poss[i], euler=self._morph.eulers[i])
-                morph_i = gs.morphs.Mesh(**mesh_data)
-                mesh_i = morph_i.file.copy()
-                mesh_i.vertices = mesh_i.vertices * morph_i.scale
-
-                sampler = self.sampler
-                if "pbs" in sampler:
-                    particles_i = pu.trimesh_to_particles_pbs(
-                        mesh=mesh_i,
-                        p_size=self._particle_size,
-                        sampler=sampler,
-                    )
-                else:
-                    particles_i = pu.trimesh_to_particles_simple(
-                        mesh=mesh_i,
-                        p_size=self._particle_size,
-                        sampler=sampler,
-                    )
-
-                particles_i += np.asarray(morph_i.pos, dtype=gs.np_float)
-                particles.append(particles_i)
+            for vmesh_i, pos_i, euler_i in zip(self._vmesh, self._morph.poss, self._morph.eulers, strict=True):
+                trans_i = np.array(pos_i, dtype=gs.np_float)
+                quat_i = gu.xyz_to_quat(np.array(euler_i, dtype=gs.np_float), rpy=True, degrees=True)
+                # Sample before posing the mesh, so the lattice and the sampling cache depend on the member shape alone
+                particles_i = vmesh_i.particlize(self._particle_size, self.sampler)
+                particles.append(gu.transform_by_trans_quat(particles_i, trans_i, quat_i))
+                vmesh_i.apply_transform(gu.trans_quat_to_T(trans_i, quat_i))
         elif isinstance(self._morph, (gs.options.morphs.Primitive, gs.options.morphs.Mesh)):
             particles = self._vmesh.particlize(self._particle_size, self.sampler)
             particles = particles.astype(gs.np_float, order="C", copy=False)
@@ -282,13 +265,6 @@ class ParticleEntity(Entity):
             self._vfaces = np.zeros((0, 3), dtype=gs.np_int)
             origin = gu.nowhere()
         elif isinstance(self._morph, gs.options.morphs.MeshSet):
-            for i in range(len(self._morph.files)):
-                # Note that particles are already transformed at this point
-                pos_i = np.asarray(self._morph.poss[i], dtype=gs.np_float)
-                euler_i = np.asarray(self._morph.eulers[i], dtype=gs.np_float)
-                quat_i = gs.utils.geom.xyz_to_quat(euler_i, rpy=True, degrees=True)
-                self._vmesh[i].apply_transform(gu.trans_quat_to_T(pos_i, quat_i))
-
             self.mesh_set_group_ids = np.concatenate(
                 [np.full((len(v),), fill_value=i, dtype=gs.np_int) for i, v in enumerate(particles)]
             )
@@ -318,7 +294,7 @@ class ParticleEntity(Entity):
             else:
                 self._vverts = np.zeros((0, 3), dtype=gs.np_float)
                 self._vfaces = np.zeros((0, 3), dtype=gs.np_int)
-            origin = np.mean(self._morph.poss, dtype=gs.np_float)
+            origin = np.mean(self._morph.poss, axis=0, dtype=gs.np_float)
         else:
             # transform vmesh (the morph pose offset, e.g. an up-axis conversion, is composed onto the morph pose)
             pos, quat = gu.transform_pos_quat_by_trans_quat(

--- a/tests/particles/test_mpm.py
+++ b/tests/particles/test_mpm.py
@@ -1,11 +1,15 @@
+import numpy as np
 import pytest
 import torch
+import trimesh
 
 import genesis as gs
 
+from ..utils.assertions import assert_allclose
+
 
 @pytest.mark.required
-def test_particle_constraints(show_viewer):
+def test_particle_constraints(show_viewer, tol):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
             dt=2e-3,
@@ -15,6 +19,11 @@ def test_particle_constraints(show_viewer):
             grid_density=64,
             lower_bound=(-1.0, -1.0, 0.0),
             upper_bound=(1.0, 1.0, 1.0),
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.5, -1.2, 1.0),
+            camera_lookat=(0.0, 0.3, 0.35),
+            camera_fov=32,
         ),
         show_viewer=show_viewer,
         show_FPS=False,
@@ -38,7 +47,40 @@ def test_particle_constraints(show_viewer):
             size=(0.15, 0.15, 0.15),
         ),
     )
+    # Two copies of one box offset along its local y axis, each placed with its own member pose
+    box = trimesh.creation.box(
+        extents=(0.04, 0.12, 0.04), transform=trimesh.transformations.translation_matrix((0.0, 0.1, 0.0))
+    )
+    mpm_mesh_set = scene.add_entity(
+        morph=gs.morphs.MeshSet(
+            files=(box, box),
+            poss=((0.5, 0.5, 0.3), (-0.5, 0.5, 0.3)),
+            eulers=((0.0, 0.0, 90.0), (90.0, 0.0, 0.0)),
+        ),
+        material=gs.materials.MPM.Elastic(
+            sampler="regular",
+        ),
+    )
     scene.build(n_envs=2)
+
+    # Each member is rotated about its own position: the box offset lands at -x for the member rotated about z and at
+    # +z for the one rotated about x, and the long axis follows. A regular lattice spans the box minus one particle.
+    particles = mpm_mesh_set.init_particles
+    particle_size = mpm_mesh_set.particle_size
+    long_span, short_span = 0.12 - particle_size, 0.04 - particle_size
+    particles_z90 = particles[particles[:, 0] > 0.0]
+    particles_x90 = particles[particles[:, 0] < 0.0]
+    assert_allclose(particles_z90.mean(axis=0), (0.4, 0.5, 0.3), tol=tol)
+    assert_allclose(np.ptp(particles_z90, axis=0), (long_span, short_span, short_span), tol=tol)
+    assert_allclose(particles_x90.mean(axis=0), (-0.5, 0.5, 0.4), tol=tol)
+    assert_allclose(np.ptp(particles_x90, axis=0), (short_span, short_span, long_span), tol=tol)
+    # The visual mesh carries the same member poses
+    assert_allclose(mpm_mesh_set.vmesh.verts.min(axis=0), (-0.52, 0.48, 0.28), tol=tol)
+    assert_allclose(mpm_mesh_set.vmesh.verts.max(axis=0), (0.46, 0.52, 0.46), tol=tol)
+    # Positioning the set as a whole moves the mean member position there, keeping the members' layout
+    mpm_mesh_set.set_position((0.0, 0.5, 0.5))
+    mpm_mesh_set.process_input()
+    assert_allclose(mpm_mesh_set.get_particles_pos(), particles + (0.0, 0.0, 0.2), tol=tol)
 
     # Test get_particles_in_bbox - returns (n_envs, n_particles) mask
     mask = mpm_cube.get_particles_in_bbox((-0.08, -0.08, 0.41), (0.08, 0.08, 0.44))


### PR DESCRIPTION
## Description

`ParticleEntity.sample()` translated the particles sampled from each `MeshSet` member but dropped the member's rotation, while the member's visual mesh received its full pose. Each member pose is now derived once and applied to both, sampling through the member's visual mesh as for a single mesh, and a member without a pose is refused. The origin used by `set_position` is the per-axis mean of the member positions; it was a scalar mean over every coordinate, which misplaced every `MeshSet` entity.

## Related Issue
Resolves #3169. 
Supersedes #3171 by @prexhu.

## Motivation and Context
Hybrid entities build their soft part as a `MeshSet` from the rigid links' world poses, so the skin of any rotated link stayed aligned with the link's local axes while the rendered mesh was rotated.

## How Has This Been / Can This Be Tested?
The assertions are folded into `tests/particles/test_mpm.py::test_particle_constraints`: a `MeshSet` of two off-center copies of one box, rotated about z and about x, checked for per-member centroid and extents, the visual mesh bounds, and a `set_position` round trip. The centroid check fails on `main`, and the `set_position` check fails with only the origin fix reverted.

```bash
pytest -v tests/particles/test_mpm.py::test_particle_constraints
```
`tests/particles` and `tests/coupling/test_hybrid.py::test_rigid_mpm_muscle` pass locally on the CPU backend.

## Screenshots
Two copies of one box, one rotated about z and one about x, visual mesh translucent, particles in red. Left `main`, right this branch. #3169 shows the same defect on a hybrid robot.

| main | this branch |
|---|---|
| <img width="1280" height="720" alt="meshset_before" src="https://github.com/user-attachments/assets/21c477a3-f328-42bb-a838-cec9aa6208bc" /> | <img width="1280" height="720" alt="meshset_after" src="https://github.com/user-attachments/assets/b7681fa9-ab1a-47ba-abf8-e3cda3732544" /> |

## Checklist:
- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.