### PR TITLE
[BREAKING][FEATURE] Save and restore a built scene in memory, and record and replay its trajectory to a file.

### DIFF
--- a/examples/manipulation/grasp_env.py
+++ b/examples/manipulation/grasp_env.py
@@ -146,11 +146,11 @@ class GraspEnv:
 
         # Debug live preview of sensor cameras
         if self.env_cfg.get("visualize_camera", False):
-            self.scene.start_recording(
+            self.scene.add_recorder(
                 data_func=partial(_read_sensor_cam, self.left_cam),
                 rec_options=gs.recorders.MPLImagePlot(title="Left Camera"),
             )
-            self.scene.start_recording(
+            self.scene.add_recorder(
                 data_func=partial(_read_sensor_cam, self.right_cam),
                 rec_options=gs.recorders.MPLImagePlot(title="Right Camera"),
             )
@@ -160,7 +160,7 @@ class GraspEnv:
         for cam_name, filename in record_video.items():
             cam = getattr(self, cam_name)
             reader = _read_scene_cam if isinstance(cam, Camera) else _read_sensor_cam
-            self.scene.start_recording(
+            self.scene.add_recorder(
                 data_func=partial(reader, cam),
                 rec_options=gs.recorders.VideoFile(filename=filename),
             )

--- a/examples/rigid/hibernation.py
+++ b/examples/rigid/hibernation.py
@@ -111,7 +111,7 @@ def main():
     def plot_data():
         return {"step_rate": [step_rate[0]], "awake_bodies": [n_awake[0]]}
 
-    scene.start_recording(
+    scene.add_recorder(
         plot_data,
         gs.recorders.MPLLinePlot(
             labels={"step_rate": ["steps/s"], "awake_bodies": ["awake bodies"]},

--- a/examples/sensors/imu_franka.py
+++ b/examples/sensors/imu_franka.py
@@ -75,20 +75,20 @@ def main():
             }
 
         if IS_PYQTGRAPH_AVAILABLE:
-            scene.start_recording(
+            scene.add_recorder(
                 data_func,
                 gs.recorders.PyQtLinePlot(labels=labels, title="IMU Ground Truth Data"),
             )
         elif IS_MATPLOTLIB_AVAILABLE:
             gs.logger.info("pyqtgraph not found, falling back to matplotlib.")
-            scene.start_recording(
+            scene.add_recorder(
                 data_func,
                 gs.recorders.MPLLinePlot(labels=labels, title="IMU Ground Truth Data"),
             )
         else:
             print("matplotlib or pyqtgraph not found, skipping real-time plotting.")
 
-    scene.start_recording(
+    scene.add_recorder(
         data_func=lambda: imu.read()._asdict(),
         rec_options=gs.recorders.NPZFile(filename="out/imu_data.npz"),
     )

--- a/examples/sensors/joint_torque_franka.py
+++ b/examples/sensors/joint_torque_franka.py
@@ -90,13 +90,13 @@ def main():
 
     if args.vis:
         if IS_PYQTGRAPH_AVAILABLE:
-            scene.start_recording(
+            scene.add_recorder(
                 data_func,
                 gs.recorders.PyQtLinePlot(labels=labels, title="JointTorqueSensor - Franka"),
             )
         elif IS_MATPLOTLIB_AVAILABLE:
             gs.logger.info("pyqtgraph not found, falling back to matplotlib.")
-            scene.start_recording(
+            scene.add_recorder(
                 data_func,
                 gs.recorders.MPLLinePlot(labels=labels, history_length=steps, title="JointTorqueSensor - Franka"),
             )

--- a/examples/sensors/lidar_teleop.py
+++ b/examples/sensors/lidar_teleop.py
@@ -105,7 +105,7 @@ def main():
 
     if args.pattern == "depth":
         sensor = scene.add_sensor(gs.sensors.DepthCamera(pattern=gs.sensors.DepthCameraPattern(), **sensor_kwargs))
-        scene.start_recording(
+        scene.add_recorder(
             data_func=(lambda: sensor.read_image()[0]) if args.num_envs > 0 else sensor.read_image,
             rec_options=gs.recorders.MPLImagePlot(),
         )

--- a/examples/sensors/tactile_franka.py
+++ b/examples/sensors/tactile_franka.py
@@ -122,7 +122,7 @@ def _plot_tactile_sensor(
     positions = sensors[0].probe_local_pos.reshape(-1, 3)
     if sensor_type == "elastomer":
         # ElastomerTaxel read() is grid-shaped (ny, nx, 3); flatten each finger to (N, 3) before stacking.
-        scene.start_recording(
+        scene.add_recorder(
             lambda: torch.stack([sensor.read().reshape(-1, 3) for sensor in sensors]),
             gs.recorders.MPLVectorFieldPlot(
                 title="ElastomerTaxel marker displacements",
@@ -134,7 +134,7 @@ def _plot_tactile_sensor(
             ),
         )
     elif sensor_type == "kinematic":
-        scene.start_recording(
+        scene.add_recorder(
             lambda: _force_torque_field(sensors),
             gs.recorders.MPLVectorFieldPlot(
                 title="KinematicTaxel force + twist",
@@ -148,7 +148,7 @@ def _plot_tactile_sensor(
             ),
         )
     elif sensor_type == "proximity":
-        scene.start_recording(
+        scene.add_recorder(
             lambda: _force_torque_field(sensors),
             gs.recorders.MPLVectorFieldPlot(
                 title="ProximityTaxel force + twist",
@@ -162,7 +162,7 @@ def _plot_tactile_sensor(
             ),
         )
     elif sensor_type == "depth":
-        scene.start_recording(
+        scene.add_recorder(
             lambda: tuple(sensor.read().max() for sensor in sensors),
             gs.recorders.MPLLinePlot(
                 labels=labels,

--- a/examples/sensors/tactile_sandbox.py
+++ b/examples/sensors/tactile_sandbox.py
@@ -201,7 +201,7 @@ def _plot_tactile_sensor(
         title, scale_factor, max_magnitude, twist_scale_factor, twist_max_magnitude, read_field = vector_field_setup[
             sensor_type
         ]
-        scene.start_recording(
+        scene.add_recorder(
             read_field,
             gs.recorders.MPLVectorFieldPlot(
                 title=title,
@@ -221,7 +221,7 @@ def _plot_tactile_sensor(
         "depth": ("ContactDepthProbe max depth", "depth", lambda r: float(r.max())),
         "contact": ("ContactProbe taxels in contact", "# taxels", lambda r: float(r.sum())),
     }[sensor_type]
-    scene.start_recording(
+    scene.add_recorder(
         lambda: tuple(reduce_fn(sensor.read()[i]) for i in range(n_envs)),
         gs.recorders.MPLLinePlot(
             labels=env_titles,

--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -143,6 +143,12 @@ def play(filename=None, collision=False, scale=1.0):
         scene.step()
 
 
+def replay(filename):
+    gs.init()
+
+    gs.Scene.load_trajectory(filename, show_viewer=True).play(loop=True)
+
+
 def animate(filename_pattern, fps):
     import glob
 
@@ -192,6 +198,9 @@ def main():
     )
     parser_play.add_argument("-s", "--scale", type=float, default=1.0, help="Scale of the entity")
 
+    parser_replay = subparsers.add_parser("replay", help="Replay a recorded trajectory in the viewer")
+    parser_replay.add_argument("filename", type=str, help="Trajectory file (.gstraj)")
+
     parser_animate = subparsers.add_parser("animate", help="Compile a list of image files into a video")
     parser_animate.add_argument("filename_pattern", type=str, help="Image files, via glob pattern")
     parser_animate.add_argument("--fps", type=int, default=30, help="FPS of the output video")
@@ -209,6 +218,8 @@ def main():
         )
     elif args.command == "play":
         play(args.filename, args.collision, args.scale)
+    elif args.command == "replay":
+        replay(args.filename)
     elif args.command == "animate":
         animate(args.filename_pattern, args.fps)
     elif args.command is None:

--- a/genesis/engine/couplers/legacy_coupler.py
+++ b/genesis/engine/couplers/legacy_coupler.py
@@ -880,7 +880,7 @@ class LegacyCoupler(RBC):
                 self.rigid_solver.dyn_info.geoms,
                 self.rigid_solver.collider._sdf._sdf_info,
                 self.rigid_solver.rigid_info,
-                self.rigid_solver.collider._collider_static_config,
+                self.rigid_solver.collider.collider_config,
             )
 
     def couple(self, f):
@@ -894,7 +894,7 @@ class LegacyCoupler(RBC):
                 links_state=self.rigid_solver.dyn_state.links,
                 rigid_info=self.rigid_solver.rigid_info,
                 sdf_info=self.rigid_solver.collider._sdf._sdf_info,
-                collider_static_config=self.rigid_solver.collider._collider_static_config,
+                collider_static_config=self.rigid_solver.collider.collider_config,
             )
 
         # SPH <-> Rigid
@@ -907,7 +907,7 @@ class LegacyCoupler(RBC):
                 self.rigid_solver.dyn_info.links,
                 self.rigid_solver.rigid_info,
                 self.rigid_solver.collider._sdf._sdf_info,
-                self.rigid_solver.collider._collider_static_config,
+                self.rigid_solver.collider.collider_config,
             )
 
         # PBD <-> Rigid
@@ -918,7 +918,7 @@ class LegacyCoupler(RBC):
                 links_state=self.rigid_solver.dyn_state.links,
                 sdf_info=self.rigid_solver.collider._sdf._sdf_info,
                 rigid_info=self.rigid_solver.rigid_info,
-                collider_static_config=self.rigid_solver.collider._collider_static_config,
+                collider_static_config=self.rigid_solver.collider.collider_config,
             )
 
             # 1-way: animate particles by links, over the substep interval and no faster than the clamp allows.
@@ -934,7 +934,7 @@ class LegacyCoupler(RBC):
                 self.rigid_solver.dyn_state.links,
                 self.rigid_solver.rigid_info,
                 self.rigid_solver.collider._sdf._sdf_info,
-                self.rigid_solver.collider._collider_static_config,
+                self.rigid_solver.collider.collider_config,
             )
             self.fem_rigid_link_constraints()
 
@@ -947,7 +947,7 @@ class LegacyCoupler(RBC):
                 self.rigid_solver.dyn_state.links,
                 self.rigid_solver.rigid_info,
                 self.rigid_solver.collider._sdf._sdf_info,
-                self.rigid_solver.collider._collider_static_config,
+                self.rigid_solver.collider.collider_config,
             )
         if self.mpm_solver.is_active:
             self.mpm_grid_op.grad(
@@ -958,7 +958,7 @@ class LegacyCoupler(RBC):
                 links_state=self.rigid_solver.dyn_state.links,
                 rigid_info=self.rigid_solver.rigid_info,
                 sdf_info=self.rigid_solver.collider._sdf._sdf_info,
-                collider_static_config=self.rigid_solver.collider._collider_static_config,
+                collider_static_config=self.rigid_solver.collider.collider_config,
             )
 
     @property

--- a/genesis/engine/couplers/sap_coupler.py
+++ b/genesis/engine/couplers/sap_coupler.py
@@ -353,7 +353,7 @@ class SAPCoupler(RBC):
         self.rigid_volume_elems_geom_idx = qd.field(gs.qd_int, shape=(self.n_rigid_volume_elems,))
         self.rigid_volume_elems_geom_idx.from_numpy(rigid_volume_elems_geom_idx_np)
         # FIXME: Convert collision_pair_idx to field here because SAPCoupler cannot support ndarray/field switch yet
-        np_collision_pair_idx = self.rigid_solver.collider._collider_info.collision_pair_idx.to_numpy()
+        np_collision_pair_idx = self.rigid_solver.collider.collider_info.collision_pair_idx.to_numpy()
         self.rigid_collision_pair_idx = qd.field(gs.qd_int, shape=np_collision_pair_idx.shape)
         self.rigid_collision_pair_idx.from_numpy(np_collision_pair_idx)
         self.rigid_pressure_field = qd.field(gs.qd_float, shape=(self.n_rigid_volume_verts,))

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -1,8 +1,13 @@
 import collections.abc
 import dataclasses
+import hashlib
+import io
+import json
+import math
 import os
 import sys
 import weakref
+import zipfile
 from collections import Counter
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, overload
 
@@ -18,7 +23,7 @@ from genesis.engine.entities.base_entity import Entity, EntityDescription
 from genesis.engine.entities.rigid_entity import KinematicEntity
 from genesis.engine.force_fields import ForceField
 from genesis.engine.materials.base import EntityT, Material
-from genesis.engine.states.solvers import SimState
+from genesis.engine.states.solvers import SimState, SimulatorCheckpoint
 from genesis.options import (
     SceneOptions,
     BaseCouplerOptions,
@@ -42,8 +47,9 @@ from genesis.options.surfaces import Surface
 from genesis.recorders import RecorderManager
 from genesis.repr_base import RBC
 from genesis.utils import serialization
-from genesis.utils.serialization import pixel_less_textures
+from genesis.utils.array_class import check_data
 from genesis.utils.misc import sanitize_index, tensor_to_array
+from genesis.utils.serialization import ARRAY_MEMBER, MANIFEST_NAME, pixel_less_textures
 from genesis.utils.tools import FPSTracker
 from genesis.utils.warnings import warn_once
 from genesis.vis import Visualizer
@@ -69,6 +75,53 @@ class SceneDescription:
 
     options: SceneOptions
     entities: list[EntityDescription] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class EnvironmentLayout:
+    """The environment layout given to 'Scene.build'. It sizes every array of the state."""
+
+    n_envs: int
+    env_spacing: tuple[float, float]
+    n_envs_per_row: int
+    center_envs_at_origin: bool
+
+
+@dataclasses.dataclass
+class SceneCheckpoint:
+    """The checkpoint of a built scene, which 'Scene.__getstate__' returns and a pickled scene serializes."""
+
+    scene: SceneDescription
+    digest: str
+    layout: EnvironmentLayout
+    sim: SimulatorCheckpoint
+
+
+def description_digest(desc: SceneDescription) -> str:
+    """Digest what a description states of the physics: its entities and every option group but the visual ones, which
+    'Scene.load' replaces. Two scenes sharing the digest allocate the same state, so a record of one restores into the
+    other. The Genesis version and sources are left out, so a record survives the code moving on.
+
+    The digest exports the description in memory, meshes included, so it is taken once per built scene and once per
+    trajectory opened, never per restore.
+    """
+    defaults = SceneOptions()
+    visual = {
+        "vis": defaults.vis,
+        "viewer": defaults.viewer,
+        "renderer": defaults.renderer,
+        "profiling": defaults.profiling,
+    }
+    buffer = io.BytesIO()
+    serialization.export(buffer, {"scene": dataclasses.replace(desc, options=desc.options.model_copy(update=visual))})
+    with zipfile.ZipFile(buffer) as archive:
+        manifest = json.loads(archive.read(MANIFEST_NAME))
+        arrays = np.load(io.BytesIO(archive.read(ARRAY_MEMBER)))
+        digest = hashlib.sha256(json.dumps((manifest["schema"], manifest["held"]), sort_keys=True).encode())
+        for name in sorted(arrays):
+            digest.update(f"{name}{arrays[name].shape}{arrays[name].dtype.str}".encode())
+            digest.update(arrays[name].tobytes())
+    return digest.hexdigest()
 
 
 @gs.assert_initialized
@@ -202,6 +255,7 @@ class Scene(RBC):
 
         self._uid = gs.UID()
         self._is_built = False
+        self._desc_digest: str | None = None
         self._pre_step_callbacks: list = []
 
         gs.logger.info(f"Scene ~~~<{self._uid}>~~~ created.")
@@ -778,6 +832,8 @@ class Scene(RBC):
             # reset state
             self._reset()
 
+            # The description is fixed once built, so its digest is taken once (see 'description_digest')
+            self._desc_digest = description_digest(self._desc)
             self._is_built = True
 
         with gs.logger.timer("Compiling simulation kernels..."):
@@ -811,11 +867,12 @@ class Scene(RBC):
         self._envs_idx = torch.arange(self._B, dtype=gs.tc_int, device=gs.device)
 
         if self.n_envs_per_row is None:
-            self.n_envs_per_row = np.ceil(np.sqrt(self._B)).astype(int)
+            self.n_envs_per_row = math.ceil(math.sqrt(self._B))
 
         # compute offset values for visualizing each env
         if not isinstance(env_spacing, (list, tuple)) or len(env_spacing) != 2:
             gs.raise_exception("`env_spacing` should be a tuple of length 2.")
+        self._layout = EnvironmentLayout(n_envs, tuple(env_spacing), self.n_envs_per_row, center_envs_at_origin)
         offset_x = (np.arange(self._B) // self.n_envs_per_row) * self.env_spacing[0]
         offset_y = (np.arange(self._B) % self.n_envs_per_row) * self.env_spacing[1]
         offset_z = np.zeros((self._B,))
@@ -875,7 +932,10 @@ class Scene(RBC):
             self._sim.reset(state, envs_idx)
         else:
             self._init_state = self._get_state()
+        self._restart()
 
+    def _restart(self):
+        """Restart what surrounds the state: the gradient tape, the cache of the visualizer and the emitters."""
         self._forward_ready = True
         self._reset_grad()
 
@@ -1395,28 +1455,33 @@ class Scene(RBC):
         self._backward_ready = False
         self._forward_ready = False
 
-    def export(self, path: str | os.PathLike) -> None:
-        """Write a portable copy of this scene to a file that anyone can open.
+    @gs.assert_built
+    def get_time(self, envs_idx=None):
+        """
+        Get the simulated time of each environment, in seconds.
 
-        What is written is what the scene was authored from and what its build resolved, so the file stands on its
-        own: opening it reads no mesh, no model file and no texture from disk, and creates only the options,
-        descriptions and meshes Genesis declares. The file is therefore self-contained enough to attach to a bug
-        report.
-
-        A scene opened from a file stands at the configuration its entities were given rather than where the
-        simulation had run to, so the simulated state has to be reproduced by stepping it again. Adding an entity
-        resolves its description, so a scene is exported before it is built as readily as after.
-
-        Only a rigid or a kinematic entity carries a description. A scene
-        holding anything that alters the simulation raises, naming it: an emitter and a force field. Everything else
-        a description leaves out is written without, with a warning naming it: a camera, a recorder, a sensor, a
-        callback Genesis calls at every step, a texture read from an HDR or EXR file, and the visual vertices an
-        entity was given at runtime.
+        Environments are stepped and reset independently, so each one carries its own simulated time. The number of
+        `scene.step()` calls is a separate scalar, `Simulator.cur_step_global`.
 
         Parameters
         ----------
-        path : str or os.PathLike
-            Where to write the file.
+        envs_idx : None | array_like, optional
+            The indices of the environments. If None, all environments are returned. Defaults to None.
+
+        Returns
+        -------
+        time : torch.Tensor, shape (n_envs,) or scalar
+            The simulated time of each environment.
+        """
+        return self._sim.get_time(envs_idx)
+
+    # ------------------------------------------------------------------------------------
+    # ----------------------------------- utilities --------------------------------------
+    # ------------------------------------------------------------------------------------
+
+    def _reject_unexportable(self) -> None:
+        """Raise when the scene holds an entity, an emitter or a force field no description covers, and warn about what
+        'export' leaves out.
         """
         # A scene holding what alters the simulation is rejected, since a file leaving it out would restore other
         # physics. Everything else is left out with a warning: what observes or draws the simulation, and every
@@ -1451,6 +1516,30 @@ class Scene(RBC):
                 )
                 report(f"A scene holding {listing} {ending}")
 
+    def export(self, path: str | os.PathLike) -> None:
+        """Write a portable copy of this scene to a file that anyone can open.
+
+        What is written is what the scene was authored from and what its build resolved, so the file stands on its
+        own: opening it reads no mesh, no model file and no texture from disk, and creates only the options,
+        descriptions and meshes Genesis declares. The file is therefore self-contained enough to attach to a bug
+        report.
+
+        A scene opened from a file stands at the configuration its entities were given rather than where the
+        simulation had run to, so the simulated state has to be reproduced by stepping it again. Adding an entity
+        resolves its description, so a scene is exported before it is built as readily as after.
+
+        Only a rigid or a kinematic entity carries a description. A scene
+        holding anything that alters the simulation raises, naming it: an emitter and a force field. Everything else
+        a description leaves out is written without, with a warning naming it: a camera, a recorder, a sensor, a
+        callback Genesis calls at every step, a texture read from an HDR or EXR file, and the visual vertices an
+        entity was given at runtime.
+
+        Parameters
+        ----------
+        path : str or os.PathLike
+            Where to write the file.
+        """
+        self._reject_unexportable()
         serialization.export(path, {"scene": self.desc})
 
     @classmethod
@@ -1473,18 +1562,95 @@ class Scene(RBC):
         scene : Scene
             The scene the file describes, holding every entity it was authored with and waiting to be built.
         """
-        described = serialization.load(path, {"scene": SceneDescription})["scene"]
-        scene = cls(show_viewer=show_viewer, options=described.options)
+        return cls.from_description(serialization.load(path, {"scene": SceneDescription})["scene"], show_viewer)
 
+    @classmethod
+    def from_description(cls, described: SceneDescription, show_viewer: bool = False) -> "Scene":
+        """Create the scene a description states, holding every entity it names and waiting to be built.
+
+        Parameters
+        ----------
+        described : SceneDescription
+            The scene to create, as 'Scene.desc' describes one.
+        show_viewer : bool, optional
+            Whether to open an interactive viewer on the scene. Defaults to False.
+
+        Returns
+        -------
+        scene : Scene
+            The created scene.
+        """
+        scene = cls(show_viewer=show_viewer, options=described.options)
         # 'add_entity' would resolve a material and a surface the description already holds, and read the asset it
         # replaces.
         for desc in described.entities:
             scene._sim._add_entity(desc=desc)
         return scene
 
-    # ------------------------------------------------------------------------------------
-    # ----------------------------------- utilities --------------------------------------
-    # ------------------------------------------------------------------------------------
+    @gs.assert_built
+    def __getstate__(self) -> SceneCheckpoint:
+        """Return the SceneCheckpoint of this built scene, for '__setstate__' to restore.
+
+        The description travels by reference and the arrays as copies made where they live (see 'Solver.__getstate__'),
+        so a save and a restore within one process cost one copy on the device. Pickling a scene reads this record,
+        and unpickling creates and builds the scene, then restores the record. What a description leaves out is left
+        out of a copy the same way, and reported as 'export' reports it.
+
+        Returns
+        -------
+        state : SceneCheckpoint
+            The scene as its description, the environment layout it was built with, and the state of its simulator.
+        """
+        self._reject_unexportable()
+        return SceneCheckpoint(
+            scene=self.desc, digest=self._desc_digest, layout=self._layout, sim=self._sim.__getstate__()
+        )
+
+    def __reduce__(self):
+        return (self._from_state, (self.__getstate__(),))
+
+    @classmethod
+    def _from_state(cls, state: SceneCheckpoint) -> "Scene":
+        """Create, build and restore the scene a checkpoint describes. '__reduce__' names it as the loader."""
+        scene = cls.from_description(state.scene)
+        scene.build(**dataclasses.asdict(state.layout))
+        scene.__setstate__(state)
+        return scene
+
+    @gs.assert_built
+    def __setstate__(self, state: SceneCheckpoint) -> None:
+        """Put this built scene in the state a checkpoint holds, as if it had run to there.
+
+        The scene must be built from the description the state was read from, with the same environment layout, since
+        the arrays written back are the ones that build allocates. A state from another layout is rejected, and a state
+        from another build by the names of the arrays that differ. Everything around the state restarts as under
+        'reset': the gradient tape, the sensors and the recorders forget the run that led here, and the visualizer
+        redraws.
+
+        Parameters
+        ----------
+        state : SceneCheckpoint
+            The state to put back, as read by '__getstate__'.
+        """
+        if state.layout != self._layout:
+            gs.raise_exception(
+                f"The state was read from a scene built with {state.layout} and this one was built with {self._layout}."
+            )
+        if state.digest != self._desc_digest:
+            gs.raise_exception("The state was read from another scene: its entities or physics options differ.")
+        # Every solver checks its record before anything is touched, so a record from another scene leaves this one as
+        # it was
+        solvers = {type(solver).__name__: solver for solver in self._sim.active_solvers}
+        if set(state.sim.solvers) != set(solvers):
+            gs.raise_exception(
+                f"The checkpoint holds {sorted(state.sim.solvers)} where this scene simulates {sorted(solvers)}."
+            )
+        for name, solver in solvers.items():
+            record = state.sim.solvers[name]
+            check_data((item for item in solver.data if item.kind in record.kinds), record.arrays)
+        self._sim.__setstate__(state.sim)
+        self._restart()
+        self._recorder_manager.reset()
 
     def _sanitize_envs_idx(
         self, envs_idx: int | range | slice | tuple[int, ...] | list[int] | torch.Tensor | np.ndarray | None
@@ -1512,26 +1678,6 @@ class Scene(RBC):
             return self._envs_idx[envs_idx : envs_idx + 1]
 
         return sanitize_index(envs_idx, -1, self.n_envs, 0, "envs_idx")
-
-    @gs.assert_built
-    def get_time(self, envs_idx=None):
-        """
-        Get the simulated time of each environment, in seconds.
-
-        Environments are stepped and reset independently, so each one carries its own simulated time. The number of
-        `scene.step()` calls is a separate scalar, `Simulator.cur_step_global`.
-
-        Parameters
-        ----------
-        envs_idx : None | array_like, optional
-            The indices of the environments. If None, all environments are returned. Defaults to None.
-
-        Returns
-        -------
-        time : torch.Tensor, shape (n_envs,) or scalar
-            The simulated time of each environment.
-        """
-        return self._sim.get_time(envs_idx)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -9,7 +9,7 @@ import sys
 import weakref
 import zipfile
 from collections import Counter
-from typing import TYPE_CHECKING, Callable, Iterable, Literal, overload
+from typing import BinaryIO, Callable, Iterable, Literal, NamedTuple, TYPE_CHECKING, overload
 
 import numpy as np
 import torch
@@ -41,10 +41,11 @@ from genesis.options import (
     VisOptions,
 )
 from genesis.options.morphs import Morph
-from genesis.options.recorders import RecorderOptions
+from genesis.options.recorders import RecorderOptions, TrajectoryFile
 from genesis.options.renderers import RendererOptions
 from genesis.options.surfaces import Surface
 from genesis.recorders import RecorderManager
+from genesis.recorders.trajectory import Trajectory, save_checkpoint
 from genesis.repr_base import RBC
 from genesis.utils import serialization
 from genesis.utils.array_class import check_data
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
     from genesis.engine.entities.base_entity import Entity
     from genesis.engine.entities.rigid_entity import RigidEntity
     from genesis.engine.sensors.base_sensor import Sensor
+    from genesis.engine.simulator import Simulator
     from genesis.options.sensors.options import SensorOptions, SensorT
     from genesis.recorders import Recorder
 
@@ -95,6 +97,14 @@ class SceneCheckpoint:
     digest: str
     layout: EnvironmentLayout
     sim: SimulatorCheckpoint
+
+
+class TrajectorySource(NamedTuple):
+    """The simulator, scene description and environment layout a trajectory recorder reads at build."""
+
+    sim: "Simulator"
+    desc: SceneDescription
+    layout: EnvironmentLayout
 
 
 def description_digest(desc: SceneDescription) -> str:
@@ -271,18 +281,20 @@ class Scene(RBC):
             # This scene may have been destroyed previously
             pass
 
-        if getattr(self, "_recorder_manager", None) is not None:
-            if self._recorder_manager.is_recording:
-                self._recorder_manager.stop()
+        # The recorders are the first to go, and a failure they raise leaves nothing of the scene alive behind it
+        try:
+            if getattr(self, "_recorder_manager", None) is not None and self._recorder_manager.is_recording:
+                self.stop_recording()
+        finally:
             self._recorder_manager = None
 
-        if getattr(self, "_visualizer", None) is not None:
-            self._visualizer.destroy()
-            self._visualizer = None
+            if getattr(self, "_visualizer", None) is not None:
+                self._visualizer.destroy()
+                self._visualizer = None
 
-        if getattr(self, "_sim", None) is not None:
-            self._sim.destroy()
-            self._sim = None
+            if getattr(self, "_sim", None) is not None:
+                self._sim.destroy()
+                self._sim = None
 
     @overload
     def add_entity(
@@ -624,6 +636,31 @@ class Scene(RBC):
         return self._recorder_manager.add_recorder(data_func, rec_options)
 
     @gs.assert_unbuilt
+    def start_recording(self, rec_options: TrajectoryFile) -> "Recorder":
+        """Record the state of the scene at every step to a trajectory file, which 'load_trajectory' opens to seek and
+        replay.
+
+        Recording starts with the build and stops with 'stop_recording'. See 'TrajectoryFile' for what a frame holds
+        and how the file is written.
+
+        Parameters
+        ----------
+        rec_options : TrajectoryFile
+            The file to write and the mode to record in.
+
+        Returns
+        -------
+        recorder : Recorder
+            The created recorder object.
+        """
+
+        def data_func() -> TrajectorySource:
+            self._reject_unexportable()
+            return TrajectorySource(self._sim, self.desc, self._layout)
+
+        return self._recorder_manager.add_recorder(data_func, rec_options)
+
+    @gs.assert_unbuilt
     def add_camera(
         self,
         model="pinhole",
@@ -917,8 +954,12 @@ class Scene(RBC):
             The indices of the environments. If None, all environments will be considered. Defaults to None.
         """
         gs.logger.debug(f"Resetting Scene ~~~<{self._uid}>~~~.")
-        self._reset(state, envs_idx=envs_idx)
+        # The recorders finish the run first: a reset of the whole scene records the state it leaves behind, and a file
+        # rotated on reset ends with it.
+        if envs_idx is None:
+            self._recorder_manager.record(self._sim.cur_step_global)
         self._recorder_manager.reset(envs_idx)
+        self._reset(state, envs_idx=envs_idx)
 
     def _reset(self, state: SimState | None = None, *, envs_idx=None, keep_init: bool = False):
         if self._is_built:
@@ -1026,6 +1067,9 @@ class Scene(RBC):
         if advance:
             if not self._forward_ready:
                 gs.raise_exception("Forward simulation not allowed after backward pass. Please reset scene state.")
+            # The recorders read the state a step starts from, with the inputs the step consumes: 'Simulator.step'
+            # zeroes the applied forces at its end. The pre-step callbacks ran, so their inputs are read as well.
+            self._recorder_manager.step(self._sim.cur_step_global)
             self._sim.step()
 
         if update_visualizer:
@@ -1036,12 +1080,16 @@ class Scene(RBC):
         if advance:
             if self.options.profiling.show_FPS:
                 self.FPS_tracker.step()
-            self._recorder_manager.step(self._sim.cur_step_global)
             for camera in self._visualizer.cameras:
                 camera.update_recording()
 
     def stop_recording(self):
-        self._recorder_manager.stop()
+        # The recorders read before each step, so the state the last step left is recorded here, whatever the
+        # sampling rate: it is the state a stopped run is resumed or studied from.
+        try:
+            self._recorder_manager.record(self._sim.cur_step_global)
+        finally:
+            self._recorder_manager.stop()
 
     def _step_grad(self):
         self._sim.collect_output_grads()
@@ -1491,7 +1539,6 @@ class Scene(RBC):
         rejected_kinds.update(type(emitter).__name__ for emitter in self._emitters)
         rejected_kinds.update(type(force_field).__name__ for force_field in self._sim.solvers[0].force_fields)
         omitted_kinds = Counter(type(sensor).__name__ for sensor in self._sim._sensor_manager.sensors)
-        omitted_kinds.update(type(recorder).__name__ for recorder in self._recorder_manager.recorders)
         if self._visualizer is not None:
             omitted_kinds.update(type(camera).__name__ for camera in self._visualizer.cameras)
         if self._pre_step_callbacks:
@@ -1531,9 +1578,9 @@ class Scene(RBC):
 
         Only a rigid or a kinematic entity carries a description. A scene
         holding anything that alters the simulation raises, naming it: an emitter and a force field. Everything else
-        a description leaves out is written without, with a warning naming it: a camera, a recorder, a sensor, a
-        callback Genesis calls at every step, a texture read from an HDR or EXR file, and the visual vertices an
-        entity was given at runtime.
+        a description leaves out is written without, with a warning naming it: a camera, a sensor, a callback Genesis
+        calls at every step, a texture read from an HDR or EXR file, and the visual vertices an entity was given at
+        runtime. A recorder neither simulates nor draws, so it is left out without a word.
 
         Parameters
         ----------
@@ -1544,7 +1591,14 @@ class Scene(RBC):
         serialization.export(path, {"scene": self.desc})
 
     @classmethod
-    def load(cls, path: str | os.PathLike, show_viewer: bool = False) -> "Scene":
+    def load(
+        cls,
+        path: str | os.PathLike | BinaryIO,
+        show_viewer: bool = False,
+        viewer_options: ViewerOptions | None = None,
+        vis_options: VisOptions | None = None,
+        renderer: RendererOptions | None = None,
+    ) -> "Scene":
         """Create the scene a file holds, as written by 'Scene.export'.
 
         The file names what it holds rather than carrying code to run, and Genesis creates only the options,
@@ -1553,35 +1607,42 @@ class Scene(RBC):
 
         Parameters
         ----------
-        path : str or os.PathLike
+        path : str, os.PathLike or binary file
             The file to read.
         show_viewer : bool, optional
             Whether to open an interactive viewer on the scene. Defaults to False.
+        viewer_options : ViewerOptions, optional
+            Viewer options replacing the recorded ones. If None, the recorded ones stand. Defaults to None.
+        vis_options : VisOptions, optional
+            Visualizer options replacing the recorded ones. If None, the recorded ones stand. Defaults to None.
+        renderer : RendererOptions, optional
+            Renderer replacing the recorded one. If None, the recorded one stands. Defaults to None.
 
         Returns
         -------
         scene : Scene
             The scene the file describes, holding every entity it was authored with and waiting to be built.
         """
-        return cls.from_description(serialization.load(path, {"scene": SceneDescription})["scene"], show_viewer)
+        described = serialization.load(path, {"scene": SceneDescription})["scene"]
+        return cls._from_description(described, show_viewer, viewer_options, vis_options, renderer)
 
     @classmethod
-    def from_description(cls, described: SceneDescription, show_viewer: bool = False) -> "Scene":
-        """Create the scene a description states, holding every entity it names and waiting to be built.
+    def _from_description(
+        cls,
+        described: SceneDescription,
+        show_viewer: bool = False,
+        viewer_options: ViewerOptions | None = None,
+        vis_options: VisOptions | None = None,
+        renderer: RendererOptions | None = None,
+    ) -> "Scene":
+        """Create the scene a description states, waiting to be built.
 
-        Parameters
-        ----------
-        described : SceneDescription
-            The scene to create, as 'Scene.desc' describes one.
-        show_viewer : bool, optional
-            Whether to open an interactive viewer on the scene. Defaults to False.
-
-        Returns
-        -------
-        scene : Scene
-            The created scene.
+        The viewer, visualizer and renderer options are replaced where given. The physics options stand as described,
+        since they size the arrays a recorded state fills.
         """
-        scene = cls(show_viewer=show_viewer, options=described.options)
+        replaced = (("viewer", viewer_options), ("vis", vis_options), ("renderer", renderer))
+        options = described.options.model_copy(update={name: value for name, value in replaced if value is not None})
+        scene = cls(show_viewer=show_viewer, options=options)
         # 'add_entity' would resolve a material and a surface the description already holds, and read the asset it
         # replaces.
         for desc in described.entities:
@@ -1610,10 +1671,96 @@ class Scene(RBC):
     def __reduce__(self):
         return (self._from_state, (self.__getstate__(),))
 
+    @gs.assert_built
+    def save_checkpoint(self, path: str | os.PathLike) -> None:
+        """Write the whole state of this scene to a file, for 'load_checkpoint' to open a copy standing where it stands.
+
+        The file holds the scene as 'export' writes it and every array of the simulation, scratch included, so the
+        exact state of a failing run is kept for inspection. It is a trajectory file of one frame (see 'TrajectoryFile'),
+        and 'load_trajectory' opens it as such.
+
+        Parameters
+        ----------
+        path : str or os.PathLike
+            The '.gstraj' file to write.
+        """
+        self._reject_unexportable()
+        save_checkpoint(path, TrajectorySource(self._sim, self.desc, self._layout))
+
+    @classmethod
+    def load_checkpoint(
+        cls,
+        path: str | os.PathLike,
+        show_viewer: bool = False,
+        viewer_options: ViewerOptions | None = None,
+        vis_options: VisOptions | None = None,
+        renderer: RendererOptions | None = None,
+    ) -> "Scene":
+        """Create and build the scene a checkpoint file holds, standing in the final state the file records.
+
+        The file is one written by 'save_checkpoint' or by recording a 'TrajectoryFile' to its end. The viewer,
+        visualizer and renderer options may be replaced (see 'load').
+
+        Parameters
+        ----------
+        path : str or os.PathLike
+            The file to read.
+        show_viewer : bool, optional
+            Whether to open an interactive viewer on the scene. Defaults to False.
+        viewer_options : ViewerOptions, optional
+            Viewer options replacing the recorded ones. Defaults to None.
+        vis_options : VisOptions, optional
+            Visualizer options replacing the recorded ones. Defaults to None.
+        renderer : RendererOptions, optional
+            Renderer replacing the recorded one. Defaults to None.
+
+        Returns
+        -------
+        scene : Scene
+            The built scene, in the recorded state.
+        """
+        trajectory = Trajectory(path, None, show_viewer, viewer_options, vis_options, renderer)
+        trajectory.seek(len(trajectory) - 1)
+        return trajectory.scene
+
+    @classmethod
+    def load_trajectory(
+        cls,
+        path: str | os.PathLike,
+        show_viewer: bool = False,
+        viewer_options: ViewerOptions | None = None,
+        vis_options: VisOptions | None = None,
+        renderer: RendererOptions | None = None,
+    ) -> Trajectory:
+        """Open a recorded trajectory in the scene it was recorded from, created and built here, to seek and replay.
+
+        The file is one written by recording a 'TrajectoryFile'. The viewer, visualizer and renderer options may be
+        replaced (see 'load').
+
+        Parameters
+        ----------
+        path : str or os.PathLike
+            The file to read.
+        show_viewer : bool, optional
+            Whether to open an interactive viewer on the scene. Defaults to False.
+        viewer_options : ViewerOptions, optional
+            Viewer options replacing the recorded ones. Defaults to None.
+        vis_options : VisOptions, optional
+            Visualizer options replacing the recorded ones. Defaults to None.
+        renderer : RendererOptions, optional
+            Renderer replacing the recorded one. Defaults to None.
+
+        Returns
+        -------
+        trajectory : Trajectory
+            The trajectory, holding the built scene as 'Trajectory.scene'.
+        """
+        return Trajectory(path, None, show_viewer, viewer_options, vis_options, renderer)
+
     @classmethod
     def _from_state(cls, state: SceneCheckpoint) -> "Scene":
         """Create, build and restore the scene a checkpoint describes. '__reduce__' names it as the loader."""
-        scene = cls.from_description(state.scene)
+        scene = cls._from_description(state.scene)
         scene.build(**dataclasses.asdict(state.layout))
         scene.__setstate__(state)
         return scene
@@ -1631,7 +1778,7 @@ class Scene(RBC):
         Parameters
         ----------
         state : SceneCheckpoint
-            The state to put back, as read by '__getstate__'.
+            The state to put back, as read by '__getstate__' or cut from a trajectory frame.
         """
         if state.layout != self._layout:
             gs.raise_exception(
@@ -1640,7 +1787,7 @@ class Scene(RBC):
         if state.digest != self._desc_digest:
             gs.raise_exception("The state was read from another scene: its entities or physics options differ.")
         # Every solver checks its record before anything is touched, so a record from another scene leaves this one as
-        # it was
+        # it was, the recorders included
         solvers = {type(solver).__name__: solver for solver in self._sim.active_solvers}
         if set(state.sim.solvers) != set(solvers):
             gs.raise_exception(
@@ -1649,9 +1796,12 @@ class Scene(RBC):
         for name, solver in solvers.items():
             record = state.sim.solvers[name]
             check_data((item for item in solver.data if item.kind in record.kinds), record.arrays)
+        # The recorders finish the run first (see 'reset'), and the restart follows the state, so the visualizer draws
+        # the state put back.
+        self._recorder_manager.record(self._sim.cur_step_global)
+        self._recorder_manager.reset()
         self._sim.__setstate__(state.sim)
         self._restart()
-        self._recorder_manager.reset()
 
     def _sanitize_envs_idx(
         self, envs_idx: int | range | slice | tuple[int, ...] | list[int] | torch.Tensor | np.ndarray | None

--- a/genesis/engine/scene.py
+++ b/genesis/engine/scene.py
@@ -601,12 +601,13 @@ class Scene(RBC):
         return self._sim._sensor_manager.read_sensors(entity_idx=None, envs_idx=envs_idx)
 
     @gs.assert_unbuilt
-    def start_recording(self, data_func: Callable, rec_options: "RecorderOptions") -> "Recorder":
+    def add_recorder(self, data_func: Callable, rec_options: "RecorderOptions") -> "Recorder":
         """
         Automatically read and process data. See RecorderOptions for more details.
 
-        Data from `data_func` is automatically read and processed using the recorder at the
-        frequency `rec_options.hz` (or every step if not specified) as the scene is stepped.
+        Data from `data_func` is automatically read and processed using the recorder at the frequency `rec_options.hz`
+        (or every step if not specified) as the scene is stepped. Recording starts with the build and every recorder
+        stops with 'stop_recording'.
 
         Parameters
         ----------

--- a/genesis/engine/sensors/base_sensor.py
+++ b/genesis/engine/sensors/base_sensor.py
@@ -494,7 +494,7 @@ class Sensor(RBC, Generic[OptionsT, SharedSensorContextT, SharedSensorMetadataT,
         Automatically read and process sensor data. See RecorderOptions for more details.
 
         Data from `sensor.read()` is used. If the sensor data needs to be preprocessed before passing to the recorder,
-        consider using `scene.start_recording()` instead with a custom data function.
+        consider using `scene.add_recorder()` instead with a custom data function.
 
         Parameters
         ----------

--- a/genesis/engine/sensors/kinematic_tactile.py
+++ b/genesis/engine/sensors/kinematic_tactile.py
@@ -1022,7 +1022,7 @@ class ContactDepthProbeSensor(
                 shared_metadata.filter_links_idx,
                 shared_metadata.sensor_geoms_idx,
                 shared_metadata.sensor_n_geoms,
-                solver.collider._collider_state,
+                solver.collider.collider_state,
             )
             _kernel_contact_depth_probe(
                 shared_metadata.probe_sensor_idx,
@@ -1039,7 +1039,7 @@ class ContactDepthProbeSensor(
                 measured_cols_b,
                 solver.dyn_state,
                 solver.dyn_info,
-                solver.collider._collider_info,
+                solver.collider.collider_info,
             )
         else:
             _kernel_build_sensor_contact_idx(
@@ -1047,7 +1047,7 @@ class ContactDepthProbeSensor(
                 shared_metadata.filter_links_idx,
                 shared_metadata.sensor_contacts_idx,
                 shared_metadata.sensor_n_contacts,
-                solver.collider._collider_state,
+                solver.collider.collider_state,
             )
             B, n_sensors = shared_metadata.sensor_n_contacts.shape
             mask_shape = (B, n_sensors, solver.n_geoms)
@@ -1058,7 +1058,7 @@ class ContactDepthProbeSensor(
                 shared_metadata.sensor_contacts_idx,
                 shared_metadata.sensor_n_contacts,
                 shared_metadata.sensor_candidate_geom_mask,
-                solver.collider._collider_state,
+                solver.collider.collider_state,
             )
             collision_bvh_contexts = shared_context.collision_bvh_contexts
             entry_a, entry_b = collision_bvh_contexts[0], collision_bvh_contexts[-1]
@@ -1295,7 +1295,7 @@ class KinematicTaxelSensor(
                 shared_metadata.filter_links_idx,
                 shared_metadata.sensor_geoms_idx,
                 shared_metadata.sensor_n_geoms,
-                solver.collider._collider_state,
+                solver.collider.collider_state,
             )
             _kernel_kinematic_taxel(
                 shared_metadata.probe_sensor_idx,
@@ -1319,8 +1319,8 @@ class KinematicTaxelSensor(
                 solver.dyn_state,
                 solver.dyn_info,
                 solver.rigid_info,
-                solver.collider._collider_info,
-                solver.collider._collider_static_config,
+                solver.collider.collider_info,
+                solver.collider.collider_config,
                 gs.EPS,
                 measured_equals_gt,
             )
@@ -1330,7 +1330,7 @@ class KinematicTaxelSensor(
                 shared_metadata.filter_links_idx,
                 shared_metadata.sensor_contacts_idx,
                 shared_metadata.sensor_n_contacts,
-                solver.collider._collider_state,
+                solver.collider.collider_state,
             )
             B, n_sensors = shared_metadata.sensor_n_contacts.shape
             mask_shape = (B, n_sensors, solver.n_geoms)
@@ -1341,7 +1341,7 @@ class KinematicTaxelSensor(
                 shared_metadata.sensor_contacts_idx,
                 shared_metadata.sensor_n_contacts,
                 shared_metadata.sensor_candidate_geom_mask,
-                solver.collider._collider_state,
+                solver.collider.collider_state,
             )
             collision_bvh_contexts = shared_context.collision_bvh_contexts
             entry_a, entry_b = collision_bvh_contexts[0], collision_bvh_contexts[-1]

--- a/genesis/engine/sensors/point_cloud_tactile.py
+++ b/genesis/engine/sensors/point_cloud_tactile.py
@@ -2253,7 +2253,7 @@ class ElastomerTaxelSensor(
                 shared_metadata.probe_depth_buf,
                 solver.dyn_state,
                 solver.dyn_info,
-                solver.collider._collider_info,
+                solver.collider.collider_info,
             )
         else:
             collision_bvh_contexts = shared_context.collision_bvh_contexts
@@ -2332,7 +2332,7 @@ class ElastomerTaxelSensor(
                     shared_metadata.surface_candidate_buf,
                     solver.dyn_state,
                     solver.dyn_info,
-                    solver.collider._collider_info,
+                    solver.collider.collider_info,
                     _ELASTOMER_QUERY_AABB_MARGIN,
                     BVH_STACK_SIZE,
                 )

--- a/genesis/engine/sensors/temperature.py
+++ b/genesis/engine/sensors/temperature.py
@@ -653,7 +653,7 @@ class TemperatureGridSensor(
         )
 
         # Contact area buffers
-        n_c_max = int(solver.collider._collider_info.max_candidate_contacts[None])
+        n_c_max = int(solver.collider.collider_info.max_candidate_contacts[None])
         self._shared_metadata.contact_area_buffer = torch.zeros(
             (n_c_max, solver._B), device=gs.device, dtype=gs.tc_float
         )
@@ -717,7 +717,7 @@ class TemperatureGridSensor(
             raw_data_T,
         )
         # 3) Contact heat transfer
-        collider_state = solver.collider._collider_state
+        collider_state = solver.collider.collider_state
         shared_metadata.contact_area_buffer.zero_()
         _kernel_compute_contact_areas(
             shared_metadata.contact_area_buffer,

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -23,7 +23,7 @@ from .solvers import (
 )
 from .solvers.base_solver import GravityMixin, TimeBasedMixin
 from .states.cache import QueriedStates
-from .states.solvers import SimState
+from .states.solvers import SimState, SimulatorCheckpoint
 
 if TYPE_CHECKING:
     from genesis.engine.entities.base_entity import Entity, EntityDescription
@@ -237,19 +237,52 @@ class Simulator(RBC):
             if solver.n_entities > 0:
                 solver.set_state(0, solver_state, envs_idx)
 
+        if envs_idx is None:
+            self._steps.zero_()
+        else:
+            self._steps[indices_to_mask(envs_idx)] = 0
+        self._restart(envs_idx)
+
+    def _restart(self, envs_idx=None):
+        """Restart the coupler, the gradient tape and the sensors."""
         self._coupler.reset(envs_idx=envs_idx)
 
         # TODO: keeping as is for now
         self.reset_grad()
         # The tape cursor is a position in the recorded window, not a clock, so it rewinds whole.
         self._cur_substep_global = 0
-        if envs_idx is None:
-            self._steps.zero_()
-        else:
-            self._steps[indices_to_mask(envs_idx)] = 0
 
         # reset sensors state
         self._sensor_manager.reset(envs_idx=envs_idx)
+
+    def __getstate__(self) -> SimulatorCheckpoint:
+        """Return a SimulatorCheckpoint of the simulation, for '__setstate__' to restore."""
+        if isinstance(self._coupler, IPCCoupler):
+            gs.raise_exception(
+                "A scene coupled by IPC cannot be checkpointed yet: the IPC world holds state of its own."
+            )
+        return SimulatorCheckpoint(
+            steps=self._steps.clone(),
+            solvers={type(solver).__name__: solver.__getstate__() for solver in self._active_solvers},
+        )
+
+    def __setstate__(self, state: SimulatorCheckpoint) -> None:
+        """Put the built simulation back in a state '__getstate__' read.
+
+        Everything around the state restarts as under a reset.
+
+        The clock of each environment comes back as recorded, since simulated time is state. The tape cursor, the
+        gradients, the coupler and the sensors are restarted (see 'reset'): they describe the run that led here.
+        """
+        # The record was checked against every solver by the scene (see 'Scene.__setstate__'). The restart precedes the
+        # state, whose gradients it would zero otherwise.
+        self._restart()
+        for solver in self._active_solvers:
+            solver.__setstate__(state.solvers[type(solver).__name__])
+        self._steps[:] = torch.as_tensor(state.steps, device=gs.device)
+        # Flush the zero-copy writes of fill_data on Metal.
+        if gs.use_zerocopy and gs.backend == gs.metal:
+            torch.mps.synchronize()
 
     def reset_grad(self):
         for solver in self._active_solvers:

--- a/genesis/engine/simulator.py
+++ b/genesis/engine/simulator.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import torch
@@ -6,6 +7,7 @@ import genesis as gs
 from genesis.options.morphs import Morph
 from genesis.options.solvers import IPCCouplerOptions, LegacyCouplerOptions, SAPCouplerOptions
 from genesis.repr_base import RBC
+from genesis.utils.array_class import DataItem, DataKind
 from genesis.utils.misc import indices_to_mask
 
 from .couplers import IPCCoupler, LegacyCoupler, SAPCoupler
@@ -255,6 +257,18 @@ class Simulator(RBC):
         # reset sensors state
         self._sensor_manager.reset(envs_idx=envs_idx)
 
+    def data(self, kinds: frozenset[DataKind]) -> Iterator[DataItem]:
+        """Yield every item of the given kinds the active solvers hold, each under the class name of its solver."""
+        if isinstance(self._coupler, IPCCoupler):
+            gs.raise_exception(
+                "A scene coupled by IPC cannot be checkpointed yet: the IPC world holds state of its own."
+            )
+        for solver in self._active_solvers:
+            prefix = type(solver).__name__
+            for name, value, kind in solver.data:
+                if kind in kinds:
+                    yield DataItem(f"{prefix}.{name}", value, kind)
+
     def __getstate__(self) -> SimulatorCheckpoint:
         """Return a SimulatorCheckpoint of the simulation, for '__setstate__' to restore."""
         if isinstance(self._coupler, IPCCoupler):
@@ -494,6 +508,11 @@ class Simulator(RBC):
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------
     # ------------------------------------------------------------------------------------
+
+    @property
+    def steps(self) -> torch.Tensor:
+        """The number of steps each environment has run since its last reset, of shape [B]."""
+        return self._steps
 
     @property
     def dt(self) -> float:

--- a/genesis/engine/solvers/base_solver.py
+++ b/genesis/engine/solvers/base_solver.py
@@ -1,6 +1,7 @@
 import enum
 import functools
 import inspect
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
@@ -12,12 +13,13 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.materials.base import Material
-from genesis.engine.states import QueriedStates
+from genesis.engine.states import QueriedStates, SolverCheckpoint
 from genesis.repr_base import RBC
 from genesis.utils.misc import (
     assign_indexed_tensor,
     broadcast_tensor,
     indices_to_mask,
+    qd_to_numpy,
     qd_to_torch,
     sanitize_index,
     tensor_to_array,
@@ -326,8 +328,6 @@ class Solver(RBC):
         # through both the simulator-level and the per-solver loop.
         self._queried_states = QueriedStates()
 
-        self.data_manager = None
-
         # force fields
         self._ffs = list()
 
@@ -358,6 +358,34 @@ class Solver(RBC):
 
     def build(self):
         self._B = self._sim._B
+
+    @property
+    def data(self) -> Iterator[array_class.DataItem]:
+        """Yield every array and static config the solver holds, tagged by kind (see 'DataKind'), under the dotted name
+        a checkpoint and a trajectory frame use for it.
+        """
+        gs.raise_exception(f"{type(self).__name__} cannot be checkpointed yet.")
+
+    def __getstate__(self) -> SolverCheckpoint:
+        """Return a SolverCheckpoint of this solver, for '__setstate__' to restore.
+
+        The state is what 'data' yields of the kinds a checkpoint carries (see 'CHECKPOINT_KINDS'), copied where it
+        lives: on the device as torch tensors when zero-copy views exist, which keeps a save and a restore within one
+        process off the host, and as numpy arrays otherwise.
+        """
+        read = qd_to_torch if gs.use_zerocopy else qd_to_numpy
+        arrays = {}
+        configs = {}
+        for name, value, kind in self.data:
+            if kind == array_class.DataKind.CONFIG:
+                configs[name] = value
+            elif kind in array_class.CHECKPOINT_KINDS:
+                arrays[name] = read(value, copy=True)
+        return SolverCheckpoint(arrays=arrays, configs=configs, kinds=array_class.CHECKPOINT_KINDS)
+
+    def __setstate__(self, state: SolverCheckpoint) -> None:
+        """Write back the arrays of the kinds a record holds, rejecting a record read from another build."""
+        array_class.fill_data((item for item in self.data if item.kind in state.kinds), state.arrays)
 
     # ------------------------------------------------------------------------------------
     # ----------------------------------- properties -------------------------------------

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -15,7 +16,7 @@ from genesis.engine.solvers.rigid.abd.inverse_kinematics import (
     kernel_inverse_kinematics_entity,
     kernel_set_ik_targets,
 )
-from genesis.engine.states.solvers import KinematicSolverState
+from genesis.engine.states.solvers import KinematicSolverCheckpoint, KinematicSolverState
 from genesis.options.morphs import Morph
 from genesis.options.solvers import KinematicOptions
 from genesis.utils.misc import (
@@ -396,6 +397,16 @@ class KinematicSolver(Solver):
         self.dyn_state = self.data_manager.dyn_state
         self.kinematics_scratch = self.data_manager.kinematics_scratch
 
+    @property
+    def data(self) -> Iterator[array_class.DataItem]:
+        yield from array_class.iter_data(self.rigid_config, "rigid_config")
+        yield from array_class.iter_data(self.data_manager.errno, "errno", array_class.DataKind.STATE)
+        structs = ["rigid_info", "dyn_info", "dyn_state", "rigid_adjoint_cache"]
+        if self.rigid_config.requires_grad:
+            structs.append("dyn_state_adjoint_cache")
+        for name in structs:
+            yield from array_class.iter_data(getattr(self.data_manager, name), name)
+
     # ------------------------------------------------------------------------------------
     # --------------------------------- hook methods -------------------------------------
     # ------------------------------------------------------------------------------------
@@ -752,6 +763,28 @@ class KinematicSolver(Solver):
         else:
             self._is_forward_pos_updated = False
             self._is_forward_vel_updated = False
+
+    def __getstate__(self) -> KinematicSolverCheckpoint:
+        state = super().__getstate__()
+        return KinematicSolverCheckpoint(
+            arrays=state.arrays,
+            configs=state.configs,
+            kinds=state.kinds,
+            is_forward_pos_updated=self._is_forward_pos_updated,
+            is_forward_vel_updated=self._is_forward_vel_updated,
+        )
+
+    @mutates(StateChange.GEOMETRY, StateChange.DYNAMICS)
+    def __setstate__(self, state: KinematicSolverCheckpoint) -> None:
+        super().__setstate__(state)
+        if array_class.DataKind.DERIVED in state.kinds:
+            self._is_forward_pos_updated = state.is_forward_pos_updated
+            self._is_forward_vel_updated = state.is_forward_vel_updated
+        else:
+            # Without the derived arrays, forward kinematics runs now so the scene is drawn where the record put it. The
+            # next step recomputes the rest of the derived state.
+            self._is_forward_pos_updated = self._is_forward_vel_updated = False
+            self.update_forward_pos()
 
     # ------------------------------------------------------------------------------------
     # -------------------------------- process_input -------------------------------------
@@ -1572,6 +1605,16 @@ class KinematicSolver(Solver):
         if self.is_built:
             return self._n_qs
         return sum(entity.n_qs for entity in self._entities)
+
+    @property
+    def is_forward_pos_updated(self) -> bool:
+        """Whether the link and geom poses are current for the configuration, so the next step skips forward kinematics."""
+        return self._is_forward_pos_updated
+
+    @property
+    def is_forward_vel_updated(self) -> bool:
+        """Whether the link velocities are current for the generalized velocities."""
+        return self._is_forward_vel_updated
 
     @property
     def n_dofs(self):

--- a/genesis/engine/solvers/mpm_solver.py
+++ b/genesis/engine/solvers/mpm_solver.py
@@ -578,7 +578,7 @@ class MPMSolver(GravityMixin, TimeBasedMixin, Solver):
             self.sim.coupler.rigid_solver.dyn_state.links,
             self.sim.coupler.rigid_solver.rigid_info,
             self.sim.coupler.rigid_solver.collider._sdf._sdf_info,
-            self.sim.coupler.rigid_solver.collider._collider_static_config,
+            self.sim.coupler.rigid_solver.collider.collider_config,
         )
 
     def substep_pre_coupling_grad(self, f):
@@ -589,7 +589,7 @@ class MPMSolver(GravityMixin, TimeBasedMixin, Solver):
             self.sim.coupler.rigid_solver.dyn_state.links,
             self.sim.coupler.rigid_solver.rigid_info,
             self.sim.coupler.rigid_solver.collider._sdf._sdf_info,
-            self.sim.coupler.rigid_solver.collider._collider_static_config,
+            self.sim.coupler.rigid_solver.collider.collider_config,
         )
         self.svd_grad(f)
         self.compute_F_tmp.grad(f)

--- a/genesis/engine/solvers/rigid/collider/collider.py
+++ b/genesis/engine/solvers/rigid/collider/collider.py
@@ -7,6 +7,7 @@ terrain), and contact management.
 """
 
 import math
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -96,16 +97,16 @@ class Collider:
 
         self._init_static_config()
         self._use_split_narrowphase = (
-            self._collider_static_config.has_non_box_plane_convex_convex
+            self.collider_config.has_non_box_plane_convex_convex
             and gs.backend != gs.cpu
             and not self._solver._requires_grad
         )
 
-        if self._collider_static_config.has_nonconvex_nonterrain:
+        if self.collider_config.has_nonconvex_nonterrain:
             self._sdf.activate()
-        if self._collider_static_config.has_non_box_plane_convex_convex:
+        if self.collider_config.has_non_box_plane_convex_convex:
             self._gjk.activate()
-        if self._collider_static_config.has_terrain or self._collider_static_config.has_non_box_plane_convex_convex:
+        if self.collider_config.has_terrain or self.collider_config.has_non_box_plane_convex_convex:
             self._support_field.activate()
 
         self._init_collision_fields()
@@ -119,11 +120,11 @@ class Collider:
             # in its SNode tree no zero-copy view exists, and get_contacts falls back to the gather-kernel path.
             self._contact_data: dict[str, torch.Tensor] | None = {}
             try:
-                qd_to_torch(self._collider_state.n_contacts, copy=False)
-                qd_to_torch(self._collider_state.contact_sort_idx, transpose=True, copy=False)
-                qd_to_torch(self._collider_state.first_time, copy=False)
-                qd_to_torch(self._collider_state.contact_cache.normal, copy=False)
-                qd_to_torch(self._collider_state.contact_cache.penetration, copy=False)
+                qd_to_torch(self.collider_state.n_contacts, copy=False)
+                qd_to_torch(self.collider_state.contact_sort_idx, transpose=True, copy=False)
+                qd_to_torch(self.collider_state.first_time, copy=False)
+                qd_to_torch(self.collider_state.contact_cache.normal, copy=False)
+                qd_to_torch(self.collider_state.contact_cache.penetration, copy=False)
                 for key, name in (
                     ("link_a", "link_a"),
                     ("link_b", "link_b"),
@@ -135,13 +136,30 @@ class Collider:
                     ("force", "force"),
                 ):
                     self._contact_data[key] = qd_to_torch(
-                        getattr(self._collider_state.contact_data, name), transpose=True, copy=False
+                        getattr(self.collider_state.contact_data, name), transpose=True, copy=False
                     )
             except ValueError:
                 self._contact_data = None
 
         # Make sure that the initial state is clean
         self.clear()
+
+    @property
+    def data(self) -> Iterator[array_class.DataItem]:
+        """Yield every array and static config of the collider, tagged by kind (see 'Solver.data')."""
+        structs = [
+            (self, "collider_config"),
+            (self._gjk, "gjk_config"),
+            (self, "collider_info"),
+            (self, "collider_state"),
+            (self._mpr, "mpr_state"),
+            (self._gjk, "gjk_state"),
+        ]
+        if self._use_split_narrowphase:
+            structs += [(self, name) for name in ("contact0_mpr_state", "contact0_gjk_state")]
+            structs += [(self, name) for name in ("multicontact_mpr_state", "multicontact_gjk_state")]
+        for owner, name in structs:
+            yield from array_class.iter_data(getattr(owner, name), name)
 
     def _init_static_config(self) -> None:
         # Identify the convex collision detection (ccd) algorithm
@@ -224,7 +242,7 @@ class Collider:
 
         # Initialize the static config, which stores every data that are compile-time constants.
         # Note that updating any of them will trigger recompilation.
-        self._collider_static_config = array_class.ColliderStaticConfig(
+        self.collider_config = array_class.ColliderStaticConfig(
             has_terrain=has_terrain,
             has_non_box_plane_convex_convex=has_non_box_plane_convex_convex,
             has_convex_specialization=has_convex_specialization,
@@ -244,11 +262,11 @@ class Collider:
 
         # Initialize [info], which stores every data that must be considered mutable from Quadrants's perspective,
         # i.e. unknown at compile time, but IMMUTABLE from Genesis scene's perspective after build.
-        self._collider_info = array_class.get_collider_info(
+        self.collider_info = array_class.get_collider_info(
             self._solver,
             n_vert_neighbors,
             n_valid_pairs,
-            self._collider_static_config,
+            self.collider_config,
             self._mpr._mpr_info,
             self._gjk._gjk_info,
             self._support_field._support_field_info,
@@ -272,13 +290,13 @@ class Collider:
 
         # Initialize [state], which stores every data that are may be updated at every single simulation step
         n_possible_pairs_ = max(self._n_possible_pairs, 1)
-        self._collider_state = array_class.get_collider_state(
+        self.collider_state = array_class.get_collider_state(
             self._solver,
             self._solver.rigid_config,
             n_possible_pairs_,
             self._solver._options.multiplier_collision_broad_phase,
-            self._collider_info,
-            self._collider_static_config,
+            self.collider_info,
+            self.collider_config,
         )
 
         # 'contact_data_cache' is not used in Quadrants kernels, so keep it outside of the collider state / info
@@ -310,19 +328,19 @@ class Collider:
         if self._use_split_narrowphase:
             self._contact0_n_chunks = max(1, math.ceil(gpu_cores / self._solver._B))
             self._contact0_grid_size = self._solver._B * self._contact0_n_chunks
-            self._contact0_mpr_state = array_class.get_mpr_state(self._contact0_grid_size)
-            self._contact0_gjk_state = array_class.get_gjk_state_contact_only(self._contact0_grid_size)
+            self.contact0_mpr_state = array_class.get_mpr_state(self._contact0_grid_size)
+            self.contact0_gjk_state = array_class.get_gjk_state_contact_only(self._contact0_grid_size)
 
             self._multicontact_n_total_threads = gpu_cores
             self._multicontact_max_items_per_thread = cores_per_unit
-            self._multicontact_mpr_state = array_class.get_mpr_state(self._multicontact_n_total_threads)
+            self.multicontact_mpr_state = array_class.get_mpr_state(self._multicontact_n_total_threads)
 
     def _init_multicontact_gjk_state(self):
         """Allocate the GJK scratch state for the multicontact pass.
 
         Must be called after self._gjk is initialized. Sized to all multicontact threads because any thread may fall
         back to GJK for its own contact."""
-        self._multicontact_gjk_state = array_class.get_gjk_state(
+        self.multicontact_gjk_state = array_class.get_gjk_state(
             self._multicontact_n_total_threads,
             self._solver.rigid_config,
             self._gjk._gjk_info,
@@ -654,7 +672,7 @@ class Collider:
             geoms_inv_cell_size[i_g] = inv_cell_size
             offset_vert = offset_vert + len(verts)
 
-        verts_spatial_grid = self._collider_info.verts_spatial_grid
+        verts_spatial_grid = self.collider_info.verts_spatial_grid
         verts_spatial_grid.verts_idx.from_numpy(np.concatenate(verts_idx, dtype=gs.np_int))
         verts_spatial_grid.verts_pos.from_numpy(np.concatenate(verts_pos, dtype=gs.np_float))
         verts_spatial_grid.cells_vert_start.from_numpy(np.concatenate(cells_vert_start, dtype=gs.np_int))
@@ -663,19 +681,19 @@ class Collider:
 
     def _init_collision_pair_idx(self, collision_pair_idx):
         if self._n_possible_pairs == 0:
-            self._collider_info.collision_pair_idx.fill(-1)
+            self.collider_info.collision_pair_idx.fill(-1)
             return
-        self._collider_info.collision_pair_idx.from_numpy(collision_pair_idx)
+        self.collider_info.collision_pair_idx.from_numpy(collision_pair_idx)
 
     def _init_valid_pairs(self):
         if len(self._valid_collision_pairs) > 0:
-            self._collider_info.valid_collision_pairs.from_numpy(self._valid_collision_pairs)
+            self.collider_info.valid_collision_pairs.from_numpy(self._valid_collision_pairs)
 
     def _init_verts_connectivity(self, vert_neighbors, vert_neighbor_start, vert_n_neighbors):
         if self._solver.n_verts > 0:
-            self._collider_info.vert_neighbors.from_numpy(vert_neighbors)
-            self._collider_info.vert_neighbor_start.from_numpy(vert_neighbor_start)
-            self._collider_info.vert_n_neighbors.from_numpy(vert_n_neighbors)
+            self.collider_info.vert_neighbors.from_numpy(vert_neighbors)
+            self.collider_info.vert_neighbor_start.from_numpy(vert_neighbor_start)
+            self.collider_info.vert_n_neighbors.from_numpy(vert_n_neighbors)
 
     def _init_max_contacts(self, n_possible_pairs, large_contact_pair_mask):
         n_possible_nonconvex_pairs = int(np.count_nonzero(large_contact_pair_mask))
@@ -685,8 +703,8 @@ class Collider:
         # (larger-cap) nonconvex pairs as exist, then the rest with convex pairs. The budget of a nonconvex pair is
         # shared between its two vertex scans: the verification scan appends while the pair is under its cap and then
         # only displaces the pair's least-penetrating contact, so the cap holds regardless of the number of scans.
-        cap_nonconvex = self._collider_static_config.n_contacts_per_nonconvex_pair
-        cap_convex = self._collider_static_config.n_contacts_per_convex_pair
+        cap_nonconvex = self.collider_config.n_contacts_per_nonconvex_pair
+        cap_convex = self.collider_config.n_contacts_per_convex_pair
         n_nonconvex = min(n_possible_nonconvex_pairs, max_collision_pairs)
         n_convex = min(n_possible_pairs - n_possible_nonconvex_pairs, max_collision_pairs - n_nonconvex)
         max_candidate_contacts = n_nonconvex * cap_nonconvex + n_convex * cap_convex
@@ -704,7 +722,7 @@ class Collider:
         # 'max_contacts' is set.
         max_contacts = max_candidate_contacts
         if (
-            self._collider_static_config.has_prunable_contacts
+            self.collider_config.has_prunable_contacts
             and not self._solver._requires_grad
             and self._solver._options.contact_pruning_tolerance is not None
         ):
@@ -718,14 +736,14 @@ class Collider:
             max_contacts_pruned_total = max(int(max_contacts_pruned.sum()), self._prune_max_contacts_floor)
             max_contacts = min(max_contacts, max_contacts_pruned_total)
 
-        self._collider_info.max_possible_pairs[None] = n_possible_pairs
-        self._collider_info.max_collision_pairs[None] = max_collision_pairs
-        self._collider_info.max_collision_pairs_broad[None] = max_collision_pairs_broad
-        self._collider_info.max_candidate_contacts[None] = max_candidate_contacts
-        self._collider_info.max_contacts[None] = max_contacts
+        self.collider_info.max_possible_pairs[None] = n_possible_pairs
+        self.collider_info.max_collision_pairs[None] = max_collision_pairs
+        self.collider_info.max_collision_pairs_broad[None] = max_collision_pairs_broad
+        self.collider_info.max_candidate_contacts[None] = max_candidate_contacts
+        self.collider_info.max_contacts[None] = max_contacts
 
     def _init_terrain_state(self):
-        if self._collider_static_config.has_terrain:
+        if self.collider_config.has_terrain:
             solver = self._solver
             links_idx = solver.dyn_info.geoms.link_idx.to_numpy()[
                 solver.dyn_info.geoms.type.to_numpy() == gs.GEOM_TYPE.TERRAIN
@@ -748,10 +766,10 @@ class Collider:
                 dtype=gs.np_float,
             )
 
-            self._collider_info.terrain_hf.from_numpy(entity.terrain_hf)
-            self._collider_info.terrain_rc.from_numpy(rc)
-            self._collider_info.terrain_scale.from_numpy(entity.terrain_scale)
-            self._collider_info.terrain_xyz_maxmin.from_numpy(xyz_maxmin)
+            self.collider_info.terrain_hf.from_numpy(entity.terrain_hf)
+            self.collider_info.terrain_rc.from_numpy(rc)
+            self.collider_info.terrain_scale.from_numpy(entity.terrain_scale)
+            self.collider_info.terrain_xyz_maxmin.from_numpy(xyz_maxmin)
 
     def activate_sdf(self) -> None:
         """Enable SDF queries against this collider's geometry. Idempotent."""
@@ -762,12 +780,12 @@ class Collider:
         if gs.use_zerocopy and self._contact_data is not None:
             envs_mask = indices_to_mask(envs_idx)
             if not cache_only:
-                first_time = qd_to_torch(self._collider_state.first_time, copy=False)
+                first_time = qd_to_torch(self.collider_state.first_time, copy=False)
                 assign_indexed_tensor(first_time, envs_mask, True)
 
             pairs_mask = (slice(None), *envs_mask)
-            normal = qd_to_torch(self._collider_state.contact_cache.normal, copy=False)
-            penetration = qd_to_torch(self._collider_state.contact_cache.penetration, copy=False)
+            normal = qd_to_torch(self.collider_state.contact_cache.normal, copy=False)
+            penetration = qd_to_torch(self.collider_state.contact_cache.penetration, copy=False)
             assign_indexed_tensor(normal, pairs_mask, 0.0)
             assign_indexed_tensor(penetration, pairs_mask, 0.0)
 
@@ -776,7 +794,7 @@ class Collider:
             return
 
         envs_idx = self._solver._scene._sanitize_envs_idx(envs_idx)
-        collider_kernel_reset(envs_idx, self._collider_state, self._solver.rigid_config, cache_only)
+        collider_kernel_reset(envs_idx, self.collider_state, self._solver.rigid_config, cache_only)
 
     def clear(self, envs_idx=None):
         self.reset(envs_idx, cache_only=False)
@@ -787,15 +805,15 @@ class Collider:
             and not self._solver._use_hibernation
             and (not isinstance(envs_idx, torch.Tensor) or (not IS_OLD_TORCH or envs_idx.dtype == torch.bool))
         ):
-            n_contacts = qd_to_torch(self._collider_state.n_contacts, copy=False)
-            link_a = qd_to_torch(self._collider_state.contact_data.link_a, copy=False)
-            link_b = qd_to_torch(self._collider_state.contact_data.link_b, copy=False)
-            geom_a = qd_to_torch(self._collider_state.contact_data.geom_a, copy=False)
-            geom_b = qd_to_torch(self._collider_state.contact_data.geom_b, copy=False)
-            penetration = qd_to_torch(self._collider_state.contact_data.penetration, copy=False)
-            pos = qd_to_torch(self._collider_state.contact_data.pos, copy=False)
-            normal = qd_to_torch(self._collider_state.contact_data.normal, copy=False)
-            force = qd_to_torch(self._collider_state.contact_data.force, copy=False)
+            n_contacts = qd_to_torch(self.collider_state.n_contacts, copy=False)
+            link_a = qd_to_torch(self.collider_state.contact_data.link_a, copy=False)
+            link_b = qd_to_torch(self.collider_state.contact_data.link_b, copy=False)
+            geom_a = qd_to_torch(self.collider_state.contact_data.geom_a, copy=False)
+            geom_b = qd_to_torch(self.collider_state.contact_data.geom_b, copy=False)
+            penetration = qd_to_torch(self.collider_state.contact_data.penetration, copy=False)
+            pos = qd_to_torch(self.collider_state.contact_data.pos, copy=False)
+            normal = qd_to_torch(self.collider_state.contact_data.normal, copy=False)
+            force = qd_to_torch(self.collider_state.contact_data.force, copy=False)
             if isinstance(envs_idx, torch.Tensor) and envs_idx.dtype == torch.bool:
                 n_contacts.masked_fill_(envs_idx, 0)
                 link_a.masked_fill_(envs_idx[None, :], -1)
@@ -837,21 +855,21 @@ class Collider:
             fn = kernel_masked_collider_clear
         else:
             fn = kernel_collider_clear
-        fn(envs_idx, self._solver.dyn_state, self._collider_state, self._solver.dyn_info, self._solver.rigid_config)
+        fn(envs_idx, self._solver.dyn_state, self.collider_state, self._solver.dyn_info, self._solver.rigid_config)
 
     def _call_multicontact(self):
         narrowphase._func_narrowphase_multicontact(
             self._solver.geoms_init_AABB,
             self._solver.dyn_state,
-            self._collider_state,
-            self._multicontact_mpr_state,
-            self._multicontact_gjk_state,
+            self.collider_state,
+            self.multicontact_mpr_state,
+            self.multicontact_gjk_state,
             self._solver.dyn_info,
             self._solver.rigid_info,
-            self._collider_info,
+            self.collider_info,
             self._solver.rigid_config,
-            self._collider_static_config,
-            self._gjk._gjk_static_config,
+            self.collider_config,
+            self._gjk.gjk_config,
             self._multicontact_n_total_threads,
             self._multicontact_max_items_per_thread,
             self._solver._errno,
@@ -872,79 +890,79 @@ class Collider:
             self._solver.rigid_info,
             self._solver.rigid_config,
             self._solver.constraint_solver.constraint_state,
-            self._collider_state,
-            self._collider_info,
+            self.collider_state,
+            self.collider_info,
             self._solver._errno,
         )
         if self._use_split_narrowphase:
-            narrowphase._func_reset_narrowphase_work_queues(self._collider_state)
+            narrowphase._func_reset_narrowphase_work_queues(self.collider_state)
             narrowphase._func_narrowphase_contact0(
                 self._solver.geoms_init_AABB,
                 self._solver.dyn_state,
-                self._collider_state,
-                self._contact0_mpr_state,
-                self._contact0_gjk_state,
+                self.collider_state,
+                self.contact0_mpr_state,
+                self.contact0_gjk_state,
                 self._solver.dyn_info,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver.rigid_config,
-                self._collider_static_config,
+                self.collider_config,
                 self._solver._B,
                 self._contact0_n_chunks,
                 self._solver._errno,
             )
             self._call_multicontact()
-        elif self._collider_static_config.has_non_box_plane_convex_convex:
+        elif self.collider_config.has_non_box_plane_convex_convex:
             narrowphase.func_narrow_phase_convex_vs_convex(
                 self._solver.geoms_init_AABB,
                 self._solver.dyn_state,
-                self._collider_state,
-                self._mpr._mpr_state,
-                self._gjk._gjk_state,
-                self._gjk._gjk_state.diff_contact_input,
+                self.collider_state,
+                self._mpr.mpr_state,
+                self._gjk.gjk_state,
+                self._gjk.gjk_state.diff_contact_input,
                 self._solver.dyn_info,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver.rigid_config,
-                self._collider_static_config,
-                self._gjk._gjk_static_config,
+                self.collider_config,
+                self._gjk.gjk_config,
                 self._solver._errno,
             )
-        if self._collider_static_config.has_convex_specialization:
+        if self.collider_config.has_convex_specialization:
             func_narrow_phase_convex_specializations(
                 self._solver.geoms_init_AABB,
                 self._solver.dyn_state,
-                self._collider_state,
+                self.collider_state,
                 self._solver.dyn_info,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver.rigid_config,
-                self._collider_static_config,
+                self.collider_config,
                 self._solver._errno,
             )
-        if self._collider_static_config.has_terrain:
+        if self.collider_config.has_terrain:
             func_narrow_phase_any_vs_terrain(
                 self._solver.geoms_init_AABB,
                 self._solver.dyn_state,
-                self._collider_state,
-                self._mpr._mpr_state,
+                self.collider_state,
+                self._mpr.mpr_state,
                 self._solver.dyn_info,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver.rigid_config,
-                self._collider_static_config,
+                self.collider_config,
                 self._solver._errno,
             )
-        if self._collider_static_config.has_nonconvex_nonterrain:
+        if self.collider_config.has_nonconvex_nonterrain:
             func_narrow_phase_nonconvex_vs_nonterrain(
                 self._solver.geoms_init_AABB,
                 self._solver.dyn_state,
-                self._collider_state,
+                self.collider_state,
                 self._solver.dyn_info,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver.rigid_config,
-                self._collider_static_config,
+                self.collider_config,
                 self._solver._errno,
             )
 
@@ -954,26 +972,26 @@ class Collider:
         ran_fused_dedup_coop = (
             gs.backend != gs.cpu
             and not self._solver.rigid_config.requires_grad
-            and self._collider_static_config.has_prunable_contacts
+            and self.collider_config.has_prunable_contacts
             and (self._solver._options.contact_pruning_tolerance or 0.0) > 0.0
             and self._solver._B * 2 <= self._gpu_cores
         )
         if ran_fused_dedup_coop:
             func_clamp_prune_contacts_coop(
                 self._solver.dyn_state,
-                self._collider_state,
+                self.collider_state,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver._errno,
             )
         else:
             func_clamp_prune_contacts(
                 self._solver.dyn_state,
-                self._collider_state,
+                self.collider_state,
                 self._solver.rigid_info,
-                self._collider_info,
+                self.collider_info,
                 self._solver.rigid_config,
-                self._collider_static_config,
+                self.collider_config,
                 self._solver._errno,
             )
 
@@ -982,7 +1000,7 @@ class Collider:
         # kernel_fill_diff_contact_input_analytic).
         if self._solver.rigid_config.requires_grad:
             narrowphase.kernel_fill_diff_contact_input_analytic(
-                self._solver.dyn_state, self._collider_state, self._solver.dyn_info, self._solver.rigid_config
+                self._solver.dyn_state, self.collider_state, self._solver.dyn_info, self._solver.rigid_config
             )
 
     def get_contacts(
@@ -1001,11 +1019,10 @@ class Collider:
         # views, then materialize each field via a single torch.gather along the contact axis. This still avoids the
         # Quadrants gather kernel and produces a contiguous output suitable for downstream consumers.
         zerocopy_aligned = (
-            not self._collider_static_config.has_prunable_contacts
-            and not self._collider_static_config.spatial_sort_supported
+            not self.collider_config.has_prunable_contacts and not self.collider_config.spatial_sort_supported
         )
         if gs.use_zerocopy and self._contact_data is not None:
-            n_contacts = qd_to_torch(self._collider_state.n_contacts, copy=False)
+            n_contacts = qd_to_torch(self.collider_state.n_contacts, copy=False)
             # 'is_padded' returns fixed-capacity tensors (plus per-env 'n_contacts'), skipping the
             # 'n_contacts.max().item()' device->host sync that trimming to the live count needs.
             padded = is_padded
@@ -1018,7 +1035,7 @@ class Collider:
                 # field; per-env trimming to n_contacts[i] happens in the ragged split below.
                 if not (as_tensor or n_envs == 0) and not padded:
                     n_contacts_max = n_contacts.max().item()
-                sort_idx_view = qd_to_torch(self._collider_state.contact_sort_idx, transpose=True, copy=False)
+                sort_idx_view = qd_to_torch(self.collider_state.contact_sort_idx, transpose=True, copy=False)
                 if padded:
                     # Gather the full capacity so no host-side trim (sync) is needed. Sort indices past the live
                     # range may be stale; clamp (out-of-place, preserving the zero-copy view) keeps them in-bounds.
@@ -1075,7 +1092,7 @@ class Collider:
             return contact_data.copy()
 
         # Find out how much dynamic memory must be allocated
-        n_contacts = qd_to_numpy(self._collider_state.n_contacts)
+        n_contacts = qd_to_numpy(self.collider_state.n_contacts)
         n_contacts_max = n_contacts.max().item()
         # 'is_padded' is honored here too so the result matches the zero-copy path on every backend (this path
         # already syncs to size its buffers, so padding only fixes the shape). Padding needs the dense rectangular
@@ -1099,7 +1116,7 @@ class Collider:
 
         # Copy contact data
         if n_contacts_max > 0:
-            collider_kernel_get_contacts(iout, fout, self._collider_state, self._solver.rigid_config, dense)
+            collider_kernel_get_contacts(iout, fout, self.collider_state, self._solver.rigid_config, dense)
 
         # Build structured view (no copy)
         if dense:
@@ -1109,7 +1126,7 @@ class Collider:
             if padded:
                 # Widen from the live count to the fixed capacity the zero-copy path returns (contact buffers are
                 # sized max(max_candidate_contacts, 1)). New slots keep the sentinel (-1 ints / 0 floats).
-                capacity = max(self._collider_info.max_candidate_contacts[None], 1)
+                capacity = max(self.collider_info.max_candidate_contacts[None], 1)
                 if to_torch:
                     iout_full = torch.full((nb, capacity, 4), -1, dtype=gs.tc_int, device=gs.device)
                     fout_full = torch.zeros((nb, capacity, 10), dtype=gs.tc_float, device=gs.device)
@@ -1175,17 +1192,17 @@ class Collider:
         return contact_data.copy()
 
     def backward(self, dL_dposition, dL_dnormal, dL_dpenetration):
-        func_set_upstream_grad(dL_dposition, dL_dnormal, dL_dpenetration, self._collider_state)
+        func_set_upstream_grad(dL_dposition, dL_dnormal, dL_dpenetration, self.collider_state)
         self.backward_narrowphase()
 
     def backward_narrowphase(self):
         func_narrow_phase_diff_convex_vs_convex.grad(
             self._solver.dyn_state,
-            self._collider_state,
-            self._collider_state.diff_contact_input,
+            self.collider_state,
+            self.collider_state.diff_contact_input,
             self._solver.dyn_info,
             self._solver.rigid_info,
-            self._collider_info,
+            self.collider_info,
             self._solver.rigid_config,
             self._solver._errno,
         )

--- a/genesis/engine/solvers/rigid/collider/gjk.py
+++ b/genesis/engine/solvers/rigid/collider/gjk.py
@@ -78,7 +78,7 @@ class GJK:
             max_contacts_per_pair = 1
             max_contact_polygon_verts = 1
 
-        self._gjk_static_config = array_class.GJKStaticConfig(enable_contact_patch=enable_contact_patch)
+        self.gjk_config = array_class.GJKStaticConfig(enable_contact_patch=enable_contact_patch)
 
         # Initialize GJK info
         self._gjk_info = array_class.get_gjk_info(
@@ -117,7 +117,7 @@ class GJK:
         )
 
         # Initialize GJK state
-        self._gjk_state = array_class.get_gjk_state(
+        self.gjk_state = array_class.get_gjk_state(
             rigid_solver._B, rigid_solver.rigid_config, self._gjk_info, False, rigid_solver.rigid_config.requires_grad
         )
 
@@ -127,7 +127,7 @@ class GJK:
         if self._is_active:
             return
 
-        self._gjk_state = array_class.get_gjk_state(
+        self.gjk_state = array_class.get_gjk_state(
             self._solver._B, self._solver.rigid_config, self._gjk_info, True, self._solver.rigid_config.requires_grad
         )
         self._is_active = True

--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -24,7 +24,7 @@ class MPR:
             # Bounds that refinement, which is not otherwise guaranteed to terminate.
             CCD_ITERATIONS=50,
         )
-        self._mpr_state = array_class.get_mpr_state(self._solver._B)
+        self.mpr_state = array_class.get_mpr_state(self._solver._B)
 
 
 @qd.kernel

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -110,7 +111,7 @@ class ConstraintSolver:
         # When 'max_contacts' is set, it overrides the post-pruning contact budget enforced by the collider.
         # Resolve the max_contacts option in place: from the collider's post-pruning budget when unset, else clamped
         # to the candidate budget and written back so the collider honors the user's cap. Downstream reads the option.
-        collider_info = rigid_solver.collider._collider_info
+        collider_info = rigid_solver.collider.collider_info
         if rigid_solver._options.max_contacts is None:
             rigid_solver._options.max_contacts = collider_info.max_contacts[None]
         else:
@@ -201,6 +202,11 @@ class ConstraintSolver:
                 self._solver.dyn_state, self.constraint_state, self._solver.dyn_info, self._solver.rigid_config
             )
 
+    @property
+    def data(self) -> Iterator[array_class.DataItem]:
+        """Yield every array of the constraint solver, tagged by kind (see 'Solver.data')."""
+        yield from array_class.iter_data(self.constraint_state, "constraint_state")
+
     def reset(self, envs_idx=None):
         self._eq_const_info_cache.clear()
 
@@ -266,7 +272,7 @@ class ConstraintSolver:
 
         add_equality_constraints(
             self._solver.dyn_state,
-            self._collider._collider_state,
+            self._collider.collider_state,
             self.constraint_state,
             self._solver.dyn_info,
             self._solver.rigid_info,
@@ -276,12 +282,12 @@ class ConstraintSolver:
     def add_inequality_constraints(self):
         add_inequality_constraints(
             self._solver.dyn_state,
-            self._collider._collider_state,
+            self._collider.collider_state,
             self.constraint_state,
             self._solver.dyn_info,
             self._solver.rigid_info,
             self._solver.rigid_config,
-            self._collider._collider_static_config,
+            self._collider.collider_config,
         )
 
     def resolve(self):
@@ -304,7 +310,7 @@ class ConstraintSolver:
 
         func_update_contact_force(
             self._solver.dyn_state,
-            self._collider._collider_state,
+            self._collider.collider_state,
             self.constraint_state,
             self._solver.dyn_info,
             self._solver.rigid_config,
@@ -313,7 +319,7 @@ class ConstraintSolver:
     def noslip(self):
         constraint_noslip.kernel_noslip(
             self._solver.dyn_state,
-            self._collider._collider_state,
+            self._collider.collider_state,
             self.constraint_state,
             self._solver.rigid_info,
             self._solver.rigid_config,

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1,6 +1,7 @@
 import math
 import os
 import sys
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -15,7 +16,7 @@ from genesis.constants import link_ref_frame
 from genesis.engine.entities import DroneEntity, RigidEntity, TerrainEntity
 from genesis.engine.entities.base_entity import Entity
 from genesis.engine.materials import Rigid
-from genesis.engine.states import QueriedStates, RigidSolverState
+from genesis.engine.states import KinematicSolverCheckpoint, QueriedStates, RigidSolverState
 from genesis.options.morphs import Drone, Morph, Terrain
 from genesis.options.solvers import RigidOptions
 from genesis.utils.misc import (
@@ -1291,7 +1292,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             self._func_constraint_force()
             kernel_step_2(
                 self.dyn_state,
-                self.collider._collider_state,
+                self.collider.collider_state,
                 self.constraint_solver.constraint_state,
                 self.dyn_info,
                 self.rigid_info,
@@ -1318,19 +1319,19 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             errno = kernel_bit_reduction(self._errno)
 
         if errno & array_class.ErrorCode.OVERFLOW_CANDIDATE_CONTACTS:
-            max_collision_pairs_broad = self.collider._collider_info.max_collision_pairs_broad[None]
+            max_collision_pairs_broad = self.collider.collider_info.max_collision_pairs_broad[None]
             gs.raise_exception(
                 f"Exceeding max number of broad phase candidate contact pairs ({max_collision_pairs_broad}). "
                 f"Please increase the value of RigidSolver's option 'multiplier_collision_broad_phase'."
             )
         if errno & array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS:
-            max_candidate_contacts = self.collider._collider_info.max_candidate_contacts[None]
+            max_candidate_contacts = self.collider.collider_info.max_candidate_contacts[None]
             gs.raise_exception(
                 f"Exceeding max number of candidate contact points ({max_candidate_contacts}). Please increase the "
                 "value of RigidSolver's option 'max_collision_pairs'."
             )
         if errno & array_class.ErrorCode.OVERFLOW_CONTACTS:
-            max_contacts = self.collider._collider_info.max_contacts[None]
+            max_contacts = self.collider.collider_info.max_contacts[None]
             gs.raise_exception(
                 f"Exceeding max number of post-pruning contact points ({max_contacts}) supported by the constraint "
                 "solver. Please increase the value of RigidSolver's option 'max_contacts'."
@@ -1355,10 +1356,10 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         # TODO: support batching
         self._kernel_detect_collision()
 
-        n_collision = qd_to_numpy(self.collider._collider_state.n_contacts)[env_idx]
+        n_collision = qd_to_numpy(self.collider.collider_state.n_contacts)[env_idx]
         collision_pairs = np.empty((n_collision, 2), dtype=np.int32)
-        collision_pairs[:, 0] = qd_to_numpy(self.collider._collider_state.contact_data.geom_a)[:n_collision, env_idx]
-        collision_pairs[:, 1] = qd_to_numpy(self.collider._collider_state.contact_data.geom_b)[:n_collision, env_idx]
+        collision_pairs[:, 0] = qd_to_numpy(self.collider.collider_state.contact_data.geom_a)[:n_collision, env_idx]
+        collision_pairs[:, 1] = qd_to_numpy(self.collider.collider_state.contact_data.geom_b)[:n_collision, env_idx]
 
         return collision_pairs
 
@@ -1373,7 +1374,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             if self._use_hibernation:
                 kernel_wake_up_entities_on_new_contact(
                     self.dyn_state,
-                    self.collider._collider_state,
+                    self.collider.collider_state,
                     self.constraint_solver.constraint_state,
                     self.dyn_info,
                     self.rigid_info,
@@ -1425,7 +1426,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         )
 
         if self._enable_collision:
-            collider_state = self.collider._collider_state
+            collider_state = self.collider.collider_state
             qd_zero_grad(collider_state.contact_data.pos)
             qd_zero_grad(collider_state.contact_data.normal)
             qd_zero_grad(collider_state.contact_data.penetration)
@@ -1445,7 +1446,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         if self._enable_joint_limit:
             kernel_manual_add_joint_limit_constraints_bw(
                 self.dyn_state,
-                self.collider._collider_state,
+                self.collider.collider_state,
                 constraint_state,
                 self.dyn_info,
                 self.rigid_info,
@@ -1652,7 +1653,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
 
         kernel_step_2.grad(
             self.dyn_state,
-            self.collider._collider_state,
+            self.collider.collider_state,
             self.constraint_solver.constraint_state,
             self.dyn_info,
             self.rigid_info,
@@ -1698,7 +1699,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             update_qacc_from_qvel_delta(self.dyn_state, self.rigid_info, self.rigid_config)
             kernel_step_2(
                 self.dyn_state,
-                self.collider._collider_state,
+                self.collider.collider_state,
                 self.constraint_solver.constraint_state,
                 self.dyn_info,
                 self.rigid_info,
@@ -1912,9 +1913,28 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             self._is_forward_pos_updated = False
             self._is_forward_vel_updated = False
 
+        self._restart()
+
+    @property
+    def data(self) -> Iterator[array_class.DataItem]:
+        yield from super().data
+        yield from self.collider.data
+        yield from self.constraint_solver.data
+
+    def _restart(self):
+        """Clear the contact and equality caches of the last query and re-arm the once-per-step propeller guard of
+        each drone (see 'set_propellers_rpm').
+        """
+        self.collider._contact_data_cache.clear()
+        self.constraint_solver._eq_const_info_cache.clear()
         for entity in self.entities:
             if isinstance(entity, DroneEntity):
                 entity._prev_prop_t = -1
+
+    @mutates(StateChange.GEOMETRY, StateChange.DYNAMICS)
+    def __setstate__(self, state: KinematicSolverCheckpoint) -> None:
+        super().__setstate__(state)
+        self._restart()
 
     def process_input(self, in_backward=False):
         for entity in self._entities:

--- a/genesis/engine/states/entities.py
+++ b/genesis/engine/states/entities.py
@@ -21,14 +21,6 @@ class ToolEntityState:
         self.vel = gs.zeros((self.entity.sim._B, 3), **args)
         self.ang = gs.zeros((self.entity.sim._B, 3), **args)
 
-    def serializable(self):
-        self.entity = None
-
-        self.pos = self.pos.detach()
-        self.quat = self.quat.detach()
-        self.vel = self.vel.detach()
-        self.ang = self.ang.detach()
-
     # def __repr__(self):
     #     return f'{self.__repr_name__()}\n' \
     #            f'entity : {_repr(self.entity)}\n' \
@@ -61,16 +53,6 @@ class MPMEntityState(RBC):
         args["dtype"] = int
         args["requires_grad"] = False
         self._active = gs.zeros(base_shape, **args)
-
-    def serializable(self):
-        self._entity = None
-
-        self._pos = self._pos.detach()
-        self._vel = self._vel.detach()
-        self._C = self._C.detach()
-        self._F = self._F.detach()
-        self._Jp = self._Jp.detach()
-        self._active = self._active.detach()
 
     @property
     def entity(self):
@@ -162,13 +144,6 @@ class FEMEntityState:
         args["requires_grad"] = False
         self._active = gs.zeros((self.entity.sim._B, self.entity.n_elements), **args)
 
-    def serializable(self):
-        self._entity = None
-
-        self._pos = self._pos.detach()
-        self._vel = self._vel.detach()
-        self._active = self._active.detach()
-
     @property
     def entity(self):
         return self._entity
@@ -204,12 +179,6 @@ class RigidEntityState(RBC):
         scene = self._entity.scene
         self._pos = gs.zeros((num_batch, 3), dtype=float, requires_grad=requires_grad, scene=scene)
         self._quat = gs.zeros((num_batch, 4), dtype=float, requires_grad=requires_grad, scene=scene)
-
-    def serializable(self):
-        self._entity = None
-
-        self._pos = self._pos.detach()
-        self._quat = self._quat.detach()
 
     @property
     def entity(self):

--- a/genesis/engine/states/solvers.py
+++ b/genesis/engine/states/solvers.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import NamedTuple
 
 import numpy as np
 import torch
@@ -36,6 +37,20 @@ class KinematicSolverCheckpoint(SolverCheckpoint):
 
     is_forward_pos_updated: bool
     is_forward_vel_updated: bool
+
+
+class FrameField(NamedTuple):
+    """Where one array stands in a trajectory frame.
+
+    The name, canonical shape, numpy dtype string, byte offset and byte length cut a frame back into its arrays without
+    the scene.
+    """
+
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+    offset: int
+    nbytes: int
 
 
 @dataclasses.dataclass

--- a/genesis/engine/states/solvers.py
+++ b/genesis/engine/states/solvers.py
@@ -1,5 +1,53 @@
+import dataclasses
+
+import numpy as np
+import torch
+
 import genesis as gs
 from genesis.repr_base import RBC
+from genesis.utils.array_class import DataKind
+
+
+@dataclasses.dataclass
+class SolverCheckpoint:
+    """The arrays of one solver of the given kinds (see 'DataKind'), for 'Solver.__setstate__' to write back.
+
+    A checkpoint '__getstate__' reads holds every kind a step reads from one step to the next (see 'CHECKPOINT_KINDS'),
+    so stepping on from it lands where the original went. A trajectory frame may hold the state alone, and writing it
+    back recomputes what it leaves out. Each array stands under the name 'Solver.data' gives it, copied where it lives:
+    on the device as a torch tensor when zero-copy views exist, as a numpy array otherwise. The static configs come
+    along as provenance and are never written back.
+    """
+
+    arrays: dict[str, np.ndarray | torch.Tensor]
+    configs: dict[str, object]
+    kinds: frozenset[DataKind]
+
+
+@dataclasses.dataclass
+class KinematicSolverCheckpoint(SolverCheckpoint):
+    """A SolverCheckpoint plus the two forward-kinematics flags of a kinematic or rigid solver,
+    'is_forward_pos_updated' and 'is_forward_vel_updated'.
+
+    The flags decide whether the next step recomputes the Cartesian pose and velocity of the links. Recomputing them
+    where the saved scene skipped it rounds differently on some backends, so the flags travel with the derived arrays
+    they describe.
+    """
+
+    is_forward_pos_updated: bool
+    is_forward_vel_updated: bool
+
+
+@dataclasses.dataclass
+class SimulatorCheckpoint:
+    """The state a simulation stands in.
+
+    How many steps each environment has run, and what every active solver reads from one step to the next, under the
+    name of its class.
+    """
+
+    steps: np.ndarray | torch.Tensor
+    solvers: dict[str, SolverCheckpoint]
 
 
 class SimState(RBC):
@@ -19,13 +67,6 @@ class SimState(RBC):
         self._solvers_state = list()
         for solver in solvers:
             self._solvers_state.append(solver.get_state(f_local))
-
-    def serializable(self):
-        self.scene = None
-
-        for solver_state in self._solvers_state:
-            if solver_state is not None:
-                solver_state.serializable()
 
     @property
     def scene(self):
@@ -66,13 +107,6 @@ class KinematicSolverState:
         self.links_pos = gs.zeros((_B, scene.sim.kinematic_solver.n_links, 3), **args)
         self.links_quat = gs.zeros((_B, scene.sim.kinematic_solver.n_links, 4), **args)
 
-    def serializable(self):
-        self.scene = None
-        self.qpos = self.qpos.detach()
-        self.dofs_vel = self.dofs_vel.detach()
-        self.links_pos = self.links_pos.detach()
-        self.links_quat = self.links_quat.detach()
-
     @property
     def s_global(self):
         return self._s_global
@@ -101,15 +135,6 @@ class RigidSolverState:
         self.links_quat = gs.zeros((_B, scene.sim.rigid_solver.n_links, 4), **args)
         self.friction_ratio = gs.ones((_B, scene.sim.rigid_solver.n_geoms), **args)
 
-    def serializable(self):
-        self.scene = None
-        self.qpos = self.qpos.detach()
-        self.dofs_vel = self.dofs_vel.detach()
-        self.dofs_acc = self.dofs_acc.detach()
-        self.links_pos = self.links_pos.detach()
-        self.links_quat = self.links_quat.detach()
-        self.friction_ratio = self.friction_ratio.detach()
-
     @property
     def s_global(self):
         return self._s_global
@@ -123,12 +148,6 @@ class ToolSolverState:
     def __init__(self, scene):
         self.scene = scene
         self.entities = []
-
-    def serializable(self):
-        self.scene = None
-
-        for entity_state in self.entities:
-            entity_state.serializable()
 
     def __len__(self):
         return len(self.entities)
@@ -161,16 +180,6 @@ class MPMSolverState(RBC):
         args["dtype"] = gs.tc_bool
         args["requires_grad"] = False
         self._active = gs.zeros((scene.sim._B, scene.sim.mpm_solver.n_particles), **args)
-
-    def serializable(self):
-        self._scene = None
-
-        self._pos = self._pos.detach()
-        self._vel = self._vel.detach()
-        self._C = self._C.detach()
-        self._F = self._F.detach()
-        self._Jp = self._Jp.detach()
-        self._active = self._active.detach()
 
     @property
     def scene(self):
@@ -284,13 +293,6 @@ class FEMSolverState:
         args["dtype"] = gs.tc_bool
         args["requires_grad"] = False
         self._active = gs.zeros((scene.sim._B, scene.sim.fem_solver.n_elements), **args)
-
-    def serializable(self):
-        self._scene = None
-
-        self._pos = self._pos.detach()
-        self._vel = self._vel.detach()
-        self._active = self._active.detach()
 
     @property
     def scene(self):

--- a/genesis/options/recorders.py
+++ b/genesis/options/recorders.py
@@ -143,6 +143,46 @@ class NPZFile(BaseFileWriterOptions):
     filename: PathType = Field(pattern=r"(?i).*\.npz$")
 
 
+class TrajectoryFile(BaseFileWriterOptions):
+    """
+    Record the scene state at every sampled step into a '.gstraj' file, which 'Scene.load_trajectory' opens to seek and
+    replay. Recording starts with the build and stops with 'Scene.stop_recording'.
+
+    The file contains the scene as 'Scene.export' writes it, then one frame per sampled step, the last being the state
+    the recording stopped at. Every frame is kept: the recorder runs on the stepping thread and compresses and writes
+    each completed chunk on a thread of its own while the simulation steps on. A chunk waits for the write of the
+    previous one, so recording slows the simulation only when the disk cannot keep up, and a crash keeps every completed
+    chunk.
+
+    Exact mode records everything a step reads or writes: replay is bit-for-bit and the simulation resumes from any
+    frame. Compressed mode records the model parameters, configuration, velocities, accelerations, control inputs,
+    contacts and constraint forces. Its file is several times smaller, which matters for batched scenes, and a load
+    recomputes the poses of links and geoms, which may differ at the last bits.
+
+    Parameters
+    ----------
+    filename : str
+        The '.gstraj' file to write.
+    exact : bool, optional
+        Whether to record in exact mode. If None, resolved based on the number of environments: exact for a single
+        environment, compressed for a batched scene, with a warning. Defaults to None.
+    chunk_size : int, optional
+        Frames per chunk. Larger chunks compress better and seek slower, and a crash loses at most one. Defaults to 64.
+    max_size : int, optional
+        Bytes the file may grow to. A record that would pass it is dropped, the file is closed as a valid log, and the
+        next step raises, so a run left recording fills the disk by at most this much. Raise it for a long run whose
+        size is planned. If None, the file grows with the run. Defaults to 2 GiB.
+    save_on_reset : bool, optional
+        Whether a reset of the whole scene starts a new file, numbered after this one. A reset of some environments is
+        recorded by their clocks in the same file. Defaults to False.
+    """
+
+    filename: PathType = Field(pattern=r"(?i).*\.gstraj$")
+    exact: StrictBool | None = None
+    chunk_size: PositiveInt = 64
+    max_size: PositiveInt | None = 2**31
+
+
 class BasePlotterOptions(RecorderOptions):
     """
     Base class for plot visualization.

--- a/genesis/options/recorders.py
+++ b/genesis/options/recorders.py
@@ -48,13 +48,9 @@ class BaseFileWriterOptions(RecorderOptions):
     ----------
     filename: str
         The path of the output file.
-    save_on_reset: bool, optional
-        Whether to save the data on reset. Defaults to False.
-        If True, a counter will be added to the filename and incremented on each reset.
     """
 
     filename: PathType
-    save_on_reset: StrictBool = False
 
 
 class VideoFile(BaseFileWriterOptions):
@@ -80,9 +76,6 @@ class VideoFile(BaseFileWriterOptions):
         Defaults to 1.0.
     codec_options: dict[str, str]
         Additional low-level codec options that will be pass to ffmpeg. Empty by default.
-    save_on_reset: bool, optional
-        Whether to save the data on reset. If True, a counter will be added to the filename and incremented on each
-        reset. Defaults to False.
     """
 
     filename: PathType = Field(pattern=r"(?i).*\.mp4$")
@@ -115,9 +108,6 @@ class CSVFile(BaseFileWriterOptions):
         after flattening the values.
     save_every_write: bool, optional
         Whether to flush the data to disk as soon as new data is recieved. Defaults to False.
-    save_on_reset: bool, optional
-        Whether to save the data on scene reset. Defaults to False.
-        If True, a counter will be added to the filename and incremented on each reset.
     """
 
     filename: PathType = Field(pattern=r"(?i).*\.csv$")
@@ -135,9 +125,6 @@ class NPZFile(BaseFileWriterOptions):
     ----------
     filename : str
         The name of the .npz file to save the data.
-    save_on_reset: bool, optional
-        Whether to save the data on reset. Defaults to False.
-        If True, a counter will be added to the filename and incremented on each reset.
     """
 
     filename: PathType = Field(pattern=r"(?i).*\.npz$")
@@ -172,9 +159,6 @@ class TrajectoryFile(BaseFileWriterOptions):
         Bytes the file may grow to. A record that would pass it is dropped, the file is closed as a valid log, and the
         next step raises, so a run left recording fills the disk by at most this much. Raise it for a long run whose
         size is planned. If None, the file grows with the run. Defaults to 2 GiB.
-    save_on_reset : bool, optional
-        Whether a reset of the whole scene starts a new file, numbered after this one. A reset of some environments is
-        recorded by their clocks in the same file. Defaults to False.
     """
 
     filename: PathType = Field(pattern=r"(?i).*\.gstraj$")

--- a/genesis/recorders/__init__.py
+++ b/genesis/recorders/__init__.py
@@ -2,4 +2,5 @@ from ..options.recorders import *
 from . import base_recorder
 from . import plotters
 from . import file_writers
+from . import trajectory
 from .recorder_manager import RecorderManager, register_recording

--- a/genesis/recorders/base_recorder.py
+++ b/genesis/recorders/base_recorder.py
@@ -30,6 +30,7 @@ class Recorder(Generic[T]):
         self._error: Exception | None = None
         self._is_built = False
         self._is_recording = False
+        self._is_alive = True
 
         self._data_queue: queue.Queue | None = None
         self._processor_thread: threading.Thread | None = None
@@ -124,9 +125,11 @@ class Recorder(Generic[T]):
             try:
                 self.process(data, timestamp)
             except Exception as error:
-                # Forwarded to the stepping thread, which raises it at its next step or sync (see 'step'). The samples
-                # left in the queue are marked done, so 'sync' returns.
+                # Forwarded to the stepping thread, which raises it at its next step or sync (see 'step'). The recorder
+                # stops recording for good, as it does when a sample fails on the stepping thread (see 'record'). The
+                # samples left in the queue are marked done, so 'sync' returns.
                 self._error = error
+                self._is_alive = False
                 self._data_queue.task_done()
                 while True:
                     try:
@@ -150,10 +153,7 @@ class Recorder(Generic[T]):
         if self.run_in_thread:
             self.join_thread()
         self.cleanup()
-        self._raise_error()
-
-    def _raise_error(self):
-        """Raise on the calling thread the failure the background thread recorded, once."""
+        # The failure the background thread recorded is raised on the calling thread, once
         if self._error is not None:
             error, self._error = self._error, None
             gs.raise_exception_from(f"[{type(self).__name__}] Processing failed in the background: {error}", error)
@@ -199,37 +199,50 @@ class Recorder(Generic[T]):
                 start_time = time.time()
 
             # A frame taken off the queue is still being processed until the worker marks its task done. A failure
-            # leaves no task pending (see '_process_data_loop'), so it is checked before waiting and while waiting.
-            self._raise_error()
-            while self._data_queue.unfinished_tasks:
-                self._raise_error()
+            # leaves no task pending (see '_process_data_loop'), so it is raised here, once, before and while waiting.
+            while True:
+                if self._error is not None:
+                    error, self._error = self._error, None
+                    gs.raise_exception_from(
+                        f"[{type(self).__name__}] Processing failed in the background: {error}", error
+                    )
+                if not self._data_queue.unfinished_tasks:
+                    break
                 if timeout is not None and time.time() - start_time > timeout:
                     gs.raise_exception(f"[{type(self).__name__}] sync(): Timeout waiting for data queue to be empty.")
 
                 dt = min(timestep, (start_time + timeout) - time.time()) if timeout is not None else timestep
                 if dt > 0.0:
                     time.sleep(dt)
-            self._raise_error()
 
     @gs.assert_built
     def step(self, global_step: int):
-        """Process a simulation step, potentially recording data."""
-        if not self._is_recording:
-            return
-        self._raise_error()
+        """Record the step when the sampling rate selects it, raising what the background thread reported."""
+        if self._error is not None:
+            error, self._error = self._error, None
+            gs.raise_exception_from(f"[{type(self).__name__}] Processing failed in the background: {error}", error)
+        if self._is_recording and global_step % self._steps_per_sample == 0:
+            self.record(global_step)
 
-        if global_step % self._steps_per_sample != 0:
+    @gs.assert_built
+    def record(self, global_step: int):
+        """Record the current state whatever the sampling rate, such as the state a run stops or resets at."""
+        if not self._is_recording or not self._is_alive:
             return
 
         global_time = global_step * self._manager._step_dt
-        # Sanitize to CPU numpy once at the boundary: process() code never has to branch on torch vs numpy, and no
-        # GPU tensor is ever queued for cross-thread access in threaded mode.
-        data = self._get_frame()
-
-        if not self.run_in_thread:
-            # non-threaded mode: process data synchronously
-            self.process(data, global_time)
-            return
+        # A sample that raises ends the recorder for good, on this thread as on a worker (see '_process_data_loop'): a
+        # reset restarts the others (see 'RecorderManager.reset') and the stop flushes what it wrote.
+        try:
+            # Sanitize to CPU numpy once at the boundary: process() code never has to branch on torch vs numpy, and no
+            # GPU tensor is ever queued for cross-thread access in threaded mode.
+            data = self._get_frame()
+            if not self.run_in_thread:
+                self.process(data, global_time)
+                return
+        except Exception:
+            self._is_alive = False
+            raise
 
         # threaded mode: put data in queue
         try:
@@ -256,3 +269,10 @@ class Recorder(Generic[T]):
     @property
     def is_built(self) -> bool:
         return self._is_built
+
+    @property
+    def is_alive(self) -> bool:
+        """Whether no sample or write of the recorder raised. A recorder that raised records no more, a reset restarts
+        the others (see 'RecorderManager.reset'), and the stop flushes what it wrote.
+        """
+        return self._is_alive

--- a/genesis/recorders/base_recorder.py
+++ b/genesis/recorders/base_recorder.py
@@ -27,6 +27,7 @@ class Recorder(Generic[T]):
         self._manager = manager
         self._data_func = data_func
         self._steps_per_sample = 1
+        self._error: Exception | None = None
         self._is_built = False
         self._is_recording = False
 
@@ -91,6 +92,12 @@ class Recorder(Generic[T]):
             # sync the thread to ensure all data is processed
             self.sync()
 
+    def _get_frame(self):
+        """Return the frame of one recorded step from 'data_func' as host numpy arrays, so 'process' handles host data
+        only. A subclass overrides this when its 'data_func' returns the source it reads the frame from.
+        """
+        return data_to_array(self._data_func())
+
     @property
     def run_in_thread(self) -> bool:
         """
@@ -112,10 +119,22 @@ class Recorder(Generic[T]):
         while self._is_recording or not self._data_queue.empty():
             try:
                 data, timestamp = self._data_queue.get(timeout=1.0)
-                self.process(data, timestamp)
-                self._data_queue.task_done()
             except queue.Empty:
                 continue
+            try:
+                self.process(data, timestamp)
+            except Exception as error:
+                # Forwarded to the stepping thread, which raises it at its next step or sync (see 'step'). The samples
+                # left in the queue are marked done, so 'sync' returns.
+                self._error = error
+                self._data_queue.task_done()
+                while True:
+                    try:
+                        self._data_queue.get_nowait()
+                        self._data_queue.task_done()
+                    except queue.Empty:
+                        return
+            self._data_queue.task_done()
 
     @gs.assert_built
     def start(self):
@@ -131,6 +150,13 @@ class Recorder(Generic[T]):
         if self.run_in_thread:
             self.join_thread()
         self.cleanup()
+        self._raise_error()
+
+    def _raise_error(self):
+        """Raise on the calling thread the failure the background thread recorded, once."""
+        if self._error is not None:
+            error, self._error = self._error, None
+            gs.raise_exception_from(f"[{type(self).__name__}] Processing failed in the background: {error}", error)
 
     @gs.assert_built
     def join_thread(self):
@@ -172,19 +198,25 @@ class Recorder(Generic[T]):
             if timeout is not None:
                 start_time = time.time()
 
-            while not self._data_queue.empty():
+            # A frame taken off the queue is still being processed until the worker marks its task done. A failure
+            # leaves no task pending (see '_process_data_loop'), so it is checked before waiting and while waiting.
+            self._raise_error()
+            while self._data_queue.unfinished_tasks:
+                self._raise_error()
                 if timeout is not None and time.time() - start_time > timeout:
                     gs.raise_exception(f"[{type(self).__name__}] sync(): Timeout waiting for data queue to be empty.")
 
                 dt = min(timestep, (start_time + timeout) - time.time()) if timeout is not None else timestep
                 if dt > 0.0:
                     time.sleep(dt)
+            self._raise_error()
 
     @gs.assert_built
     def step(self, global_step: int):
         """Process a simulation step, potentially recording data."""
         if not self._is_recording:
             return
+        self._raise_error()
 
         if global_step % self._steps_per_sample != 0:
             return
@@ -192,7 +224,7 @@ class Recorder(Generic[T]):
         global_time = global_step * self._manager._step_dt
         # Sanitize to CPU numpy once at the boundary: process() code never has to branch on torch vs numpy, and no
         # GPU tensor is ever queued for cross-thread access in threaded mode.
-        data = data_to_array(self._data_func())
+        data = self._get_frame()
 
         if not self.run_in_thread:
             # non-threaded mode: process data synchronously
@@ -213,6 +245,8 @@ class Recorder(Generic[T]):
         gs.logger.debug("[Recorder] Data queue is full, dropping oldest data sample.")
         try:
             self._data_queue.get_nowait()
+            # A dropped sample counts as done, since 'sync' waits for every sample taken off the queue
+            self._data_queue.task_done()
         except queue.Empty:
             # Queue became empty between operations, just put the data
             pass

--- a/genesis/recorders/file_writers.py
+++ b/genesis/recorders/file_writers.py
@@ -23,29 +23,15 @@ class BaseFileWriter(Recorder):
     """
     Base class for file writers.
 
-    Handles filename counter when save_on_reset is True.
     """
 
     def build(self):
         super().build()
-        self.counter = 0
 
         os.makedirs(os.path.abspath(os.path.dirname(self._options.filename)), exist_ok=True)
         self._initialize_writer()
 
-    def reset(self, envs_idx=None):
-        super().reset(envs_idx)
-
-        # no envs specific saving supported
-        if self._options.save_on_reset:
-            self.cleanup()
-            self.counter += 1
-            self._initialize_writer()
-
     def _get_filename(self):
-        if self._options.save_on_reset:
-            path, ext = os.path.splitext(self._options.filename)
-            return f"{path}_{self.counter}{ext}"
         return self._options.filename
 
     def _initialize_writer(self):

--- a/genesis/recorders/recorder_manager.py
+++ b/genesis/recorders/recorder_manager.py
@@ -33,7 +33,9 @@ class RecorderManager:
         Parameters
         ----------
         data_func: Callable[[], Any]
-            A function with no arguments that returns the data to be recorded.
+            A callable with no arguments that returns the data a step records. A recorder that overrides
+            'Recorder._get_frame' receives from it the object it reads the frame from (the trajectory recorder receives
+            a TrajectorySource).
         rec_options: RecorderOptions
             The options for the recorder which determines how the data is recorded and processed.
 
@@ -63,9 +65,17 @@ class RecorderManager:
             gs.logger.warning("[DataRecorder] Ignoring stop(): data recording is not active.")
         else:
             self._is_recording = False
+            # Every recorder is stopped and flushed before the first failure is raised
+            error = None
             for recorder in self._recorders:
-                recorder.stop()
+                try:
+                    recorder.stop()
+                except Exception as recorder_error:
+                    if error is None:
+                        error = recorder_error
             self._recorders.clear()
+            if error is not None:
+                raise error
 
     @gs.assert_built
     def reset(self, envs_idx=None):

--- a/genesis/recorders/recorder_manager.py
+++ b/genesis/recorders/recorder_manager.py
@@ -52,9 +52,26 @@ class RecorderManager:
     @gs.assert_unbuilt
     def build(self):
         """Start data recording."""
-        for recorder in self._recorders:
-            recorder.build()
-            recorder.start()
+        # A recorder that fails to build leaves none of the recorders started before it running
+        started = []
+        try:
+            for recorder in self._recorders:
+                recorder.build()
+                recorder.start()
+                started.append(recorder)
+        except Exception:
+            # Every started recorder is stopped before a failure is raised: the first stop that raised, with the build
+            # failure as its context, or the build failure itself
+            stop_error = None
+            for recorder in started:
+                try:
+                    recorder.stop()
+                except Exception as error:
+                    if stop_error is None:
+                        stop_error = error
+            if stop_error is not None:
+                raise stop_error
+            raise
         self._is_recording = True
         self._is_built = True
 
@@ -80,8 +97,9 @@ class RecorderManager:
     @gs.assert_built
     def reset(self, envs_idx=None):
         for recorder in self._recorders:
-            recorder.reset(envs_idx)
-            recorder.start()
+            if recorder.is_alive:
+                recorder.reset(envs_idx)
+                recorder.start()
 
     @gs.assert_built
     def step(self, global_step: int):
@@ -95,6 +113,23 @@ class RecorderManager:
 
         for recorder in self._recorders:
             recorder.step(global_step)
+
+    @gs.assert_built
+    def record(self, global_step: int):
+        """Record the current state through every recorder, whatever its sampling rate."""
+        if not self._is_recording:
+            return
+
+        # Every recorder gets the state before the first failure is raised: it is the state each log ends with
+        error = None
+        for recorder in self._recorders:
+            try:
+                recorder.record(global_step)
+            except Exception as recorder_error:
+                if error is None:
+                    error = recorder_error
+        if error is not None:
+            raise error
 
     @property
     def recorders(self) -> "list[Recorder]":

--- a/genesis/recorders/trajectory.py
+++ b/genesis/recorders/trajectory.py
@@ -30,7 +30,6 @@ from genesis.utils import serialization
 from genesis.utils.array_class import CHECKPOINT_KINDS, DataKind
 from genesis.utils.misc import qd_to_numpy, qd_to_torch, tensor_to_array
 
-from .base_recorder import Recorder
 from .file_writers import BaseFileWriter
 from .recorder_manager import register_recording
 
@@ -350,14 +349,6 @@ class TrajectoryFileWriter(BaseFileWriter):
         (gs.logger or LOGGER).info(
             f'[TrajectoryFileWriter] Saved {self._n_frames} frames to ~<"{self._get_filename()}">~.'
         )
-
-    def reset(self, envs_idx=None):
-        # The per-environment step counts in each frame record a reset of some environments, so only a whole-scene
-        # reset starts a new file.
-        if envs_idx is None:
-            super().reset()
-        else:
-            Recorder.reset(self, envs_idx)
 
     @property
     def run_in_thread(self) -> bool:

--- a/genesis/recorders/trajectory.py
+++ b/genesis/recorders/trajectory.py
@@ -1,0 +1,575 @@
+"""Log the state of a scene as it steps, one frame per step, and read the log back to seek and replay it.
+
+A trajectory file holds the scene as 'Scene.export' writes it, then its frames in compressed chunks. Every part carries
+its own length and checksum, so a run that crashes leaves every chunk written before readable, and a reader stops at the
+first part it cannot trust. A checkpoint file (see 'Scene.save_checkpoint') is a trajectory file of one frame holding
+every array, scratch included.
+"""
+
+import bisect
+import dataclasses
+import enum
+import io
+import json
+import logging
+import os
+import struct
+import threading
+import time
+import zlib
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+import torch
+
+import genesis as gs
+from genesis.engine.solvers import KinematicSolver
+from genesis.engine.states.solvers import KinematicSolverCheckpoint, SimulatorCheckpoint, SolverCheckpoint
+from genesis.options.recorders import TrajectoryFile
+from genesis.utils import serialization
+from genesis.utils.array_class import CHECKPOINT_KINDS, DataKind
+from genesis.utils.misc import qd_to_numpy, qd_to_torch, tensor_to_array
+
+from .base_recorder import Recorder
+from .file_writers import BaseFileWriter
+from .recorder_manager import register_recording
+
+if TYPE_CHECKING:
+    from genesis.engine.scene import Scene, TrajectorySource
+    from genesis.engine.simulator import Simulator
+    from genesis.options.renderers import RendererOptions
+    from genesis.options.vis import ViewerOptions, VisOptions
+
+LOGGER = logging.getLogger(__name__)
+
+TRAJECTORY_FORMAT = ".gstraj"
+MAGIC = b"GSTRAJ1\n"
+CHUNK_MAGIC = b"CHNK"
+# A chunk record: frame count, payload length, payload checksum.
+CHUNK_HEADER = struct.Struct("<IQI")
+LAST_MAGIC = b"LAST"
+# The record a trajectory ends with: payload length, payload checksum.
+LAST_HEADER = struct.Struct("<QI")
+LENGTH = struct.Struct("<Q")
+# What a frame holds in each mode (see TrajectoryFile). A checkpoint file and the record a trajectory ends with hold
+# every array but the static configs and constants, the scratch of the solvers included. They serve the analysis of a
+# failure, and a failure may depend on the platform and never reproduce once shared. What the last step computed is
+# therefore kept whole.
+COMPRESSED_KINDS = frozenset((DataKind.INFO, DataKind.STATE))
+EXACT_KINDS = CHECKPOINT_KINDS
+CHECKPOINT_FILE_KINDS = frozenset(DataKind) - {DataKind.CONFIG, DataKind.CONSTANT}
+# The per-environment step counts and the forward-kinematics flags of a solver, which follow the arrays in a frame.
+STEPS_FIELD = "steps"
+FLAGS_SUFFIX = ".forward_flags"
+
+
+class FrameField(NamedTuple):
+    """Where one array stands in a frame: its name, kind, canonical shape, numpy dtype string, byte offset and byte
+    length.
+    """
+
+    name: str
+    kind: DataKind
+    shape: tuple[int, ...]
+    dtype: str
+    offset: int
+    nbytes: int
+
+
+def _json_value(value):
+    """Return a value as JSON holds it: the name of an enum member, a native for a numpy scalar, a list for a tuple."""
+    if isinstance(value, enum.Enum):
+        return value.name
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def _fields_to_json(fields: list[FrameField]) -> list:
+    """Return the frame layout as the JSON rows the file header holds."""
+    return [
+        [field.name, field.kind.name, list(field.shape), field.dtype, field.offset, field.nbytes] for field in fields
+    ]
+
+
+def _fields_from_json(rows: list) -> list[FrameField]:
+    """Return the frame layout the JSON rows of a file header hold."""
+    return [
+        FrameField(name, DataKind[kind], tuple(shape), dtype, offset, nbytes)
+        for name, kind, shape, dtype, offset, nbytes in rows
+    ]
+
+
+def _frame_arrays(frame: np.ndarray, fields: list[FrameField], kinds: frozenset[DataKind]) -> dict[str, np.ndarray]:
+    """Return the arrays of the given kinds that a frame holds, by name, shaped as the scene holds them."""
+    return {
+        field.name: frame[field.offset : field.offset + field.nbytes].view(field.dtype).reshape(field.shape)
+        for field in fields
+        if field.kind in kinds
+    }
+
+
+def _frame_fields(sim: "Simulator", kinds: frozenset[DataKind]) -> list[FrameField]:
+    """Lay out one frame of the given kinds (see '_read_frame'): every array, then the step count of each environment
+    and the forward-kinematics flags of every kinematic or rigid solver.
+    """
+    fields = []
+    offset = 0
+    for name, value, kind in sim.data(kinds):
+        array = qd_to_numpy(value)
+        fields.append(FrameField(name, kind, array.shape, array.dtype.str, offset, array.nbytes))
+        offset += array.nbytes
+    steps = tensor_to_array(sim.steps)
+    fields.append(FrameField(STEPS_FIELD, DataKind.STATE, steps.shape, steps.dtype.str, offset, steps.nbytes))
+    offset += steps.nbytes
+    for solver in sim.active_solvers:
+        if isinstance(solver, KinematicSolver):
+            name = f"{type(solver).__name__}{FLAGS_SUFFIX}"
+            fields.append(FrameField(name, DataKind.STATE, (2,), "|u1", offset, 2))
+            offset += 2
+    return fields
+
+
+def _read_frame(sim: "Simulator", kinds: frozenset[DataKind]) -> np.ndarray:
+    """Return one frame as a flat uint8 buffer laid out as '_frame_fields' states.
+
+    Where zero-copy views exist the arrays are concatenated on the device and cross to the host once. Otherwise each
+    array crosses on its own and the concatenation runs on the host.
+    """
+    flags = [
+        flag
+        for solver in sim.active_solvers
+        if isinstance(solver, KinematicSolver)
+        for flag in (solver.is_forward_pos_updated, solver.is_forward_vel_updated)
+    ]
+    if gs.use_zerocopy:
+        parts = [qd_to_torch(value).contiguous().reshape(-1).view(torch.uint8) for _, value, _ in sim.data(kinds)]
+        parts.append(sim.steps.reshape(-1).view(torch.uint8))
+        parts.append(torch.tensor(flags, dtype=torch.uint8, device=gs.device))
+        return tensor_to_array(torch.cat(parts))
+    parts = [qd_to_numpy(value).reshape(-1).view(np.uint8) for _, value, _ in sim.data(kinds)]
+    parts.append(tensor_to_array(sim.steps).reshape(-1).view(np.uint8))
+    parts.append(np.array(flags, dtype=np.uint8))
+    return np.concatenate(parts)
+
+
+def _header(
+    source: "TrajectorySource", exact: bool, chunk_size: int, fields: list[FrameField], last_fields: list[FrameField]
+) -> bytes:
+    """Return the magic, the JSON manifest and the scene description that open a trajectory file, 'fields' laying out
+    its frames and 'last_fields' the record it ends with.
+    """
+    sim, desc, layout = source
+    description = io.BytesIO()
+    serialization.export(description, {"scene": desc})
+    manifest = {
+        "genesis": gs.__version__,
+        "source": serialization.source_digest(),
+        "backend": gs.backend.name,
+        "precision": np.dtype(gs.np_float).name,
+        "exact": exact,
+        "chunk_size": chunk_size,
+        "dt": sim.dt,
+        "layout": {key: _json_value(value) for key, value in dataclasses.asdict(layout).items()},
+        "configs": {
+            name: {key: _json_value(value) for key, value in vars(config).items() if not key.startswith("_")}
+            for solver in sim.active_solvers
+            for name, config, kind in solver.data
+            if kind == DataKind.CONFIG
+        },
+        "fields": _fields_to_json(fields),
+        "last_fields": _fields_to_json(last_fields),
+    }
+    text = json.dumps(manifest).encode()
+    return MAGIC + LENGTH.pack(len(text)) + text + LENGTH.pack(description.getbuffer().nbytes) + description.getvalue()
+
+
+def save_checkpoint(path: str | os.PathLike, source: "TrajectorySource") -> None:
+    """Write the whole state of a built scene as a trajectory file of one frame, the record a trajectory ends with (see
+    'Scene.save_checkpoint').
+    """
+    fields = _frame_fields(source.sim, CHECKPOINT_FILE_KINDS)
+    with open(path, "wb") as file:
+        file.write(_header(source, exact=True, chunk_size=1, fields=fields, last_fields=fields))
+        payload = zlib.compress(_read_frame(source.sim, CHECKPOINT_FILE_KINDS).tobytes())
+        file.write(LAST_MAGIC + LAST_HEADER.pack(len(payload), zlib.crc32(payload)) + payload)
+
+
+@register_recording(TrajectoryFile)
+class TrajectoryFileWriter(BaseFileWriter):
+    """Write the frames of a scene to a trajectory file (see TrajectoryFile), one chunk at a time.
+
+    Each frame captures the state a step starts from, control inputs included, since it is read before the step.
+    Within a chunk the writer stores each frame as its XOR with the previous frame. Unchanged bytes thus become zeros
+    for zlib to remove, and an unchanged info array costs nothing. The frames are appended on the stepping thread; a
+    completed chunk is compressed and written by a thread of its own, one chunk in flight at a time, so memory use is
+    the open chunk and the one being written, whatever the file size.
+    """
+
+    def build(self):
+        self._source: TrajectorySource = self._data_func()
+        sim = self._source.sim
+        self._is_exact = self._options.exact if self._options.exact is not None else sim.n_envs <= 1
+        if not self._is_exact:
+            gs.logger.warning(
+                "[TrajectoryFileWriter] Recording the state alone: link and geom poses are recomputed at load and may "
+                "differ at the last bits, and the log cannot resume the simulation bit-for-bit. Set 'exact=True' to "
+                "log everything a step reads or writes."
+            )
+        self._kinds = EXACT_KINDS if self._is_exact else COMPRESSED_KINDS
+        self._fields = _frame_fields(sim, self._kinds)
+        self._last_fields = _frame_fields(sim, CHECKPOINT_FILE_KINDS)
+        self._frame_size = sum(field.nbytes for field in self._fields)
+        self._steps_field = next(field for field in self._fields if field.name == STEPS_FIELD)
+        self._chunk = bytearray()
+        self._n_chunk_frames = 0
+        self._previous: np.ndarray | None = None
+        self._n_frames = 0
+        self._written = 0
+        self._fault: str | None = None
+        self._error: Exception | None = None
+        self._writer: threading.Thread | None = None
+        self._file: io.BufferedWriter | None = None
+
+        super().build()
+
+    def _initialize_writer(self):
+        # The header goes out with the first record. A run that ends before any leaves an empty file, which no reader
+        # takes for a trajectory.
+        self._file = open(self._get_filename(), "wb")
+        self._header = _header(self._source, self._is_exact, self._options.chunk_size, self._fields, self._last_fields)
+        self._written = 0
+
+    def _get_frame(self):
+        return _read_frame(self._source.sim, self._kinds)
+
+    def step(self, global_step: int):
+        # A failed write ends the recorder, as a failed sample does (see 'Recorder.record')
+        if self._fault is not None:
+            self._is_alive = False
+            fault, self._fault = self._fault, None
+            gs.raise_exception(fault)
+        if self._error is not None:
+            self._is_alive = False
+            error, self._error = self._error, None
+            gs.raise_exception_from(f"[TrajectoryFileWriter] Writing '{self._get_filename()}' failed.", error)
+        super().step(global_step)
+
+    def process(self, data, cur_time):
+        if self._file is None:
+            return
+        # A full chunk is written as the next frame arrives, so the open chunk holds the latest frame. The stop replaces
+        # that frame with the whole state (see 'cleanup').
+        if self._n_chunk_frames == self._options.chunk_size:
+            self._start_chunk_write()
+        delta = data if self._previous is None else np.bitwise_xor(data, self._previous)
+        self._chunk += delta.tobytes()
+        self._previous = data
+        self._n_chunk_frames += 1
+
+    def _start_chunk_write(self):
+        """Hand the open chunk to a writer thread, once the write of the previous chunk has ended."""
+        if self._writer is not None:
+            self._writer.join()
+            self._writer = None
+        if self._n_chunk_frames == 0 or self._file is None:
+            return
+        chunk, n_chunk_frames = bytes(self._chunk), self._n_chunk_frames
+        self._chunk.clear()
+        self._n_chunk_frames = 0
+        self._previous = None
+        self._writer = threading.Thread(target=self._write_chunk, args=(chunk, n_chunk_frames), daemon=True)
+        self._writer.start()
+
+    def _write(self, record: bytes, n_record_frames: int):
+        """Append one record holding 'n_record_frames' frames, with the header ahead of the first, if the file may still
+        grow by that much. Otherwise the file is closed and the fault recorded.
+        """
+        record = self._header + record
+        if self._options.max_size is not None and self._written + len(record) > self._options.max_size:
+            self._file.close()
+            self._file = None
+            if self._written == 0:
+                # A limit below the header and the first record leaves nothing to read, so the empty file goes too
+                os.remove(self._get_filename())
+                self._fault = (
+                    f"The max_size of {self._options.max_size} bytes cannot hold the header and the first record of "
+                    f"'{self._get_filename()}'."
+                )
+            else:
+                self._fault = (
+                    f"'{self._get_filename()}' reached its max_size of {self._options.max_size} bytes after "
+                    f"{self._n_frames} frames, and was closed."
+                )
+            return
+        self._file.write(record)
+        self._file.flush()
+        self._header = b""
+        self._written += len(record)
+        self._n_frames += n_record_frames
+
+    def _write_chunk(self, chunk: bytes, n_chunk_frames: int):
+        """Compress and append one chunk on the writer thread. A failure is raised on the stepping thread (see 'step')."""
+        try:
+            payload = zlib.compress(chunk)
+            chunk_header = CHUNK_MAGIC + CHUNK_HEADER.pack(n_chunk_frames, len(payload), zlib.crc32(payload))
+            self._write(chunk_header + payload, n_chunk_frames)
+        except Exception as error:
+            self._error = error
+
+    def cleanup(self):
+        sim = self._source.sim
+        if self._file is not None and self._n_chunk_frames > 0:
+            # The frame the stop recorded carries the step counts of the live state. The whole state ends the file in
+            # its place (see CHECKPOINT_FILE_KINDS), so it leaves the chunk.
+            field = self._steps_field
+            steps = self._previous[field.offset : field.offset + field.nbytes].view(field.dtype).reshape(field.shape)
+            if np.array_equal(steps, tensor_to_array(sim.steps)):
+                del self._chunk[-self._frame_size :]
+                self._n_chunk_frames -= 1
+        self._start_chunk_write()
+        self._previous = None
+        if self._writer is not None:
+            self._writer.join()
+            self._writer = None
+        try:
+            if self._error is None and self._file is not None:
+                payload = zlib.compress(_read_frame(sim, CHECKPOINT_FILE_KINDS).tobytes())
+                self._write(LAST_MAGIC + LAST_HEADER.pack(len(payload), zlib.crc32(payload)) + payload, 1)
+        finally:
+            if self._file is not None:
+                self._file.close()
+                self._file = None
+        # No step follows to raise what the last writes left, so it is raised here, the file closed
+        if self._error is not None:
+            gs.raise_exception_from(f"[TrajectoryFileWriter] Writing '{self._get_filename()}' failed.", self._error)
+        if self._fault is not None:
+            gs.raise_exception(self._fault)
+        (gs.logger or LOGGER).info(
+            f'[TrajectoryFileWriter] Saved {self._n_frames} frames to ~<"{self._get_filename()}">~.'
+        )
+
+    def reset(self, envs_idx=None):
+        # The per-environment step counts in each frame record a reset of some environments, so only a whole-scene
+        # reset starts a new file.
+        if envs_idx is None:
+            super().reset()
+        else:
+            Recorder.reset(self, envs_idx)
+
+    @property
+    def run_in_thread(self) -> bool:
+        return False
+
+
+class Trajectory:
+    """A recorded trajectory and the built scene it plays in (see 'Scene.load_trajectory').
+
+    Frame i is the state the scene stood in after i steps, and the last frame is the state the recording stopped at,
+    whole: every array but the static configs and constants (see CHECKPOINT_FILE_KINDS).
+
+    Parameters
+    ----------
+    path : str or os.PathLike
+        The file to read, as written by recording with 'TrajectoryFile' or by 'Scene.save_checkpoint'.
+    scene : Scene, optional
+        A built scene to play the trajectory in, from the same description and environment layout as the recorded
+        one. If None, the recorded scene is created and built. Defaults to None.
+    show_viewer : bool, optional
+        Whether the created scene opens an interactive viewer. Defaults to False.
+    viewer_options : ViewerOptions, optional
+        Viewer options replacing the recorded ones in the created scene. If None, the recorded ones stand.
+    vis_options : VisOptions, optional
+        Visualizer options replacing the recorded ones in the created scene. If None, the recorded ones stand.
+    renderer : RendererOptions, optional
+        Renderer replacing the recorded one in the created scene. If None, the recorded one stands.
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike,
+        scene: "Scene | None" = None,
+        show_viewer: bool = False,
+        viewer_options: "ViewerOptions | None" = None,
+        vis_options: "VisOptions | None" = None,
+        renderer: "RendererOptions | None" = None,
+    ):
+        # The scene module imports the recorders, so its classes are reached here rather than at import.
+        from genesis.engine.scene import EnvironmentLayout, SceneCheckpoint, SceneDescription, description_digest
+
+        self._path = path
+        with open(path, "rb") as file:
+            if file.read(len(MAGIC)) != MAGIC:
+                gs.raise_exception(f"'{path}' is not a Genesis trajectory.")
+            (length,) = LENGTH.unpack(file.read(LENGTH.size))
+            self._manifest = json.loads(file.read(length))
+            (length,) = LENGTH.unpack(file.read(LENGTH.size))
+            description = file.read(length)
+            self._fields = _fields_from_json(self._manifest["fields"])
+            self._last_fields = _fields_from_json(self._manifest["last_fields"])
+            self._frame_size = sum(field.nbytes for field in self._fields)
+            # Each record is trusted by its checksum, so the offsets stop at the first one a crash left incomplete.
+            self._chunk_offsets: list[int] = []
+            self._chunk_ends: list[int] = []
+            self._last_offset: int | None = None
+            n_frames = 0
+            while True:
+                offset = file.tell()
+                magic = file.read(len(CHUNK_MAGIC))
+                if magic == CHUNK_MAGIC:
+                    header = file.read(CHUNK_HEADER.size)
+                    if len(header) < CHUNK_HEADER.size:
+                        break
+                    n_chunk_frames, length, crc = CHUNK_HEADER.unpack(header)
+                    payload = file.read(length)
+                    if len(payload) < length or zlib.crc32(payload) != crc:
+                        break
+                    n_frames += n_chunk_frames
+                    self._chunk_offsets.append(offset)
+                    self._chunk_ends.append(n_frames)
+                elif magic == LAST_MAGIC:
+                    header = file.read(LAST_HEADER.size)
+                    if len(header) < LAST_HEADER.size:
+                        break
+                    length, crc = LAST_HEADER.unpack(header)
+                    payload = file.read(length)
+                    if len(payload) < length or zlib.crc32(payload) != crc:
+                        break
+                    self._last_offset = offset
+                else:
+                    break
+        self._n_frames = n_frames + (self._last_offset is not None)
+        if self._n_frames == 0:
+            gs.raise_exception(f"'{path}' holds no frame.")
+        self._i_cached_chunk: int | None = None
+        self._cached_frames: np.ndarray | None = None
+
+        layout = self._manifest["layout"]
+        self._layout = EnvironmentLayout(
+            layout["n_envs"], tuple(layout["env_spacing"]), layout["n_envs_per_row"], layout["center_envs_at_origin"]
+        )
+        self._checkpoint_class = SceneCheckpoint
+        if scene is None:
+            scene = gs.Scene.load(io.BytesIO(description), show_viewer, viewer_options, vis_options, renderer)
+            scene.build(**dataclasses.asdict(self._layout))
+            description = None
+        self._scene = scene
+        self._digest = description_digest(scene.desc)
+        if description is not None:
+            recorded = serialization.load(io.BytesIO(description), {"scene": SceneDescription})["scene"]
+            if description_digest(recorded) != self._digest:
+                gs.raise_exception(f"'{path}' was recorded from another scene: its entities or physics options differ.")
+
+    def __len__(self) -> int:
+        return self._n_frames
+
+    @property
+    def scene(self) -> "Scene":
+        """The built scene the trajectory plays in."""
+        return self._scene
+
+    @property
+    def is_exact(self) -> bool:
+        """Whether the frames hold everything a step reads or writes, or the state alone (see TrajectoryFile)."""
+        return self._manifest["exact"]
+
+    @property
+    def n_envs(self) -> int:
+        """The number of environments the scene was recorded with."""
+        return self._layout.n_envs
+
+    def frame(self, index: int, kinds: frozenset[DataKind] = frozenset(DataKind)) -> dict[str, np.ndarray]:
+        """Return the arrays of frame 'index' of the given kinds by name, shaped as the scene holds them. A negative
+        'index' counts from the end.
+        """
+        try:
+            index = range(len(self))[index]
+        except IndexError:
+            gs.raise_exception(f"Frame {index} is out of the {len(self)} frames of '{self._path}'.")
+        if self._last_offset is not None and index == len(self) - 1:
+            with open(self._path, "rb") as file:
+                file.seek(self._last_offset + len(LAST_MAGIC))
+                length, _ = LAST_HEADER.unpack(file.read(LAST_HEADER.size))
+                # A writable buffer, as the restore wraps the arrays as tensors
+                frame = np.frombuffer(bytearray(zlib.decompress(file.read(length))), np.uint8)
+            return _frame_arrays(frame, self._last_fields, kinds)
+        # The chunk holding the frame is decoded whole, undoing its chain of differences, and kept for the frames of
+        # the same chunk read next.
+        i_chunk = bisect.bisect_right(self._chunk_ends, index)
+        if i_chunk != self._i_cached_chunk:
+            with open(self._path, "rb") as file:
+                file.seek(self._chunk_offsets[i_chunk] + len(CHUNK_MAGIC))
+                n_chunk_frames, length, _ = CHUNK_HEADER.unpack(file.read(CHUNK_HEADER.size))
+                deltas = np.frombuffer(zlib.decompress(file.read(length)), np.uint8)
+            frames = deltas.reshape((n_chunk_frames, self._frame_size)).copy()
+            np.bitwise_xor.accumulate(frames, axis=0, out=frames)
+            self._i_cached_chunk = i_chunk
+            self._cached_frames = frames
+        i_frame_start = self._chunk_ends[i_chunk - 1] if i_chunk > 0 else 0
+        return _frame_arrays(self._cached_frames[index - i_frame_start], self._fields, kinds)
+
+    def time(self, index: int) -> np.ndarray:
+        """The simulated time of each environment at frame 'index', in seconds, as 'Scene.get_time' reports it."""
+        # Multiplied as the simulator multiplies its own clock, so the two agree to the bit.
+        return tensor_to_array(torch.as_tensor(self.frame(index)[STEPS_FIELD], device="cpu") * self._manifest["dt"])
+
+    def seek(self, index: int) -> None:
+        """Put the scene in the state of frame 'index', counted from the end when negative.
+
+        An exact frame puts back everything a step reads or writes, so the scene steps on from there bit-for-bit. A
+        compressed frame puts back the state and recomputes the link and geom poses by forward kinematics. The scratch a
+        checkpoint file also holds is for inspection: its shape follows the backend of the recording.
+        """
+        kinds = EXACT_KINDS if self.is_exact else COMPRESSED_KINDS
+        values = self.frame(index, kinds)
+        arrays: dict[str, dict[str, np.ndarray]] = {}
+        flags: dict[str, tuple[bool, bool]] = {}
+        for name, value in values.items():
+            if name == STEPS_FIELD:
+                continue
+            solver_name, array_name = name.split(".", 1)
+            if name.endswith(FLAGS_SUFFIX):
+                # Native booleans: the step hands these to kernels as template arguments.
+                flags[solver_name] = tuple(map(bool, value))
+            else:
+                arrays.setdefault(solver_name, {})[array_name] = value
+        solvers = {}
+        for solver_name, solver_arrays in arrays.items():
+            if solver_name in flags:
+                is_pos_updated, is_vel_updated = flags[solver_name]
+                solvers[solver_name] = KinematicSolverCheckpoint(
+                    solver_arrays, {}, kinds, is_pos_updated, is_vel_updated
+                )
+            else:
+                solvers[solver_name] = SolverCheckpoint(solver_arrays, {}, kinds)
+        sim = SimulatorCheckpoint(steps=values[STEPS_FIELD], solvers=solvers)
+        self._scene.__setstate__(
+            self._checkpoint_class(scene=self._scene.desc, digest=self._digest, layout=self._layout, sim=sim)
+        )
+
+    def play(self, loop: bool = False) -> None:
+        """Seek every frame in turn, which redraws the scene at each and plays the run in the viewer at its pace.
+
+        With 'loop', the run starts over until the interactive viewer is closed, so the scene must have one.
+        """
+        viewer = self._scene.viewer
+        if loop and viewer is None:
+            gs.raise_exception("Looping a trajectory needs an interactive viewer.")
+        # The viewer holds each redraw to one step of wall time (see ViewerOptions.realtime_factor). A frame spanning
+        # more steps than one, as frames recorded every few steps do, waits for the steps beyond that one as well.
+        is_paced = viewer is not None and viewer.realtime_factor is not None
+        while True:
+            steps_prev = None
+            for index in range(len(self)):
+                # A closed viewer ends the replay before a redraw reaches it
+                if viewer is not None and not viewer.is_alive():
+                    return
+                steps = self.frame(index)[STEPS_FIELD]
+                if is_paced and steps_prev is not None:
+                    time.sleep(max((steps - steps_prev).max() - 1, 0) * self._manifest["dt"] / viewer.realtime_factor)
+                self.seek(index)
+                steps_prev = steps
+            if not loop:
+                return

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -1,7 +1,8 @@
 import dataclasses
 import math
+from collections.abc import Iterable, Iterator, Mapping
 from enum import IntEnum
-from typing import NamedTuple
+from typing import ClassVar, NamedTuple
 
 import quadrants as qd
 from typing_extensions import dataclass_transform  # Made it into standard lib from Python 3.12
@@ -9,6 +10,7 @@ import numpy as np
 import torch
 
 import genesis as gs
+from genesis.utils.misc import qd_to_torch
 
 
 def _tensor_backend():
@@ -77,6 +79,126 @@ def V_SCALAR_FROM(dtype, value):
     return data
 
 
+class DataKind(IntEnum):
+    """The kind of every array or static config a solver yields (see 'Solver.data'), which checkpoints and trajectories
+    select by.
+
+    CONFIG is a static config of plain Python natives that keys the compiled kernels, recorded as provenance only.
+    CONSTANT is an array the build computes from the scene description once. INFO is a model parameter the setters
+    write, such as mass, friction, gains or limits. STATE is the reduced-space configuration, velocities,
+    accelerations, control inputs, contacts and constraint solution. WARMSTART is a cache the next solve reads to
+    reproduce the previous result bit-for-bit. Forward kinematics and dynamics recompute DERIVED from STATE. A step or
+    a solve writes SCRATCH before it reads it.
+    """
+
+    CONFIG = 0
+    CONSTANT = 1
+    INFO = 2
+    STATE = 3
+    WARMSTART = 4
+    DERIVED = 5
+    SCRATCH = 6
+
+
+# Metadata key under which 'of_kind' stores the kind of a field.
+KIND = "kind"
+# The kinds a checkpoint carries: INFO, STATE, WARMSTART and DERIVED. The static configs travel in a separate field of
+# the checkpoint as provenance.
+CHECKPOINT_KINDS = frozenset((DataKind.INFO, DataKind.STATE, DataKind.WARMSTART, DataKind.DERIVED))
+
+
+def of_kind(kind: DataKind):
+    """Declare a struct field whose kind differs from the default its struct states (see DataKind)."""
+    return dataclasses.field(metadata={KIND: kind})
+
+
+class DataItem(NamedTuple):
+    """One array or static config a solver holds, under the dotted name of the slot and fields reaching it."""
+
+    name: str
+    value: object
+    kind: DataKind
+
+
+def iter_data(struct, name: str, kind: DataKind | None = None) -> Iterator[DataItem]:
+    """Yield a DataItem for every array in a struct of arrays, named by 'name' plus field names joined with dots.
+
+    Structs are the frozen dataclasses and named tuples of this module, nested to any depth. The class attribute
+    'kind' gives the default kind of a struct's fields, and 'of_kind' on a field overrides it. An override on a
+    struct-valued field applies to every array of that struct. An array carrying gradients yields them as one more item
+    of its kind, named 'grad'. A static config yields one item of kind CONFIG, and anything else raises and names the
+    offending slot.
+    """
+    if isinstance(struct, (qd.Tensor, qd.Field, qd.Ndarray)):
+        if kind is None:
+            gs.raise_exception(f"'{name}' holds an array that no struct or annotation gives a kind.")
+        yield DataItem(name, struct, kind)
+        if struct.has_grad():
+            yield DataItem(f"{name}.grad", struct.grad, kind)
+    elif isinstance(type(struct), AutoInitMeta):
+        yield DataItem(name, struct, DataKind.CONFIG)
+    elif dataclasses.is_dataclass(struct) or isinstance(struct, tuple):
+        if dataclasses.is_dataclass(struct):
+            values = vars(struct)
+            members = [
+                (field.name, values[field.name], field.metadata.get(KIND)) for field in dataclasses.fields(struct)
+            ]
+        else:
+            members = [(member, value, None) for member, value in zip(struct._fields, struct)]
+        for member, value, stated_kind in members:
+            if stated_kind is None and kind is None and isinstance(value, (qd.Tensor, qd.Field, qd.Ndarray)):
+                stated_kind = type(struct).kind
+            yield from iter_data(value, f"{name}.{member}", kind if stated_kind is None else stated_kind)
+    else:
+        gs.raise_exception(f"'{name}' holds a {type(struct).__name__} where an array or a struct of arrays stands.")
+
+
+def check_data(items: Iterable[DataItem], values: Mapping[str, np.ndarray | torch.Tensor]) -> list[tuple]:
+    """Return the (array, value) pairs 'fill_data' writes, rejecting a record made for another scene.
+
+    A value with the array's shape fills it, cast to its dtype, so a one-byte boolean fills an int32 flag. A floating
+    value for an integer array, or the reverse, raises. 'maybe_shape' shapes an unused array as (), so an array with
+    that shape on either side stays as built. Any other shape mismatch raises, since the record comes from a different
+    build. A name on one side only raises, since the record comes from another build or version.
+    """
+    items = tuple(items)
+    unshared = sorted({name for name, _, _ in items} ^ set(values))
+    if unshared:
+        gs.raise_exception(f"The record and this scene do not share {unshared}: another build or version wrote it.")
+    writes = []
+    for name, array, _ in items:
+        value = values[name]
+        element_shape = array.element_shape if isinstance(array, (qd.VectorTensor, qd.MatrixTensor)) else ()
+        if tuple(array.shape) == () or tuple(value.shape) == element_shape:
+            continue
+        shape = (*array.shape, *element_shape)
+        if tuple(value.shape) != shape:
+            gs.raise_exception(f"'{name}' is shaped {shape} here and {value.shape} in the record: another build.")
+        if isinstance(value, torch.Tensor):
+            is_real = value.dtype.is_floating_point
+        else:
+            is_real = np.issubdtype(value.dtype, np.floating)
+        if is_real != (array.dtype in qd.types.primitive_types.real_types):
+            gs.raise_exception(f"'{name}' holds {array.dtype} values here where {value.dtype} ones were recorded.")
+        writes.append((array, value))
+    return writes
+
+
+def fill_data(items: Iterable[DataItem], values: Mapping[str, np.ndarray | torch.Tensor]) -> None:
+    """Write into each array the value recorded under its name, once every value passed 'check_data', so a record
+    from another build leaves the scene as it was.
+
+    Where zero-copy views exist the values go through them, so a device-resident record stays on the device. On Metal
+    these writes stay on the torch stream, so the caller must call 'torch.mps.synchronize' once before the next kernel.
+    """
+    for array, value in check_data(items, values):
+        if gs.use_zerocopy:
+            view = qd_to_torch(array, copy=False)
+            view.copy_(torch.as_tensor(value, device=view.device))
+        else:
+            array.from_numpy(value)
+
+
 # =========================================== ErrorCode ===========================================
 
 
@@ -96,24 +218,26 @@ class ErrorCode(IntEnum):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class RigidInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     # *_bw: Cache for backward pass
-    n_awake_dofs: qd.Tensor
-    awake_dofs: qd.Tensor
-    n_awake_entities: qd.Tensor
-    awake_entities: qd.Tensor
-    n_awake_links: qd.Tensor
-    awake_links: qd.Tensor
-    qpos0: qd.Tensor
-    qpos: qd.Tensor
-    qpos_next: qd.Tensor
-    links_T: qd.Tensor
+    n_awake_dofs: qd.Tensor = of_kind(DataKind.STATE)
+    awake_dofs: qd.Tensor = of_kind(DataKind.STATE)
+    n_awake_entities: qd.Tensor = of_kind(DataKind.STATE)
+    awake_entities: qd.Tensor = of_kind(DataKind.STATE)
+    n_awake_links: qd.Tensor = of_kind(DataKind.STATE)
+    awake_links: qd.Tensor = of_kind(DataKind.STATE)
+    qpos0: qd.Tensor = of_kind(DataKind.INFO)
+    qpos: qd.Tensor = of_kind(DataKind.STATE)
+    qpos_next: qd.Tensor = of_kind(DataKind.SCRATCH)
+    links_T: qd.Tensor = of_kind(DataKind.DERIVED)
     envs_offset: qd.Tensor
     geoms_init_AABB: qd.Tensor
-    mass_mat: qd.Tensor
-    mass_mat_L: qd.Tensor
-    mass_mat_D_inv: qd.Tensor
-    mass_mat_tiled_scratch: qd.Tensor
-    mass_mat_mask: qd.Tensor
+    mass_mat: qd.Tensor = of_kind(DataKind.DERIVED)
+    mass_mat_L: qd.Tensor = of_kind(DataKind.DERIVED)
+    mass_mat_D_inv: qd.Tensor = of_kind(DataKind.DERIVED)
+    mass_mat_tiled_scratch: qd.Tensor = of_kind(DataKind.SCRATCH)
+    mass_mat_mask: qd.Tensor = of_kind(DataKind.STATE)
     # Per-DOF bounds of the mass block the DOF belongs to: the DOFs of its branch rooted where the fixed structure
     # ends (deeper branches stay mass-coupled to their chain and belong to the enclosing block), merged across
     # entities and kept contiguous by attach(). The assemble/factor/solve restrict to these bounds.
@@ -128,9 +252,9 @@ class RigidInfo:
     # the per-entity assemble/factor/solve iterate their blocks as one flat, autodiff-compatible loop over DOFs.
     entities_mass_block_dof_start: qd.Tensor
     entities_mass_block_dof_end: qd.Tensor
-    meaninertia: qd.Tensor
+    meaninertia: qd.Tensor = of_kind(DataKind.INFO)
     mass_parent_mask: qd.Tensor
-    gravity: qd.Tensor
+    gravity: qd.Tensor = of_kind(DataKind.INFO)
     # Runtime constants
     substep_dt: qd.Tensor
     iterations: qd.Tensor
@@ -264,6 +388,8 @@ def get_rigid_info(solver, kinematic_only):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class IslandSlices:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # Per-(island, env) slices into a packed id array: island i_island's items are id[start[i_island, i_b] : start +
     # n[i_island, i_b]]. curr is the write cursor the partition build advances while filling each slice; once built,
     # curr == start + n. Indexed [n_entities, B] since an env has at most n_entities islands.
@@ -287,6 +413,8 @@ def get_slices(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class IslandState:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # Union-find partition of LINKS into islands. An island is a dynamic component: a maximal set of links connected
     # through the kinematic tree (a floating-base subtree) plus any contact/equality couplings. The union-find is over
     # links, with kinematic edges (link <-> parent) added alongside contact/equality edges - so a single Genesis entity
@@ -330,8 +458,8 @@ class IslandState:
     # component together as one island across steps: sleeping bodies generate no live contacts, so the contact/equality
     # union would otherwise fragment them (the kinematic edges still hold within a component). It is written at
     # hibernation time, walked at wakeup, and re-unioned by the partition build before labeling.
-    is_hibernated: qd.Tensor
-    hibernated_next_link: qd.Tensor
+    is_hibernated: qd.Tensor = of_kind(DataKind.STATE)
+    hibernated_next_link: qd.Tensor = of_kind(DataKind.STATE)
     # Compact (env, island) work-list for the cooperative per-island factor+solve. factor_worklist_size[0] is the total
     # island count across all envs (atomic-built by the partition pass); factor_worklist_i_b / factor_worklist_i_island
     # hold the env and island index of each work item. The cooperative kernel launches a static block grid and
@@ -370,7 +498,7 @@ def get_island_state(solver, collider):
         and solver.rigid_config.enable_per_island_solve
         and not solver.rigid_config.sparse_envelope
     )
-    max_candidate_contacts = max(collider._collider_info.max_candidate_contacts[None], 1)
+    max_candidate_contacts = max(collider.collider_info.max_candidate_contacts[None], 1)
     # Safe upper bound on active constraints, mirroring ConstraintSolver.len_constraints: rows_per_contact per
     # contact + joint-limit/frictionloss (<= n_dofs each) + equality rows (<= 6 each). The equality term must use the
     # candidate count (model equalities plus the dynamic-weld budget), not just the model equalities, otherwise
@@ -421,6 +549,8 @@ class IKState:
     stacks the per-target pose residuals.
     """
 
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # Single-target spatial Jacobian (6 x n_dofs), rebuilt per target link and copied into the stacked block.
     jacobian: qd.Tensor
     # Stacked multi-target Jacobian and its transpose, feeding the damped normal-equations solve.
@@ -468,6 +598,8 @@ class IKScratchFK:
     and integrates poses on caller-owned buffers without mutating live solver state. A column is an environment.
     """
 
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # Entity-local working configuration iterated by the solve.
     qpos: qd.Tensor
     # Link poses and joint frames placed by func_forward_kinematics_scratch, feeding the error and the Jacobian.
@@ -495,6 +627,8 @@ class IKTargets:
     orientations are vec-typed so the solver reads a target pose per (link, column) directly; the host populates
     every field before the solve.
     """
+
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
 
     # Global indices of the target links, the effective DOFs to move, and the columns (solver envs) to solve.
     links_idx: qd.Tensor
@@ -537,6 +671,8 @@ class KinematicsScratch:
     configuration so the global q indices callers already work in index it directly.
     """
 
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     jacobian: qd.Tensor
     qpos_cache: qd.Tensor
 
@@ -558,6 +694,7 @@ class WeightScratch(NamedTuple):
     hold.
     """
 
+    kind = DataKind.SCRATCH
     jac_row: qd.Tensor
     solve_out: qd.Tensor
 
@@ -576,6 +713,7 @@ class IKScratch(NamedTuple):
     entity spans; a column is an environment.
     """
 
+    kind = DataKind.SCRATCH
     state: IKState
     fk: IKScratchFK
     targets: IKTargets
@@ -597,22 +735,24 @@ def get_ik_scratch(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ConstraintState:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # Union-find partition of links into contact islands, read by the per-island Newton solve and hibernation.
     island: IslandState
-    is_warmstart: qd.Tensor
-    n_constraints: qd.Tensor
-    qd_n_equalities: qd.Tensor
+    is_warmstart: qd.Tensor = of_kind(DataKind.WARMSTART)
+    n_constraints: qd.Tensor = of_kind(DataKind.STATE)
+    qd_n_equalities: qd.Tensor = of_kind(DataKind.STATE)
     jac: qd.Tensor
     diag: qd.Tensor
     aref: qd.Tensor
     jac_dofs_idx: qd.Tensor
     jac_n_dofs: qd.Tensor
-    n_constraints_equality: qd.Tensor
-    n_constraints_frictionloss: qd.Tensor
+    n_constraints_equality: qd.Tensor = of_kind(DataKind.STATE)
+    n_constraints_frictionloss: qd.Tensor = of_kind(DataKind.STATE)
     # Number of elliptic-cone contact rows (rows_per_contact per contact), laid out contiguously at the start of the
     # collision segment. Zero for the pyramidal cone. The cone rows occupy
     # [ne + n_frictionloss, ne + n_frictionloss + n_cone).
-    n_constraints_cone: qd.Tensor
+    n_constraints_cone: qd.Tensor = of_kind(DataKind.STATE)
     improved: qd.Tensor
     Jaref: qd.Tensor
     Ma: qd.Tensor
@@ -628,12 +768,12 @@ class ConstraintState:
     # contact sliding friction coefficient read by the cone solver, and with torsional friction the spin row carries
     # the torsional coefficient the same way (the tangent rows hold 0).
     efc_frictionloss: qd.Tensor
-    efc_force: qd.Tensor
-    active: qd.Tensor
+    efc_force: qd.Tensor = of_kind(DataKind.STATE)
+    active: qd.Tensor = of_kind(DataKind.STATE)
     prev_active: qd.Tensor
-    qfrc_constraint: qd.Tensor
-    qacc: qd.Tensor
-    qacc_ws: qd.Tensor
+    qfrc_constraint: qd.Tensor = of_kind(DataKind.STATE)
+    qacc: qd.Tensor = of_kind(DataKind.STATE)
+    qacc_ws: qd.Tensor = of_kind(DataKind.WARMSTART)
     qacc_prev: qd.Tensor
     cost_ws: qd.Tensor
     cost: qd.Tensor
@@ -681,14 +821,14 @@ class ConstraintState:
     # Skyline envelope: nt_H_env_start[i_b, i_d] is the first (smallest) column index with a structural
     # nonzero in row i_d of the Hessian. Cholesky fill-in stays within this envelope, so the factor and
     # solve loops only need to visit columns [nt_H_env_start[i_d], i_d]. Only meaningful with sparse_solve.
-    nt_H_env_start: qd.Tensor
+    nt_H_env_start: qd.Tensor = of_kind(DataKind.CONSTANT)
     # Fill-reducing DOF reordering (sparse_solve). dof_perm[i_b, p] = original DOF at permuted position p;
     # dof_iperm[i_b, d] = permuted position of original DOF d. The Hessian is assembled, factored and solved in
     # permuted order (a spatial sort of bodies that keeps coupled DOFs index-adjacent), making the skyline band
     # insensitive to insertion order; grad/Mgrad are indexed through dof_perm at the solve boundary so the rest of
     # the solver stays in natural order. dof_sort_key is per-DOF scratch for the spatial sort.
-    dof_perm: qd.Tensor
-    dof_iperm: qd.Tensor
+    dof_perm: qd.Tensor = of_kind(DataKind.CONSTANT)
+    dof_iperm: qd.Tensor = of_kind(DataKind.CONSTANT)
     dof_sort_key: qd.Tensor
     nt_vec: qd.Tensor
     # Compacted list of constraints whose active state changed, used by incremental Cholesky update
@@ -884,6 +1024,8 @@ def get_constraint_state(constraint_solver, solver, collider):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ContactData:
+    kind: ClassVar[DataKind] = DataKind.STATE
+
     geom_a: qd.Tensor
     geom_b: qd.Tensor
     penetration: qd.Tensor
@@ -922,6 +1064,8 @@ def get_contact_data(solver, max_candidate_contacts, requires_grad):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class DiffContactInput:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     ### Non-differentiable input data
     # Geom id of the two geometries
     geom_a: qd.Tensor
@@ -970,6 +1114,8 @@ def get_diff_contact_input(_B, max_contacts_per_pair, is_active, requires_grad=F
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class SortBuffer:
+    kind: ClassVar[DataKind] = DataKind.WARMSTART
+
     value: qd.Tensor
     i_g: qd.Tensor
     is_max: qd.Tensor
@@ -987,6 +1133,8 @@ def get_sort_buffer(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ContactCache:
+    kind: ClassVar[DataKind] = DataKind.WARMSTART
+
     normal: qd.Tensor
     # Previous-step penetration per pair (reset to 0 when out of contact), the warm-start for the MPR->GJK gate.
     penetration: qd.Tensor
@@ -1002,6 +1150,8 @@ def get_contact_cache(solver, n_possible_pairs):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class NarrowphaseWorkQueues:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     mpr_i_b: qd.Tensor
     mpr_i_ga: qd.Tensor
     mpr_i_gb: qd.Tensor
@@ -1033,6 +1183,8 @@ def get_narrowphase_work_queues(max_entries):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ColliderState:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     sort_buffer: SortBuffer
     contact_data: ContactData
     active_buffer: qd.Tensor
@@ -1050,15 +1202,15 @@ class ColliderState:
     box_pu: qd.Tensor
     xyz_max_min: qd.Tensor
     prism: qd.Tensor
-    n_contacts: qd.Tensor
-    n_contacts_hibernated: qd.Tensor
-    first_time: qd.Tensor
+    n_contacts: qd.Tensor = of_kind(DataKind.STATE)
+    n_contacts_hibernated: qd.Tensor = of_kind(DataKind.STATE)
+    first_time: qd.Tensor = of_kind(DataKind.WARMSTART)
     contact_cache: ContactCache
     # Input data for differentiable contact detection used in the backward pass
     diff_contact_input: DiffContactInput
     narrowphase_work_queues: NarrowphaseWorkQueues
     contact_sort_key: qd.Tensor
-    contact_sort_idx: qd.Tensor
+    contact_sort_idx: qd.Tensor = of_kind(DataKind.STATE)
     contact_proj_v: qd.Tensor
     contact_keep: qd.Tensor
     contact_hull_stack: qd.Tensor
@@ -1130,6 +1282,8 @@ def get_collider_state(
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VertsSpatialGrid:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     # Per-geom 8x8x8 grid over collision verts in the local AABB: a permutation of vert indices sorted by grid
     # cell (z fastest), the matching vert positions duplicated in that order for sequential streaming, and per-cell
     # vert ranges (8^3 + 1 entries per geom), so a scan visits only the cells overlapping a query box. The cell
@@ -1186,6 +1340,8 @@ class ColliderStaticConfig(metaclass=AutoInitMeta):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class MPRSimplexSupport:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     v1: qd.Tensor
     v2: qd.Tensor
     v: qd.Tensor
@@ -1201,6 +1357,8 @@ def get_mpr_simplex_support(B_):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class MPRState:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     simplex_support: MPRSimplexSupport
     simplex_size: qd.Tensor
     # What the depth of the contact in simplex_support[1..3] is worth, a PORTAL_STATUS value. Zero means no portal.
@@ -1218,6 +1376,8 @@ def get_mpr_state(B_):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class MPRInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     CCD_EPS: qd.Tensor
     CCD_TOLERANCE: qd.Tensor
     CCD_ITERATIONS: qd.Tensor
@@ -1236,6 +1396,8 @@ def get_mpr_info(**kwargs):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class MDVertex:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # Vertex of the Minkowski difference
     obj1: qd.Tensor
     obj2: qd.Tensor
@@ -1275,6 +1437,8 @@ def get_epa_polytope_vertex(_B, gjk_info, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class GJKSimplex:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     nverts: qd.Tensor
 
 
@@ -1285,6 +1449,8 @@ def get_gjk_simplex(_B, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class GJKSimplexBuffer:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     normal: qd.Tensor
     sdist: qd.Tensor
 
@@ -1296,6 +1462,8 @@ def get_gjk_simplex_buffer(_B, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EPAPolytope:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     nverts: qd.Tensor
     nfaces: qd.Tensor
     nfaces_map: qd.Tensor
@@ -1316,6 +1484,8 @@ def get_epa_polytope(_B, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EPAPolytopeFace:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     verts_idx: qd.Tensor
     adj_idx: qd.Tensor
     normal: qd.Tensor
@@ -1338,6 +1508,8 @@ def get_epa_polytope_face(_B, polytope_max_faces, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EPAPolytopeHorizonData:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     face_idx: qd.Tensor
     edge_idx: qd.Tensor
 
@@ -1349,6 +1521,8 @@ def get_epa_polytope_horizon_data(_B, polytope_max_horizons, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ContactFace:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     vert1: qd.Tensor
     vert2: qd.Tensor
     endverts: qd.Tensor
@@ -1373,6 +1547,8 @@ def get_contact_face(_B, max_contact_polygon_verts, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ContactNormal:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     endverts: qd.Tensor
     normal: qd.Tensor
     id: qd.Tensor
@@ -1389,6 +1565,8 @@ def get_contact_normal(_B, max_contact_polygon_verts, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ContactHalfspace:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     normal: qd.Tensor
     dist: qd.Tensor
 
@@ -1400,6 +1578,8 @@ def get_contact_halfspace(_B, max_contact_polygon_verts, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class Witness:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     point_obj1: qd.Tensor
     point_obj2: qd.Tensor
 
@@ -1413,6 +1593,8 @@ def get_witness(_B, max_contacts_per_pair, is_active):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class GJKState:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     support_mesh_prev_vertex_id: qd.Tensor
     simplex_vertex: MDVertex
     simplex_buffer: GJKSimplexBuffer
@@ -1552,6 +1734,8 @@ def get_gjk_state_contact_only(_B):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class GJKInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     max_contacts_per_pair: qd.Tensor
     max_contact_polygon_verts: qd.Tensor
     # Maximum number of iterations for GJK and EPA algorithms
@@ -1644,6 +1828,8 @@ class GJKStaticConfig(metaclass=AutoInitMeta):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class SupportFieldInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     support_cell_start: qd.Tensor
     support_v: qd.Tensor
     support_vid: qd.Tensor
@@ -1664,6 +1850,8 @@ def get_support_field_info(n_geoms, n_support_cells, support_res):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class SDFGeomInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     T_mesh_to_sdf: qd.Tensor
     sdf_res: qd.Tensor
     sdf_max: qd.Tensor
@@ -1688,6 +1876,8 @@ def get_sdf_geom_info(n_geoms):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class SDFInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     geoms_info: SDFGeomInfo
     geoms_sdf_start: qd.Tensor
     geoms_sdf_val: qd.Tensor
@@ -1718,6 +1908,8 @@ def get_sdf_info(n_geoms, n_cells, n_coarse_cells):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class ColliderInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     # Narrowphase sub-component descriptions, owned by their respective builders (MPR, GJK, SupportField, SDF) and
     # embedded here so kernels receive the whole collider description as one argument. Each has a single instance,
     # activated (which may reallocate it at its final size) before this struct is built; a reassignment after the
@@ -1817,6 +2009,8 @@ def get_collider_info(
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class DofsInfo:
+    kind: ClassVar[DataKind] = DataKind.INFO
+
     entity_idx: qd.Tensor
     stiffness: qd.Tensor
     invweight: qd.Tensor
@@ -1854,6 +2048,8 @@ def get_dofs_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class DofsState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     # *_bw: Cache to avoid overwriting for backward pass
     force: qd.Tensor
     qf_bias: qd.Tensor
@@ -1862,10 +2058,10 @@ class DofsState:
     qf_applied: qd.Tensor
     act_length: qd.Tensor
     pos: qd.Tensor
-    vel: qd.Tensor
-    vel_prev: qd.Tensor
-    vel_next: qd.Tensor
-    acc: qd.Tensor
+    vel: qd.Tensor = of_kind(DataKind.STATE)
+    vel_prev: qd.Tensor = of_kind(DataKind.SCRATCH)
+    vel_next: qd.Tensor = of_kind(DataKind.SCRATCH)
+    acc: qd.Tensor = of_kind(DataKind.STATE)
     acc_smooth: qd.Tensor
     acc_smooth_bw: qd.Tensor
     qf_smooth: qd.Tensor
@@ -1878,11 +2074,11 @@ class DofsState:
     cdofd_vel: qd.Tensor
     f_vel: qd.Tensor
     f_ang: qd.Tensor
-    ctrl_force: qd.Tensor
-    ctrl_pos: qd.Tensor
-    ctrl_vel: qd.Tensor
-    ctrl_mode: qd.Tensor
-    is_hibernated: qd.Tensor
+    ctrl_force: qd.Tensor = of_kind(DataKind.STATE)
+    ctrl_pos: qd.Tensor = of_kind(DataKind.STATE)
+    ctrl_vel: qd.Tensor = of_kind(DataKind.STATE)
+    ctrl_mode: qd.Tensor = of_kind(DataKind.STATE)
+    is_hibernated: qd.Tensor = of_kind(DataKind.STATE)
 
 
 def get_dofs_state(solver):
@@ -1927,6 +2123,8 @@ def get_dofs_state(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class LinksState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     # *_bw: Cache to avoid overwriting for backward pass
     cinr_inertial: qd.Tensor
     cinr_pos: qd.Tensor
@@ -1966,13 +2164,13 @@ class LinksState:
     cacc_lin: qd.Tensor
     cfrc_ang: qd.Tensor
     cfrc_vel: qd.Tensor
-    cfrc_applied_ang: qd.Tensor
-    cfrc_applied_vel: qd.Tensor
+    cfrc_applied_ang: qd.Tensor = of_kind(DataKind.STATE)
+    cfrc_applied_vel: qd.Tensor = of_kind(DataKind.STATE)
     cfrc_coupling_ang: qd.Tensor
     cfrc_coupling_vel: qd.Tensor
     contact_force: qd.Tensor
-    is_hibernated: qd.Tensor
-    awake_steps: qd.Tensor
+    is_hibernated: qd.Tensor = of_kind(DataKind.STATE)
+    awake_steps: qd.Tensor = of_kind(DataKind.STATE)
 
 
 def get_links_state(solver):
@@ -2030,6 +2228,8 @@ def get_links_state(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class LinksInfo:
+    kind: ClassVar[DataKind] = DataKind.INFO
+
     parent_idx: qd.Tensor
     root_idx: qd.Tensor
     q_start: qd.Tensor
@@ -2090,6 +2290,8 @@ def get_links_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class JointsInfo:
+    kind: ClassVar[DataKind] = DataKind.INFO
+
     type: qd.Tensor
     sol_params: qd.Tensor
     q_start: qd.Tensor
@@ -2117,6 +2319,8 @@ def get_joints_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class JointsState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     xanchor: qd.Tensor
     xaxis: qd.Tensor
 
@@ -2136,6 +2340,8 @@ def get_joints_state(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class GeomsInfo:
+    kind: ClassVar[DataKind] = DataKind.INFO
+
     pos: qd.Tensor
     center: qd.Tensor
     quat: qd.Tensor
@@ -2209,6 +2415,8 @@ def get_geoms_info(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class GeomsState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     pos: qd.Tensor
     quat: qd.Tensor
     aabb_min: qd.Tensor
@@ -2216,8 +2424,8 @@ class GeomsState:
     verts_updated: qd.Tensor
     min_buffer_idx: qd.Tensor
     max_buffer_idx: qd.Tensor
-    is_hibernated: qd.Tensor
-    friction_ratio: qd.Tensor
+    is_hibernated: qd.Tensor = of_kind(DataKind.STATE)
+    friction_ratio: qd.Tensor = of_kind(DataKind.INFO)
 
 
 def get_geoms_state(solver, is_active=True):
@@ -2242,6 +2450,8 @@ def get_geoms_state(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VertsInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     init_pos: qd.Tensor
     init_normal: qd.Tensor
     geom_idx: qd.Tensor
@@ -2268,6 +2478,8 @@ def get_verts_info(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class FacesInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     verts_idx: qd.Tensor
     geom_idx: qd.Tensor
 
@@ -2283,6 +2495,8 @@ def get_faces_info(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EdgesInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     v0: qd.Tensor
     v1: qd.Tensor
     length: qd.Tensor
@@ -2301,6 +2515,8 @@ def get_edges_info(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VertsState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     pos: qd.Tensor
 
 
@@ -2317,6 +2533,8 @@ def get_fixed_verts_state(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VVertsInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     init_pos: qd.Tensor
     init_vnormal: qd.Tensor
     vgeom_idx: qd.Tensor
@@ -2339,6 +2557,8 @@ def get_vverts_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VVertsState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     pos: qd.Tensor
 
 
@@ -2358,6 +2578,8 @@ def get_vverts_state(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VFacesInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     vverts_idx: qd.Tensor
     vgeom_idx: qd.Tensor
 
@@ -2373,6 +2595,8 @@ def get_vfaces_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VGeomsInfo:
+    kind: ClassVar[DataKind] = DataKind.CONSTANT
+
     pos: qd.Tensor
     quat: qd.Tensor
     link_idx: qd.Tensor
@@ -2407,6 +2631,8 @@ def get_vgeoms_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class VGeomsState:
+    kind: ClassVar[DataKind] = DataKind.DERIVED
+
     pos: qd.Tensor
     quat: qd.Tensor
 
@@ -2422,6 +2648,8 @@ def get_vgeoms_state(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EqualitiesInfo:
+    kind: ClassVar[DataKind] = DataKind.INFO
+
     eq_obj1id: qd.Tensor
     eq_obj2id: qd.Tensor
     eq_data: qd.Tensor
@@ -2446,6 +2674,8 @@ def get_equalities_info(solver, is_active=True):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EntitiesInfo:
+    kind: ClassVar[DataKind] = DataKind.INFO
+
     dof_start: qd.Tensor
     dof_end: qd.Tensor
     n_dofs: qd.Tensor
@@ -2482,6 +2712,8 @@ def get_entities_info(solver):
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class EntitiesState:
+    kind: ClassVar[DataKind] = DataKind.STATE
+
     is_hibernated: qd.Tensor
 
 
@@ -2492,6 +2724,8 @@ def get_entities_state(solver, is_active=True):
 # =========================================== RigidAdjointCache ===========================================
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class RigidAdjointCache:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     # This cache stores intermediate values during rigid body simulation to use Quadrants's AD. Quadrants's AD requires
     # us not to overwrite the values that have been read during the forward pass, so we need to store the intemediate
     # values in this cache to avoid overwriting them. Specifically, after we compute next frame's qpos, dofs_vel, and
@@ -2803,6 +3037,8 @@ class DataManager:
 
 @dataclasses.dataclass(eq=True, kw_only=False, frozen=True)
 class RaycastResult:
+    kind: ClassVar[DataKind] = DataKind.SCRATCH
+
     distance: qd.Tensor
     geom_idx: qd.Tensor
     hit_point: qd.Tensor

--- a/genesis/utils/misc.py
+++ b/genesis/utils/misc.py
@@ -1,4 +1,5 @@
 import ctypes
+import dataclasses
 import datetime
 import functools
 import io
@@ -898,15 +899,19 @@ def qd_zero_grad(value) -> None:
         return
 
     cls = type(value)
-    try:
-        annotations = cls.__dict__["__annotations__"]
-    except KeyError as err:
-        raise_exception_from(
-            f"qd_zero_grad: expected `qd.Field`, `qd.Ndarray`, or a `dataclass` / `@qd.data_oriented` "
-            f"struct-of-arrays; got `{cls.__name__}`.",
-            cause=err,
-        )
-    for attr_name in annotations:
+    if dataclasses.is_dataclass(cls):
+        # The fields alone: a struct also declares its data kind as a class variable (see array_class.DataKind)
+        attr_names = [field.name for field in dataclasses.fields(cls)]
+    else:
+        try:
+            attr_names = cls.__dict__["__annotations__"]
+        except KeyError as err:
+            raise_exception_from(
+                f"qd_zero_grad: expected `qd.Field`, `qd.Ndarray`, or a `dataclass` / `@qd.data_oriented` "
+                f"struct-of-arrays; got `{cls.__name__}`.",
+                cause=err,
+            )
+    for attr_name in attr_names:
         qd_zero_grad(getattr(value, attr_name, None))
 
 

--- a/genesis/utils/path_planning.py
+++ b/genesis/utils/path_planning.py
@@ -204,7 +204,7 @@ class PathPlanner(ABC):
                 obj_geom_end,
                 ignore_geom_pairs,
                 out,
-                self._solver.collider._collider_state,
+                self._solver.collider.collider_state,
                 is_plan_with_obj,
             )
         return out
@@ -564,7 +564,7 @@ class RRT(PathPlanner):
                     obj_geom_start,
                     obj_geom_end,
                     ignore_geom_pairs,
-                    self._solver.collider._collider_state,
+                    self._solver.collider.collider_state,
                     ignore_collision,
                     is_plan_with_obj,
                 )
@@ -943,7 +943,7 @@ class RRTConnect(PathPlanner):
                 obj_geom_start,
                 obj_geom_end,
                 ignore_geom_pairs,
-                self._solver.collider._collider_state,
+                self._solver.collider.collider_state,
                 self._solver.rigid_info,
                 forward_pass,
                 ignore_collision,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -993,3 +993,23 @@ def png_snapshot(request, snapshot):
         )
 
     return snapshot_obj
+
+
+@pytest.fixture
+def trajectory_snapshot(request) -> Path:
+    from genesis.recorders.trajectory import TRAJECTORY_FORMAT
+
+    from .utils.assets import get_hf_dataset
+
+    # The path is the one syrupy gives a single-file snapshot of the test. The test reads the file itself, so syrupy
+    # leaves it out of its count of unused snapshots.
+    path = request.path.parent / "__snapshots__" / request.path.stem / f"{request.node.name}{TRAJECTORY_FORMAT}"
+    # The brackets of a parametrized test name are escaped for the same reason as in 'png_snapshot'
+    snapshot_pattern = "".join(f"[{char}]" if char in ("[", "]") else char for char in path.name)
+    tests_dir = Path(__file__).parent
+    get_hf_dataset(
+        pattern=f"{path.parent.relative_to(tests_dir).as_posix()}/{snapshot_pattern}",
+        repo_name="snapshots",
+        local_dir=tests_dir,
+    )
+    return path

--- a/tests/core/test_quadrants.py
+++ b/tests/core/test_quadrants.py
@@ -113,9 +113,9 @@ def gs_static_child(args: list[str]):
     scene.build()
 
     scene.rigid_solver.collider.detection()
-    actual_contacts = scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()
+    actual_contacts = scene.rigid_solver.collider.collider_state.n_contacts.to_numpy()
     assert actual_contacts == args.expected_num_contacts
-    if scene.rigid_solver.collider._collider_static_config.has_non_box_plane_convex_convex:
+    if scene.rigid_solver.collider.collider_config.has_non_box_plane_convex_convex:
         from genesis.engine.solvers.rigid.collider import _func_narrowphase_contact0
 
         kernel_to_check = _func_narrowphase_contact0

--- a/tests/core/test_recorders.py
+++ b/tests/core/test_recorders.py
@@ -50,7 +50,7 @@ def test_vector_field_plotter_subplots(mpl_agg_backend, png_snapshot):
     def grid_data():
         return np.stack([(positions - 0.5) * (i_title + 1) * 0.1 for i_title in range(len(titles))])
 
-    grid_plotter = scene.start_recording(
+    grid_plotter = scene.add_recorder(
         data_func=grid_data,
         rec_options=gs.recorders.MPLVectorFieldPlot(
             title="grid",
@@ -60,7 +60,7 @@ def test_vector_field_plotter_subplots(mpl_agg_backend, png_snapshot):
             subplot_titles=titles,
         ),
     )
-    single_plotter = scene.start_recording(
+    single_plotter = scene.add_recorder(
         data_func=lambda: (positions - 0.5) * 0.1,
         rec_options=gs.recorders.MPLVectorFieldPlot(
             title="single",
@@ -80,7 +80,7 @@ def test_vector_field_plotter_subplots(mpl_agg_backend, png_snapshot):
         twist[..., 2] = expected_twist
         return vectors, twist
 
-    twist_plotter = scene.start_recording(
+    twist_plotter = scene.add_recorder(
         data_func=twist_data,
         rec_options=gs.recorders.MPLVectorFieldPlot(
             title="twist",
@@ -157,7 +157,7 @@ def test_plotter(tmp_path, monkeypatch, mpl_agg_backend, png_snapshot):
             "b": [call_count * 0.01, call_count * 0.02],
         }
 
-    plotter = scene.start_recording(
+    plotter = scene.add_recorder(
         data_func=dummy_data_func,
         rec_options=gs.recorders.MPLLinePlot(
             labels={"a": ("x", "y", "z"), "b": ("u", "v")},
@@ -219,13 +219,13 @@ def test_file_writers(tmp_path):
     contact_sensor.start_recording(csv_writer)
 
     csv_array_file = tmp_path / "array_data.csv"
-    scene.start_recording(
+    scene.add_recorder(
         data_func=lambda: {"batch": np.arange(6).reshape(2, 3)},
         rec_options=gs.recorders.CSVFile(filename=csv_array_file),
     )
 
     npz_file = tmp_path / "scene_data.npz"
-    scene.start_recording(
+    scene.add_recorder(
         data_func=lambda: {"box_pos": box.get_pos(), "dummy": 1},
         rec_options=gs.recorders.NPZFile(filename=npz_file),
     )
@@ -287,7 +287,7 @@ def test_video_writer(tmp_path):
     )
     # Registered first, so that rejecting its very last frame aborts the step before the others have sampled it
     video_dtype_path = tmp_path / "test_dtype.mp4"
-    scene.start_recording(
+    scene.add_recorder(
         data_func=lambda: (
             np.zeros((64, 64, 3), dtype=np.uint8) if scene.sim.cur_step_global <= STEPS else np.full((64, 64, 3), 0.5)
         ),
@@ -296,7 +296,7 @@ def test_video_writer(tmp_path):
         ),
     )
     video_rgb_path = tmp_path / "test_rgb.mp4"
-    scene.start_recording(
+    scene.add_recorder(
         data_func=lambda: camera.render(rgb=True, depth=False, segmentation=False, normal=False)[0],
         # No explicit codec — exercises automatic codec selection
         rec_options=gs.recorders.VideoFile(
@@ -304,7 +304,7 @@ def test_video_writer(tmp_path):
         ),
     )
     video_depth_path = tmp_path / "test_depth.mp4"
-    scene.start_recording(
+    scene.add_recorder(
         data_func=lambda: as_grayscale_image(camera.render(rgb=False, depth=True, segmentation=False, normal=False)[1]),
         rec_options=gs.recorders.VideoFile(
             filename=video_depth_path,

--- a/tests/core/test_recorders.py
+++ b/tests/core/test_recorders.py
@@ -1,4 +1,5 @@
 import csv
+import time
 
 import numpy as np
 import pytest
@@ -180,11 +181,12 @@ def test_plotter(tmp_path, monkeypatch, mpl_agg_backend, png_snapshot):
 
     assert call_count == STEPS // 2 + 1  # one additional call during plot setup
     assert len(plotter.line_plot.x_data) == HISTORY_LENGTH
-    assert np.isclose(plotter.line_plot.x_data[-1], STEPS * DT, atol=gs.EPS)
+    # A recorder reads the state a step starts from, so the last sample is the one before the second to last step
+    assert np.isclose(plotter.line_plot.x_data[-1], (STEPS - 2) * DT, atol=gs.EPS)
     assert rgb_array_to_png_bytes(plotter.get_image_array()) == png_snapshot
 
     assert len(buffers) == 5
-    assert_allclose([cur_time for _, cur_time in buffers], np.arange(STEPS + 1)[::2][1:] * DT, tol=gs.EPS)
+    assert_allclose([cur_time for _, cur_time in buffers], np.arange(STEPS)[::2] * DT, tol=gs.EPS)
     for rgb_diff in np.diff([data for data, _ in buffers], axis=0):
         assert rgb_diff.max() > 10.0
 
@@ -242,7 +244,7 @@ def test_file_writers(tmp_path):
         reader = csv.reader(f)
         rows = list(reader)
 
-        assert len(rows) == STEPS + 1  # header + data rows
+        assert len(rows) == STEPS + 2  # header, the state before each step and the state the run stopped at
         assert rows[1][1] in ("False", "0")  # not in contact initially
         assert rows[-1][1] in ("True", "1")  # in contact after falling
 
@@ -259,7 +261,104 @@ def test_file_writers(tmp_path):
     assert "timestamp" in data
     assert "box_pos" in data
     assert "dummy" in data
-    assert len(data["timestamp"]) == STEPS
+    assert len(data["timestamp"]) == STEPS + 1
+
+
+@pytest.mark.required
+def test_error_handling(tmp_path):
+    scene = gs.Scene(
+        show_viewer=False,
+    )
+    box = scene.add_entity(
+        morph=gs.morphs.Box(
+            size=(0.1, 0.1, 0.1),
+            pos=(0.0, 0.0, 1.0),
+        ),
+    )
+    # Recorder options are checked as they are built
+    with pytest.raises(gs.GenesisException, match="not supported"):
+        gs.recorders.VideoFile(filename=tmp_path / "video.mp4", codec="no_such_codec")
+    # A recorder that raises records no more, a reset included. Registered first, the rejection of a frame aborts the
+    # step before the other recorders sample it. The first video rejects the frame the stop records, so it samples every
+    # step, the reset and the stop, and the second one rejects its third frame.
+    stop_video_frames = [np.zeros((64, 64, 3), dtype=np.uint8)] * 7 + [np.full((64, 64, 3), 0.5)]
+    scene.add_recorder(
+        data_func=lambda: stop_video_frames.pop(0),
+        rec_options=gs.recorders.VideoFile(
+            filename=tmp_path / "stop.mp4",
+        ),
+    )
+    step_video_path = tmp_path / "step.mp4"
+    step_video_frames = [np.zeros((64, 64, 3), dtype=np.uint8)] * 2 + [np.full((64, 64, 3), 0.5)]
+    scene.add_recorder(
+        data_func=lambda: step_video_frames.pop(0),
+        rec_options=gs.recorders.VideoFile(
+            filename=step_video_path,
+        ),
+    )
+    pos_path = tmp_path / "pos.csv"
+    scene.add_recorder(
+        data_func=box.get_pos,
+        rec_options=gs.recorders.CSVFile(
+            filename=pos_path,
+        ),
+    )
+    # Both reject the value of their second sample. Registered last, the failure of the second one is raised once the
+    # other recorders have sampled the step.
+    synced_values, stepped_values = [1.0, None], [1.0, None]
+    synced_path = tmp_path / "synced.csv"
+    synced_recorder = scene.add_recorder(
+        data_func=lambda: synced_values.pop(0),
+        rec_options=gs.recorders.CSVFile(
+            filename=synced_path,
+        ),
+    )
+    stepped_recorder = scene.add_recorder(
+        data_func=lambda: stepped_values.pop(0),
+        rec_options=gs.recorders.CSVFile(
+            filename=tmp_path / "stepped.csv",
+        ),
+    )
+    scene.build()
+    # A recorder sizes its buffers from the build, so none is registered after it
+    with pytest.raises(gs.GenesisException):
+        scene.add_recorder(data_func=box.get_pos, rec_options=gs.recorders.CSVFile(filename=tmp_path / "late.csv"))
+
+    scene.step()
+    scene.step()
+    # A failure on the recording thread is raised on the stepping thread, once, by the sync that waits for it or at the
+    # next step the recorder is reached once it failed
+    with pytest.raises(gs.GenesisException, match="Unsupported data type"):
+        synced_recorder.sync()
+    for _ in range(1000):
+        if not stepped_recorder.is_alive:
+            break
+        time.sleep(0.01)
+    assert not stepped_recorder.is_alive
+    # A normalized floating-point frame cannot be represented and is reported, rather than truncated to a black one. The
+    # step recording it is aborted.
+    with pytest.raises(gs.GenesisException, match="integer type"):
+        scene.step()
+    with pytest.raises(gs.GenesisException, match="Unsupported data type"):
+        scene.step()
+    # A reset restarts the recorders that did not fail
+    scene.reset()
+    scene.step()
+    scene.step()
+
+    # The state the run stopped at reaches every recorder, then the recorders are stopped and the failure is raised,
+    # and the destruction of the scene completes behind it
+    with pytest.raises(gs.GenesisException, match="integer type"):
+        scene.destroy()
+    assert scene.sim is None and scene.visualizer is None
+    # The header, then the first, second and fourth steps and the reset, then the two steps and the stop
+    with open(pos_path, "r") as f:
+        assert len(list(csv.reader(f))) == 1 + 4 + 3
+    # The header, then the first step
+    with open(synced_path, "r") as f:
+        assert len(list(csv.reader(f))) == 1 + 1
+    with av.open(step_video_path) as container:
+        assert sum(1 for _ in container.decode(video=0)) == 2
 
 
 @pytest.mark.required
@@ -285,16 +384,6 @@ def test_video_writer(tmp_path):
         lookat=(0.0, 0.0, 0.2),
         GUI=False,
     )
-    # Registered first, so that rejecting its very last frame aborts the step before the others have sampled it
-    video_dtype_path = tmp_path / "test_dtype.mp4"
-    scene.add_recorder(
-        data_func=lambda: (
-            np.zeros((64, 64, 3), dtype=np.uint8) if scene.sim.cur_step_global <= STEPS else np.full((64, 64, 3), 0.5)
-        ),
-        rec_options=gs.recorders.VideoFile(
-            filename=video_dtype_path,
-        ),
-    )
     video_rgb_path = tmp_path / "test_rgb.mp4"
     scene.add_recorder(
         data_func=lambda: camera.render(rgb=True, depth=False, segmentation=False, normal=False)[0],
@@ -315,16 +404,12 @@ def test_video_writer(tmp_path):
     for _ in range(STEPS):
         scene.step()
 
-    # A normalized floating-point frame cannot be represented and must be reported, whichever frame it is, rather than
-    # truncated to a black one
-    with pytest.raises(gs.GenesisException, match="integer type"):
-        scene.step()
-
     scene.stop_recording()
 
     # Every sampled step must survive into the file: frames buffered by the encoder but never flushed, or dropped
-    # because it fell behind, would leave a shorter video that a size check cannot distinguish from a complete one
-    for video_path in (video_dtype_path, video_rgb_path, video_depth_path):
+    # because it fell behind, would leave a shorter video that a size check cannot distinguish from a complete one. Each
+    # file holds the state before each step, then the state the run stopped at.
+    for video_path in (video_rgb_path, video_depth_path):
         assert video_path.exists(), "Recorded video file should exist"
         with av.open(video_path) as container:
-            assert sum(1 for _ in container.decode(video=0)) == STEPS
+            assert sum(1 for _ in container.decode(video=0)) == STEPS + 1

--- a/tests/grad/test_rigid_collision.py
+++ b/tests/grad/test_rigid_collision.py
@@ -80,7 +80,7 @@ def test_contact_per_step_force_grad_matches_fd(shape, grad_capsule, precision, 
         return scene, obj
 
     def _n_contacts(scene):
-        return qd_to_numpy(scene.rigid_solver.collider._collider_state.n_contacts)[0]
+        return qd_to_numpy(scene.rigid_solver.collider.collider_state.n_contacts)[0]
 
     # Rest z puts the body's lowest point on its support: box / sphere half extent 0.2, upright capsule
     # radius 0.1 + half length 0.2 = 0.3, box-on-ground centered at 0.40.
@@ -354,7 +354,7 @@ def test_contact_detection_jacobian_matches_fd():
                     sphere1.set_pos(sphere1_init_pos)
                     box0.set_quat(box0_init_quat + sign * rand_dx[0, 0] * fd_eps)
                     box1.set_quat(box1_init_quat + sign * rand_dx[1, 0] * fd_eps)
-                collider._collider_state.n_contacts.fill(0)
+                collider.collider_state.n_contacts.fill(0)
                 collider.detection()
                 c = collider.get_contacts(as_tensor=True, to_torch=True, keep_batch_dim=True)
                 losses.append(((c["normal"] * c["position"]).sum(dim=-1) * c["penetration"]).sum())
@@ -373,7 +373,7 @@ def test_contact_detection_jacobian_matches_fd():
     box1.set_pos(box1_init_pos)
     box0.set_quat(box0_init_quat)
     box1.set_quat(box1_init_quat)
-    collider._collider_state.n_contacts.fill(0)
+    collider.collider_state.n_contacts.fill(0)
     collider.detection()
     contacts = collider.get_contacts(as_tensor=True, to_torch=True, keep_batch_dim=True)
     assert torch.isfinite(contacts["normal"]).all()

--- a/tests/rigid/test_api.py
+++ b/tests/rigid/test_api.py
@@ -62,7 +62,7 @@ def test_data_accessor(n_envs, batched, tol):
     for _ in range(400):
         scene.step()
 
-        gs_n_contacts = gs_s.collider._collider_state.n_contacts.to_numpy()
+        gs_n_contacts = gs_s.collider.collider_state.n_contacts.to_numpy()
         assert len(gs_n_contacts) == max(n_envs, 1)
         for as_tensor in (False, True):
             for to_torch in (False, True):
@@ -96,7 +96,7 @@ def test_data_accessor(n_envs, batched, tol):
 
     # 'is_padded' returns a fixed capacity (independent of the live contact count) plus per-env 'n_contacts',
     # with the live prefix identical to the trimmed result, for every (as_tensor, to_torch) and batching.
-    capacity = max(gs_s.collider._collider_info.max_candidate_contacts[None], 1)
+    capacity = max(gs_s.collider.collider_info.max_candidate_contacts[None], 1)
     for as_tensor in (False, True):
         for to_torch in (False, True):
             trimmed = gs_s.collider.get_contacts(as_tensor, to_torch, is_padded=False)

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -2005,7 +2005,7 @@ def test_merge_entities(is_fixed, merge_fixed_links, show_viewer, tol, monkeypat
         box.attach(hand, "right_finger")
 
     # Make sure that collision between hand base link and franka attachment point has been filtered out as adjacent
-    collision_pair_idx = scene.rigid_solver.collider._collider_info.collision_pair_idx.to_numpy()
+    collision_pair_idx = scene.rigid_solver.collider.collider_info.collision_pair_idx.to_numpy()
     assert collision_pair_idx[franka.get_link("attachment").idx, hand.base_link_idx] == -1
 
     with pytest.raises(gs.GenesisException):

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -615,7 +615,7 @@ def test_contact_dedup(surface_kind, show_viewer):
         scene.step()
         if i == 20:
             sphere.set_dofs_velocity(0.2, dofs_idx_local=sphere.dof_start)
-        n_contacts = scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()
+        n_contacts = scene.rigid_solver.collider.collider_state.n_contacts.to_numpy()
         assert np.all(n_contacts == 1), f"Expected 1 contact after dedup, got {n_contacts}"
 
 
@@ -948,7 +948,7 @@ def test_contact_pruning_degenerated_hull(model_name, xml_path, show_viewer):
         scene.step()
     for _ in range(300):
         scene.step()
-        n_contacts = scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()
+        n_contacts = scene.rigid_solver.collider.collider_state.n_contacts.to_numpy()
         assert n_contacts.all()
         if model_name.startswith("side_by_side"):
             assert (n_contacts == 4).all()
@@ -1023,14 +1023,14 @@ def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, err
                 ),
             )
     scene.build()
-    assert scene.rigid_solver.collider._collider_static_config.has_prunable_contacts
+    assert scene.rigid_solver.collider.collider_config.has_prunable_contacts
 
     # The resolved contact budget must match the documented resolution: 32 contact points per link pair floored at
     # 512 when automatic (every link pair here has more than 32 candidate contact points), the explicit value clamped
     # to the candidate buffer size otherwise. The constraint buffers are sized accordingly, with 4 constraint rows
     # per contact point (all joints are free so there is no joint-limit term).
     solver = scene.rigid_solver
-    collider_info = solver.collider._collider_info
+    collider_info = solver.collider.collider_info
     if max_contacts is None:
         n_link_pairs = (N_BOWLS + 1) * N_BOWLS // 2
         expected_max_contacts = max(32 * n_link_pairs, 512)
@@ -1402,7 +1402,7 @@ def test_neutral_self_collision_masks_across_merged_entities(merged_overlapping_
     assert set(geoms_root_idx[arm_geoms].tolist()) == set(geoms_root_idx[hand_geoms].tolist())
 
     # The palm overlaps the non-adjacent a2 link at qpos0, so the neutral-overlap check masks this cross-entity pair.
-    collision_pair_idx = scene.rigid_solver.collider._collider_info.collision_pair_idx.to_numpy()
+    collision_pair_idx = scene.rigid_solver.collider.collider_info.collision_pair_idx.to_numpy()
     a2_geom = arm.get_link("a2").geoms[0].idx
     palm_geom = hand.get_link("palm").geoms[0].idx
     assert_equal(collision_pair_idx[a2_geom, palm_geom], -1)

--- a/tests/rigid/test_collision_nonconvex.py
+++ b/tests/rigid/test_collision_nonconvex.py
@@ -190,8 +190,8 @@ def test_inner_corner_multi_contact(obj_shape, show_viewer, tmp_path):
         max_v_seen = max(max_v_seen, float(np.abs(v).max()))
     assert max_v_seen < 0.05, f"velocity spike during settling: max |v| = {max_v_seen:.4f}"
 
-    contacts = scene.rigid_solver.collider._collider_state.contact_data
-    n_contacts = int(scene.rigid_solver.collider._collider_state.n_contacts[0])
+    contacts = scene.rigid_solver.collider.collider_state.contact_data
+    n_contacts = int(scene.rigid_solver.collider.collider_state.n_contacts[0])
     normals = qd_to_numpy(contacts.normal, transpose=True)
     positions = qd_to_numpy(contacts.pos, transpose=True)
     ga = qd_to_numpy(contacts.geom_a, transpose=True)
@@ -763,7 +763,7 @@ def test_convexify(euler, show_viewer, gjk_collision):
 
     # Make sure that all the geometries in the scene are convex
     assert gs_sim.rigid_solver.dyn_info.geoms.is_convex.to_numpy().all()
-    assert not gs_sim.rigid_solver.collider._collider_static_config.has_nonconvex_nonterrain
+    assert not gs_sim.rigid_solver.collider.collider_config.has_nonconvex_nonterrain
 
     # There should be only one geometry for the apple as it can be convexify without decomposition,
     # but for the others it is hard to tell... Let's use some reasonable guess.

--- a/tests/rigid/test_control.py
+++ b/tests/rigid/test_control.py
@@ -279,7 +279,7 @@ def test_drone_advanced(show_viewer):
             drone.set_propellers_rpm(50000.0)
         scene.step()
         if i > 350:
-            assert scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()[0] == 2
+            assert scene.rigid_solver.collider.collider_state.n_contacts.to_numpy()[0] == 2
             assert_allclose(scene.rigid_solver.get_dofs_velocity(), 0, tol=2e-3)
 
     # Push the drones symmetrically and wait for them to collide
@@ -289,7 +289,7 @@ def test_drone_advanced(show_viewer):
         for drone in drones:
             drone.set_propellers_rpm(50000.0)
         scene.step()
-        if scene.rigid_solver.collider._collider_state.n_contacts.to_numpy()[0] > 2:
+        if scene.rigid_solver.collider.collider_state.n_contacts.to_numpy()[0] > 2:
             break
     else:
         raise AssertionError

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -518,7 +518,7 @@ def test_energy_analytical_and_conservation(
         pe_a.append(sphere_a.get_potential_energy())
         ke_b.append(sphere_b.get_kinetic_energy())
         pe_b.append(sphere_b.get_potential_energy())
-        if impact_step < 0 and scene.rigid_solver.collider._collider_state.n_contacts.to_numpy().any():
+        if impact_step < 0 and scene.rigid_solver.collider.collider_state.n_contacts.to_numpy().any():
             impact_step = i
     assert impact_step > 0
 

--- a/tests/rigid/test_islands.py
+++ b/tests/rigid/test_islands.py
@@ -192,7 +192,7 @@ def test_partition_logics(show_viewer, n_envs, multi_free_body_path, monkeypatch
     dof_id = qd_to_numpy(island_state.dof_id)
     island_contact_n = qd_to_numpy(island_state.contact_slices.n)
     island_constraint_n = qd_to_numpy(island_state.constraint_slices.n)
-    n_contacts = qd_to_numpy(solver.collider._collider_state.n_contacts)
+    n_contacts = qd_to_numpy(solver.collider.collider_state.n_contacts)
     n_constraints = qd_to_numpy(solver.constraint_solver.constraint_state.n_constraints)
     alone_dofs = list(range(box_alone.dof_start, box_alone.dof_start + box_alone.n_dofs))
     for i_env in range(island_idx.shape[1]):

--- a/tests/rigid/test_kinematics.py
+++ b/tests/rigid/test_kinematics.py
@@ -668,7 +668,7 @@ def test_path_planning_avoidance(backend, n_envs, batch_dofs_info, show_viewer, 
         vis_mode="collision",
     )
     scene.build(n_envs=n_envs)
-    collider_state = scene.rigid_solver.collider._collider_state
+    collider_state = scene.rigid_solver.collider.collider_state
 
     hand = franka.get_link("hand")
     hand_pos_ref = torch.tensor([0.3, 0.1, 0.1], dtype=gs.tc_float, device=gs.device)

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -206,7 +206,7 @@ def test_export_and_load_rigid(
             entity_idx=box.idx,
         ),
     )
-    scene.start_recording(
+    scene.add_recorder(
         data_func=box.get_pos,
         rec_options=gs.recorders.CSVFile(
             filename=str(tmp_path / "recorded.csv"),

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import pickle
 import xml.etree.ElementTree as ET
@@ -12,7 +13,7 @@ import trimesh
 
 import genesis as gs
 import genesis.utils.geom as gu
-from genesis.engine.scene import SCENE_FORMAT
+from genesis.engine.scene import SCENE_FORMAT, description_digest
 from genesis.utils.misc import get_assets_dir
 from genesis.utils.serialization import ARRAY_MEMBER, MANIFEST_NAME
 
@@ -515,3 +516,121 @@ def test_export_rejects_unsupported_physics(tmp_path, show_viewer):
     unsupported.add_force_field(gs.force_fields.Wind(direction=(1.0, 0.0, 0.0)))
     with pytest.raises(gs.GenesisException, match="1 MPMEntity, 1 Wind cannot be exported"):
         unsupported.export(tmp_path / f"wind{SCENE_FORMAT}")
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_pickle_resumes_stepped_scene(n_envs, mimic_hinges, show_viewer):
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, 1.5, 1.0),
+            camera_lookat=(0.0, 0.0, 0.3),
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        morph=gs.morphs.Plane(),
+    )
+    # Lands on the plane within the first steps, so contacts and their warm start are part of what is read
+    box = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 0.0, 0.15),
+            size=(0.2, 0.2, 0.2),
+        ),
+    )
+    # Articulated, driven, and tied by an equality, so joints, control targets and constraints all travel
+    arm = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=ET.tostring(mimic_hinges, encoding="unicode"),
+            pos=(0.6, 0.0, 0.5),
+        ),
+    )
+    # A convex mesh, whose contacts with the plane go through the general narrowphase
+    scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file="meshes/duck.obj",
+            scale=0.05,
+            pos=(0.0, 0.6, 0.1),
+        ),
+    )
+    # A kinematic entity, whose solver holds state of its own
+    ghost = scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, -0.6, 0.5),
+            size=(0.1, 0.1, 0.1),
+        ),
+        material=gs.materials.Kinematic(),
+    )
+    with pytest.raises(gs.GenesisException):
+        pickle.dumps(scene)
+    scene.build(n_envs=n_envs)
+    arm.control_dofs_position([0.3, -0.3])
+    for _ in range(20):
+        scene.step()
+    # Set right before the state is read, so the pose the kinematic solver is left to recompute at its next step
+    # travels as such rather than as a pose already computed
+    ghost.set_dofs_position([0.1, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+    held = scene.__getstate__()
+    # A record of another scene is rejected on its description, however its arrays compare
+    other_desc = dataclasses.replace(held.scene, entities=held.scene.entities[:-1])
+    other_held = dataclasses.replace(held, scene=other_desc, digest=description_digest(other_desc))
+    with pytest.raises(gs.GenesisException, match="another scene"):
+        scene.__setstate__(other_held)
+    pickled = pickle.dumps(scene)
+    read_time = scene.get_time()
+    read_box_pos = box.get_pos()
+    read_arm_qpos = arm.get_qpos()
+    # The scene the state was read from steps on: where it lands is what putting the state back must reproduce exactly
+    for _ in range(10):
+        scene.step()
+    landing = scene.sim.rigid_solver.get_state()
+    landing_ghost_pos = ghost.get_links_pos()
+    landing_contacts = box.get_contacts()
+
+    # Unpickling creates and builds the scene from its description, then puts it back where it was pickled
+    twin = pickle.loads(pickled)
+    assert_equal(twin.get_time(), read_time)
+    assert_equal(twin.entities[1].get_pos(), read_box_pos)
+    assert_equal(twin.entities[2].get_qpos(), read_arm_qpos)
+    # Read again right away, it holds the state it was given: what was written back is every array a step reads
+    again = twin.__getstate__()
+    assert_equal(again.sim.steps, held.sim.steps)
+    for name, record in held.sim.solvers.items():
+        assert again.sim.solvers[name].is_forward_pos_updated == record.is_forward_pos_updated
+        assert again.sim.solvers[name].is_forward_vel_updated == record.is_forward_vel_updated
+        for array_name, array in record.arrays.items():
+            assert_equal(again.sim.solvers[name].arrays[array_name], array)
+    for _ in range(10):
+        twin.step()
+    resumed = twin.sim.rigid_solver.get_state()
+    assert_equal(resumed.qpos, landing.qpos)
+    assert_equal(resumed.dofs_vel, landing.dofs_vel)
+    assert_equal(resumed.dofs_acc, landing.dofs_acc)
+    assert_equal(resumed.links_pos, landing.links_pos)
+    assert_equal(resumed.links_quat, landing.links_quat)
+    assert_equal(twin.entities[4].get_links_pos(), landing_ghost_pos)
+    assert_equal(twin.entities[1].get_contacts()["force_a"], landing_contacts["force_a"])
+
+    # The scene the state was read from goes back to the same point when the state is put back into it
+    scene.__setstate__(held)
+    assert_equal(scene.get_time(), read_time)
+    for _ in range(10):
+        scene.step()
+    reloaded = scene.sim.rigid_solver.get_state()
+    assert_equal(reloaded.qpos, landing.qpos)
+    assert_equal(reloaded.dofs_vel, landing.dofs_vel)
+    assert_equal(reloaded.links_pos, landing.links_pos)
+    assert_equal(ghost.get_links_pos(), landing_ghost_pos)
+    assert_equal(box.get_contacts()["force_a"], landing_contacts["force_a"])
+
+    # A state names every array it holds. One read from a solver holding another set of arrays is rejected by the
+    # names the two do not share, and one read from another environment layout by its count.
+    rigid = held.sim.solvers["RigidSolver"]
+    dropped_name, *_ = rigid.arrays
+    arrays = {name: array for name, array in rigid.arrays.items() if name != dropped_name}
+    solvers = {**held.sim.solvers, "RigidSolver": dataclasses.replace(rigid, arrays=arrays)}
+    with pytest.raises(gs.GenesisException, match=f"do not share \\['{dropped_name}'\\]"):
+        scene.__setstate__(dataclasses.replace(held, sim=dataclasses.replace(held.sim, solvers=solvers)))
+    with pytest.raises(gs.GenesisException, match="built with EnvironmentLayout\\(n_envs=3"):
+        scene.__setstate__(dataclasses.replace(held, layout=dataclasses.replace(held.layout, n_envs=3)))

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -14,10 +14,65 @@ import trimesh
 import genesis as gs
 import genesis.utils.geom as gu
 from genesis.engine.scene import SCENE_FORMAT, description_digest
-from genesis.utils.misc import get_assets_dir
+from genesis.recorders.trajectory import CHUNK_MAGIC, TRAJECTORY_FORMAT, Trajectory
+from genesis.utils.misc import get_assets_dir, tensor_to_array
 from genesis.utils.serialization import ARRAY_MEMBER, MANIFEST_NAME
 
 from ..utils.assertions import assert_allclose, assert_equal
+
+
+@pytest.fixture
+def requires_grad():
+    return False
+
+
+@pytest.fixture
+def checkpoint_scene(mimic_hinges, requires_grad, show_viewer):
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            requires_grad=requires_grad,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, 1.5, 1.0),
+            camera_lookat=(0.0, 0.0, 0.3),
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        morph=gs.morphs.Plane(),
+    )
+    # Lands on the plane within the first steps, so contacts and their warm start are part of the state
+    scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, 0.0, 0.15),
+            size=(0.2, 0.2, 0.2),
+        ),
+    )
+    # Articulated, driven, and tied by an equality, so joints, control targets and constraints are all part of it
+    scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=ET.tostring(mimic_hinges, encoding="unicode"),
+            pos=(0.6, 0.0, 0.5),
+        ),
+    )
+    # A convex mesh, whose contacts with the plane go through the general narrowphase
+    scene.add_entity(
+        morph=gs.morphs.Mesh(
+            file="meshes/duck.obj",
+            scale=0.05,
+            pos=(0.0, 0.6, 0.1),
+        ),
+    )
+    # A kinematic entity, whose solver holds state of its own. The runtime crashes when it builds one with gradients
+    # after another scene in the same process, so a gradient scene holds a rigid box there.
+    scene.add_entity(
+        morph=gs.morphs.Box(
+            pos=(0.0, -0.6, 0.5),
+            size=(0.1, 0.1, 0.1),
+        ),
+        material=gs.materials.Rigid() if requires_grad else gs.materials.Kinematic(),
+    )
+    return scene
 
 
 @pytest.mark.required
@@ -235,7 +290,7 @@ def test_export_and_load_rigid(
     left_out = " ".join(record.getMessage() for record in caplog.records)
     assert "IMUSensor" in left_out
     assert "normal_texture" in left_out
-    assert "CSVFileWriter" in left_out
+    assert "CSVFileWriter" not in left_out
     assert "pre_step_callback" in left_out
     assert "visual vertices" in left_out
     # The manifest records each asset by bare filename, so the archive reads the same on any machine.
@@ -357,23 +412,9 @@ def test_export_and_load_rigid(
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
-def test_export_before_build(n_envs, tmp_path, show_viewer, caplog):
-    scene = gs.Scene(
-        viewer_options=gs.options.ViewerOptions(
-            camera_pos=(1.5, 1.0, 1.0),
-            camera_lookat=(0.0, 0.0, 0.3),
-        ),
-        show_viewer=show_viewer,
-    )
-    scene.add_entity(
-        morph=gs.morphs.Plane(),
-    )
-    box = scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(0.0, 0.0, 0.5),
-            size=(0.2, 0.2, 0.2),
-        ),
-    )
+def test_export_before_build(n_envs, checkpoint_scene, tmp_path, caplog):
+    scene = checkpoint_scene
+    box = scene.entities[1]
     # Adding an entity resolves its description, so a scene is written before its build as readily as after. The scene
     # holds nothing a file leaves out, so the export warns of nothing.
     exported = tmp_path / f"authored{SCENE_FORMAT}"
@@ -385,16 +426,28 @@ def test_export_before_build(n_envs, tmp_path, show_viewer, caplog):
     assert pickle.loads(pickle.dumps(scene.options.rigid)) == scene.options.rigid
     scene.build(n_envs=n_envs)
 
-    # A file states no environment layout, so whoever opens one builds it with the layout they ask for
-    restored = gs.Scene.load(exported)
+    # A file states no environment layout, so whoever opens one builds it with the layout they ask for. The visualizer
+    # options are replaced at load and the physics options stand as recorded.
+    restored = gs.Scene.load(exported, vis_options=gs.options.VisOptions(show_world_frame=False))
     assert not restored.is_built
+    assert not restored.options.vis.show_world_frame
+    assert restored.options.sim.dt == scene.options.sim.dt
     assert [entity.name for entity in restored.entities] == [entity.name for entity in scene.entities]
+    # A scene destroyed while it records closes its log on the state it stopped at
+    destroyed_path = tmp_path / f"destroyed{TRAJECTORY_FORMAT}"
+    restored.start_recording(gs.recorders.TrajectoryFile(filename=str(destroyed_path)))
     restored.build(n_envs=n_envs)
     assert restored.n_envs == scene.n_envs
     assert_equal(restored.entities[1].get_mass(), box.get_mass())
     for _ in range(20):
         restored.step()
-    assert_equal(restored.entities[1].get_pos()[..., 2] > 0.0, True)
+    box_pos = restored.entities[1].get_pos()
+    assert_equal(box_pos[..., 2] > 0.0, True)
+    restored.destroy()
+    destroyed_trajectory = Trajectory(destroyed_path, scene=scene)
+    assert len(destroyed_trajectory) == 21
+    destroyed_trajectory.seek(20)
+    assert_equal(scene.entities[1].get_pos(), box_pos)
 
     # A build resolves the options it sizes its buffers from, so a file written after one states those
     built = tmp_path / f"built{SCENE_FORMAT}"
@@ -404,17 +457,9 @@ def test_export_before_build(n_envs, tmp_path, show_viewer, caplog):
 
 
 @pytest.mark.required
-def test_load_rejects_damaged_file(mimic_hinges, tmp_path, show_viewer):
-    scene = gs.Scene(
-        show_viewer=show_viewer,
-    )
-    scene.add_entity(
-        morph=gs.morphs.MJCF(
-            file=ET.tostring(mimic_hinges, encoding="unicode"),
-        ),
-    )
+def test_load_rejects_damaged_file(checkpoint_scene, tmp_path):
     exported = tmp_path / f"authored{SCENE_FORMAT}"
-    scene.export(exported)
+    checkpoint_scene.export(exported)
 
     # A file records what the classes its values load against are made of. A field it holds that Genesis no longer
     # declares means its values say something else, so the file is rejected by the name of what moved.
@@ -503,134 +548,294 @@ def test_load_rejects_damaged_file(mimic_hinges, tmp_path, show_viewer):
 
 
 @pytest.mark.required
-def test_export_rejects_unsupported_physics(tmp_path, show_viewer):
+def test_export_rejects_unsupported_physics(checkpoint_scene, tmp_path):
     # A scene holding what alters the simulation is rejected by name, since a file leaving it out would restore
     # other physics. No description carries a particle entity either.
-    unsupported = gs.Scene(
-        show_viewer=show_viewer,
-    )
-    unsupported.add_entity(morph=gs.morphs.Box(pos=(0.5, 0.5, 0.5), size=(0.2, 0.2, 0.2)))
-    unsupported.add_entity(
+    checkpoint_scene.add_entity(
         morph=gs.morphs.Box(pos=(0.5, 0.5, 0.8), size=(0.1, 0.1, 0.1)), material=gs.materials.MPM.Elastic()
     )
-    unsupported.add_force_field(gs.force_fields.Wind(direction=(1.0, 0.0, 0.0)))
+    checkpoint_scene.add_force_field(gs.force_fields.Wind(direction=(1.0, 0.0, 0.0)))
     with pytest.raises(gs.GenesisException, match="1 MPMEntity, 1 Wind cannot be exported"):
-        unsupported.export(tmp_path / f"wind{SCENE_FORMAT}")
+        checkpoint_scene.export(tmp_path / f"wind{SCENE_FORMAT}")
 
 
 @pytest.mark.required
 @pytest.mark.parametrize("n_envs", [0, 2])
-def test_pickle_resumes_stepped_scene(n_envs, mimic_hinges, show_viewer):
-    scene = gs.Scene(
-        viewer_options=gs.options.ViewerOptions(
-            camera_pos=(2.0, 1.5, 1.0),
-            camera_lookat=(0.0, 0.0, 0.3),
-        ),
-        show_viewer=show_viewer,
-    )
-    scene.add_entity(
-        morph=gs.morphs.Plane(),
-    )
-    # Lands on the plane within the first steps, so contacts and their warm start are part of what is read
-    box = scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(0.0, 0.0, 0.15),
-            size=(0.2, 0.2, 0.2),
-        ),
-    )
-    # Articulated, driven, and tied by an equality, so joints, control targets and constraints all travel
-    arm = scene.add_entity(
-        morph=gs.morphs.MJCF(
-            file=ET.tostring(mimic_hinges, encoding="unicode"),
-            pos=(0.6, 0.0, 0.5),
-        ),
-    )
-    # A convex mesh, whose contacts with the plane go through the general narrowphase
-    scene.add_entity(
-        morph=gs.morphs.Mesh(
-            file="meshes/duck.obj",
-            scale=0.05,
-            pos=(0.0, 0.6, 0.1),
-        ),
-    )
-    # A kinematic entity, whose solver holds state of its own
-    ghost = scene.add_entity(
-        morph=gs.morphs.Box(
-            pos=(0.0, -0.6, 0.5),
-            size=(0.1, 0.1, 0.1),
-        ),
-        material=gs.materials.Kinematic(),
-    )
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_pickle_resume(n_envs, requires_grad, checkpoint_scene, tmp_path, show_viewer):
+    scene = checkpoint_scene
+    box, arm, ghost = scene.entities[1], scene.entities[2], scene.entities[4]
     with pytest.raises(gs.GenesisException):
         pickle.dumps(scene)
     scene.build(n_envs=n_envs)
     arm.control_dofs_position([0.3, -0.3])
     for _ in range(20):
         scene.step()
-    # Set right before the state is read, so the pose the kinematic solver is left to recompute at its next step
-    # travels as such rather than as a pose already computed
+    # 'set_dofs_position' runs right before the state read and leaves the kinematic solver's forward-kinematics flags
+    # False. The record therefore carries False flags for that solver.
     ghost.set_dofs_position([0.1, 0.0, 0.0, 0.0, 0.0, 0.0])
+    if requires_grad:
+        # A backward pass leaves gradients on the arrays, which the state carries. It also closes the forward run, so the
+        # scene continues from its own state as the copies do.
+        (scene.rigid_solver.get_state().qpos ** 2).sum().backward()
 
-    held = scene.__getstate__()
+    checkpoint = scene.__getstate__()
     # A record of another scene is rejected on its description, however its arrays compare
-    other_desc = dataclasses.replace(held.scene, entities=held.scene.entities[:-1])
-    other_held = dataclasses.replace(held, scene=other_desc, digest=description_digest(other_desc))
+    other_desc = dataclasses.replace(checkpoint.scene, entities=checkpoint.scene.entities[:-1])
+    other_checkpoint = dataclasses.replace(checkpoint, scene=other_desc, digest=description_digest(other_desc))
     with pytest.raises(gs.GenesisException, match="another scene"):
-        scene.__setstate__(other_held)
-    pickled = pickle.dumps(scene)
+        scene.__setstate__(other_checkpoint)
+    scene_bytes = pickle.dumps(scene)
+    checkpoint_path = tmp_path / f"state{TRAJECTORY_FORMAT}"
+    scene.save_checkpoint(checkpoint_path)
     read_time = scene.get_time()
     read_box_pos = box.get_pos()
     read_arm_qpos = arm.get_qpos()
-    # The scene the state was read from steps on: where it lands is what putting the state back must reproduce exactly
+    if requires_grad:
+        qpos_grad = checkpoint.sim.solvers["RigidSolver"].arrays["rigid_info.qpos.grad"]
+        assert_equal((tensor_to_array(qpos_grad) != 0.0).any(), True)
+        scene.__setstate__(checkpoint)
     for _ in range(10):
         scene.step()
-    landing = scene.sim.rigid_solver.get_state()
+    landing_state = scene.sim.rigid_solver.get_state()
     landing_ghost_pos = ghost.get_links_pos()
     landing_contacts = box.get_contacts()
 
-    # Unpickling creates and builds the scene from its description, then puts it back where it was pickled
-    twin = pickle.loads(pickled)
-    assert_equal(twin.get_time(), read_time)
-    assert_equal(twin.entities[1].get_pos(), read_box_pos)
-    assert_equal(twin.entities[2].get_qpos(), read_arm_qpos)
-    # Read again right away, it holds the state it was given: what was written back is every array a step reads
-    again = twin.__getstate__()
-    assert_equal(again.sim.steps, held.sim.steps)
-    for name, record in held.sim.solvers.items():
-        assert again.sim.solvers[name].is_forward_pos_updated == record.is_forward_pos_updated
-        assert again.sim.solvers[name].is_forward_vel_updated == record.is_forward_vel_updated
+    twin_scene = pickle.loads(scene_bytes)
+    assert_equal(twin_scene.get_time(), read_time)
+    assert_equal(twin_scene.entities[1].get_pos(), read_box_pos)
+    assert_equal(twin_scene.entities[2].get_qpos(), read_arm_qpos)
+    twin_checkpoint = twin_scene.__getstate__()
+    assert_equal(twin_checkpoint.sim.steps, checkpoint.sim.steps)
+    for name, record in checkpoint.sim.solvers.items():
+        assert twin_checkpoint.sim.solvers[name].is_forward_pos_updated == record.is_forward_pos_updated
+        assert twin_checkpoint.sim.solvers[name].is_forward_vel_updated == record.is_forward_vel_updated
         for array_name, array in record.arrays.items():
-            assert_equal(again.sim.solvers[name].arrays[array_name], array)
+            assert_equal(twin_checkpoint.sim.solvers[name].arrays[array_name], array)
     for _ in range(10):
-        twin.step()
-    resumed = twin.sim.rigid_solver.get_state()
-    assert_equal(resumed.qpos, landing.qpos)
-    assert_equal(resumed.dofs_vel, landing.dofs_vel)
-    assert_equal(resumed.dofs_acc, landing.dofs_acc)
-    assert_equal(resumed.links_pos, landing.links_pos)
-    assert_equal(resumed.links_quat, landing.links_quat)
-    assert_equal(twin.entities[4].get_links_pos(), landing_ghost_pos)
-    assert_equal(twin.entities[1].get_contacts()["force_a"], landing_contacts["force_a"])
+        twin_scene.step()
+    resumed_state = twin_scene.sim.rigid_solver.get_state()
+    assert_equal(resumed_state.qpos, landing_state.qpos)
+    assert_equal(resumed_state.dofs_vel, landing_state.dofs_vel)
+    assert_equal(resumed_state.dofs_acc, landing_state.dofs_acc)
+    assert_equal(resumed_state.links_pos, landing_state.links_pos)
+    assert_equal(resumed_state.links_quat, landing_state.links_quat)
+    assert_equal(twin_scene.entities[4].get_links_pos(), landing_ghost_pos)
+    assert_equal(twin_scene.entities[1].get_contacts()["force_a"], landing_contacts["force_a"])
 
-    # The scene the state was read from goes back to the same point when the state is put back into it
-    scene.__setstate__(held)
+    scene.__setstate__(checkpoint)
     assert_equal(scene.get_time(), read_time)
     for _ in range(10):
         scene.step()
-    reloaded = scene.sim.rigid_solver.get_state()
-    assert_equal(reloaded.qpos, landing.qpos)
-    assert_equal(reloaded.dofs_vel, landing.dofs_vel)
-    assert_equal(reloaded.links_pos, landing.links_pos)
+    reloaded_state = scene.sim.rigid_solver.get_state()
+    assert_equal(reloaded_state.qpos, landing_state.qpos)
+    assert_equal(reloaded_state.dofs_vel, landing_state.dofs_vel)
+    assert_equal(reloaded_state.links_pos, landing_state.links_pos)
     assert_equal(ghost.get_links_pos(), landing_ghost_pos)
     assert_equal(box.get_contacts()["force_a"], landing_contacts["force_a"])
 
-    # A state names every array it holds. One read from a solver holding another set of arrays is rejected by the
-    # names the two do not share, and one read from another environment layout by its count.
-    rigid = held.sim.solvers["RigidSolver"]
-    dropped_name, *_ = rigid.arrays
-    arrays = {name: array for name, array in rigid.arrays.items() if name != dropped_name}
-    solvers = {**held.sim.solvers, "RigidSolver": dataclasses.replace(rigid, arrays=arrays)}
-    with pytest.raises(gs.GenesisException, match=f"do not share \\['{dropped_name}'\\]"):
-        scene.__setstate__(dataclasses.replace(held, sim=dataclasses.replace(held.sim, solvers=solvers)))
+    # A checkpoint file holds the whole state, so a scene loaded from it steps on where the original went
+    loaded_scene = gs.Scene.load_checkpoint(checkpoint_path, show_viewer=show_viewer)
+    assert_equal(loaded_scene.get_time(), read_time)
+    for _ in range(10):
+        loaded_scene.step()
+    resumed_state = loaded_scene.sim.rigid_solver.get_state()
+    assert_equal(resumed_state.qpos, landing_state.qpos)
+    assert_equal(resumed_state.dofs_vel, landing_state.dofs_vel)
+    assert_equal(resumed_state.links_pos, landing_state.links_pos)
+    assert_equal(loaded_scene.entities[1].get_contacts()["force_a"], landing_contacts["force_a"])
+
+    # A record names every array, so a restore raises on a missing or extra array and names the difference. A restore
+    # of a record with another 'n_envs' raises and names both counts.
+    rigid = checkpoint.sim.solvers["RigidSolver"]
+    arrays = {name: array for name, array in rigid.arrays.items() if name != "dyn_state.links.pos"}
+    solvers = {**checkpoint.sim.solvers, "RigidSolver": dataclasses.replace(rigid, arrays=arrays)}
+    with pytest.raises(gs.GenesisException, match="do not share \\['dyn_state.links.pos'\\]"):
+        scene.__setstate__(dataclasses.replace(checkpoint, sim=dataclasses.replace(checkpoint.sim, solvers=solvers)))
     with pytest.raises(gs.GenesisException, match="built with EnvironmentLayout\\(n_envs=3"):
-        scene.__setstate__(dataclasses.replace(held, layout=dataclasses.replace(held.layout, n_envs=3)))
+        scene.__setstate__(dataclasses.replace(checkpoint, layout=dataclasses.replace(checkpoint.layout, n_envs=3)))
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_trajectory_replay(n_envs, checkpoint_scene, tmp_path, show_viewer, caplog, tol):
+    scene = checkpoint_scene
+    box, arm, ghost = scene.entities[1], scene.entities[2], scene.entities[4]
+    # Both modes logged from one run. Short chunks, so the frames span several chunks and a chunk can be cut off. The
+    # files rotate on reset, so the run ends with a reset and each first file must close on the state before it.
+    N_STEPS, CHUNK_SIZE = 30, 8
+    exact_path = tmp_path / f"exact_0{TRAJECTORY_FORMAT}"
+    compressed_path = tmp_path / f"compressed_0{TRAJECTORY_FORMAT}"
+    scene.start_recording(
+        gs.recorders.TrajectoryFile(
+            filename=str(tmp_path / f"exact{TRAJECTORY_FORMAT}"),
+            exact=True,
+            chunk_size=CHUNK_SIZE,
+            save_on_reset=True,
+        ),
+    )
+    scene.start_recording(
+        gs.recorders.TrajectoryFile(
+            filename=str(tmp_path / f"compressed{TRAJECTORY_FORMAT}"),
+            exact=False,
+            chunk_size=CHUNK_SIZE,
+            save_on_reset=True,
+        ),
+    )
+    # A third log samples every fourth step, a rate the run length is off
+    sparse_path = tmp_path / f"sparse{TRAJECTORY_FORMAT}"
+    scene.start_recording(
+        gs.recorders.TrajectoryFile(
+            filename=str(sparse_path),
+            hz=0.25 / scene.sim.dt,
+            exact=True,
+            chunk_size=CHUNK_SIZE,
+        ),
+    )
+    # A fourth log has a size limit below its header, so its first write at the stop fails and is reported there
+    capped_path = tmp_path / f"capped{TRAJECTORY_FORMAT}"
+    scene.start_recording(
+        gs.recorders.TrajectoryFile(
+            filename=str(capped_path),
+            exact=True,
+            chunk_size=2 * N_STEPS,
+            max_size=1,
+        ),
+    )
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        scene.build(n_envs=n_envs)
+    assert "Recording the state alone" in " ".join(record.getMessage() for record in caplog.records)
+    # The inputs of a step are recorded whether a setter or a pre-step callback writes them
+    scene.register_pre_step_callback(lambda: arm.control_dofs_position([0.3 + 0.001 * scene.sim.cur_step_global, -0.3]))
+    # A frame is the state a step starts from, so the record of frame i is read right before step i
+    states, ghosts_pos, forces, times = [], [], [], []
+    for i_step in range(N_STEPS):
+        ghost.set_dofs_position([0.01 * i_step, 0.0, 0.0, 0.0, 0.0, 0.0])
+        states.append(scene.sim.rigid_solver.get_state())
+        ghosts_pos.append(ghost.get_links_pos())
+        forces.append(box.get_contacts()["force_a"])
+        times.append(scene.get_time())
+        scene.step()
+    final_state = scene.sim.rigid_solver.get_state()
+    final_force = box.get_contacts()["force_a"]
+    scene.reset()
+    # Every recorder is stopped, then the failure of the capped one is raised, and it leaves no file behind
+    with pytest.raises(gs.GenesisException, match="cannot hold the header"):
+        scene.stop_recording()
+    assert not capped_path.exists()
+
+    # The state the recording stopped at closes each file, as one more frame. Both trajectories play in the same scene.
+    exact_trajectory = gs.Scene.load_trajectory(exact_path, show_viewer=show_viewer)
+    replay_scene = exact_trajectory.scene
+    compressed_trajectory = Trajectory(compressed_path, scene=replay_scene)
+    assert len(exact_trajectory) == len(compressed_trajectory) == N_STEPS + 1
+    assert exact_trajectory.is_exact and not compressed_trajectory.is_exact
+    for index, (state, ghost_pos, force, time) in enumerate(zip(states, ghosts_pos, forces, times)):
+        # An exact frame puts back everything a step reads or writes, so the scene stands exactly where it stood
+        exact_trajectory.seek(index)
+        replayed_state = replay_scene.sim.rigid_solver.get_state()
+        assert_equal(replayed_state.qpos, state.qpos)
+        assert_equal(replayed_state.dofs_vel, state.dofs_vel)
+        assert_equal(replayed_state.dofs_acc, state.dofs_acc)
+        assert_equal(replayed_state.links_pos, state.links_pos)
+        assert_equal(replayed_state.links_quat, state.links_quat)
+        assert_equal(replay_scene.entities[4].get_links_pos(), ghost_pos)
+        assert_equal(replay_scene.entities[1].get_contacts()["force_a"], force)
+        assert_equal(replay_scene.get_time(), time)
+        assert_equal(exact_trajectory.time(index), time)
+        ctrl_pos = exact_trajectory.frame(index)["RigidSolver.dyn_state.dofs.ctrl_pos"]
+        assert_allclose(ctrl_pos[arm.dof_start], 0.3 + 0.001 * index, tol=gs.EPS)
+        # A compressed frame puts back the state and leaves the poses to forward kinematics, which the mode documents
+        # as lossy at the last bits
+        compressed_trajectory.seek(index)
+        replayed_state = replay_scene.sim.rigid_solver.get_state()
+        assert_equal(replayed_state.qpos, state.qpos)
+        assert_equal(replayed_state.dofs_vel, state.dofs_vel)
+        assert_equal(replayed_state.dofs_acc, state.dofs_acc)
+        assert_equal(replay_scene.entities[1].get_contacts()["force_a"], force)
+        assert_allclose(replayed_state.links_pos, state.links_pos, tol=tol)
+        assert_allclose(replayed_state.links_quat, state.links_quat, tol=tol)
+        assert_allclose(replay_scene.entities[4].get_links_pos(), ghost_pos, tol=tol)
+
+    exact_trajectory.seek(N_STEPS - 1)
+    replay_scene.step()
+    replayed_state = replay_scene.sim.rigid_solver.get_state()
+    assert_equal(replayed_state.qpos, final_state.qpos)
+    assert_equal(replayed_state.dofs_vel, final_state.dofs_vel)
+    assert_equal(replay_scene.entities[1].get_contacts()["force_a"], final_force)
+    # The last frame is the state the reset left behind, and seeking it puts the scene where the run ended
+    assert_equal(
+        exact_trajectory.frame(N_STEPS)["RigidSolver.rigid_info.qpos"],
+        tensor_to_array(final_state.qpos).T,
+    )
+    compressed_trajectory.seek(N_STEPS)
+    assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, final_state.qpos)
+    assert_equal(replay_scene.entities[1].get_contacts()["force_a"], final_force)
+    # The last frame of each file, reached from the end as well, is the state the recording stopped at, whole: the
+    # scratch of the solvers comes beside the kinds the other frames hold
+    for trajectory in (exact_trajectory, compressed_trajectory):
+        assert set(trajectory.frame(-1)) > set(trajectory.frame(-2))
+        assert_equal(trajectory.frame(-1)["RigidSolver.rigid_info.qpos"], tensor_to_array(final_state.qpos).T)
+    exact_trajectory.seek(-1)
+    assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, final_state.qpos)
+
+    # A run cut off inside a chunk keeps every complete chunk and loses the final state
+    with open(exact_path, "rb") as file:
+        data = file.read()
+    cut_path = tmp_path / f"cut_trajectory{TRAJECTORY_FORMAT}"
+    with open(cut_path, "wb") as file:
+        file.write(data[: data.rfind(CHUNK_MAGIC) + len(CHUNK_MAGIC)])
+    cut_trajectory = Trajectory(cut_path, scene=replay_scene)
+    n_kept = N_STEPS // CHUNK_SIZE * CHUNK_SIZE
+    assert len(cut_trajectory) == n_kept
+    cut_trajectory.seek(n_kept - 1)
+    assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, states[n_kept - 1].qpos)
+    # The sparse log holds the frame of every fourth step, then the states before and after the reset, recorded off
+    # its sampling grid. Both carry the same step count, since the log keeps recording across the reset.
+    sparse_trajectory = Trajectory(sparse_path, scene=replay_scene)
+    n_sampled = len(range(0, N_STEPS, 4))
+    assert len(sparse_trajectory) == n_sampled + 2
+    for index in range(n_sampled):
+        sparse_trajectory.seek(index)
+        assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, states[4 * index].qpos)
+    sparse_trajectory.seek(n_sampled)
+    assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, final_state.qpos)
+
+    # A file cut off before its first chunk holds no frame, and is rejected as a trajectory
+    with open(cut_path, "wb") as file:
+        file.write(data[: data.find(CHUNK_MAGIC)])
+    with pytest.raises(gs.GenesisException, match="holds no frame"):
+        Trajectory(cut_path, scene=replay_scene)
+
+
+@pytest.mark.required
+@pytest.mark.precision("32")
+@pytest.mark.parametrize("n_envs", [0, 2])
+def test_trajectory_replay_across_backends(n_envs, trajectory_snapshot, show_viewer, tol):
+    # The snapshot is a log recorded on CPU in single precision, replayed here on whatever backend the session runs
+    trajectory = gs.Scene.load_trajectory(trajectory_snapshot, show_viewer=show_viewer)
+    assert trajectory.n_envs == n_envs
+    replay_scene = trajectory.scene
+    for index in range(len(trajectory)):
+        # The state read back is the one the file holds, whatever this backend stores its flags and floats as
+        trajectory.seek(index)
+        frame = trajectory.frame(index)
+        state = replay_scene.sim.rigid_solver.get_state()
+        assert_equal(tensor_to_array(state.qpos).T, frame["RigidSolver.rigid_info.qpos"])
+        assert_equal(tensor_to_array(state.dofs_vel).T, frame["RigidSolver.dyn_state.dofs.vel"])
+        # The frame holds the arrays as the solver lays them out, links first and environments second
+        links_pos = frame["RigidSolver.dyn_state.links.pos"]
+        assert_equal(tensor_to_array(state.links_pos).reshape(-1, *links_pos.shape[::2]).swapaxes(0, 1), links_pos)
+        # This log comes from a CPU fp32 run. One step after a seek, on the current backend and precision, matches the
+        # next recorded frame within the suite's tolerance.
+        if index + 1 < len(trajectory):
+            replay_scene.step()
+            following_frame = trajectory.frame(index + 1)
+            state = replay_scene.sim.rigid_solver.get_state()
+            assert_allclose(tensor_to_array(state.qpos).T, following_frame["RigidSolver.rigid_info.qpos"], tol=tol)
+            assert_allclose(
+                tensor_to_array(state.dofs_vel).T,
+                following_frame["RigidSolver.dyn_state.dofs.vel"],
+                tol=tol,
+            )

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -648,9 +648,10 @@ def test_pickle_resume(n_envs, requires_grad, checkpoint_scene, tmp_path, show_v
     # A record names every array, so a restore raises on a missing or extra array and names the difference. A restore
     # of a record with another 'n_envs' raises and names both counts.
     rigid = checkpoint.sim.solvers["RigidSolver"]
-    arrays = {name: array for name, array in rigid.arrays.items() if name != "dyn_state.links.pos"}
+    dropped_name, *_ = rigid.arrays
+    arrays = {name: array for name, array in rigid.arrays.items() if name != dropped_name}
     solvers = {**checkpoint.sim.solvers, "RigidSolver": dataclasses.replace(rigid, arrays=arrays)}
-    with pytest.raises(gs.GenesisException, match="do not share \\['dyn_state.links.pos'\\]"):
+    with pytest.raises(gs.GenesisException, match=f"do not share \\['{dropped_name}'\\]"):
         scene.__setstate__(dataclasses.replace(checkpoint, sim=dataclasses.replace(checkpoint.sim, solvers=solvers)))
     with pytest.raises(gs.GenesisException, match="built with EnvironmentLayout\\(n_envs=3"):
         scene.__setstate__(dataclasses.replace(checkpoint, layout=dataclasses.replace(checkpoint.layout, n_envs=3)))
@@ -662,24 +663,22 @@ def test_trajectory_replay(n_envs, checkpoint_scene, tmp_path, show_viewer, capl
     scene = checkpoint_scene
     box, arm, ghost = scene.entities[1], scene.entities[2], scene.entities[4]
     # Both modes logged from one run. Short chunks, so the frames span several chunks and a chunk can be cut off. The
-    # files rotate on reset, so the run ends with a reset and each first file must close on the state before it.
+    # run ends with a reset, which every log records the state before, and goes on in the same file.
     N_STEPS, CHUNK_SIZE = 30, 8
-    exact_path = tmp_path / f"exact_0{TRAJECTORY_FORMAT}"
-    compressed_path = tmp_path / f"compressed_0{TRAJECTORY_FORMAT}"
+    exact_path = tmp_path / f"exact{TRAJECTORY_FORMAT}"
+    compressed_path = tmp_path / f"compressed{TRAJECTORY_FORMAT}"
     scene.start_recording(
         gs.recorders.TrajectoryFile(
-            filename=str(tmp_path / f"exact{TRAJECTORY_FORMAT}"),
+            filename=str(exact_path),
             exact=True,
             chunk_size=CHUNK_SIZE,
-            save_on_reset=True,
         ),
     )
     scene.start_recording(
         gs.recorders.TrajectoryFile(
-            filename=str(tmp_path / f"compressed{TRAJECTORY_FORMAT}"),
+            filename=str(compressed_path),
             exact=False,
             chunk_size=CHUNK_SIZE,
-            save_on_reset=True,
         ),
     )
     # A third log samples every fourth step, a rate the run length is off
@@ -720,16 +719,18 @@ def test_trajectory_replay(n_envs, checkpoint_scene, tmp_path, show_viewer, capl
     final_state = scene.sim.rigid_solver.get_state()
     final_force = box.get_contacts()["force_a"]
     scene.reset()
+    reset_state = scene.sim.rigid_solver.get_state()
     # Every recorder is stopped, then the failure of the capped one is raised, and it leaves no file behind
     with pytest.raises(gs.GenesisException, match="cannot hold the header"):
         scene.stop_recording()
     assert not capped_path.exists()
 
-    # The state the recording stopped at closes each file, as one more frame. Both trajectories play in the same scene.
+    # Each file holds the frame before each step, the state the reset left behind and the state the recording stopped
+    # at. Both trajectories play in the same scene.
     exact_trajectory = gs.Scene.load_trajectory(exact_path, show_viewer=show_viewer)
     replay_scene = exact_trajectory.scene
     compressed_trajectory = Trajectory(compressed_path, scene=replay_scene)
-    assert len(exact_trajectory) == len(compressed_trajectory) == N_STEPS + 1
+    assert len(exact_trajectory) == len(compressed_trajectory) == N_STEPS + 2
     assert exact_trajectory.is_exact and not compressed_trajectory.is_exact
     for index, (state, ghost_pos, force, time) in enumerate(zip(states, ghosts_pos, forces, times)):
         # An exact frame puts back everything a step reads or writes, so the scene stands exactly where it stood
@@ -764,7 +765,7 @@ def test_trajectory_replay(n_envs, checkpoint_scene, tmp_path, show_viewer, capl
     assert_equal(replayed_state.qpos, final_state.qpos)
     assert_equal(replayed_state.dofs_vel, final_state.dofs_vel)
     assert_equal(replay_scene.entities[1].get_contacts()["force_a"], final_force)
-    # The last frame is the state the reset left behind, and seeking it puts the scene where the run ended
+    # The frame after the run is the state the reset left behind, and seeking it puts the scene where the run ended
     assert_equal(
         exact_trajectory.frame(N_STEPS)["RigidSolver.rigid_info.qpos"],
         tensor_to_array(final_state.qpos).T,
@@ -776,9 +777,10 @@ def test_trajectory_replay(n_envs, checkpoint_scene, tmp_path, show_viewer, capl
     # scratch of the solvers comes beside the kinds the other frames hold
     for trajectory in (exact_trajectory, compressed_trajectory):
         assert set(trajectory.frame(-1)) > set(trajectory.frame(-2))
-        assert_equal(trajectory.frame(-1)["RigidSolver.rigid_info.qpos"], tensor_to_array(final_state.qpos).T)
+        assert_equal(trajectory.frame(-1)["RigidSolver.rigid_info.qpos"], tensor_to_array(reset_state.qpos).T)
     exact_trajectory.seek(-1)
-    assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, final_state.qpos)
+    assert_equal(replay_scene.sim.rigid_solver.get_state().qpos, reset_state.qpos)
+    assert_equal(replay_scene.get_time(), 0.0)
 
     # A run cut off inside a chunk keeps every complete chunk and loses the final state
     with open(exact_path, "rb") as file:

--- a/tests/utils/assets.py
+++ b/tests/utils/assets.py
@@ -16,12 +16,13 @@ from PIL import Image, UnidentifiedImageError
 from requests.exceptions import HTTPError
 
 from genesis.constants import GLTF_FORMATS, MESH_FORMATS, MJCF_FORMAT, URDF_FORMAT, USD_FORMATS
+from genesis.recorders.trajectory import TRAJECTORY_FORMAT
 
 REPOSITY_URL = "Genesis-Embodied-AI/Genesis"
 DEFAULT_BRANCH_NAME = "main"
 
 HUGGINGFACE_ASSETS_REVISION = "990a727788f11e34ad006c69bf769303b20cb11c"
-HUGGINGFACE_SNAPSHOT_REVISION = "106c05a1c4170d058b96d22851ce4c5f0244a364"
+HUGGINGFACE_SNAPSHOT_REVISION = "3b9b1fc205b9fea4b103b4aa31721aefe4236567"
 
 MESH_EXTENSIONS = (".mtl", *MESH_FORMATS, *GLTF_FORMATS, *USD_FORMATS)
 IMAGE_EXTENSIONS = (".png", ".jpg")
@@ -135,7 +136,7 @@ def get_hf_dataset(
                     continue
 
                 ext = path.suffix.lower()
-                if ext not in (URDF_FORMAT, MJCF_FORMAT, *IMAGE_EXTENSIONS, *MESH_EXTENSIONS):
+                if ext not in (URDF_FORMAT, MJCF_FORMAT, TRAJECTORY_FORMAT, *IMAGE_EXTENSIONS, *MESH_EXTENSIONS):
                     continue
 
                 has_files = True

--- a/tests/utils/mujoco_parity.py
+++ b/tests/utils/mujoco_parity.py
@@ -465,14 +465,14 @@ def _pair_constraint_rows(gs_sim, mj_sim, gs_dofs_idx, mj_dofs_idx, *, qvel_prev
     gs_n_constraints = gs_sim.rigid_solver.constraint_solver.n_constraints.to_numpy()[0]
     mj_n_constraints = mj_sim.data.nefc
     assert gs_n_constraints == mj_n_constraints
-    gs_n_contacts = gs_sim.rigid_solver.collider._collider_state.n_contacts.to_numpy()[0]
+    gs_n_contacts = gs_sim.rigid_solver.collider.collider_state.n_contacts.to_numpy()[0]
     mj_n_contacts = mj_sim.data.ncon
-    gs_contact_pos = gs_sim.rigid_solver.collider._collider_state.contact_data.pos.to_numpy()[:gs_n_contacts, 0]
+    gs_contact_pos = gs_sim.rigid_solver.collider.collider_state.contact_data.pos.to_numpy()[:gs_n_contacts, 0]
     mj_contact_pos = mj_sim.data.contact.pos
     gs_contact_geoms = np.stack(
         (
-            gs_sim.rigid_solver.collider._collider_state.contact_data.geom_a.to_numpy()[:gs_n_contacts, 0],
-            gs_sim.rigid_solver.collider._collider_state.contact_data.geom_b.to_numpy()[:gs_n_contacts, 0],
+            gs_sim.rigid_solver.collider.collider_state.contact_data.geom_a.to_numpy()[:gs_n_contacts, 0],
+            gs_sim.rigid_solver.collider.collider_state.contact_data.geom_b.to_numpy()[:gs_n_contacts, 0],
         ),
         axis=-1,
     )
@@ -514,7 +514,7 @@ def _pair_constraint_rows(gs_sim, mj_sim, gs_dofs_idx, mj_dofs_idx, *, qvel_prev
     n_head = mj_n_constraints - n_mj_contact_rows - int(is_mj_limit.sum())
     rows_per_contact = n_mj_contact_rows // mj_n_contacts if mj_n_contacts else 0
 
-    gs_contact_sort_idx = gs_sim.rigid_solver.collider._collider_state.contact_sort_idx.to_numpy()[:gs_n_contacts, 0]
+    gs_contact_sort_idx = gs_sim.rigid_solver.collider.collider_state.contact_sort_idx.to_numpy()[:gs_n_contacts, 0]
     gs_block_of_contact = np.empty(gs_n_contacts, dtype=int)
     gs_block_of_contact[gs_contact_sort_idx] = np.arange(gs_n_contacts)
 
@@ -625,7 +625,7 @@ def check_mujoco_data_consistency(
     mj_qfrc_actuator = mj_sim.data.qfrc_actuator
     assert_allclose(gs_qfrc_actuator, mj_qfrc_actuator[mj_dofs_idx], tol=tol)
 
-    gs_n_contacts = gs_sim.rigid_solver.collider._collider_state.n_contacts.to_numpy()[0]
+    gs_n_contacts = gs_sim.rigid_solver.collider.collider_state.n_contacts.to_numpy()[0]
     mj_n_contacts = mj_sim.data.ncon
     assert gs_n_contacts == mj_n_contacts, f"contact count differs: gs={gs_n_contacts} mj={mj_n_contacts}"
     gs_n_constraints = gs_sim.rigid_solver.constraint_solver.n_constraints.to_numpy()[0]
@@ -635,7 +635,7 @@ def check_mujoco_data_consistency(
     efc_atol, qvel_atol = _compute_efc_tolerances(mj_sim, tol)
 
     if gs_n_constraints and not ignore_constraints:
-        gs_contact_pos = gs_sim.rigid_solver.collider._collider_state.contact_data.pos.to_numpy()[:gs_n_contacts, 0]
+        gs_contact_pos = gs_sim.rigid_solver.collider.collider_state.contact_data.pos.to_numpy()[:gs_n_contacts, 0]
         mj_contact_pos = mj_sim.data.contact.pos
         # Sort based on the axis with the largest variation
         max_var_axis = 0
@@ -650,12 +650,12 @@ def check_mujoco_data_consistency(
         gs_sidx = np.argsort(gs_contact_pos[:, max_var_axis])
         mj_sidx = np.argsort(mj_contact_pos[:, max_var_axis])
         assert_allclose(gs_contact_pos[gs_sidx], mj_contact_pos[mj_sidx], tol=tol)
-        gs_contact_normal = gs_sim.rigid_solver.collider._collider_state.contact_data.normal.to_numpy()[
+        gs_contact_normal = gs_sim.rigid_solver.collider.collider_state.contact_data.normal.to_numpy()[
             :gs_n_contacts, 0
         ]
         mj_contact_normal = -mj_sim.data.contact.frame[:, :3]
         assert_allclose(gs_contact_normal[gs_sidx], mj_contact_normal[mj_sidx], tol=tol)
-        gs_penetration = gs_sim.rigid_solver.collider._collider_state.contact_data.penetration.to_numpy()[
+        gs_penetration = gs_sim.rigid_solver.collider.collider_state.contact_data.penetration.to_numpy()[
             :gs_n_contacts, 0
         ]
         mj_penetration = -mj_sim.data.contact.dist


### PR DESCRIPTION
## Description

- Every solver array declares its kind (config, constant, info, state, warm start, derived, scratch) as field metadata in `array_class`, and each solver yields its arrays through a `data` property.
- A built scene saves and restores its state in memory through the pickle protocol: `scene.__getstate__()` / `scene.__setstate__(state)`, and `pickle.loads(pickle.dumps(scene))` gives a built copy. Stepping a restored scene lands bit-for-bit where the original went, and a differentiable scene carries its gradients along. `scene.save_checkpoint(path)` / `Scene.load_checkpoint(path)` do the same through a file holding every array, scratch included, which is a trajectory file of one frame.
- **Breaking:** every recorder records the state a step starts from, inputs included, with `stop_recording`, a whole-scene reset and the destruction of the scene recording the state they leave behind, whatever the sampling rate. A recorder whose sample raises stops recording, the failure is raised on the stepping thread, at once or at the next step for a background thread, and `Recorder.sync` waits for the frame being processed.
- **Breaking:** the generic entry point is renamed `scene.add_recorder(data_func, rec_options)`, beside `add_camera` and `add_sensor`. `scene.start_recording(rec_options)` records the scene itself, as `camera.start_recording` and `sensor.start_recording` record theirs.
- `scene.start_recording(gs.recorders.TrajectoryFile(...))` streams every frame to a `.gstraj` file, in exact mode (bit-for-bit replay and resume) or compressed mode (state only, poses recomputed at load), by chunks with a checksum so a crash keeps every completed chunk. `Scene.load_trajectory(path)` builds the recorded scene and returns a `Trajectory` to seek and play it, on any backend and precision. The writer runs on the stepping thread and compresses and writes each completed chunk on a thread of its own, one chunk in flight at a time, so every frame is kept. `gs replay file.gstraj` plays it in the viewer.
- `Scene.load`, `load_checkpoint` and `load_trajectory` take viewer, visualizer and renderer options replacing the recorded ones.
- A record restores into a scene sharing the recorded description, entities and physics options, and is rejected otherwise before anything is touched. The last frame of a trajectory, like a checkpoint file, holds every array but the configs and constants, scratch included, for the analysis of a failure that may never reproduce elsewhere.
- **Breaking:** the `save_on_reset` option of the file recorders is removed. A recorder writes at the stop and at the destruction of the scene, and a reset goes on in the same file.

The documentation is updated in Genesis-Embodied-AI/genesis-doc#149 and Genesis-Embodied-AI/genesis-doc#150.

## Motivation and Context

Checkpointing a run, sharing a reproducible trajectory across machines, and inspecting the final state of a crashed run all need one declaration of what a solver carries from one step to the next. The declaration also bounds what a checkpoint or a frame holds, so a log of a batched scene stays small.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_serialization.py`: `test_pickle_resume` (over `requires_grad` as well), `test_trajectory_replay` and `test_trajectory_replay_across_backends`, each over `n_envs` 0 and 2; `tests/core/test_recorders.py` covers the pre-step recording, and `test_error_handling` every failure path of the recorders. The last one replays a log recorded on CPU in single precision on the backend and precision of the session; its two snapshots are in the snapshots repository at the pinned revision.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.



