### PR TITLE
[BUG FIX] Bound the MPR portal-discovery loop and report a dropped contact per env.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -277,11 +277,22 @@ def mpr_refine_portal(
     collider_static_config: qd.template(),
 ):
     ret = 1
+    iterations = 0
     while True:
         direction = mpr_portal_dir(i_ga, i_gb, i_b, mpr_state)
 
         if mpr_portal_encapsules_origin(i_ga, i_gb, i_b, direction, mpr_state, collider_info):
             ret = 0
+            break
+
+        iterations += 1
+        if iterations > collider_info.mpr.CCD_ITERATIONS[None]:
+            # Same bound as the refinement in mpr_find_penetration (and libccd's): a portal that keeps expanding by
+            # rounding-sized steps without ever encapsulating the origin or reaching the tolerance would otherwise
+            # spin forever, which wedges the whole GPU kernel. Report it as no portal, with a status the callers can
+            # tell from a genuine miss.
+            mpr_state.portal_status[i_b] = PORTAL_STATUS.UNCONVERGED
+            ret = -1
             break
 
         v, v1, v2 = compute_support(

--- a/genesis/engine/solvers/rigid/collider/narrowphase.py
+++ b/genesis/engine/solvers/rigid/collider/narrowphase.py
@@ -1954,6 +1954,10 @@ def func_convex_convex_contact(
                                 )
                                 is_mpr_updated = True
 
+                        if not is_col and mpr_state.portal_status[i_b] == PORTAL_STATUS.UNCONVERGED:
+                            # Portal discovery hit its cap: the pair is dropped for this step and the env is flagged.
+                            errno[i_b] = errno[i_b] | array_class.ErrorCode.UNCONVERGED_CONTACT_PORTAL
+
                         if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MPR):
                             prefer_gjk = func_prefer_gjk_refinement(
                                 i_pair,
@@ -2541,6 +2545,7 @@ def _func_multicontact_mpr(
                 gb_pos_original, gb_quat_original, contact0_pos, gu.qd_inv_quat(qrot)
             )
 
+            mpr_state.portal_status[i_scratch] = PORTAL_STATUS.NONE
             is_col, normal, contact_pos, penetration, _used_gjk = _func_multicontact_run_detection(
                 i_ga,
                 i_gb,
@@ -2569,6 +2574,10 @@ def _func_multicontact_mpr(
                 ),
                 is_initial_detection=False,
             )
+            if not is_col and mpr_state.portal_status[i_scratch] == PORTAL_STATUS.UNCONVERGED:
+                # Portal discovery hit its cap (and the GJK fallback found nothing either): the perturbed contact is
+                # dropped for this step and the env is flagged.
+                errno[i_b] = errno[i_b] | array_class.ErrorCode.UNCONVERGED_CONTACT_PORTAL
 
             if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MPR):
                 if is_col:
@@ -2975,6 +2984,10 @@ def _func_narrowphase_contact0(
                                 collider_static_config,
                             )
                             is_mpr_updated = True
+
+                    if not is_col and mpr_state.portal_status[flat_idx] == PORTAL_STATUS.UNCONVERGED:
+                        # Portal discovery hit its cap: the pair is dropped for this step and the env is flagged.
+                        errno[i_b] = errno[i_b] | array_class.ErrorCode.UNCONVERGED_CONTACT_PORTAL
 
                     if qd.static(collider_static_config.ccd_algorithm == CCD_ALGORITHM_CODE.MPR):
                         prefer_gjk = func_prefer_gjk_refinement(

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -89,6 +89,10 @@ class ErrorCode(IntEnum):
     INVALID_CONTACT_NAN = 0b00000000000000000000000000010000
     INVALID_FORCE_NAN = 0b00000000000000000000000000100000
     INVALID_ACC_NAN = 0b00000000000000000000000001000000
+    # MPR portal discovery hit its iteration cap for a pair of this env, and that pair was reported as not colliding
+    # for the step. Exposed through 'RigidSolver.get_error_envs_mask' only: the step is still valid, so 'check_errno'
+    # does not raise on it.
+    UNCONVERGED_CONTACT_PORTAL = 0b00000000000000000000000010000000
 
 
 # =========================================== RigidInfo ===========================================

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -1407,3 +1407,129 @@ def test_neutral_self_collision_masks_across_merged_entities(merged_overlapping_
     palm_geom = hand.get_link("palm").geoms[0].idx
     assert_equal(collision_pair_idx[a2_geom, palm_geom], -1)
     assert_equal(collision_pair_idx[palm_geom, a2_geom], -1)
+
+
+def _mpr_refine_portal_with_stubbed_predicates(queue):
+    """Call mpr_refine_portal on a portal that can never succeed and report its return value.
+
+    Runs in a child process: without an iteration cap the loop never returns, and only the parent can time that out.
+    The three predicates that end the loop are stubbed so that every iteration expands the portal again, which is
+    what a portal that keeps growing by rounding-sized steps does on real geometry.
+    """
+    import quadrants as qd
+
+    import genesis as gs
+    import genesis.utils.array_class as array_class
+    from genesis.engine.solvers.rigid.collider import mpr
+    from genesis.engine.solvers.rigid.collider.constants import PORTAL_STATUS
+
+    gs.init(backend=gs.cpu, logging_level="warning")
+
+    scene = gs.Scene(rigid_options=gs.options.RigidOptions(use_gjk_collision=False), show_viewer=False)
+    scene.add_entity(gs.morphs.Plane())
+    box = scene.add_entity(gs.morphs.Box(size=(0.1, 0.1, 0.1), pos=(0.0, 0.0, 0.5)))
+    scene.build(n_envs=1)
+    solver = scene.sim.rigid_solver
+    collider = solver.collider
+
+    @qd.func
+    def never_encapsulates_origin(
+        i_ga, i_gb, i_b, direction, mpr_state: array_class.MPRState, collider_info: array_class.ColliderInfo
+    ):
+        return False
+
+    @qd.func
+    def always_can_encapsule_origin(v, direction, collider_info: array_class.ColliderInfo):
+        return True
+
+    @qd.func
+    def never_reaches_tolerance(
+        i_ga, i_gb, i_b, ccd_tol, v, direction, mpr_state: array_class.MPRState, collider_info: array_class.ColliderInfo
+    ):
+        return False
+
+    mpr.mpr_portal_encapsules_origin = never_encapsulates_origin
+    mpr.mpr_portal_can_encapsule_origin = always_can_encapsule_origin
+    mpr.mpr_portal_reach_tolerance = never_reaches_tolerance
+
+    @qd.kernel
+    def refine_portal(
+        i_g: int,
+        pos: qd.types.ndarray(),
+        quat: qd.types.ndarray(),
+        collider_state: array_class.ColliderState,
+        mpr_state: array_class.MPRState,
+        dyn_info: array_class.DynInfo,
+        collider_info: array_class.ColliderInfo,
+        rigid_config: qd.template(),
+        collider_static_config: qd.template(),
+        out: qd.types.ndarray(),
+    ):
+        pos_a = qd.Vector([pos[0], pos[1], pos[2]])
+        quat_a = qd.Vector([quat[0], quat[1], quat[2], quat[3]])
+        # A non-degenerate seed portal, so the direction and support queries are well defined.
+        mpr_state.simplex_support.v[0, 0] = qd.Vector([0.0, 0.0, 0.0])
+        mpr_state.simplex_support.v[1, 0] = qd.Vector([0.1, 0.0, 0.0])
+        mpr_state.simplex_support.v[2, 0] = qd.Vector([0.0, 0.1, 0.0])
+        mpr_state.simplex_support.v[3, 0] = qd.Vector([0.0, 0.0, 0.1])
+        mpr_state.simplex_size[0] = 4
+        out[0] = mpr.mpr_refine_portal(
+            i_g,
+            i_g,
+            0,
+            1e-6,
+            pos_a,
+            quat_a,
+            pos_a,
+            quat_a,
+            collider_state,
+            mpr_state,
+            dyn_info,
+            collider_info,
+            rigid_config,
+            collider_static_config,
+        )
+
+    mpr_state = collider._mpr._mpr_state
+    out = qd.ndarray(qd.i32, shape=(1,))
+    refine_portal(
+        box.geoms[0].idx,
+        box.get_pos()[0].cpu().numpy().astype(np.float32),
+        box.get_quat()[0].cpu().numpy().astype(np.float32),
+        collider._collider_state,
+        mpr_state,
+        solver.dyn_info,
+        collider._collider_info,
+        solver.rigid_config,
+        collider._collider_static_config,
+        out,
+    )
+    qd.sync()
+    queue.put((int(out.to_numpy()[0]), int(mpr_state.portal_status.to_numpy()[0]), int(PORTAL_STATUS.UNCONVERGED)))
+
+
+@pytest.mark.required
+@pytest.mark.parametrize("backend", [gs.cpu])
+def test_mpr_portal_discovery_is_bounded():
+    """The MPR portal-discovery loop must return on a portal that never converges.
+
+    Regression test for genesis-world#3314: 'mpr_refine_portal' had no iteration cap (unlike the refinement loop in
+    'mpr_find_penetration' and libccd), so a portal that kept expanding by rounding-sized steps spun one GPU lane
+    forever and wedged the whole narrowphase kernel. With the cap it reports 'no portal' and marks the portal
+    UNCONVERGED after CCD_ITERATIONS iterations.
+    """
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    queue = ctx.Queue()
+    proc = ctx.Process(target=_mpr_refine_portal_with_stubbed_predicates, args=(queue,))
+    proc.start()
+    proc.join(timeout=300.0)
+    if proc.is_alive():
+        proc.kill()
+        proc.join()
+        pytest.fail("mpr_refine_portal did not return within 300 s: the portal-discovery loop is unbounded.")
+    assert proc.exitcode == 0, f"child process failed with exit code {proc.exitcode}"
+    ret, status, unconverged = queue.get(timeout=10.0)
+    assert ret == -1
+    assert status == unconverged


### PR DESCRIPTION
Fixes #3314. Related: #3310.

## Problem

`mpr_refine_portal` (`genesis/engine/solvers/rigid/collider/mpr.py`) walks the MPR portal with a
`while True` whose only exits are the encapsulation test and the tolerance test. Its sibling,
`mpr_find_penetration`, is bounded by `CCD_ITERATIONS` ("Bounds that refinement, which is not otherwise
guaranteed to terminate"), and libccd bounds both loops. A portal that keeps expanding by rounding-sized
steps without ever encapsulating the origin or reaching the tolerance therefore spins forever. On the GPU
that is one lane that never leaves the narrowphase kernel; the host then blocks at its next device sync,
which is why the stacks in #3310 pointed at unrelated Python lines.

Evidence (details and logs in #3314):
- cuda-gdb attached to the frozen process (RTX 5090, genesis-world 1.3.3, quadrants 1.3.0, 512 envs): one
  block of `_func_narrowphase_multicontact` still running, one warp, one active lane, 31 parked, PC inside
  the kernel body (constraint-solver arm `func_solve_body_monolith` pinned). With the decomposed arm the
  same picture in `_func_narrowphase_contact0`. Both kernels reach `mpr_refine_portal` through
  `func_mpr_contact` (`narrowphase.py`: the contact0 kernel, the perturbed re-detections of the
  multicontact kernel, and the non-split convex path).
- No NaN and no blown-up state are needed: on an A100-PCIE the same seed stopped at the same PPO update in
  three allocations with finite state and no error flag one update earlier; on an RTX 5090 with the monolith
  arm pinned, 3 of 3 runs stopped after the first update on a bit-identical trajectory.
- Host-side fences and `QD_GRAPH=0` do not prevent it.

## Fix

- `mpr_refine_portal`: count iterations like `mpr_find_penetration` does; past `CCD_ITERATIONS` mark the
  portal `PORTAL_STATUS.UNCONVERGED` and return -1 (no portal), which the caller already treats as
  "no contact for this pair" — the same outcome libccd chooses.
- New `ErrorCode.UNCONVERGED_CONTACT_PORTAL` (bit 7), set for the env at the three call sites where `errno`
  is in scope when a detection ends with no contact and an UNCONVERGED portal (after the retry loop, so a
  successful retry or GJK fallback is not reported). It is exposed through `RigidSolver.get_error_envs_mask()`
  only; `check_errno()` does not raise on it, because the step is still valid (one pair, one substep,
  reported as not colliding) and raising would abort long batched trainings on a transient event that the
  previous behaviour turned into a hang. Users who want to reset the affected env can do so from the mask.
  Before the perturbed re-detection of the multicontact kernel the slot's status is cleared, since that
  detection may take an analytic path that never touches the MPR state (otherwise a stale UNCONVERGED from
  an earlier pair in the same thread would be reported against the wrong pair).

Diff: 28 lines added, 0 removed, in `mpr.py`, `narrowphase.py`, `utils/array_class.py`. No option, no
behaviour change for portals that converge.

Not included (follow-up): the three `while is_improving*` chases in
`multi_contact.py::func_approximate_polygon_with_quad` are also unbounded and spin on a NaN
clipped-polygon vertex; they are only reachable with `enable_contact_patch=True` (see #3314).

## Test

`tests/rigid/test_collision.py::test_mpr_portal_discovery_is_bounded` (`required`, CPU): a spawned child
builds a one-box scene, stubs the three predicates that end the discovery loop so that every iteration
expands the portal again (what a portal growing by rounding-sized steps does on real geometry), and calls
`mpr_refine_portal` from a one-thread kernel. The parent fails the test if the child has not returned after
300 s. With the fix the call returns -1 with the portal marked UNCONVERGED.

Verified against `main` (48a690a3) in a fresh env (Python 3.12, quadrants 1.3.0, torch 2.8.0+cu128, CPU):

    python -m pytest tests/rigid/test_collision.py -k test_mpr_portal_discovery_is_bounded --backend=cpu --numprocesses=1 -p no:pytest-retry -p no:rerunfailures

- with the fix: `1 passed in 31.48s`
- on unpatched `main`: `Failed: mpr_refine_portal did not return within 300 s: the portal-discovery loop is unbounded.` (`1 failed in 306.84s`)

`pre-commit run --files <changed files>`: ruff check and ruff format pass.

## Tested on (full training workload, genesis-world 1.3.3 + this change as a patch)

- RTX 5090 (sm_120, 595.84): monolith arm pinned, 512 envs — stock froze after update 1 in 3 of 3 runs on a
  bit-identical trajectory; patched: one portal cap in one env in that interval, env flagged, run completed
  10 updates (and 10 more with zero-copy views off). Decomposed arm, 256 envs, device conditional graph —
  stock froze at update 16 twice; patched: 31 clean updates, one cap in one env at step 4096, run continued.
- RTX 5070 (sm_120, 580.173.02), L40S (sm_89, 580.173.02): stock monolith-arm freezes at per-env step
  216 / 185 (#3310).
- A100-PCIE-40GB (sm_80, 580.173.02): stock decomposed-arm freeze at the same PPO update (49) for the same
  seed in three allocations; patched result pending (will be posted on #3314).
- CPU: the test above.
