### PR TITLE
[BUG FIX] Fix dynamics of attached entities and resolve assets identically in every precision.

### DIFF
--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -45,6 +45,7 @@ from .inertial import (
     RHO_OBJECT,
     RHO_ROBOT,
     GeomInertialInfo,
+    LinkInertial,
     LinkInertialInfo,
     compose_inertial_from_g_infos,
     compose_inertial_properties,
@@ -181,15 +182,16 @@ class KinematicLinkDescription:
 class RigidLinkDescription(KinematicLinkDescription):
     """Describe one simulated link: the frame and geoms of a kinematic link, plus its dynamics.
 
-    Every inertial quantity holds the simulated value: the authored one where the asset states it, the geometry
-    estimate otherwise. The inverse weight holds the asset value, zeros for a link the world carries, or the sentinel
-    '-1.0', which the solver's refresh completes at build.
+    Every inertial quantity of a moving link holds the simulated value: the authored one where the asset states it,
+    the geometry estimate otherwise. A link the world carries holds what the asset states and None where it states
+    nothing, until an attach sets it moving or the build resolves it. The inverse weight holds the asset value, zeros
+    for a link the world carries, or the sentinel '-1.0', which the solver's refresh completes at build.
     """
 
-    inertial_pos: np.ndarray
-    inertial_quat: np.ndarray
-    inertia: np.ndarray
-    mass: float
+    inertial_pos: np.ndarray | None
+    inertial_quat: np.ndarray | None
+    inertia: np.ndarray | None
+    mass: float | None
     invweight: np.ndarray
     geoms: list[RigidGeomDescription] = field(default_factory=list)
 
@@ -1562,9 +1564,9 @@ class RigidEntityDescription(KinematicEntityDescription):
         invweight = l_info.get("invweight")
 
         # A fixed link takes no geometry estimate: it may be the environment or an object welded for this scene alone,
-        # and nothing in the asset tells which. It is massless when it states no mass, so that an attach setting it
-        # moving computes the estimate then (see 'KinematicEntity.attach'). A moving link without geometry keeps the
-        # mass 'finalize_inertial' floors at 'gs.EPS'.
+        # and nothing in the asset tells which. It keeps what the asset states for an attach that sets it moving to
+        # resolve (see 'KinematicEntity.attach'), and the build zeroes the rest (see 'RigidEntity._build'). A moving
+        # link without geometry keeps the mass 'finalize_inertial' floors at 'gs.EPS'.
         hint = InertialProperties(0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float))
         if not is_fixed and inertial_info.hint is not None:
             hint = inertial_info.hint
@@ -1639,7 +1641,10 @@ class RigidEntityDescription(KinematicEntityDescription):
 
         # The final inertial comes from the explicit values and the geometry estimate. The align anchor shares
         # 'finalize_inertial', so the dynamics inertia and that anchor stay in lockstep.
-        inertial = finalize_inertial(mass, com, quat, inertia, *hint, clamp_min_mass=not is_fixed)
+        if is_fixed:
+            inertial = LinkInertial(mass, com, quat, inertia)
+        else:
+            inertial = finalize_inertial(mass, com, quat, inertia, *hint)
 
         # override invweight if fixed
         if is_fixed:

--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -1481,7 +1481,9 @@ class RigidEntityDescription(KinematicEntityDescription):
                 v_l_info.get("inertial_quat"),
                 v_l_info.get("inertial_i"),
             )
-        inertial = finalize_inertial(mass, com, quat, inertia, *inertial_info.hint)
+        inertial = finalize_inertial(
+            mass, com, quat, inertia, *inertial_info.hint, clamp_min_mass=not is_link_fixed(self.links, i_link)
+        )
         return RigidVariantLinkDescription(
             vgeoms=[description_from_info(RigidVisGeomDescription, vg_info) for vg_info in vg_infos],
             mass=inertial.mass,
@@ -1558,11 +1560,14 @@ class RigidEntityDescription(KinematicEntityDescription):
         inertia = None if is_inertia_recomputed else l_info.get("inertial_i")
         invweight = l_info.get("invweight")
 
-        # A link holding no geometry keeps the mass 'finalize_inertial' floors at 'gs.EPS'.
+        # A fixed link takes no geometry estimate: it may be the environment or an object welded for this scene alone,
+        # and nothing in the asset tells which. It is massless when it states no mass, so that an attach setting it
+        # moving computes the estimate then (see 'KinematicEntity.attach'). A moving link without geometry keeps the
+        # mass 'finalize_inertial' floors at 'gs.EPS'.
         hint = InertialProperties(0.0, np.zeros(3, dtype=gs.np_float), np.zeros((3, 3), dtype=gs.np_float))
-        if inertial_info.hint is not None:
-            hint = inertial_info.hint
         if not is_fixed and inertial_info.hint is not None:
+            hint = inertial_info.hint
+
             # Compute the bounding box of the links using both visual and collision geometries to be conservative
             aabb_min = np.full((3,), float("inf"), dtype=gs.np_float)
             aabb_max = np.full((3,), float("-inf"), dtype=gs.np_float)
@@ -1633,7 +1638,7 @@ class RigidEntityDescription(KinematicEntityDescription):
 
         # The final inertial comes from the explicit values and the geometry estimate. The align anchor shares
         # 'finalize_inertial', so the dynamics inertia and that anchor stay in lockstep.
-        inertial = finalize_inertial(mass, com, quat, inertia, *hint)
+        inertial = finalize_inertial(mass, com, quat, inertia, *hint, clamp_min_mass=not is_fixed)
 
         # override invweight if fixed
         if is_fixed:

--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -1148,7 +1148,7 @@ class KinematicEntityDescription(EntityDescription):
                         "links or none of them."
                     )
                 # A body without inertia gets no anchor and keeps its frame, like the articulated body above. The solver
-                # and the setters then read it as unaligned (see 'func_midpoint_is_aligned' and '_init_mass_mat').
+                # and the setters then read it as unaligned (see 'func_midpoint_is_aligned' and '_init_tree_fields').
                 if not inertial_info:
                     root.is_aligned = False
                     continue
@@ -1177,7 +1177,8 @@ class KinematicEntityDescription(EntityDescription):
 
                 # Every link keeps its own mass and inertia. The inertial frame moves with the geoms into the anchored
                 # frame: getters and wrenches read it as 'link_COM', and the inverse weight derives from it. The solver
-                # composes the body from its links each step, so the composite is diagonal there (see '_init_mass_mat').
+                # composes the body from its links each step, so the composite is diagonal there (see
+                # '_init_tree_fields').
                 if isinstance(root, RigidLinkDescription):
                     for i_l in subtree:
                         desc = links[i_l] if i_v == 0 else variants[i_v].links[i_l]

--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -37,6 +37,8 @@ from genesis.utils.misc import get_assets_dir
 from ..base_entity import EntityDescription
 from .inertial import (
     AABB_EPS,
+    INERTIA_EIGVAL_ATOL,
+    INERTIA_EIGVAL_RTOL,
     INERTIA_RATIO_MAX,
     MASS_EPS,
     RHO_MUJOCO,
@@ -48,6 +50,9 @@ from .inertial import (
     compose_inertial_properties,
     finalize_inertial,
 )
+
+# Rounding a pose parsed from a file may carry, within which it reads as the identity
+POSE_EPS = 1e-9
 
 
 @dataclass(kw_only=True)
@@ -852,15 +857,16 @@ class KinematicEntityDescription(EntityDescription):
                 # Compute eigenvalues of inertia matrix after enforcing symmetry
                 inertia_diag, Q = np.linalg.eigh(0.5 * (inertia_i + inertia_i.T))
 
-                # Make sure that all eigenvalues are positive, ignoring rounding errors
-                if (inertia_diag < -gs.EPS).any():
+                # Make sure that all eigenvalues are positive, ignoring the rounding of the authored tensor
+                if (inertia_diag < -(np.abs(inertia_diag).max() * INERTIA_EIGVAL_RTOL + INERTIA_EIGVAL_ATOL)).any():
                     gs.raise_exception(
                         f"Inertia matrix of link '{l_info['name']}' not positive definite (eigenvalues: {inertia_diag})."
                     )
 
                 # Make sure that the inertia matrix is physically valid (nothing to do with numerical conditioning)
                 if any(
-                    inertia_diag[i] + inertia_diag[(i + 1) % 3] < inertia_diag[(i + 2) % 3] * (1.0 - 1e-6) - 1e-9
+                    inertia_diag[i] + inertia_diag[(i + 1) % 3]
+                    < inertia_diag[(i + 2) % 3] * (1.0 - INERTIA_EIGVAL_RTOL) - INERTIA_EIGVAL_ATOL
                     for i in range(3)
                 ):
                     gs.raise_exception(
@@ -882,9 +888,9 @@ class KinematicEntityDescription(EntityDescription):
         base_j_info, base_g_info = links_j_infos[0], links_g_infos[0]
         if len(l_infos) > 1 and (sum(j_info["n_dofs"] for j_info in base_j_info) == 0) and not base_g_info:
             child_has_freejoint = any(j_info["type"] == gs.JOINT_TYPE.FREE for j_info in links_j_infos[1])
-            child_is_identity = (np.abs(l_infos[1]["pos"]) < gs.EPS).all() and (
-                np.abs(l_infos[1]["quat"] - (1, 0, 0, 0)) < gs.EPS
-            ).all()
+            child_is_identity = np.allclose(l_infos[1]["pos"], 0.0, rtol=0.0, atol=POSE_EPS) and np.allclose(
+                l_infos[1]["quat"], (1.0, 0.0, 0.0, 0.0), rtol=0.0, atol=POSE_EPS
+            )
             if child_has_freejoint or child_is_identity:
                 del l_infos[0], links_j_infos[0], links_g_infos[0]
                 for l_info in l_infos:
@@ -1010,7 +1016,7 @@ class KinematicEntityDescription(EntityDescription):
         for j_info in (
             j_info for link_j_infos in links_j_infos for j_info in link_j_infos if j_info["type"] == gs.JOINT_TYPE.FREE
         ):
-            if not all((j_info[name] < gs.EPS).all() for name in non_physical_fieldnames if name in j_info):
+            if any((j_info[name] != 0.0).any() for name in non_physical_fieldnames if name in j_info):
                 gs.logger.warning(
                     "Some free joint has non-zero frictionloss, damping or armature parameters. Beware it is "
                     "non-physical."
@@ -1112,7 +1118,9 @@ class KinematicEntityDescription(EntityDescription):
                 explicit_mass_flags = set()
                 for i_l in subtree:
                     props, is_mass_explicit, _ = resolution.links_inertial_info[i_l][i_v]
-                    if props.mass < gs.EPS:
+                    # The stash holds the unit-density estimate, so a mass however small is a body of the composite, and
+                    # only a link without geometry or authored mass is left out.
+                    if props.mass <= 0.0:
                         continue
                     explicit_mass_flags.add(is_mass_explicit)
                     rot = gu.quat_to_R(props.quat)
@@ -1145,7 +1153,7 @@ class KinematicEntityDescription(EntityDescription):
                     root.is_aligned = False
                     continue
                 mass_total, com_root, inertia_root = compose_inertial_properties(inertial_info)
-                if mass_total <= gs.EPS:
+                if mass_total <= 0.0:
                     root.is_aligned = False
                     continue
                 principal_quat = gu.R_to_quat(uu.principal_axes_rot(inertia_root))
@@ -1298,14 +1306,17 @@ class KinematicEntityDescription(EntityDescription):
             # hint sets "convexify"/"decimate"/"decompose_error_threshold"), with the morph options as defaults for
             # whatever is left unset. Post-processing merges geoms within a call, so each set of effective options
             # gets its own call; geoms without overrides share one, preserving the whole-entity merge behavior.
-            # Thresholds match under gs.EPS tolerance so float noise cannot split a group.
+            # Thresholds match within the tolerance the mesh cache matches options with, so float noise cannot split a
+            # group.
             cg_infos_by_options: list[tuple[tuple, list]] = []
             for g_info in cg_infos:
                 convexify = g_info.pop("convexify", morph.convexify)
                 decimate = g_info.pop("decimate", morph.decimate)
                 threshold = g_info.pop("decompose_error_threshold", decompose_error_threshold)
                 for options, options_cg_infos in cg_infos_by_options:
-                    if options[:2] == (convexify, decimate) and math.isclose(options[2], threshold, abs_tol=gs.EPS):
+                    if options[:2] == (convexify, decimate) and math.isclose(
+                        options[2], threshold, rel_tol=mu.MESH_CACHE_MATCH_RTOL
+                    ):
                         options_cg_infos.append(g_info)
                         break
                 else:
@@ -1570,7 +1581,7 @@ class RigidEntityDescription(KinematicEntityDescription):
                 aabb_max = np.maximum(aabb_max, verts.max(axis=0))
 
             # Make sure that provided spatial inertia is consistent with the estimate from the geometries if not fixed
-            if (mass or hint.mass) > MASS_EPS and hint.mass > gs.EPS:
+            if (mass or hint.mass) > MASS_EPS and hint.mass > 0.0:
                 # An omitted center of mass resolves to the link frame origin whenever the inertia tensor is
                 # authored (see 'finalize_inertial'). It then takes the same consistency check as an authored one.
                 checked_com = gu.zero_pos() if com is None and inertia is not None else com

--- a/genesis/engine/entities/rigid_entity/inertial.py
+++ b/genesis/engine/entities/rigid_entity/inertial.py
@@ -18,6 +18,9 @@ RHO_MUJOCO = 1000.0
 MASS_EPS = 0.005
 AABB_EPS = 0.002
 INERTIA_RATIO_MAX = 100.0
+# Rounding of an authored inertia tensor, relative to its largest eigenvalue and absolute, that its checks forgive
+INERTIA_EIGVAL_RTOL = 1e-6
+INERTIA_EIGVAL_ATOL = 1e-9
 
 
 def get_local_inertial_from_geom(
@@ -202,7 +205,7 @@ def finalize_inertial(
     mass and does not inflate the fixed-subtree composite by ``gs.EPS``.
     """
     mass, com, quat, inertia = explicit_mass, explicit_com, explicit_quat, explicit_inertia
-    if mass is not None and hint_mass > gs.EPS:
+    if mass is not None and hint_mass > 0.0:
         hint_inertia = hint_inertia * (mass / hint_mass)
         hint_mass = mass
     if mass is None:

--- a/genesis/engine/entities/rigid_entity/inertial.py
+++ b/genesis/engine/entities/rigid_entity/inertial.py
@@ -201,8 +201,9 @@ def finalize_inertial(
     anchor resolve their inertial here, so the rigid dynamics inertia and the align anchor agree.
 
     With ``clamp_min_mass`` the resolved mass is floored at ``gs.EPS`` so a geometry-less moving link stays
-    non-singular in the dynamics. The align stash passes ``False``, so a genuinely massless link keeps its ``0.0``
-    mass and does not inflate the fixed-subtree composite by ``gs.EPS``.
+    non-singular in the dynamics. The align stash and the links fixed to the world pass ``False``, so a genuinely
+    massless link keeps its ``0.0`` mass: it neither inflates the fixed-subtree composite by ``gs.EPS`` nor reads as
+    stated once an attach sets it moving.
     """
     mass, com, quat, inertia = explicit_mass, explicit_com, explicit_quat, explicit_inertia
     if mass is not None and hint_mass > 0.0:

--- a/genesis/engine/entities/rigid_entity/inertial.py
+++ b/genesis/engine/entities/rigid_entity/inertial.py
@@ -201,9 +201,8 @@ def finalize_inertial(
     anchor resolve their inertial here, so the rigid dynamics inertia and the align anchor agree.
 
     With ``clamp_min_mass`` the resolved mass is floored at ``gs.EPS`` so a geometry-less moving link stays
-    non-singular in the dynamics. The align stash and the links fixed to the world pass ``False``, so a genuinely
-    massless link keeps its ``0.0`` mass: it neither inflates the fixed-subtree composite by ``gs.EPS`` nor reads as
-    stated once an attach sets it moving.
+    non-singular in the dynamics. The align stash and the variants of a link fixed to the world pass ``False``, so a
+    genuinely massless link keeps its ``0.0`` mass there and leaves the fixed-subtree composite alone.
     """
     mass, com, quat, inertia = explicit_mass, explicit_com, explicit_quat, explicit_inertia
     if mass is not None and hint_mass > 0.0:

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -431,13 +431,10 @@ class KinematicEntity(Entity):
                             rho = RHO_ROBOT if desc.is_robot else RHO_OBJECT
                     # A geom description holds the fields a parse states it with, so one composition serves either.
                     hint = compose_inertial_from_g_infos([vars(g_desc) for g_desc in (desc.geoms or desc.vgeoms)], rho)
-                    # A fixed link is described massless when it states no mass (see '_describe_link').
-                    stated_mass = desc.mass if desc.mass > 0.0 else None
-                    stated_inertia = desc.inertia if desc.inertia is not None and desc.inertia.any() else None
-                    stated_com = desc.inertial_pos if stated_inertia is not None else None
-                    stated_quat = desc.inertial_quat if stated_inertia is not None else None
+                    # A fixed link holds what the asset states and None elsewhere (see 'RigidLinkDescription'), so
+                    # this resolves it exactly as '_describe_link' resolves a moving link.
                     desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia = finalize_inertial(
-                        stated_mass, stated_com, stated_quat, stated_inertia, *hint
+                        desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia, *hint
                     )
 
         # The anchor of an aligned free root is the center of mass and principal axes of the body the build described,
@@ -1932,6 +1929,20 @@ class RigidEntity(KinematicEntity):
     def _build(self):
         self._n_geoms = self.n_geoms
         self._geoms = self.geoms
+
+        # A link the world carries holds None where its asset states nothing (see 'RigidLinkDescription'). The solver
+        # stores a value for every link, and the inertial of such a link never enters the dynamics, so zero it is.
+        for link in self._links:
+            if link.is_fixed:
+                desc = link.desc
+                if desc.mass is None:
+                    desc.mass = 0.0
+                if desc.inertial_pos is None:
+                    desc.inertial_pos = gu.zero_pos()
+                if desc.inertial_quat is None:
+                    desc.inertial_quat = gu.identity_quat()
+                if desc.inertia is None:
+                    desc.inertia = np.zeros((3, 3), dtype=gs.np_float)
 
         super()._build()
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -302,7 +302,7 @@ class KinematicEntity(Entity):
                 gs.raise_exception(f"Mounting 'pos' must have shape (3,), got {mount_pos.shape}.")
             if mount_quat.shape != (4,):
                 gs.raise_exception(f"Mounting 'quat' must have shape (4,) (w, x, y, z), got {mount_quat.shape}.")
-            if np.linalg.norm(mount_quat) < gs.EPS:
+            if np.linalg.norm(mount_quat) == 0.0:
                 gs.raise_exception("Mounting 'quat' cannot be a zero-length quaternion.")
             mount_quat = gu.normalize(mount_quat)
 

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -443,7 +443,7 @@ class KinematicEntity(Entity):
         # The anchor of an aligned free root is the center of mass and principal axes of the body the build described,
         # and the attached links now extend that body. Its frame and qpos stay where they are, so the anchor stops
         # standing for the body: the mass block keeps its off-diagonal terms and the midpoint pass turns the body about
-        # its actual center of mass (see '_init_mass_mat' and 'func_midpoint_is_aligned').
+        # its actual center of mass (see '_init_tree_fields' and 'func_midpoint_is_aligned').
         root_link.desc.is_aligned = False
 
         # Apply the explicit mounting transform. Forward kinematics interprets the base link's local pose relative to

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -2987,10 +2987,10 @@ class RigidEntity(KinematicEntity):
     def get_potential_energy(self, envs_idx=None) -> torch.Tensor:
         """Get the total potential energy of the entity in Joules [J] (gravitational + joint springs).
 
-        Gravity contributes ``-sum_i(m_i * g^T * p_i)`` over the entity's links, where ``p_i`` is the center-of-mass
-        position of link *i* and ``g`` is the gravity vector obtained from the solver. Its joint springs contribute
-        ``0.5 * sum_d(stiffness_d * (q_d - q0_d)^2)``, the elastic energy stored by holding each DOF away from its
-        neutral position.
+        Gravity contributes ``-sum_i(m_i * g^T * p_i)`` over the links of the entity free to move, where ``p_i`` is the
+        center-of-mass position of link *i* and ``g`` is the gravity vector obtained from the solver. Its joint springs
+        contribute ``0.5 * sum_d(stiffness_d * (q_d - q0_d)^2)``, the elastic energy stored by holding each DOF away
+        from its neutral position.
 
         Parameters
         ----------

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -440,6 +440,12 @@ class KinematicEntity(Entity):
                         stated_mass, stated_com, stated_quat, stated_inertia, *hint
                     )
 
+        # The anchor of an aligned free root is the center of mass and principal axes of the body the build described,
+        # and the attached links now extend that body. Its frame and qpos stay where they are, so the anchor stops
+        # standing for the body: the mass block keeps its off-diagonal terms and the midpoint pass turns the body about
+        # its actual center of mass (see '_init_mass_mat' and 'func_midpoint_is_aligned').
+        root_link.desc.is_aligned = False
+
         # Apply the explicit mounting transform. Forward kinematics interprets the base link's local pose relative to
         # its (new) parent link, so overwriting it here mounts the entity at (pos, quat) in the parent link frame.
         # Compose with the morph frame offset exactly as '_align_link' does for the morph pose at load time, so the

--- a/genesis/engine/entities/rigid_entity/rigid_entity.py
+++ b/genesis/engine/entities/rigid_entity/rigid_entity.py
@@ -21,6 +21,7 @@ from .description import (
     RigidEqualityDescription,
     RigidLinkDescription,
 )
+from .inertial import RHO_MUJOCO, RHO_OBJECT, RHO_ROBOT, compose_inertial_from_g_infos, finalize_inertial
 from .rigid_equality import RigidEquality
 from .rigid_geom import RigidGeom
 from .rigid_joint import RigidJoint
@@ -407,12 +408,37 @@ class KinematicEntity(Entity):
         # links of other trees declared in the same file keep their own root, as do the fixed flag and invweight.
         for link in self._solver.links:
             if link.root_idx == base_link.idx:
+                was_fixed = link.is_fixed
                 link._root_idx = parent_link.root_idx
                 link._is_fixed &= parent_link.is_fixed
 
                 # The attach moves this link into another kinematic tree, so its old tree's inverse weight no longer
                 # applies. The sentinel makes the solver recompute it during its refresh.
                 link.desc.invweight = np.full((2,), fill_value=-1.0, dtype=gs.np_float)
+
+                # Inertial resolution skips the geometry estimate for a world-carried link (see '_describe_link'), so a
+                # link that starts moving recomputes it from its geoms at the density its entity simulates. Values the
+                # asset states still win over the estimate.
+                if was_fixed and not link.is_fixed and isinstance(link.desc, RigidLinkDescription):
+                    desc = link.desc
+                    # An entity attached beneath this one shares its root, so the density comes from the link's own
+                    # entity rather than from this one.
+                    rho = link.entity.material.rho
+                    if rho is None:
+                        if self._solver._enable_mujoco_compatibility:
+                            rho = RHO_MUJOCO
+                        else:
+                            rho = RHO_ROBOT if desc.is_robot else RHO_OBJECT
+                    # A geom description holds the fields a parse states it with, so one composition serves either.
+                    hint = compose_inertial_from_g_infos([vars(g_desc) for g_desc in (desc.geoms or desc.vgeoms)], rho)
+                    # A fixed link is described massless when it states no mass (see '_describe_link').
+                    stated_mass = desc.mass if desc.mass > 0.0 else None
+                    stated_inertia = desc.inertia if desc.inertia is not None and desc.inertia.any() else None
+                    stated_com = desc.inertial_pos if stated_inertia is not None else None
+                    stated_quat = desc.inertial_quat if stated_inertia is not None else None
+                    desc.mass, desc.inertial_pos, desc.inertial_quat, desc.inertia = finalize_inertial(
+                        stated_mass, stated_com, stated_quat, stated_inertia, *hint
+                    )
 
         # Apply the explicit mounting transform. Forward kinematics interprets the base link's local pose relative to
         # its (new) parent link, so overwriting it here mounts the entity at (pos, quat) in the parent link frame.

--- a/genesis/engine/solvers/kinematic_solver.py
+++ b/genesis/engine/solvers/kinematic_solver.py
@@ -344,6 +344,7 @@ class KinematicSolver(Solver):
         self._init_vvert_fields()
         self._init_vgeom_fields()
         self._init_link_fields()
+        self._init_tree_fields()
         self._init_entity_fields()
         self._init_vfaces_raycast_mask()
 
@@ -438,6 +439,14 @@ class KinematicSolver(Solver):
             )
 
         self.dyn_state.dofs.force.fill(0)
+
+    def _init_tree_fields(self):
+        """Initialize the fields describing the kinematic trees, which the kernels walk link by link."""
+        # The links come in build order, so the last one met for a root closes its tree.
+        links_tree_end = np.zeros(self.n_links_, dtype=gs.np_int)
+        for i_l, link in enumerate(self.links):
+            links_tree_end[link.root_idx] = i_l + 1
+        self.rigid_info.links_tree_end.from_numpy(links_tree_end)
 
     def _init_link_fields(self):
         if self.links:

--- a/genesis/engine/solvers/rigid/abd/forward_dynamics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_dynamics.py
@@ -1790,26 +1790,35 @@ def func_update_force(
                     + dyn_state.links.cfrc_coupling_ang[i_l, i_b]
                 )
 
+    # One thread folds the forces of a whole kinematic tree from its leaves up to its root, gating each link of the
+    # span on that root, like func_crb_fold: a tree spans several entities once one is attached beneath another, and a
+    # child must fold into its parent before the parent folds further up.
     qd.loop_config(serialize=rigid_config.para_level < gs.PARA_LEVEL.ALL)
-    for i_0, i_b in (
+    for i_l_, i_b in (
         qd.ndrange(1, dyn_state.links.pos.shape[1])
         if qd.static(rigid_config.use_hibernation)
-        else qd.ndrange(dyn_info.entities.n_links.shape[0], dyn_state.links.pos.shape[1])
+        else qd.ndrange(dyn_info.links.root_idx.shape[0], dyn_state.links.pos.shape[1])
     ):
-        for i_1 in (
-            range(rigid_info.n_awake_entities[i_b]) if qd.static(rigid_config.use_hibernation) else qd.static(range(1))
+        for i_l_awake in (
+            range(rigid_info.n_awake_links[i_b]) if qd.static(rigid_config.use_hibernation) else qd.static(range(1))
         ):
-            if func_check_index_range(i_1, 0, rigid_info.n_awake_entities[i_b], rigid_config.use_hibernation):
-                i_e = rigid_info.awake_entities[i_1, i_b] if qd.static(rigid_config.use_hibernation) else i_0
-
-                for i_l_ in range(dyn_info.entities.n_links[i_e]):
-                    i_l = dyn_info.entities.link_end[i_e] - 1 - i_l_
-                    I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
-                    i_p = dyn_info.links.parent_idx[I_l]
-                    I_p = [i_p, i_b]
-                    if i_p != -1:
-                        func_add_safe_backward(I_p, dyn_state.links.cfrc_vel[i_l, i_b], dyn_state.links.cfrc_vel, BW)
-                        func_add_safe_backward(I_p, dyn_state.links.cfrc_ang[i_l, i_b], dyn_state.links.cfrc_ang, BW)
+            if func_check_index_range(i_l_awake, 0, rigid_info.n_awake_links[i_b], rigid_config.use_hibernation):
+                i_l_root = rigid_info.awake_links[i_l_awake, i_b] if qd.static(rigid_config.use_hibernation) else i_l_
+                I_l_root = [i_l_root, i_b] if qd.static(rigid_config.batch_links_info) else i_l_root
+                if dyn_info.links.root_idx[I_l_root] == i_l_root:
+                    tree_end = rigid_info.links_tree_end[i_l_root]
+                    for k in range(tree_end - i_l_root):
+                        i_l = tree_end - 1 - k
+                        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+                        i_p = dyn_info.links.parent_idx[I_l]
+                        I_p = [i_p, i_b]
+                        if dyn_info.links.root_idx[I_l] == i_l_root and i_p != -1:
+                            func_add_safe_backward(
+                                I_p, dyn_state.links.cfrc_vel[i_l, i_b], dyn_state.links.cfrc_vel, BW
+                            )
+                            func_add_safe_backward(
+                                I_p, dyn_state.links.cfrc_ang[i_l, i_b], dyn_state.links.cfrc_ang, BW
+                            )
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/abd/forward_kinematics.py
+++ b/genesis/engine/solvers/rigid/abd/forward_kinematics.py
@@ -137,23 +137,23 @@ def func_COM_links(
     rigid_config: qd.template(),
     is_backward: qd.template(),
 ):
-    BW = qd.static(is_backward)
+    """Compute the center of mass of every kinematic tree of one environment and the inertial of every link about it."""
     i_b = qd.cast(i_b, qd.i32)
 
-    for i_e_ in (
-        range(rigid_info.n_awake_entities[i_b])
+    for i_l_ in (
+        range(rigid_info.n_awake_links[i_b])
         if qd.static(rigid_config.use_hibernation)
-        else range(dyn_info.entities.n_links.shape[0])
+        else range(dyn_info.links.root_idx.shape[0])
     ):
-        if func_check_index_range(i_e_, 0, rigid_info.n_awake_entities[i_b], rigid_config.use_hibernation):
-            i_e = rigid_info.awake_entities[i_e_, i_b] if qd.static(rigid_config.use_hibernation) else i_e_
-
-            func_COM_links_entity(i_e, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
+        i_l = rigid_info.awake_links[i_l_, i_b] if qd.static(rigid_config.use_hibernation) else i_l_
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.root_idx[I_l] == i_l:
+            func_COM_links_tree(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
 
 
 @qd.func
-def func_COM_links_entity(
-    i_e,
+def func_COM_links_tree(
+    i_l_root,
     i_b,
     dyn_state: array_class.DynState,
     dyn_info: array_class.DynInfo,
@@ -161,181 +161,160 @@ def func_COM_links_entity(
     rigid_config: qd.template(),
     is_backward: qd.template(),
 ):
+    """Compute the center of mass of one kinematic tree and the inertial of each of its links about it.
+
+    One call handles the whole tree whose root is this link, walking its link span and gating each link on that root
+    (see links_tree_end in array_class.py), so that a tree spanning several entities, one attached beneath another,
+    accumulates every link of its own before it divides. Mirrors the tree walk of func_crb_fold. The callers pass awake
+    roots, and a tree sleeps as a unit, so no link of it is hibernated here.
+    """
     EPS = rigid_info.EPS[None]
     BW = qd.static(is_backward)
     i_b = qd.cast(i_b, qd.i32)
 
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
-        dyn_state.links.root_COM_bw[i_l, i_b].fill(0.0)
-        dyn_state.links.mass_sum[i_l, i_b] = 0.0
+    dyn_state.links.root_COM_bw[i_l_root, i_b].fill(0.0)
+    dyn_state.links.mass_sum[i_l_root, i_b] = 0.0
 
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
+    for i_l in range(i_l_root, rigid_info.links_tree_end[i_l_root]):
         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
-
-        mass = dyn_info.links.inertial_mass[I_l]
-        (dyn_state.links.i_pos_bw[i_l, i_b], dyn_state.links.i_quat[i_l, i_b]) = gu.qd_transform_pos_quat_by_trans_quat(
-            dyn_info.links.inertial_pos[I_l],
-            dyn_info.links.inertial_quat[I_l],
-            dyn_state.links.pos[i_l, i_b],
-            dyn_state.links.quat[i_l, i_b],
-        )
-
-        i_r = dyn_info.links.root_idx[I_l]
-        dyn_state.links.mass_sum[i_r, i_b] = dyn_state.links.mass_sum[i_r, i_b] + mass
-        dyn_state.links.root_COM_bw[i_r, i_b] = (
-            dyn_state.links.root_COM_bw[i_r, i_b] + mass * dyn_state.links.i_pos_bw[i_l, i_b]
-        )
-
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
-        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
-
-        i_r = dyn_info.links.root_idx[I_l]
-        if i_l == i_r:
-            mass_sum = dyn_state.links.mass_sum[i_l, i_b]
-            if mass_sum > EPS:
-                dyn_state.links.root_COM[i_l, i_b] = (
-                    dyn_state.links.root_COM_bw[i_l, i_b] / dyn_state.links.mass_sum[i_l, i_b]
+        if dyn_info.links.root_idx[I_l] == i_l_root:
+            mass = dyn_info.links.inertial_mass[I_l]
+            (dyn_state.links.i_pos_bw[i_l, i_b], dyn_state.links.i_quat[i_l, i_b]) = (
+                gu.qd_transform_pos_quat_by_trans_quat(
+                    dyn_info.links.inertial_pos[I_l],
+                    dyn_info.links.inertial_quat[I_l],
+                    dyn_state.links.pos[i_l, i_b],
+                    dyn_state.links.quat[i_l, i_b],
                 )
-            else:
-                dyn_state.links.root_COM[i_l, i_b] = dyn_state.links.i_pos_bw[i_r, i_b]
+            )
 
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
+            dyn_state.links.mass_sum[i_l_root, i_b] = dyn_state.links.mass_sum[i_l_root, i_b] + mass
+            dyn_state.links.root_COM_bw[i_l_root, i_b] = (
+                dyn_state.links.root_COM_bw[i_l_root, i_b] + mass * dyn_state.links.i_pos_bw[i_l, i_b]
+            )
+
+    mass_sum = dyn_state.links.mass_sum[i_l_root, i_b]
+    if mass_sum > EPS:
+        dyn_state.links.root_COM[i_l_root, i_b] = dyn_state.links.root_COM_bw[i_l_root, i_b] / mass_sum
+    else:
+        dyn_state.links.root_COM[i_l_root, i_b] = dyn_state.links.i_pos_bw[i_l_root, i_b]
+
+    for i_l in range(i_l_root, rigid_info.links_tree_end[i_l_root]):
         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.root_idx[I_l] == i_l_root:
+            dyn_state.links.root_COM[i_l, i_b] = dyn_state.links.root_COM[i_l_root, i_b]
 
-        i_r = dyn_info.links.root_idx[I_l]
-        dyn_state.links.root_COM[i_l, i_b] = dyn_state.links.root_COM[i_r, i_b]
-
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
+    for i_l in range(i_l_root, rigid_info.links_tree_end[i_l_root]):
         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.root_idx[I_l] == i_l_root:
+            dyn_state.links.i_pos[i_l, i_b] = dyn_state.links.i_pos_bw[i_l, i_b] - dyn_state.links.root_COM[i_l, i_b]
 
-        i_r = dyn_info.links.root_idx[I_l]
-        dyn_state.links.i_pos[i_l, i_b] = dyn_state.links.i_pos_bw[i_l, i_b] - dyn_state.links.root_COM[i_l, i_b]
+            (
+                dyn_state.links.cinr_inertial[i_l, i_b],
+                dyn_state.links.cinr_pos[i_l, i_b],
+                dyn_state.links.cinr_quat[i_l, i_b],
+                dyn_state.links.cinr_mass[i_l, i_b],
+            ) = gu.qd_transform_inertia_by_trans_quat(
+                dyn_info.links.inertial_i[I_l],
+                dyn_info.links.inertial_mass[I_l],
+                dyn_state.links.i_pos[i_l, i_b],
+                dyn_state.links.i_quat[i_l, i_b],
+                rigid_info.EPS[None],
+            )
 
-        (
-            dyn_state.links.cinr_inertial[i_l, i_b],
-            dyn_state.links.cinr_pos[i_l, i_b],
-            dyn_state.links.cinr_quat[i_l, i_b],
-            dyn_state.links.cinr_mass[i_l, i_b],
-        ) = gu.qd_transform_inertia_by_trans_quat(
-            dyn_info.links.inertial_i[I_l],
-            dyn_info.links.inertial_mass[I_l],
-            dyn_state.links.i_pos[i_l, i_b],
-            dyn_state.links.i_quat[i_l, i_b],
-            rigid_info.EPS[None],
-        )
-
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
+    for i_l in range(i_l_root, rigid_info.links_tree_end[i_l_root]):
         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.root_idx[I_l] == i_l_root:
+            if dyn_info.links.n_dofs[I_l] > 0:
+                i_p = dyn_info.links.parent_idx[I_l]
 
-        if dyn_info.links.n_dofs[I_l] > 0:
-            i_p = dyn_info.links.parent_idx[I_l]
+                _i_j = dyn_info.links.joint_start[I_l]
+                _I_j = [_i_j, i_b] if qd.static(rigid_config.batch_joints_info) else _i_j
+                joint_type = dyn_info.joints.type[_I_j]
 
-            _i_j = dyn_info.links.joint_start[I_l]
-            _I_j = [_i_j, i_b] if qd.static(rigid_config.batch_joints_info) else _i_j
-            joint_type = dyn_info.joints.type[_I_j]
+                p_pos = qd.Vector.zero(gs.qd_float, 3)
+                p_quat = gu.qd_identity_quat()
+                if i_p != -1:
+                    p_pos = dyn_state.links.pos[i_p, i_b]
+                    p_quat = dyn_state.links.quat[i_p, i_b]
 
-            p_pos = qd.Vector.zero(gs.qd_float, 3)
-            p_quat = gu.qd_identity_quat()
-            if i_p != -1:
-                p_pos = dyn_state.links.pos[i_p, i_b]
-                p_quat = dyn_state.links.quat[i_p, i_b]
-
-            if joint_type == gs.JOINT_TYPE.FREE or (dyn_info.links.is_fixed[I_l] and i_p == -1):
-                dyn_state.links.j_pos[i_l, i_b] = dyn_state.links.pos[i_l, i_b]
-                dyn_state.links.j_quat[i_l, i_b] = dyn_state.links.quat[i_l, i_b]
-            else:
-                (dyn_state.links.j_pos_bw[i_l, 0, i_b], dyn_state.links.j_quat_bw[i_l, 0, i_b]) = (
-                    gu.qd_transform_pos_quat_by_trans_quat(
-                        dyn_info.links.pos[I_l], dyn_info.links.quat[I_l], p_pos, p_quat
-                    )
-                )
-
-                n_joints = dyn_info.links.joint_end[I_l] - dyn_info.links.joint_start[I_l]
-
-                for i_j_ in range(n_joints):
-                    i_j = i_j_ + dyn_info.links.joint_start[I_l]
-
-                    curr_i_j = 0 if qd.static(not BW) else i_j_
-                    next_i_j = 0 if qd.static(not BW) else i_j_ + 1
-
-                    if func_check_index_range(i_j, dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l], BW):
-                        I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
-
-                        (
-                            dyn_state.links.j_pos_bw[i_l, next_i_j, i_b],
-                            dyn_state.links.j_quat_bw[i_l, next_i_j, i_b],
-                        ) = gu.qd_transform_pos_quat_by_trans_quat(
-                            dyn_info.joints.pos[I_j],
-                            gu.qd_identity_quat(),
-                            dyn_state.links.j_pos_bw[i_l, curr_i_j, i_b],
-                            dyn_state.links.j_quat_bw[i_l, curr_i_j, i_b],
+                if joint_type == gs.JOINT_TYPE.FREE or (dyn_info.links.is_fixed[I_l] and i_p == -1):
+                    dyn_state.links.j_pos[i_l, i_b] = dyn_state.links.pos[i_l, i_b]
+                    dyn_state.links.j_quat[i_l, i_b] = dyn_state.links.quat[i_l, i_b]
+                else:
+                    (dyn_state.links.j_pos_bw[i_l, 0, i_b], dyn_state.links.j_quat_bw[i_l, 0, i_b]) = (
+                        gu.qd_transform_pos_quat_by_trans_quat(
+                            dyn_info.links.pos[I_l], dyn_info.links.quat[I_l], p_pos, p_quat
                         )
+                    )
 
-                i_j_ = 0 if qd.static(not BW) else n_joints
-                dyn_state.links.j_pos[i_l, i_b] = dyn_state.links.j_pos_bw[i_l, i_j_, i_b]
-                dyn_state.links.j_quat[i_l, i_b] = dyn_state.links.j_quat_bw[i_l, i_j_, i_b]
+                    n_joints = dyn_info.links.joint_end[I_l] - dyn_info.links.joint_start[I_l]
 
-    for i_l in range(dyn_info.entities.link_start[i_e], dyn_info.entities.link_end[i_e]):
-        if qd.static(rigid_config.use_hibernation):
-            if dyn_state.links.is_hibernated[i_l, i_b]:
-                continue
+                    for i_j_ in range(n_joints):
+                        i_j = i_j_ + dyn_info.links.joint_start[I_l]
+
+                        curr_i_j = 0 if qd.static(not BW) else i_j_
+                        next_i_j = 0 if qd.static(not BW) else i_j_ + 1
+
+                        if func_check_index_range(
+                            i_j, dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l], BW
+                        ):
+                            I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+
+                            (
+                                dyn_state.links.j_pos_bw[i_l, next_i_j, i_b],
+                                dyn_state.links.j_quat_bw[i_l, next_i_j, i_b],
+                            ) = gu.qd_transform_pos_quat_by_trans_quat(
+                                dyn_info.joints.pos[I_j],
+                                gu.qd_identity_quat(),
+                                dyn_state.links.j_pos_bw[i_l, curr_i_j, i_b],
+                                dyn_state.links.j_quat_bw[i_l, curr_i_j, i_b],
+                            )
+
+                    i_j_ = 0 if qd.static(not BW) else n_joints
+                    dyn_state.links.j_pos[i_l, i_b] = dyn_state.links.j_pos_bw[i_l, i_j_, i_b]
+                    dyn_state.links.j_quat[i_l, i_b] = dyn_state.links.j_quat_bw[i_l, i_j_, i_b]
+
+    for i_l in range(i_l_root, rigid_info.links_tree_end[i_l_root]):
         I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.root_idx[I_l] == i_l_root:
+            if dyn_info.links.n_dofs[I_l] > 0:
+                for i_j in range(dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l]):
+                    offset_pos = dyn_state.links.root_COM[i_l, i_b] - dyn_state.joints.xanchor[i_j, i_b]
+                    I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
+                    joint_type = dyn_info.joints.type[I_j]
 
-        if dyn_info.links.n_dofs[I_l] > 0:
-            for i_j in range(dyn_info.links.joint_start[I_l], dyn_info.links.joint_end[I_l]):
-                offset_pos = dyn_state.links.root_COM[i_l, i_b] - dyn_state.joints.xanchor[i_j, i_b]
-                I_j = [i_j, i_b] if qd.static(rigid_config.batch_joints_info) else i_j
-                joint_type = dyn_info.joints.type[I_j]
+                    dof_start = dyn_info.joints.dof_start[I_j]
 
-                dof_start = dyn_info.joints.dof_start[I_j]
+                    if joint_type == gs.JOINT_TYPE.REVOLUTE:
+                        dyn_state.dofs.cdof_ang[dof_start, i_b] = dyn_state.joints.xaxis[i_j, i_b]
+                        dyn_state.dofs.cdof_vel[dof_start, i_b] = dyn_state.joints.xaxis[i_j, i_b].cross(offset_pos)
+                    elif joint_type == gs.JOINT_TYPE.PRISMATIC:
+                        dyn_state.dofs.cdof_ang[dof_start, i_b] = qd.Vector.zero(gs.qd_float, 3)
+                        dyn_state.dofs.cdof_vel[dof_start, i_b] = dyn_state.joints.xaxis[i_j, i_b]
+                    elif joint_type == gs.JOINT_TYPE.SPHERICAL:
+                        xmat_T = gu.qd_quat_to_R(dyn_state.links.quat[i_l, i_b], EPS).transpose()
+                        for i in qd.static(range(3)):
+                            dyn_state.dofs.cdof_ang[i + dof_start, i_b] = xmat_T[i, :]
+                            dyn_state.dofs.cdof_vel[i + dof_start, i_b] = xmat_T[i, :].cross(offset_pos)
+                    elif joint_type == gs.JOINT_TYPE.FREE:
+                        for i in qd.static(range(3)):
+                            dyn_state.dofs.cdof_ang[i + dof_start, i_b] = qd.Vector.zero(gs.qd_float, 3)
+                            dyn_state.dofs.cdof_vel[i + dof_start, i_b] = qd.Vector.zero(gs.qd_float, 3)
+                            dyn_state.dofs.cdof_vel[i + dof_start, i_b][i] = 1.0
 
-                if joint_type == gs.JOINT_TYPE.REVOLUTE:
-                    dyn_state.dofs.cdof_ang[dof_start, i_b] = dyn_state.joints.xaxis[i_j, i_b]
-                    dyn_state.dofs.cdof_vel[dof_start, i_b] = dyn_state.joints.xaxis[i_j, i_b].cross(offset_pos)
-                elif joint_type == gs.JOINT_TYPE.PRISMATIC:
-                    dyn_state.dofs.cdof_ang[dof_start, i_b] = qd.Vector.zero(gs.qd_float, 3)
-                    dyn_state.dofs.cdof_vel[dof_start, i_b] = dyn_state.joints.xaxis[i_j, i_b]
-                elif joint_type == gs.JOINT_TYPE.SPHERICAL:
-                    xmat_T = gu.qd_quat_to_R(dyn_state.links.quat[i_l, i_b], EPS).transpose()
-                    for i in qd.static(range(3)):
-                        dyn_state.dofs.cdof_ang[i + dof_start, i_b] = xmat_T[i, :]
-                        dyn_state.dofs.cdof_vel[i + dof_start, i_b] = xmat_T[i, :].cross(offset_pos)
-                elif joint_type == gs.JOINT_TYPE.FREE:
-                    for i in qd.static(range(3)):
-                        dyn_state.dofs.cdof_ang[i + dof_start, i_b] = qd.Vector.zero(gs.qd_float, 3)
-                        dyn_state.dofs.cdof_vel[i + dof_start, i_b] = qd.Vector.zero(gs.qd_float, 3)
-                        dyn_state.dofs.cdof_vel[i + dof_start, i_b][i] = 1.0
+                        xmat_T = gu.qd_quat_to_R(dyn_state.links.quat[i_l, i_b], EPS).transpose()
+                        for i in qd.static(range(3)):
+                            dyn_state.dofs.cdof_ang[i + dof_start + 3, i_b] = xmat_T[i, :]
+                            dyn_state.dofs.cdof_vel[i + dof_start + 3, i_b] = xmat_T[i, :].cross(offset_pos)
 
-                    xmat_T = gu.qd_quat_to_R(dyn_state.links.quat[i_l, i_b], EPS).transpose()
-                    for i in qd.static(range(3)):
-                        dyn_state.dofs.cdof_ang[i + dof_start + 3, i_b] = xmat_T[i, :]
-                        dyn_state.dofs.cdof_vel[i + dof_start + 3, i_b] = xmat_T[i, :].cross(offset_pos)
-
-                for i_d in range(dof_start, dyn_info.joints.dof_end[I_j]):
-                    dyn_state.dofs.cdofvel_ang[i_d, i_b] = (
-                        dyn_state.dofs.cdof_ang[i_d, i_b] * dyn_state.dofs.vel[i_d, i_b]
-                    )
-                    dyn_state.dofs.cdofvel_vel[i_d, i_b] = (
-                        dyn_state.dofs.cdof_vel[i_d, i_b] * dyn_state.dofs.vel[i_d, i_b]
-                    )
+                    for i_d in range(dof_start, dyn_info.joints.dof_end[I_j]):
+                        dyn_state.dofs.cdofvel_ang[i_d, i_b] = (
+                            dyn_state.dofs.cdof_ang[i_d, i_b] * dyn_state.dofs.vel[i_d, i_b]
+                        )
+                        dyn_state.dofs.cdofvel_vel[i_d, i_b] = (
+                            dyn_state.dofs.cdof_vel[i_d, i_b] * dyn_state.dofs.vel[i_d, i_b]
+                        )
 
 
 @qd.func
@@ -1086,7 +1065,27 @@ def func_hibernate_link_and_zero_dof_velocities(
 
 
 @qd.func
-def func_update_cartesian_space_entity(
+def func_is_entity_in_tree(
+    j_e,
+    i_b,
+    i_l_start,
+    i_l_end,
+    dyn_info: array_class.DynInfo,
+    rigid_config: qd.template(),
+):
+    """Whether entity j_e belongs to the kinematic tree of the entity holding links [i_l_start, i_l_end).
+
+    An entity roots at its own base link, or, once attached beneath another entity, at a link of that entity. The
+    root of its base link therefore tells which entity carries it.
+    """
+    j_l_start = dyn_info.entities.link_start[j_e]
+    J_l_start = [j_l_start, i_b] if qd.static(rigid_config.batch_links_info) else j_l_start
+    j_l_root = dyn_info.links.root_idx[J_l_start]
+    return i_l_start <= j_l_root and j_l_root < i_l_end
+
+
+@qd.func
+def func_update_cartesian_space_tree(
     i_e,
     i_b,
     qpos: qd.Tensor,
@@ -1097,11 +1096,29 @@ def func_update_cartesian_space_entity(
     force_update_fixed_geoms: qd.template(),
     is_backward: qd.template(),
 ):
-    func_forward_kinematics_entity(i_e, i_b, qpos, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
-    func_COM_links_entity(i_e, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
-    func_update_geoms_entity(
-        i_e, i_b, dyn_state, dyn_info, rigid_info, rigid_config, force_update_fixed_geoms, is_backward
-    )
+    """Update the kinematic trees of entity i_e and of every entity attached beneath one of its links.
+
+    An attached entity roots at a link of the entity it hangs from, which may be a jointed link rather than the base,
+    and comes after that entity. The forward kinematics run over these entities in order, so the poses a parent passes
+    down are final when its children read them; the center of mass of each tree then walks the tree whole (see
+    func_COM_links_tree), and the geoms follow.
+    """
+    i_l_start = dyn_info.entities.link_start[i_e]
+    i_l_end = dyn_info.entities.link_end[i_e]
+    n_entities = dyn_info.entities.n_links.shape[0]
+
+    for j_e in range(i_e, n_entities):
+        if func_is_entity_in_tree(j_e, i_b, i_l_start, i_l_end, dyn_info, rigid_config):
+            func_forward_kinematics_entity(j_e, i_b, qpos, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
+    for i_l in range(i_l_start, i_l_end):
+        I_l = [i_l, i_b] if qd.static(rigid_config.batch_links_info) else i_l
+        if dyn_info.links.root_idx[I_l] == i_l:
+            func_COM_links_tree(i_l, i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
+    for j_e in range(i_e, n_entities):
+        if func_is_entity_in_tree(j_e, i_b, i_l_start, i_l_end, dyn_info, rigid_config):
+            func_update_geoms_entity(
+                j_e, i_b, dyn_state, dyn_info, rigid_info, rigid_config, force_update_fixed_geoms, is_backward
+            )
 
 
 @qd.func
@@ -1115,20 +1132,29 @@ def func_update_cartesian_space_batch(
     force_update_fixed_geoms: qd.template(),
     is_backward: qd.template(),
 ):
+    """Update the Cartesian space of one environment: forward kinematics, centers of mass, then geoms."""
     BW = qd.static(is_backward)
     i_b = qd.cast(i_b, qd.i32)
 
-    # This loop is considered an inner loop
+    # These loops are considered inner loops
     qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
-    for i_0 in (
+    for i_e_ in (
         range(rigid_info.n_awake_entities[i_b])
         if qd.static(rigid_config.use_hibernation)
         else range(dyn_info.entities.n_links.shape[0])
     ):
-        i_e = rigid_info.awake_entities[i_0, i_b] if qd.static(rigid_config.use_hibernation) else i_0
-
-        func_update_cartesian_space_entity(
-            i_e, i_b, qpos, dyn_state, dyn_info, rigid_info, rigid_config, force_update_fixed_geoms, is_backward
+        i_e = rigid_info.awake_entities[i_e_, i_b] if qd.static(rigid_config.use_hibernation) else i_e_
+        func_forward_kinematics_entity(i_e, i_b, qpos, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
+    func_COM_links(i_b, dyn_state, dyn_info, rigid_info, rigid_config, is_backward)
+    qd.loop_config(serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.ALL))
+    for i_e_ in (
+        range(rigid_info.n_awake_entities[i_b])
+        if qd.static(rigid_config.use_hibernation)
+        else range(dyn_info.entities.n_links.shape[0])
+    ):
+        i_e = rigid_info.awake_entities[i_e_, i_b] if qd.static(rigid_config.use_hibernation) else i_e_
+        func_update_geoms_entity(
+            i_e, i_b, dyn_state, dyn_info, rigid_info, rigid_config, force_update_fixed_geoms, is_backward
         )
 
 
@@ -1163,24 +1189,22 @@ def func_update_cartesian_space(
             name="update_cartesian_space", serialize=qd.static(rigid_config.para_level < gs.PARA_LEVEL.PARTIAL)
         )
         for i_e, i_b in qd.ndrange(dyn_info.entities.n_links.shape[0], dyn_state.links.pos.shape[1]):
+            # An entity roots at one of its own links unless it hangs from another entity, whose thread carries it.
             i_l_start = dyn_info.entities.link_start[i_e]
             I_l_start = [i_l_start, i_b] if qd.static(rigid_config.batch_links_info) else i_l_start
-            if dyn_info.links.root_idx[I_l_start] == i_l_start:
-                for j_e in range(i_e, dyn_info.entities.n_links.shape[0]):
-                    j_l_start = dyn_info.entities.link_start[j_e]
-                    J_l_start = [j_l_start, i_b] if qd.static(rigid_config.batch_links_info) else j_l_start
-                    if dyn_info.links.root_idx[J_l_start] == i_l_start:
-                        func_update_cartesian_space_entity(
-                            j_e,
-                            i_b,
-                            rigid_info.qpos,
-                            dyn_state,
-                            dyn_info,
-                            rigid_info,
-                            rigid_config,
-                            force_update_fixed_geoms,
-                            is_backward,
-                        )
+            i_l_root = dyn_info.links.root_idx[I_l_start]
+            if i_l_start <= i_l_root and i_l_root < dyn_info.entities.link_end[i_e]:
+                func_update_cartesian_space_tree(
+                    i_e,
+                    i_b,
+                    rigid_info.qpos,
+                    dyn_state,
+                    dyn_info,
+                    rigid_info,
+                    rigid_config,
+                    force_update_fixed_geoms,
+                    is_backward,
+                )
 
 
 @qd.kernel(fastcache=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -81,7 +81,6 @@ from .abd.misc import (
 from .abd.forward_kinematics import (
     func_aggregate_awake_entities,
     func_COM_links,
-    func_COM_links_entity,
     func_forward_kinematics_batch,
     func_forward_kinematics_entity,
     func_forward_velocity,
@@ -91,7 +90,6 @@ from .abd.forward_kinematics import (
     func_update_all_verts,
     func_update_cartesian_space,
     func_update_cartesian_space_batch,
-    func_update_cartesian_space_entity,
     func_update_geoms,
     func_update_geoms_batch,
     func_update_geoms_entity,
@@ -3211,10 +3209,11 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
     def get_potential_energy(self, links_idx=None, dofs_idx=None, envs_idx=None):
         """Get the potential energy of the specified links and DOFs in Joules [J] (gravitational + joint springs).
 
-        Gravity contributes ``-sum_i(m_i * g^T * p_i)`` over the links, where ``p_i`` is the center of mass (COM)
-        position of link *i*. Joint springs contribute ``0.5 * sum_d(stiffness_d * (q_d - q0_d)^2)``, the elastic
-        energy stored by holding each DOF away from its neutral position. Both are state functions, so their sum with
-        the kinetic energy is conserved by a passive, frictionless, contact-free model.
+        Gravity contributes ``-sum_i(m_i * g^T * p_i)`` over the links free to move, where ``p_i`` is the center of
+        mass (COM) position of link *i*. A link fixed to the world is left out, as it is of the mass of an entity: its
+        potential is a constant of the scene. Joint springs contribute ``0.5 * sum_d(stiffness_d * (q_d - q0_d)^2)``,
+        the elastic energy stored by holding each DOF away from its neutral position. Both are state functions, so
+        their sum with the kinetic energy is conserved by a passive, frictionless, contact-free model.
 
         Contacts contribute nothing: they are resolved by the constraint solver, which stabilizes a penetration
         rather than storing it as an elastic potential.
@@ -3234,7 +3233,12 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         """
         gravity = self.get_gravity(envs_idx=envs_idx)  # (3,) or (n_envs, 3)
         links_pos = self.get_links_pos(links_idx, envs_idx, ref=link_ref_frame.link_COM)  # (..., n_links, 3)
-        links_mass = self.get_links_mass(links_idx, envs_idx if self._options.batch_links_info else None)
+        links_envs_idx = envs_idx if self._options.batch_links_info else None
+        links_mass = qd_to_torch(self.dyn_info.links.inertial_mass, links_envs_idx, links_idx, transpose=True)
+        links_is_fixed = qd_to_torch(self.dyn_info.links.is_fixed, links_envs_idx, links_idx, transpose=True)
+        links_mass = links_mass.masked_fill(links_is_fixed.to(torch.bool), 0.0)
+        if self.n_envs == 0 and self._options.batch_links_info:
+            links_mass = links_mass[0]
 
         # PE_i = m_i * g^T * p_i => PE = sum_i(m_i * (g . p_i))
         # g is (..., 3), links_pos is (..., n_links, 3) -> broadcast g to (..., 1, 3)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -389,8 +389,6 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
 
         super().build()
 
-        self._init_mass_mat()
-
         self._init_vert_fields()
         self._init_geom_fields()
         self._init_equality_fields()
@@ -611,7 +609,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             rigid_config["prefer_decomposed_solver"] = 0
 
         # Per-DOF mass-block bounds (see dofs_mass_block_start in array_class.py), computed here because the tiled
-        # factor arms below are sized for the largest block; _init_mass_mat uploads them.
+        # factor arms below are sized for the largest block; _init_tree_fields uploads them.
         links_by_idx = {link.idx: link for link in self.links}
         dofs_mass_block_start = np.arange(self.n_dofs_, dtype=gs.np_int)
         for link in self.links:
@@ -933,7 +931,11 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             self._is_forward_vel_updated,
         )
 
-    def _init_mass_mat(self):
+    def _init_tree_fields(self):
+        """Initialize the fields describing the kinematic trees, the structure of the joint-space mass matrix
+        included."""
+        super()._init_tree_fields()
+
         self.mass_mat = self.rigid_info.mass_mat
         self.mass_mat_L = self.rigid_info.mass_mat_L
         self.mass_mat_D_inv = self.rigid_info.mass_mat_D_inv
@@ -957,13 +959,6 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         # Per-DOF mass-block bounds, computed by _build_static_config (which sizes the tiled factor arms from them).
         dofs_mass_block_start = self._dofs_mass_block_start
         dofs_mass_block_end = self._dofs_mass_block_end
-
-        # See links_tree_end in array_class.py: one past the last link of each tree, which may reach past interleaved
-        # links of other trees (the CRB fold gates on root_idx).
-        links_root_idx = np.array([link.root_idx for link in self.links], dtype=gs.np_int)
-        links_tree_end = np.zeros(self.n_links_, dtype=gs.np_int)
-        if self.links:
-            np.maximum.at(links_tree_end, links_root_idx, np.arange(self.n_links) + 1)
 
         # An aligned free body whose only DOFs are its own free joint has a diagonal joint-space mass block, so zero its
         # within-link off-diagonal mask to make the assembled mass exactly diagonal (else ~1e-6 round-off once it
@@ -1005,7 +1000,6 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         self.rigid_info.mass_parent_mask.from_numpy(mass_parent_mask)
         self.rigid_info.dofs_mass_block_start.from_numpy(dofs_mass_block_start)
         self.rigid_info.dofs_mass_block_end.from_numpy(dofs_mass_block_end)
-        self.rigid_info.links_tree_end.from_numpy(links_tree_end)
         self.rigid_info.entities_mass_block_dof_start.from_numpy(entities_mass_block_dof_start)
         self.rigid_info.entities_mass_block_dof_end.from_numpy(entities_mass_block_dof_end)
 
@@ -2276,9 +2270,9 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
             skip_allocation=True,
         )
         if links_idx_ is not None:
-            # TODO: the anchor of an aligned root keeps its mass block diagonal (see _init_mass_mat). A center of mass
-            # or an inertia written on any link of the body moves the anchor. A mass write keeps it only as one rescale
-            # of every link of the body, inertia included. A frame move shifts the local pose of every geom
+            # TODO: the anchor of an aligned root keeps its mass block diagonal (see _init_tree_fields). A center of
+            # mass or an inertia written on any link of the body moves the anchor. A mass write keeps it only as one
+            # rescale of every link of the body, inertia included. A frame move shifts the local pose of every geom
             # ('GeomsInfo.pos' / 'quat', one entry per geom for all environments). It also shifts 'qpos', quoted in the
             # anchored frame, and the origin a fixed child reports. A per-environment value has no frame to go to, so
             # the guard stays until 'GeomsInfo' gets a batch dimension.

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -200,7 +200,7 @@ def get_rigid_info(solver, kinematic_only):
             mass_mat_mask=V(dtype=gs.qd_bool, shape=()),
             dofs_mass_block_start=V(dtype=gs.qd_int, shape=()),
             dofs_mass_block_end=V(dtype=gs.qd_int, shape=()),
-            links_tree_end=V(dtype=gs.qd_int, shape=()),
+            links_tree_end=V(dtype=gs.qd_int, shape=(solver.n_links_,)),
             entities_mass_block_dof_start=V(dtype=gs.qd_int, shape=()),
             entities_mass_block_dof_end=V(dtype=gs.qd_int, shape=()),
             mass_parent_mask=V(dtype=gs.qd_float, shape=()),

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -502,7 +502,7 @@ def parse_link(mj, i_l, scale):
     # Note that the mass matrix of a poly-articulated robot does not scale trivially as it is a copnfiguration-depends
     # mixing of s ** 3 factor for masses and s ** 5 factor for inertia tensors. As a result, it is much simpler to
     # consider invweight indefined, which will trigger recomputation at build time.
-    if abs(1.0 - scale) > gs.EPS:
+    if abs(1.0 - scale) > np.finfo(np.double).eps:
         l_info["pos"] *= scale
         l_info["inertial_pos"] *= scale
         l_info["inertial_mass"] *= scale**3

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -583,8 +583,8 @@ def compose_inertial_properties(mass1, com1, inertia1, mass2, com2, inertia2):
         combined_inertia: Combined inertia tensor (3,3) array
     """
     combined_mass = mass1 + mass2
-    if combined_mass < gs.EPS:
-        gs.raise_exception("Combined mass is less than EPS")
+    if combined_mass <= 0.0:
+        gs.raise_exception("Combined mass is zero")
     combined_com = (mass1 * com1 + mass2 * com2) / combined_mass
     inertia1_new = translate_inertia(inertia1, mass1, combined_com - com1)
     inertia2_new = translate_inertia(inertia2, mass2, combined_com - com2)
@@ -612,7 +612,7 @@ def merge_inertia(link1, link2):
     com2, R2 = link2.inertial.origin[:3, 3], link2.inertial.origin[:3, :3]
 
     combined_mass = m1 + m2
-    if combined_mass > gs.EPS:
+    if combined_mass > 0.0:
         combined_com = (m1 * com1 + m2 * com2) / combined_mass
     else:
         combined_com = com1

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -643,13 +643,13 @@ def free_bodies_in_one_model():
 @pytest.fixture(scope="session")
 def degenerate_inertials():
     """Generate a URDF stating a degenerate inertial on several of its links: a zero mass on the root, a zero
-    mass beside geometry on a fixed child, a zero mass above a fixed child that carries all of it, a zero inertia
-    beside an authored center of mass, and a zero inertia on a fixed child. MuJoCo rejects a moving body whose rigid
-    subtree carries no inertia, so each degenerate branch either roots the robot or holds a fixed child that authors
-    one."""
+    mass beside geometry and an authored center of mass on a fixed child, a zero mass above a fixed child that carries
+    all of it, a zero inertia beside an authored center of mass, and a zero inertia on a fixed child. MuJoCo rejects a
+    moving body whose rigid subtree carries no inertia, so each degenerate branch either roots the robot or holds a
+    fixed child that authors one."""
     urdf = ET.Element("robot", name="degenerate_inertials")
     _add_sphere_link(urdf, "base_link", "0.0 0.0 0.09", mass=0.0, inertia=(0.11, 0.01, 0.02, 0.22, 0.03, 0.30))
-    _add_sphere_link(urdf, "massless_marker", "0.0 0.0 0.09", mass=0.0, inertia=(0.0,) * 6)
+    _add_sphere_link(urdf, "massless_marker", "0.0 0.0 0.09", mass=0.0, inertia=(0.0,) * 6, inertial_pos="0.0 0.0 0.11")
     _add_sphere_link(urdf, "implicit_origin", "0.0 0.0 0.09", mass=2.5, inertia=(0.11, 0.01, 0.02, 0.22, 0.03, 0.30))
     _add_sphere_link(urdf, "no_inertial", "0.0 0.0 0.09")
     _add_sphere_link(urdf, "connector", "0.0 0.0 0.09", mass=0.0, inertia=(0.0,) * 6)

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -275,6 +275,23 @@ def test_parsing_inertia_defaults(
             merge_fixed_links=False,
         ),
     )
+    # The same asset welded and then attached to a moving link, so that the links the world carried resolve at attach.
+    carrier_welded = scene.add_entity(
+        morph=gs.morphs.Box(
+            size=(0.2, 0.2, 0.2),
+            pos=(0.0, -8.0, 1.0),
+        ),
+    )
+    entity_mounted = scene.add_entity(
+        morph=gs.morphs.URDF(
+            file=degenerate_inertials,
+            pos=(0.0, -8.0, 1.3),
+            fixed=True,
+            batch_fixed_verts=True,
+            merge_fixed_links=False,
+        ),
+    )
+    entity_mounted.attach(carrier_welded, parent_link_name=carrier_welded.base_link.name, pos=(0.0, 0.0, 0.2))
     entity_zero_density = scene.add_entity(
         morph=gs.morphs.MJCF(
             file=zero_density_marker_mjcf,
@@ -404,7 +421,8 @@ def test_parsing_inertia_defaults(
         # The root states a zero mass and a valid inertia, and the geometry estimate replaces both. Its fixed child
         # 'massless_marker' keeps its zero mass, so the root has no mass-bearing child.
         (entity.base_link, estimate.mass, GEOM_POS, SPHERE_INERTIA_PER_MASS),
-        (entity.get_link("massless_marker"), gs.EPS, GEOM_POS, 0.0),
+        # A zero mass beside an authored center of mass keeps that center of mass, as the geometry supplies no inertia.
+        (entity.get_link("massless_marker"), gs.EPS, INERTIAL_POS, 0.0),
         # An omitted inertial origin places the center of mass at the link frame.
         (entity.get_link("implicit_origin"), 2.5, (0.0, 0.0, 0.0), np.linalg.eigvalsh(INERTIA) / 2.5),
         # Geometry supplies the inertia scaled to the authored mass, and the link keeps its authored center of mass.
@@ -428,8 +446,11 @@ def test_parsing_inertia_defaults(
             err_msg=link.name,
         )
     # The links the joints still move resolve exactly as in the free copy. The two the world carries keep the asset's
-    # values, degenerate as they are: a zero mass and no inertia.
-    for link, link_welded in zip(entity.links, entity_welded.links):
+    # values, degenerate as they are: a zero mass and no inertia. Attached, every link resolves as in the free copy.
+    for link, link_welded, link_mounted in zip(entity.links, entity_welded.links, entity_mounted.links):
+        assert_allclose(link_mounted.desc.mass, link.desc.mass, tol=gs.EPS, err_msg=link.name)
+        assert_allclose(link_mounted.desc.inertial_pos, link.desc.inertial_pos, tol=gs.EPS, err_msg=link.name)
+        assert_allclose(link_mounted.desc.inertia, link.desc.inertia, tol=gs.EPS, err_msg=link.name)
         if link_welded.is_fixed:
             assert_equal(link_welded.desc.mass, 0.0, err_msg=link.name)
             assert_equal(link_welded.desc.inertia, 0.0, err_msg=link.name)
@@ -444,7 +465,7 @@ def test_parsing_inertia_defaults(
     # Resolving the center of mass to the link frame can place it outside the geometry, which stays worth reporting.
     # Only the link whose geometry is offset qualifies, once per copy of the robot.
     dubious_com_records = [record for record in caplog.records if "dubious center of mass" in record.getMessage()]
-    assert len(dubious_com_records) == 2
+    assert len(dubious_com_records) == 3
 
     # Every link of an aligned free body keeps its own mass, so each link reads its authored mass. The two totals are
     # accumulated by independent code paths, so their agreement is bounded by that cross-path floor.

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -266,7 +266,7 @@ def test_parsing_inertia_defaults(
             merge_fixed_links=False,
         ),
     )
-    # The same asset welded to the world resolves every link exactly as the free copy does.
+    # The same asset welded to the world, so that the links the world carries resolve without a geometry estimate.
     entity_welded = scene.add_entity(
         morph=gs.morphs.URDF(
             file=degenerate_inertials,
@@ -427,10 +427,16 @@ def test_parsing_inertia_defaults(
             tol=tol,
             err_msg=link.name,
         )
+    # The links the joints still move resolve exactly as in the free copy. The two the world carries keep the asset's
+    # values, degenerate as they are: a zero mass and no inertia.
     for link, link_welded in zip(entity.links, entity_welded.links):
-        assert_allclose(link_welded.desc.mass, link.desc.mass, tol=gs.EPS, err_msg=link.name)
-        assert_allclose(link_welded.desc.inertial_pos, link.desc.inertial_pos, tol=gs.EPS, err_msg=link.name)
-        assert_allclose(link_welded.desc.inertia, link.desc.inertia, tol=gs.EPS, err_msg=link.name)
+        if link_welded.is_fixed:
+            assert_equal(link_welded.desc.mass, 0.0, err_msg=link.name)
+            assert_equal(link_welded.desc.inertia, 0.0, err_msg=link.name)
+            continue
+        assert_equal(link_welded.desc.mass, link.desc.mass, err_msg=link.name)
+        assert_equal(link_welded.desc.inertial_pos, link.desc.inertial_pos, err_msg=link.name)
+        assert_equal(link_welded.desc.inertia, link.desc.inertia, err_msg=link.name)
 
     # Every asset above is parsed by MuJoCo, a zero or missing inertial included.
     assert not any("legacy URDF parser" in record.getMessage() for record in caplog.records)

--- a/tests/rigid/test_collision_nonconvex.py
+++ b/tests/rigid/test_collision_nonconvex.py
@@ -910,7 +910,7 @@ def test_many_objects_collision(convexify, show_viewer, tol):
 
     # Wait for the pile to collapse and settle at rest
     vmax_trace, wmax_trace, energy_trace = [], [], []
-    for i in range(1500):
+    for i in range(1600):
         scene.step()
         energy_trace.append(tensor_to_array(scene.rigid_solver.get_total_energy()))
         if show_viewer:

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -417,6 +417,16 @@ def test_energy_analytical_and_conservation(
             file=spring_double_pendulum,
         ),
     )
+    # A load hung on the elbow link weighs on both joints of the arm and swings with it.
+    arm_load = scene.add_entity(
+        gs.morphs.URDF(
+            file=implicit_inertial_origin_chain,
+            pos=(0.45, 0.5, 0.8),
+            fixed=True,
+            batch_fixed_verts=True,
+        ),
+    )
+    arm_load.attach(arm, parent_link_name="arm_lower", pos=(0.2, 0.0, 0.0))
     # Three copies of a tumbling free body, high enough to fall for the whole horizon: one link, a root with a fixed
     # child, and one link with armature on its angular DOFs.
     tumblers = [
@@ -429,7 +439,38 @@ def test_energy_analytical_and_conservation(
         )
         for x, merge_fixed_links in ((1.0, True), (1.6, False), (2.2, True))
     ]
+    # A fourth copy receives a fixed entity off its center of mass, so the body it tumbles as is the pair.
+    tumblers.append(
+        scene.add_entity(
+            gs.morphs.URDF(
+                file=implicit_inertial_origin_chain,
+                pos=(2.8, 1.0, 2.0),
+            ),
+        )
+    )
+    load = scene.add_entity(
+        gs.morphs.URDF(
+            file=implicit_inertial_origin_chain,
+            pos=(2.8, 1.0, 2.0),
+            fixed=True,
+            batch_fixed_verts=True,
+        ),
+    )
+    load.attach(tumblers[-1], parent_link_name=tumblers[-1].base_link.name, pos=(0.3, 0.0, 0.0))
     scene.build()
+    rigid_solver = scene.rigid_solver
+    # The attachment leaves the anchor of the receiving body where the build put it, so its configuration reads exactly
+    # as the lone copy's, offset by the morph pose.
+    assert_allclose(tumblers[-1].get_qpos() - tumblers[0].get_qpos(), (1.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), tol=gs.EPS)
+    arm_links_idx = [link.idx for link in (*arm.links, *arm_load.links)]
+    arm_dofs_idx = slice(arm.dof_start, arm.dof_end)
+    tumblers_links_idx = [[link.idx for link in tumbler.links] for tumbler in tumblers]
+    tumblers_links_idx[-1] += [link.idx for link in load.links]
+    tumblers_dofs_idx = [slice(tumbler.dof_start, tumbler.dof_end) for tumbler in tumblers]
+    tumblers_links_mass = [rigid_solver.get_links_mass(links_idx) for links_idx in tumblers_links_idx]
+    # One row of mass fractions per tumbler turns the links' centers of mass into the tumblers' own.
+    tumblers_all_links_idx = [idx for links_idx in tumblers_links_idx for idx in links_idx]
+    tumblers_weights = torch.block_diag(*[(links_mass / links_mass.sum())[None] for links_mass in tumblers_links_mass])
 
     arm.set_dofs_position([0.5, -0.8])
     ARMATURE = 0.05
@@ -445,12 +486,34 @@ def test_energy_analytical_and_conservation(
     mass = sphere_a.get_links_mass()
     te_initial = sphere_a.get_total_energy()
 
-    ke_a, pe_a, ke_b, pe_b, te_arm, ke_tumblers = [], [], [], [], [], []
+    ke_a, pe_a, ke_b, pe_b, te_arm, ke_tumblers, vel_tumblers, pos_tumblers = [], [], [], [], [], [], [], []
+    pos_tumblers.append(
+        tumblers_weights @ rigid_solver.get_links_pos(tumblers_all_links_idx, ref=gs.link_ref_frame.link_COM)
+    )
+    vel_tumblers.append(
+        tumblers_weights @ rigid_solver.get_links_vel(tumblers_all_links_idx, ref=gs.link_ref_frame.link_COM)
+    )
     impact_step = -1
     for i in range(n_steps):
         scene.step()
-        te_arm.append(arm.get_total_energy())
-        ke_tumblers.append(torch.stack([tumbler.get_kinetic_energy() for tumbler in tumblers]))
+        pos_tumblers.append(
+            tumblers_weights @ rigid_solver.get_links_pos(tumblers_all_links_idx, ref=gs.link_ref_frame.link_COM)
+        )
+        vel_tumblers.append(
+            tumblers_weights @ rigid_solver.get_links_vel(tumblers_all_links_idx, ref=gs.link_ref_frame.link_COM)
+        )
+        te_arm.append(
+            rigid_solver.get_kinetic_energy(arm_links_idx, arm_dofs_idx)
+            + rigid_solver.get_potential_energy(arm_links_idx, arm_dofs_idx)
+        )
+        ke_tumblers.append(
+            torch.stack(
+                [
+                    rigid_solver.get_kinetic_energy(links_idx, dofs_idx)
+                    for links_idx, dofs_idx in zip(tumblers_links_idx, tumblers_dofs_idx)
+                ]
+            )
+        )
         ke_a.append(sphere_a.get_kinetic_energy())
         pe_a.append(sphere_a.get_potential_energy())
         ke_b.append(sphere_b.get_kinetic_energy())
@@ -478,19 +541,31 @@ def test_energy_analytical_and_conservation(
     te_b_final = ke_b[-1] + pe_b[-1]
     assert te_b_final < te_initial
 
-    # Spring-driven arm: nothing dissipates, so its energy holds throughout the swing to integration error
+    # Spring-driven arm with its load: nothing dissipates, so its energy holds through the swing to integration error
     te_arm = torch.stack(te_arm)
     assert_allclose(te_arm, te_arm[0], tol=0.01)
-    # The springs must carry a real share of that energy, otherwise the check above would hold with no spring term
+    # The springs must carry a real share of the arm's own energy, or the check above would hold with no spring term
     spring_energy = 0.5 * torch.sum(arm.get_dofs_stiffness() * arm.get_dofs_position() ** 2)
-    assert spring_energy > 0.1 * te_arm[-1]
+    assert spring_energy > 0.1 * arm.get_total_energy()
 
+    # Gravity is the only force on a tumbling body, so its center of mass falls along the parabola the velocity-implicit
+    # update traces, whatever the body turns about it. A body anchored on its center of mass integrates that point
+    # itself and follows the parabola exactly. The pair is anchored on its first link alone: its center of mass starts
+    # moving with the spin, which the parabola carries through the initial velocity, and turns about the integrated
+    # origin, which leaves the parabola by the rotation of the offset over one step, a second-order term per step.
+    tumblers_mass = torch.stack([links_mass.sum() for links_mass in tumblers_links_mass])
+    steps = torch.arange(n_steps + 1, dtype=gs.tc_float, device=gs.device)[:, None, None]
+    pos_tumblers, vel_tumblers = torch.stack(pos_tumblers), torch.stack(vel_tumblers)
+    gravity = torch.tensor((0.0, 0.0, -g), dtype=gs.tc_float, device=gs.device)
+    pos_expected = pos_tumblers[0] + vel_tumblers[0] * steps * dt + gravity * dt**2 * steps * (steps + 1) / 2
+    assert_allclose(pos_tumblers[:, :-1], pos_expected[:, :-1], tol=tol)
+    pair_offset = np.linalg.norm(tensor_to_array(pos_tumblers[0, -1] - tumblers[-1].get_pos()))
+    pair_spin = np.linalg.norm(tensor_to_array(tumblers[-1].get_dofs_velocity()[3:]))
+    assert_allclose(pos_tumblers[:, -1], pos_expected[:, -1], atol=n_steps * (dt * pair_spin) ** 2 * pair_offset)
     # Gravity exerts no torque about the center of mass, so the rotational energy of a tumbling body is a constant of
     # its motion. The midpoint rule keeps it, with armature the augmented energy w^T (I + A) w / 2. Each Newton solve
     # leaves a residual at the working precision, and the horizon accumulates them.
-    tumblers_mass = torch.stack([tumbler.get_mass() for tumbler in tumblers])
-    steps = torch.arange(1, n_steps + 1, dtype=gs.tc_float, device=gs.device)
-    ke_rot = torch.stack(ke_tumblers) - 0.5 * tumblers_mass * (steps[:, None] * g * dt) ** 2
+    ke_rot = torch.stack(ke_tumblers) - 0.5 * tumblers_mass * vel_tumblers[1:].square().sum(dim=-1)
     if integrator != gs.integrator.Euler:
         assert_allclose(ke_rot, ke_rot[0], tol=10.0 * tol)
 


### PR DESCRIPTION
## Description

- A link fixed to the world keeps what its asset states and nothing else, instead of taking a geometry estimate; an attach that sets it moving resolves it from its geometry exactly as the same asset added free, and the build zeroes what is still unstated.
- The potential energy getters leave links fixed to the world out, as `RigidEntity.get_mass` does.
- The gates of the asset resolution compare against an exact zero or a fixed tolerance instead of `gs.EPS`, so an asset resolves identically in every precision.
- An entity attached beneath another is simulated as one body with it: the receiving free body drops its anchor, the center of mass of a kinematic tree is accumulated over every entity before it is divided, the bias force folds over the whole tree, and the Cartesian-space update claims the entities rooted at a jointed link.
- The object pile of `test_many_objects_collision` gets 1600 steps to settle.

## Motivation and Context

Two tests failed after #3261 and #3304: a Terrain given a geometry mass of 4.6e6 kg swamped the per-environment energy difference in single precision, and the alignment pass dropped a pillar whose unit-density volume sits below the single-precision `gs.EPS` as massless, so single and double precision integrated the same body along different branches. Probing the second exposed four older defects of attached entities: a free body receiving a load kept a mass block zeroed for an anchor it no longer had, the midpoint pass read a center of mass accumulated over the root's entity alone, the joints above an attached load never felt its weight, and a load attached to a jointed link of a fixed-base chain was refreshed one step late.

## How Has This Been / Can This Be Tested?

`test_energy_analytical_and_conservation` tumbles a free body carrying an attached load and hangs a load on the elbow of the spring arm, `test_parsing_inertia_defaults` checks the welded copy of the degenerate asset and an attached one against the free copy, and `test_batched_info` and `test_elliptic_cone_push_isotropy` cover the two failures.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

