### PR TITLE
[BUG FIX] Fix scaling wrongly applied for in-memory URDF file morph.

### DIFF
--- a/genesis/ext/urdfpy/urdf.py
+++ b/genesis/ext/urdfpy/urdf.py
@@ -710,7 +710,7 @@ class Mesh(URDFType):
             for i, m in enumerate(meshes):
                 meshes[i] = m.apply_transform(sm)
         base, fn = os.path.split(self.filename)
-        fn = "{}{}".format(prefix, self.filename)
+        fn = "{}{}".format(prefix, fn)
         m = Mesh(
             filename=os.path.join(base, fn),
             scale=(self.scale.copy() if self.scale is not None else None),
@@ -1345,7 +1345,7 @@ class Inertial(URDFType):
         """
         if mass is None:
             mass = self.mass
-        if origin is None:
+        if origin is None and self.origin is not None:
             origin = self.origin.copy()
         if inertia is None:
             inertia = self.inertia.copy()

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -73,7 +73,9 @@ def build_model(
     if isinstance(xml, (str, Path, urdfpy.URDF)):
         if isinstance(xml, urdfpy.URDF):
             is_urdf_file = True
-            asset_path = get_assets_dir()
+            # An in-memory model resolves its relative mesh paths against the working directory, as the URDF pass does
+            # (see parse_urdf in urdf.py), so that both passes read the same files.
+            asset_path = os.getcwd()
             root = xml._unparse(asset_path)
             mjcf = ET.SubElement(root, "mujoco")
         else:

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -148,8 +148,8 @@ def parse_urdf(morph, surface):
             robot = urdfpy.URDF.load(path)
     else:
         parent_dir = os.getcwd()
-        # A model the caller owns is parsed on a copy: scaling and fixed-link merging below write into the model, and
-        # the same object is parsed again by the MuJoCo pass (see `_parse_scene`).
+        # The caller's model is parsed on a copy: the scaling and fixed-link merging below write into it, and the MuJoCo
+        # pass parses the same object again (see parse_xml in mjcf.py).
         robot = morph.file.copy()
 
     # Merge links connected by fixed joints

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -148,7 +148,9 @@ def parse_urdf(morph, surface):
             robot = urdfpy.URDF.load(path)
     else:
         parent_dir = os.getcwd()
-        robot = morph.file
+        # A model the caller owns is parsed on a copy: scaling and fixed-link merging below write into the model, and
+        # the same object is parsed again by the MuJoCo pass (see `_parse_scene`).
+        robot = morph.file.copy()
 
     # Merge links connected by fixed joints
     if morph.merge_fixed_links:

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -229,6 +229,42 @@ def scaled_mjcf_joint_equalities():
 
 
 @pytest.fixture(scope="session")
+def urdf_arm_with_tool():
+    """A free base carrying an arm on a revolute joint and a tool on a fixed joint, every link with an inertial."""
+    robot = ET.Element("robot", name="arm_with_tool")
+    links = (
+        ("base", "1.0", "0 0 0"),
+        ("arm", "0.5", "0.1 0 0"),
+        ("tool", "0.2", None),
+    )
+    for link_name, mass, com_xyz in links:
+        link = ET.SubElement(robot, "link", name=link_name)
+        inertial = ET.SubElement(link, "inertial")
+        ET.SubElement(inertial, "mass", value=mass)
+        if com_xyz is not None:
+            ET.SubElement(inertial, "origin", xyz=com_xyz)
+        ET.SubElement(inertial, "inertia", ixx="1e-3", iyy="2e-3", izz="3e-3", ixy="0", ixz="0", iyz="0")
+    # The tool omits its inertial origin and references its mesh by a relative path with a directory component, the
+    # two forms of a model that a copy of it must carry through.
+    visual = ET.SubElement(robot.find("link[@name='tool']"), "visual")
+    geometry = ET.SubElement(visual, "geometry")
+    ET.SubElement(geometry, "mesh", filename="meshes/sphere.obj", scale="0.02 0.02 0.02")
+    joints = (
+        ("shoulder", "revolute", "base", "arm", "0.3 0 0"),
+        ("wrist", "fixed", "arm", "tool", "0.2 0 0"),
+    )
+    for joint_name, joint_type, parent_name, child_name, origin_xyz in joints:
+        joint = ET.SubElement(robot, "joint", name=joint_name, type=joint_type)
+        ET.SubElement(joint, "parent", link=parent_name)
+        ET.SubElement(joint, "child", link=child_name)
+        ET.SubElement(joint, "origin", xyz=origin_xyz)
+        if joint_type == "revolute":
+            ET.SubElement(joint, "axis", xyz="0 0 1")
+            ET.SubElement(joint, "limit", lower="-1.0", upper="1.0", effort="100", velocity="1.0")
+    return ET.tostring(robot, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
 def scaled_urdf_mimic():
     robot = ET.Element("robot", name="scaled_urdf_mimic")
     ET.SubElement(robot, "link", name="base")

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -229,42 +229,6 @@ def scaled_mjcf_joint_equalities():
 
 
 @pytest.fixture(scope="session")
-def urdf_arm_with_tool():
-    """A free base carrying an arm on a revolute joint and a tool on a fixed joint, every link with an inertial."""
-    robot = ET.Element("robot", name="arm_with_tool")
-    links = (
-        ("base", "1.0", "0 0 0"),
-        ("arm", "0.5", "0.1 0 0"),
-        ("tool", "0.2", None),
-    )
-    for link_name, mass, com_xyz in links:
-        link = ET.SubElement(robot, "link", name=link_name)
-        inertial = ET.SubElement(link, "inertial")
-        ET.SubElement(inertial, "mass", value=mass)
-        if com_xyz is not None:
-            ET.SubElement(inertial, "origin", xyz=com_xyz)
-        ET.SubElement(inertial, "inertia", ixx="1e-3", iyy="2e-3", izz="3e-3", ixy="0", ixz="0", iyz="0")
-    # The tool omits its inertial origin and references its mesh by a relative path with a directory component, the
-    # two forms of a model that a copy of it must carry through.
-    visual = ET.SubElement(robot.find("link[@name='tool']"), "visual")
-    geometry = ET.SubElement(visual, "geometry")
-    ET.SubElement(geometry, "mesh", filename="meshes/sphere.obj", scale="0.02 0.02 0.02")
-    joints = (
-        ("shoulder", "revolute", "base", "arm", "0.3 0 0"),
-        ("wrist", "fixed", "arm", "tool", "0.2 0 0"),
-    )
-    for joint_name, joint_type, parent_name, child_name, origin_xyz in joints:
-        joint = ET.SubElement(robot, "joint", name=joint_name, type=joint_type)
-        ET.SubElement(joint, "parent", link=parent_name)
-        ET.SubElement(joint, "child", link=child_name)
-        ET.SubElement(joint, "origin", xyz=origin_xyz)
-        if joint_type == "revolute":
-            ET.SubElement(joint, "axis", xyz="0 0 1")
-            ET.SubElement(joint, "limit", lower="-1.0", upper="1.0", effort="100", velocity="1.0")
-    return ET.tostring(robot, encoding="unicode")
-
-
-@pytest.fixture(scope="session")
 def scaled_urdf_mimic():
     robot = ET.Element("robot", name="scaled_urdf_mimic")
     ET.SubElement(robot, "link", name="base")

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -895,13 +895,14 @@ def test_color_overwrite(overwrite, show_viewer):
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 @pytest.mark.parametrize(
-    "xml_path",
+    "file, is_model_shared",
     [
-        pytest.param("xml/franka_emika_panda/panda.xml", marks=pytest.mark.slow),
-        "urdf/go2/urdf/go2.urdf",
+        pytest.param("xml/franka_emika_panda/panda.xml", False, marks=pytest.mark.slow),
+        ("urdf/go2/urdf/go2.urdf", False),
+        ("urdf_arm_with_tool", True),
     ],
 )
-def test_robot_scale_and_dofs_armature(xml_path, tol):
+def test_robot_scale_and_dofs_armature(file, is_model_shared, request, monkeypatch, tol):
     ROBOT_SCALES = (1.0, 0.2, 5.0)
 
     scene = gs.Scene(
@@ -914,19 +915,54 @@ def test_robot_scale_and_dofs_armature(xml_path, tol):
         show_viewer=False,
         show_FPS=False,
     )
-    for i, scale in enumerate(ROBOT_SCALES):
-        morph_kwargs = dict(file=xml_path, scale=scale)
-        if xml_path.endswith(".xml"):
-            morph = gs.morphs.MJCF(**morph_kwargs)
-        else:
-            morph = gs.morphs.URDF(**morph_kwargs)
-        scene.add_entity(morph)
+    # The model object is shared by every entity built from it, so parsing must leave it untouched. It is checked after
+    # every load: the scales multiply to one, so a model scaled in place by each load ends back on its authored values.
+    urdf_model = None
+    if is_model_shared:
+        # A bare name is the fixture generating the model, as for `xml_path`. An in-memory model resolves its relative
+        # mesh paths against the working directory.
+        file = request.getfixturevalue(file)
+        monkeypatch.chdir(get_assets_dir())
+        roots = (ET.fromstring(file), ET.fromstring(file))
+        urdf_model, urdf_model_ref = (urdfpy.URDF._from_xml(root, root, get_assets_dir()) for root in roots)
+    morph_cls = gs.morphs.MJCF if file.endswith(".xml") else gs.morphs.URDF
+    robots_scale = []
+    for scale in ROBOT_SCALES:
+        morphs = [
+            morph_cls(
+                file=file,
+                scale=scale,
+            ),
+        ]
+        if urdf_model is not None:
+            morphs.append(
+                gs.morphs.URDF(
+                    file=urdf_model,
+                    scale=scale,
+                ),
+            )
+        for morph in morphs:
+            scene.add_entity(
+                morph=morph,
+            )
+            robots_scale.append(scale)
+        if urdf_model is not None:
+            for joint, joint_ref in zip(urdf_model.joints, urdf_model_ref.joints, strict=True):
+                assert_equal(joint.origin, joint_ref.origin)
+            for link, link_ref in zip(urdf_model.links, urdf_model_ref.links, strict=True):
+                assert_equal(link.inertial.mass, link_ref.inertial.mass)
+                assert_equal(link.inertial.inertia, link_ref.inertial.inertia)
+                if link_ref.inertial.origin is None:
+                    assert link.inertial.origin is None
+                else:
+                    assert_equal(link.inertial.origin, link_ref.inertial.origin)
+                assert len(link.visuals) == len(link_ref.visuals)
     scene.build()
 
     # Disable armature because it messes up with the mass matrix.
     # It is also a good opportunity to check that it updates 'invweight' and meaninertia accordingly.
     attr_orig = {}
-    for scale, robot in zip(ROBOT_SCALES, scene.entities):
+    for scale, robot in zip(robots_scale, scene.entities, strict=True):
         links_invweight = robot.get_links_invweight()
         dofs_invweight = robot.get_dofs_invweight()
         robot.set_dofs_armature(torch.ones((robot.n_dofs,), dtype=gs.tc_float, device=gs.device))

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -287,9 +287,12 @@ def test_parsing_inertia_defaults(
             merge_fixed_links=False,
         ),
     )
+    # The two merged chains are built from one in-memory model, which parsing must leave intact for the second one.
+    chain_root = ET.fromstring(implicit_inertial_origin_chain)
+    chain_model = urdfpy.URDF._from_xml(chain_root, chain_root, get_assets_dir())
     entity_chain_merged = scene.add_entity(
         morph=gs.morphs.URDF(
-            file=implicit_inertial_origin_chain,
+            file=chain_model,
             pos=(0.8, 2.0, 0.5),
         ),
     )
@@ -303,7 +306,7 @@ def test_parsing_inertia_defaults(
     )
     entity_chain_merged_unaligned = scene.add_entity(
         morph=gs.morphs.URDF(
-            file=implicit_inertial_origin_chain,
+            file=chain_model,
             pos=(1.6, 1.0, 0.5),
             align=False,
         ),
@@ -895,14 +898,14 @@ def test_color_overwrite(overwrite, show_viewer):
 @pytest.mark.required
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 @pytest.mark.parametrize(
-    "file, is_model_shared",
+    "xml_path",
     [
-        pytest.param("xml/franka_emika_panda/panda.xml", False, marks=pytest.mark.slow),
-        ("urdf/go2/urdf/go2.urdf", False),
-        ("urdf_arm_with_tool", True),
+        pytest.param("xml/franka_emika_panda/panda.xml", marks=pytest.mark.slow),
+        "urdf/go2/urdf/go2.urdf",
+        "urdf/panda_bullet/panda.urdf",
     ],
 )
-def test_robot_scale_and_dofs_armature(file, is_model_shared, request, monkeypatch, tol):
+def test_robot_scale_and_dofs_armature(xml_path, monkeypatch, tol):
     ROBOT_SCALES = (1.0, 0.2, 5.0)
 
     scene = gs.Scene(
@@ -915,54 +918,29 @@ def test_robot_scale_and_dofs_armature(file, is_model_shared, request, monkeypat
         show_viewer=False,
         show_FPS=False,
     )
-    # The model object is shared by every entity built from it, so parsing must leave it untouched. It is checked after
-    # every load: the scales multiply to one, so a model scaled in place by each load ends back on its authored values.
-    urdf_model = None
-    if is_model_shared:
-        # A bare name is the fixture generating the model, as for `xml_path`. An in-memory model resolves its relative
-        # mesh paths against the working directory.
-        file = request.getfixturevalue(file)
-        monkeypatch.chdir(get_assets_dir())
-        roots = (ET.fromstring(file), ET.fromstring(file))
-        urdf_model, urdf_model_ref = (urdfpy.URDF._from_xml(root, root, get_assets_dir()) for root in roots)
-    morph_cls = gs.morphs.MJCF if file.endswith(".xml") else gs.morphs.URDF
+    files = [xml_path]
+    if xml_path.endswith(".urdf"):
+        # The asset is also loaded as one in-memory model shared by an entity at every scale, which parsing must leave
+        # intact for the next one. An in-memory model resolves its relative mesh paths against the working directory.
+        urdf_path = os.path.join(get_assets_dir(), xml_path)
+        monkeypatch.chdir(os.path.dirname(urdf_path))
+        files.append(urdfpy.URDF.load(urdf_path))
     robots_scale = []
     for scale in ROBOT_SCALES:
-        morphs = [
-            morph_cls(
-                file=file,
-                scale=scale,
-            ),
-        ]
-        if urdf_model is not None:
-            morphs.append(
-                gs.morphs.URDF(
-                    file=urdf_model,
-                    scale=scale,
-                ),
-            )
-        for morph in morphs:
-            scene.add_entity(
-                morph=morph,
-            )
+        for file in files:
+            morph_kwargs = dict(file=file, scale=scale)
+            if xml_path.endswith(".xml"):
+                morph = gs.morphs.MJCF(**morph_kwargs)
+            else:
+                morph = gs.morphs.URDF(**morph_kwargs)
+            scene.add_entity(morph)
             robots_scale.append(scale)
-        if urdf_model is not None:
-            for joint, joint_ref in zip(urdf_model.joints, urdf_model_ref.joints, strict=True):
-                assert_equal(joint.origin, joint_ref.origin)
-            for link, link_ref in zip(urdf_model.links, urdf_model_ref.links, strict=True):
-                assert_equal(link.inertial.mass, link_ref.inertial.mass)
-                assert_equal(link.inertial.inertia, link_ref.inertial.inertia)
-                if link_ref.inertial.origin is None:
-                    assert link.inertial.origin is None
-                else:
-                    assert_equal(link.inertial.origin, link_ref.inertial.origin)
-                assert len(link.visuals) == len(link_ref.visuals)
     scene.build()
 
     # Disable armature because it messes up with the mass matrix.
     # It is also a good opportunity to check that it updates 'invweight' and meaninertia accordingly.
     attr_orig = {}
-    for scale, robot in zip(robots_scale, scene.entities, strict=True):
+    for scale, robot in zip(robots_scale, scene.entities):
         links_invweight = robot.get_links_invweight()
         dofs_invweight = robot.get_dofs_invweight()
         robot.set_dofs_armature(torch.ones((robot.n_dofs,), dtype=gs.tc_float, device=gs.device))


### PR DESCRIPTION
## Description

The URDF parser copies a caller-provided `urdfpy.URDF` model before scaling it and merging its fixed links, so the model stays usable for further entities and the second parsing pass reads the authored values.

Both parsing passes now resolve the relative mesh paths of an in-memory model against the working directory. The vendored `urdfpy` copy keeps an omitted inertial origin omitted and keeps a mesh path with a directory component intact.

## Related Issue

Resolves #3312

## Motivation and Context

Genesis parses every URDF morph twice. The first pass scaled the caller's object in place and merged its fixed links into it, so the second pass and every later entity built from the same object applied the scale and the merge again. The rigid skeleton of a hybrid entity built from a mesh takes this route.

An in-memory model with meshes could not be loaded at all: the URDF pass resolved its mesh paths against the working directory and the MuJoCo pass against the assets directory.

## How Has This Been / Can This Be Tested?

`test_robot_scale_and_dofs_armature` loads every URDF asset once more as one in-memory model shared by the entities at all scales, with `panda_bullet/panda.urdf` added as an asset whose mesh paths carry a directory component. `test_parsing_inertia_defaults` builds its two merged chains, whose inertial origins are omitted, from one shared in-memory model. The existing physical assertions catch a model scaled or merged more than once.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
