### PR TITLE
[FEATURE] Allow skipping the warmup step when building a scene.

### DIFF
--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -908,9 +908,16 @@ class Scene(RBC):
 
             self._is_built = True
 
-        with gs.logger.timer("Compiling simulation kernels..."):
-            self._sim.step()
-            self._reset()
+        # Running one step ahead of time compiles (or loads from cache) the kernels it goes through, so the first user
+        # step is not slowed down by compilation. Set 'GS_SKIP_BUILD_WARMUP=1' to skip it when the scene is built for
+        # visualization only and never stepped.
+        if os.environ.get("GS_SKIP_BUILD_WARMUP") != "1":
+            with gs.logger.timer("Warming up the simulation..."):
+                self._sim.step()
+
+        # Restore the initial state, which also seeds the sensors and the coupler. Must run whether or not the warmup
+        # step did, since it is the only simulator reset during build.
+        self._reset()
 
         # visualizer
         with gs.logger.timer("Building visualizer..."):

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -434,6 +434,9 @@ class RigidSolver(KinematicSolver):
 
         self._init_invweight_and_meaninertia(force_update=False)
         self._func_update_geoms(self._scene._envs_idx, force_update_fixed_geoms=True)
+        # Seed the geom AABBs from the initial poses. Collision detection refreshes them at every step, so this only
+        # matters before the first one, where 'get_AABB' would otherwise report an empty box at the origin.
+        kernel_update_geom_aabbs(self.geoms_init_AABB, self.dyn_state, self.rigid_config)
 
         self._init_collider()
         self._init_constraint_solver()

--- a/tests/core/test_misc.py
+++ b/tests/core/test_misc.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 
 import numpy as np
 import pytest
+import torch
 import trimesh
 
 import quadrants as qd
@@ -546,3 +547,87 @@ def test_warn_solver_numerical_stability(boxes_size, caplog):
     with caplog.at_level("WARNING"):
         scene.build()
     assert any("too small for the constraint solver" in record.message for record in caplog.records)
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+@pytest.mark.parametrize("is_warmup_skipped", [False, True])
+def test_build_state_independent_of_warmup_step(monkeypatch, show_viewer, tol, n_envs, is_warmup_skipped):
+    DT = 0.01
+    GRAVITY = -10.0
+    N_STEPS = 20
+    DROP_HEIGHT = 0.5
+    PLATFORM_SIZE = 0.2
+    BASE_TEMP = 22.0
+
+    if is_warmup_skipped:
+        monkeypatch.setenv("GS_SKIP_BUILD_WARMUP", "1")
+
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+            gravity=(0.0, 0.0, GRAVITY),
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.5, -1.5, 1.0),
+            camera_lookat=(0.0, 0.0, 0.3),
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        morph=gs.morphs.Plane(),
+    )
+    platform = scene.add_entity(
+        morph=gs.morphs.Box(
+            size=(PLATFORM_SIZE, PLATFORM_SIZE, PLATFORM_SIZE),
+            pos=(0.0, 0.0, PLATFORM_SIZE / 2),
+            fixed=True,
+        ),
+    )
+    ball = scene.add_entity(
+        morph=gs.morphs.Sphere(
+            radius=0.05,
+            pos=(1.0, 0.0, DROP_HEIGHT),
+        ),
+    )
+    contact = scene.add_sensor(
+        gs.sensors.Contact(
+            entity_idx=ball.idx,
+            history_length=4,
+        )
+    )
+    temperature = scene.add_sensor(
+        gs.sensors.TemperatureGrid(
+            ambient_temperature=BASE_TEMP,
+            entity_idx=platform.idx,
+            grid_size=(2, 2, 1),
+            properties_dict={
+                platform.base_link_idx: gs.sensors.TemperatureProperties(
+                    base_temperature=BASE_TEMP,
+                ),
+            },
+        )
+    )
+    scene.build(n_envs=n_envs)
+
+    # Sensors are seeded by the reset that closes the build, which the warmup step must not be the only trigger for.
+    assert_allclose(temperature.read_ground_truth(), BASE_TEMP, tol=tol)
+    assert_equal(contact.read(), 0)
+
+    # Collision detection refreshes the geom AABBs at every step, so they are only meaningful before the first one if
+    # the build seeds them.
+    aabb_shape = (*((n_envs,) if n_envs > 0 else ()), 2, 3)
+    geoms_aabb = torch.stack(
+        [geom.get_AABB().expand(aabb_shape) for entity in scene.entities for geom in entity.geoms], dim=-3
+    )
+    assert_allclose(scene.sim.rigid_solver.get_AABB(), geoms_aabb, tol=gs.EPS)
+
+    for _ in range(N_STEPS):
+        scene.step()
+
+    # Semi-implicit Euler free fall, the ball being far from the platform and above the ground the whole time.
+    assert_allclose(
+        np.atleast_1d(tensor_to_array(ball.get_pos()))[..., 2],
+        DROP_HEIGHT + GRAVITY * DT**2 * N_STEPS * (N_STEPS + 1) / 2,
+        tol=tol,
+    )


### PR DESCRIPTION
## Description

Building a scene runs one full simulation step so that the kernels it goes through are compiled, or loaded from cache, before the user's first `step()`. A scene that is built for visualization and never stepped pays that step for nothing. `GS_SKIP_BUILD_WARMUP=1` skips it.

Two things the warmup step was silently responsible for now happen on both paths:

- **The reset that follows it is the only simulator reset during build**, and it is what seeds the sensors and the coupler. It now runs whether or not the warmup step did. Skipping it left temperature sensors reading zero instead of their base temperature, and sensor history rings holding uninitialized memory.
- **The geom axis-aligned bounding boxes (AABB) are seeded at build.** Collision detection refreshes them every step, so without the warmup step `get_AABB()` reported an empty box at the origin until the first one.

## Related Issue

Context: [SIM-372](https://linear.app/genesis-ai-company/issue/SIM-372/enable-scene-viewer-without-physics-build) (scene viewer without a physics build), under [SIM-330](https://linear.app/genesis-ai-company/issue/SIM-330/improve-gui-experience). The warmup step is a general build cost rather than a preview-only one, which is why it is split out here.

## Motivation and Context

A scene editor rebuilds its scene for every structural edit (add, remove, duplicate, swap asset, scale, layout switch) and holds the GIL for the whole build. The warmup step is pure overhead in that loop, and it is unconditional today with no way to opt out.

## How Has This Been / Can This Be Tested?

`tests/core/test_misc.py::test_build_state_independent_of_warmup_step`, parametrized over `is_warmup_skipped=[False, True]` and `n_envs=[0, 2]`. It asserts the build leaves the same observable state either way: sensors read their base temperature rather than zero, geom AABBs match the initial poses, and a ball in free fall follows semi-implicit Euler.

```
pytest tests/core/test_misc.py -k warmup
```

## Draft: what is left

- **Needs a rebase.** The branch is 48 commits behind `main` and conflicts in `genesis/engine/solvers/rigid/rigid_solver.py`: the build order changed there (`_init_collider` / `_init_constraint_solver` now precede `_refresh_invweight_and_meaninertia`, and the `_func_update_geoms` call the AABB seeding was anchored to has moved), so the seeding hunk needs re-placing rather than a line-offset fix.
- **The escape hatch is an environment variable**, which is worth a second opinion against a typed option. `GS_PARA_LEVEL` and `GS_ENABLE_NDARRAY` are precedent for a perf knob living in the environment, but a build-time behavior change may belong on `SimOptions` or on `Scene.build()` instead.
- Warmup-skipped build time is not measured here yet.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [ ] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
