### PR TITLE
[BUG FIX] Honor the textures of URDF materials.

### DIFF
--- a/genesis/ext/urdfpy/urdf.py
+++ b/genesis/ext/urdfpy/urdf.py
@@ -903,10 +903,6 @@ class Texture(URDFType):
         return Texture(**kwargs)
 
     def _to_xml(self, parent, path):
-        # Save the image
-        filepath = get_filename(path, self.filename, makedirs=True)
-        self.image.save(filepath)
-
         return self._unparse(path)
 
     def copy(self, prefix="", scale=None):

--- a/genesis/ext/urdfpy/urdf.py
+++ b/genesis/ext/urdfpy/urdf.py
@@ -227,7 +227,7 @@ class URDFType(object):
             if r or v is not None:
                 node.attrib[a] = self._unparse_attrib(t, v)
 
-    def _unparse_simple_elements(self, node, path):
+    def _unparse_simple_elements(self, node):
         """Unparse all Python types from the _ELEMENTS array back into child
         nodes of an XML node.
 
@@ -236,30 +236,21 @@ class URDFType(object):
         node : :class:`object`
             The XML node for this object. Elements will be added as children
             of this node.
-        path : str
-            The string path where the XML file is being written to (used for
-            writing out meshes and image files).
         """
         for a in self._ELEMENTS:
             t, r, m = self._ELEMENTS[a]
             v = getattr(self, a, None)
             if not m:
                 if r or v is not None:
-                    node.append(v._to_xml(node, path))
+                    node.append(v._to_xml(node))
             else:
                 vs = v
                 for v in vs:
-                    node.append(v._to_xml(node, path))
+                    node.append(v._to_xml(node))
 
-    def _unparse(self, path):
+    def _unparse(self):
         """Create a node for this object and unparse all elements and
         attributes in the class arrays.
-
-        Parameters
-        ----------
-        path : str
-            The string path where the XML file is being written to (used for
-            writing out meshes and image files).
 
         Returns
         -------
@@ -268,10 +259,10 @@ class URDFType(object):
         """
         node = ET.Element(self._TAG)
         self._unparse_simple_attribs(node)
-        self._unparse_simple_elements(node, path)
+        self._unparse_simple_elements(node)
         return node
 
-    def _to_xml(self, parent, path):
+    def _to_xml(self, parent):
         """Create and return an XML node for this object.
 
         Parameters
@@ -280,16 +271,13 @@ class URDFType(object):
             The parent node that this element will eventually be added to.
             This base implementation doesn't use this information, but
             classes that override this function may use it.
-        path : str
-            The string path where the XML file is being written to (used for
-            writing out meshes and image files).
 
         Returns
         -------
         node : :class:`xml.etree.ElementTree.Element`
             The newly-created node.
         """
-        return self._unparse(path)
+        return self._unparse()
 
 
 ###############################################################################
@@ -671,8 +659,8 @@ class Mesh(URDFType):
 
         return Mesh(**kwargs)
 
-    def _to_xml(self, parent, path):
-        return self._unparse(path)
+    def _to_xml(self, parent):
+        return self._unparse()
 
     def copy(self, prefix="", scale=None):
         """Create a deep copy with the prefix applied to all names.
@@ -902,8 +890,8 @@ class Texture(URDFType):
 
         return Texture(**kwargs)
 
-    def _to_xml(self, parent, path):
-        return self._unparse(path)
+    def _to_xml(self, parent):
+        return self._unparse()
 
     def copy(self, prefix="", scale=None):
         """Create a deep copy with the prefix applied to all names.
@@ -996,12 +984,12 @@ class Material(URDFType):
 
         return Material(**kwargs)
 
-    def _to_xml(self, parent, path):
+    def _to_xml(self, parent):
         # Simplify materials by collecting them at the top level.
 
         # For top-level elements, save the full material specification
         if parent.tag == "robot":
-            node = self._unparse(path)
+            node = self._unparse()
             if self.color is not None:
                 color = ET.Element("color")
                 color.attrib["rgba"] = np.array2string(self.color)[1:-1]
@@ -1091,8 +1079,8 @@ class Collision(URDFType):
         kwargs["origin"] = parse_origin(node, default=True)
         return Collision(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         node.append(unparse_origin(self.origin))
         return node
 
@@ -1199,8 +1187,8 @@ class Visual(URDFType):
         kwargs["origin"] = parse_origin(node, default=True)
         return Visual(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         node.append(unparse_origin(self.origin))
         return node
 
@@ -1295,7 +1283,7 @@ class Inertial(URDFType):
         inertia = np.array([[xx, xy, xz], [xy, yy, yz], [xz, yz, zz]], dtype=np.float64)
         return Inertial(mass=mass, inertia=inertia, origin=origin)
 
-    def _to_xml(self, parent, path):
+    def _to_xml(self, parent):
         node = ET.Element("inertial")
         if self.origin is not None:
             node.append(unparse_origin(self.origin))
@@ -1825,8 +1813,8 @@ class Actuator(URDFType):
         kwargs["hardwareInterfaces"] = hi
         return Actuator(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         if self.mechanicalReduction is not None:
             mr = ET.Element("mechanicalReduction")
             mr.text = str(self.mechanicalReduction)
@@ -1911,8 +1899,8 @@ class TransmissionJoint(URDFType):
         kwargs["hardwareInterfaces"] = hi
         return TransmissionJoint(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         if len(self.hardwareInterfaces) > 0:
             for hi in self.hardwareInterfaces:
                 h = ET.Element("hardwareInterface")
@@ -2033,8 +2021,8 @@ class Transmission(URDFType):
         kwargs["trans_type"] = node.find("type").text
         return Transmission(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         ttype = ET.Element("type")
         ttype.text = self.trans_type
         node.append(ttype)
@@ -2424,8 +2412,8 @@ class Joint(URDFType):
         kwargs["origin"] = parse_origin(node, default=True)
         return Joint(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         parent = ET.Element("parent")
         parent.attrib["link"] = self.parent
         node.append(parent)
@@ -3608,30 +3596,9 @@ class URDF(URDFType):
             other_xml=self.other_xml,
         )
 
-    def save(self, file_obj):
-        """Save this URDF to a file.
-
-        Parameters
-        ----------
-        file_obj : str or file-like object
-            The file to save the URDF to. Should be the path to the
-            ``.urdf`` XML file. Any paths in the URDF should be specified
-            as relative paths to the ``.urdf`` file instead of as ROS
-            resources.
-
-        Returns
-        -------
-        urdf : :class:`.URDF`
-            The parsed URDF.
-        """
-        if isinstance(file_obj, str):
-            path = os.path.dirname(file_obj)
-        else:
-            path = os.path.dirname(os.path.realpath(file_obj.name))
-
-        node = self._to_xml(None, path)
-        tree = ET.ElementTree(node)
-        tree.write(file_obj, pretty_print=True, xml_declaration=True, encoding="utf-8")
+    def to_xml(self):
+        """Return the XML document of this URDF as the root node of an element tree."""
+        return self._to_xml(None)
 
     def join(self, other, link, origin=None, name=None, prefix=""):
         """Join another URDF to this one by rigidly fixturing the two at a link.
@@ -3928,8 +3895,8 @@ class URDF(URDFType):
         kwargs["other_xml"] = data
         return URDF(**kwargs)
 
-    def _to_xml(self, parent, path):
-        node = self._unparse(path)
+    def _to_xml(self, parent):
+        node = self._unparse()
         if self.other_xml:
             extra_tree = ET.fromstring(self.other_xml)
             for child in extra_tree:

--- a/genesis/ext/urdfpy/utils.py
+++ b/genesis/ext/urdfpy/utils.py
@@ -188,7 +188,7 @@ def unparse_origin(matrix):
     return node
 
 
-def get_filename(base_path, file_path, makedirs=False):
+def get_filename(base_path, file_path):
     """Formats a file path correctly for URDF loading.
 
     Parameters
@@ -197,9 +197,6 @@ def get_filename(base_path, file_path, makedirs=False):
         The base path to the URDF's folder.
     file_path : str
         The path to the file.
-    makedirs : bool, optional
-        If ``True``, the directories leading to the file will be created
-        if needed.
 
     Returns
     -------
@@ -225,10 +222,6 @@ def get_filename(base_path, file_path, makedirs=False):
     if not os.path.isfile(fn):
         gs.raise_exception(f"Asset file not found: {fn}")
 
-    if makedirs:
-        d, _ = os.path.split(fn)
-        if not os.path.exists(d):
-            os.makedirs(d)
     return fn
 
 

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -1725,9 +1725,9 @@ def _exported_urdf(robot: urdfpy.URDF, exporting: serialization.Exporting) -> st
     """Export a URDF model built in memory as the document it stands for.
 
     Relative asset paths stay as written: an in-memory model resolves them against the working directory when it is
-    read (see '_loaded_urdf' and 'build_model' in mjcf.py).
+    read (see '_loaded_urdf').
     """
-    return ET.tostring(robot._unparse(os.getcwd()), encoding="unicode")
+    return ET.tostring(robot.to_xml(), encoding="unicode")
 
 
 def _loaded_urdf(raw: str, loading: serialization.Loading) -> urdfpy.URDF:

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -1104,9 +1104,9 @@ class URDF(FileMorph):
         Whether to batch fixed vertices. This will allow setting env-specific poses to fixed geometries, at the cost of
         significantly increasing memory usage. Default to true. **This is only used for RigidEntity.**
     prioritize_urdf_material : bool, optional
-        Sometimes a geom in a urdf file will be assigned a color, and the geom asset file also contains its own visual
-        material. This parameter controls whether to prioritize the URDF-defined material over the asset's own material.
-        Defaults to False.
+        Sometimes a geom in a urdf file will be assigned a color or a texture, and the geom asset file also contains its
+        own visual material. This parameter controls whether to prioritize the URDF-defined material over the asset's
+        own material. Defaults to False.
     merge_fixed_links : bool, optional
         Whether to merge links connected via a fixed joint. Defaults to True.
     links_to_keep : list of str, optional
@@ -1235,9 +1235,9 @@ class Drone(FileMorph):
     collision : bool, optional
         **NB**: Drone doesn't support collision checking for now.
     prioritize_urdf_material : bool, optional
-        Sometimes a geom in a urdf file will be assigned a color, and the geom asset file also contains its own visual
-        material. This parameter controls whether to prioritize the URDF-defined material over the asset's own material.
-        Defaults to False.
+        Sometimes a geom in a urdf file will be assigned a color or a texture, and the geom asset file also contains its
+        own visual material. This parameter controls whether to prioritize the URDF-defined material over the asset's
+        own material. Defaults to False.
     model : str, optional
         The model of the drone. Defaults to 'CF2X'. Supported models are 'CF2X', 'CF2P', and 'RACE'.
     COM_link_name : str, optional

--- a/genesis/options/textures.py
+++ b/genesis/options/textures.py
@@ -162,7 +162,7 @@ class ImageTexture(Texture, SerializationMixin):
                 if image_path.endswith((".exr")):
                     image_path = mu.check_exr_compression(image_path)
             else:
-                image_array = np.array(Image.open(image_path))
+                image_array = mu.PIL_to_array(Image.open(image_path))
         else:
             # Normalize image array
             if not isinstance(image_array, np.ndarray):

--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -87,7 +87,7 @@ def get_glb_image(glb, image_index, image_type=None):
         image = Image.open(uri_to_PIL(glb.images[image_index].uri))
         if image_type is not None:
             image = image.convert(image_type)
-        return np.array(image)
+        return mu.PIL_to_array(image)
     return None
 
 

--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -884,6 +884,9 @@ def adjust_alpha_cutoff(alpha_cutoff, alpha_mode):
 
 
 def PIL_to_array(image):
+    # A paletted image stores indices into its palette, so its texels are the colors those indices stand for
+    if isinstance(image, Image.Image) and image.mode == "P":
+        image = image.convert("RGBA" if "transparency" in image.info else "RGB")
     return np.array(image)
 
 

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -76,7 +76,7 @@ def build_model(
             # An in-memory model resolves its relative mesh paths against the working directory, as the URDF pass does
             # (see parse_urdf in urdf.py), so that both passes read the same files.
             asset_path = os.getcwd()
-            root = xml._unparse(asset_path)
+            root = xml.to_xml()
             mjcf = ET.SubElement(root, "mujoco")
         else:
             # Make sure that it is pointing to a valid XML content (either file path or string)
@@ -196,7 +196,7 @@ def build_model(
             # Merge fixed links if requested
             if merge_fixed_links:
                 robot = uu.merge_fixed_links(robot, links_to_keep)
-                root = robot._to_xml(None, asset_path)
+                root = robot.to_xml()
                 root.append(mjcf)
 
             # Enforce some compiler options

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -13,6 +13,7 @@ from genesis.constants import GLTF_FORMATS, XACRO_FORMAT
 from genesis.ext import urdfpy
 
 from . import geom as gu
+from . import mesh as mu
 from .misc import get_assets_dir
 
 
@@ -255,12 +256,21 @@ def parse_urdf(morph, surface):
                     geom_surface = gs.surfaces.Collision()
                 elif (
                     surface.texture is None
-                    and getattr(geom_prop, "material") is not None
-                    and geom_prop.material.color is not None
+                    and geom_prop.material is not None
+                    and (geom_prop.material.texture is not None or geom_prop.material.color is not None)
                     and (morph.prioritize_urdf_material or not tmesh.visual.defined)
                 ):
                     is_urdf_material = True
-                    geom_surface = gs.surfaces.Default(color=geom_prop.material.color)
+                    if geom_prop.material.texture is not None:
+                        # The image stands in for the color, as it does for the material of a mesh asset (see
+                        # from_trimesh in engine/mesh.py)
+                        geom_surface = gs.surfaces.Default(
+                            diffuse_texture=gs.textures.ImageTexture(
+                                image_array=mu.PIL_to_array(geom_prop.material.texture.image)
+                            )
+                        )
+                    else:
+                        geom_surface = gs.surfaces.Default(color=geom_prop.material.color)
                 else:
                     geom_surface = surface
 

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -252,13 +252,19 @@ def parse_urdf(morph, surface):
             for tmesh, metadata in zip(tmeshes, metadatas, strict=True):
                 # Overwrite surface color by original color specified in URDF file only if necessary
                 is_urdf_material = False
+                # trimesh gives a mesh holding texture coordinates and no material its placeholder material, which
+                # states nothing about the appearance the asset authored
+                has_asset_material = tmesh.visual.defined and not (
+                    isinstance(tmesh.visual, trimesh.visual.texture.TextureVisuals)
+                    and hash(tmesh.visual.material) == hash(trimesh.visual.material.empty_material())
+                )
                 if geom_is_col:
                     geom_surface = gs.surfaces.Collision()
                 elif (
                     surface.texture is None
                     and geom_prop.material is not None
                     and (geom_prop.material.texture is not None or geom_prop.material.color is not None)
-                    and (morph.prioritize_urdf_material or not tmesh.visual.defined)
+                    and (morph.prioritize_urdf_material or not has_asset_material)
                 ):
                     is_urdf_material = True
                     if geom_prop.material.texture is not None:

--- a/genesis/utils/usd/usd_material.py
+++ b/genesis/utils/usd/usd_material.py
@@ -124,7 +124,7 @@ def parse_preview_surface(prim: Usd.Prim, output_name):
             texture_asset = Ar.GetResolver().OpenAsset(Ar.ResolvedPath(texture.resolvedPath))
             if texture_asset is None:
                 gs.raise_exception(f"Unable to open UsdUVTexture asset: {texture.resolvedPath}")
-            texture_image = np.asarray(Image.open(io.BytesIO(texture_asset.GetBuffer())))
+            texture_image = mu.PIL_to_array(Image.open(io.BytesIO(texture_asset.GetBuffer())))
             if texture_image.ndim == 3:
                 if output_name == "r":
                     texture_image = texture_image[:, :, 0]

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import pytest
 import trimesh
+from PIL import Image
 
 from genesis.utils.misc import get_assets_dir
 
@@ -163,21 +164,55 @@ def tet_meshball():
 
 
 @pytest.fixture(scope="session")
-def urdf_with_external_mesh(asset_tmp_path):
-    """Generate a URDF naming a mesh by an absolute path outside the directory the model itself sits in."""
-    meshes = asset_tmp_path / "external_meshes"
-    meshes.mkdir(exist_ok=True)
-    mesh_file = meshes / "sphere.obj"
-    if not mesh_file.exists():
-        mesh_file.symlink_to(os.path.join(get_assets_dir(), "meshes", "sphere.obj"))
-    robot = ET.Element("robot", name="external_mesh")
+def urdf_with_external_assets(asset_tmp_path):
+    """Generate a URDF naming a mesh and a texture by absolute paths outside the directory the model itself sits in.
+
+    Its material carries both a color and an image texture, shared by a sphere visual without texture coordinates and
+    a quad visual with them.
+    """
+    assets = asset_tmp_path / "external_assets"
+    assets.mkdir(exist_ok=True)
+    sphere_path = assets / "sphere.obj"
+    if not sphere_path.exists():
+        sphere_path.symlink_to(os.path.join(get_assets_dir(), "meshes", "sphere.obj"))
+    quad_path = assets / "textured_quad.obj"
+    quad_lines = (
+        "v 0 0 0",
+        "v 1 0 0",
+        "v 1 1 0",
+        "v 0 1 0",
+        "vt 0 0",
+        "vt 1 0",
+        "vt 1 1",
+        "vt 0 1",
+        "f 1/1 2/2 3/3",
+        "f 1/1 3/3 4/4",
+    )
+    quad_path.write_text("\n".join(quad_lines))
+    texture_path = assets / "texture.png"
+    texture = np.array(
+        [
+            [[100, 0, 255], [100, 0, 255]],
+            [[200, 0, 255], [200, 0, 255]],
+        ],
+        dtype=np.uint8,
+    )
+    Image.fromarray(texture).save(texture_path)
+    robot = ET.Element("robot", name="external_mesh_and_texture")
+    material = ET.SubElement(robot, "material", name="textured")
+    ET.SubElement(material, "color", rgba="0 1 0 1")
+    ET.SubElement(material, "texture", filename=str(texture_path))
     link = ET.SubElement(robot, "link", name="base_link")
     inertial = ET.SubElement(link, "inertial")
     ET.SubElement(inertial, "mass", value="1.0")
     ET.SubElement(inertial, "inertia", ixx="0.01", ixy="0", ixz="0", iyy="0.01", iyz="0", izz="0.01")
     for tag in ("visual", "collision"):
         geometry = ET.SubElement(ET.SubElement(link, tag), "geometry")
-        ET.SubElement(geometry, "mesh", filename=str(mesh_file), scale="0.05 0.05 0.05")
+        ET.SubElement(geometry, "mesh", filename=str(sphere_path), scale="0.05 0.05 0.05")
+    ET.SubElement(link.find("visual"), "material", name="textured")
+    quad_visual = ET.SubElement(link, "visual")
+    ET.SubElement(ET.SubElement(quad_visual, "geometry"), "mesh", filename=str(quad_path))
+    ET.SubElement(quad_visual, "material", name="textured")
     return ET.tostring(robot, encoding="unicode")
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -197,7 +197,7 @@ def urdf_with_external_assets(asset_tmp_path):
         ],
         dtype=np.uint8,
     )
-    Image.fromarray(texture).save(texture_path)
+    Image.fromarray(texture).convert("P", palette=Image.Palette.ADAPTIVE).save(texture_path)
     robot = ET.Element("robot", name="external_mesh_and_texture")
     material = ET.SubElement(robot, "material", name="textured")
     ET.SubElement(material, "color", rgba="0 1 0 1")

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -869,7 +869,6 @@ def test_color_overwrite(overwrite, urdf_with_external_assets, show_viewer):
     textured = scene.add_entity(
         gs.morphs.URDF(
             file=urdf_with_external_assets,
-            prioritize_urdf_material=True,
         ),
         surface=gs.surfaces.Default(
             color=(1.0, 0.0, 0.0, 1.0) if overwrite else None,

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import pytest
 import torch
+from PIL import Image
 
 import genesis as gs
 import genesis.utils.geom as gu
@@ -817,7 +818,7 @@ def test_xacro_loading(xacro_robot, show_viewer, tol):
 @pytest.mark.required
 @pytest.mark.required
 @pytest.mark.parametrize("overwrite", [False, True])
-def test_color_overwrite(overwrite, show_viewer):
+def test_color_overwrite(overwrite, urdf_with_external_assets, show_viewer):
     scene = gs.Scene(show_viewer=show_viewer)
     box = scene.add_entity(
         gs.morphs.URDF(
@@ -865,20 +866,32 @@ def test_color_overwrite(overwrite, show_viewer):
             color=(1.0, 0.0, 0.0, 1.0) if overwrite else None,
         ),
     )
+    textured = scene.add_entity(
+        gs.morphs.URDF(
+            file=urdf_with_external_assets,
+            prioritize_urdf_material=True,
+        ),
+        surface=gs.surfaces.Default(
+            color=(1.0, 0.0, 0.0, 1.0) if overwrite else None,
+        ),
+    )
     if show_viewer:
         scene.build()
+
     for vgeom in box.vgeoms:
         assert vgeom.vmesh.metadata["is_visual_overwritten"] == overwrite
         visual = vgeom.vmesh.trimesh.visual
         assert visual.defined
         color = np.unique(visual.vertex_colors, axis=0)
         assert_equal(color, (255, 0, 0, 255) if overwrite else (0, 0, 255, 255))
+
     for vgeom in chain.vgeoms:
         assert vgeom.vmesh.metadata["is_visual_overwritten"] == overwrite
         visual = vgeom.vmesh.trimesh.visual
         assert visual.defined
         color = np.unique(visual.vertex_colors, axis=0)
         assert_equal(color, (255, 0, 0, 255) if overwrite else (51, 51, 51, 255))
+
     for vgeom in humanoid.vgeoms:
         # FIXME: The original material is lost because the visuals are collision geometries that has been duplicated as
         # visual to circumvent the lack of dedicated visuals.
@@ -895,6 +908,7 @@ def test_color_overwrite(overwrite, show_viewer):
                     assert_equal(color, (128, 128, 128, 255))
         else:
             assert_equal(color, (255, 0, 0, 255) if overwrite else (128, 128, 128, 255))
+
     for vgeom in axis.vgeoms:
         assert vgeom.vmesh.metadata["is_visual_overwritten"] == overwrite
         visual = vgeom.vmesh.trimesh.visual
@@ -904,6 +918,7 @@ def test_color_overwrite(overwrite, show_viewer):
             assert_equal(color, (255, 0, 0, 255))
         else:
             assert_equal(color, [[0, 0, 178, 255], [0, 178, 0, 255], [178, 0, 0, 255], [255, 255, 255, 255]])
+
     for vgeom in table.vgeoms:
         assert vgeom.vmesh.metadata["is_visual_overwritten"] == overwrite
         visual = vgeom.vmesh.trimesh.visual
@@ -911,6 +926,23 @@ def test_color_overwrite(overwrite, show_viewer):
         if overwrite:
             color = np.unique(visual.vertex_colors, axis=0)
             assert_equal(color, (255, 0, 0, 255))
+
+    texture_path = ET.fromstring(urdf_with_external_assets).find("material/texture").get("filename")
+    texture = np.array(Image.open(texture_path))
+    sphere_vgeom, quad_vgeom = textured.vgeoms
+    for vgeom in (sphere_vgeom, quad_vgeom):
+        assert vgeom.vmesh.metadata["is_visual_overwritten"] == overwrite
+        assert vgeom.vmesh.trimesh.visual.defined
+    if overwrite:
+        for vgeom in (sphere_vgeom, quad_vgeom):
+            color = np.unique(vgeom.vmesh.trimesh.visual.vertex_colors, axis=0)
+            assert_equal(color, (255, 0, 0, 255))
+    else:
+        assert_equal(np.array(quad_vgeom.vmesh.trimesh.visual.material.image.convert("RGB")), texture)
+        # A visual without texture coordinates takes the mean color of the texture
+        color = np.unique(sphere_vgeom.vmesh.trimesh.visual.vertex_colors, axis=0)
+        assert_equal(color, (*texture.mean(axis=(0, 1)), 255))
+
     for entity in scene.entities:
         for geom in entity.geoms:
             assert geom.mesh.metadata["is_visual_overwritten"]

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -821,7 +821,7 @@ def test_color_overwrite(overwrite, show_viewer):
     scene = gs.Scene(show_viewer=show_viewer)
     box = scene.add_entity(
         gs.morphs.URDF(
-            file="genesis/assets/urdf/blue_box/model.urdf",
+            file="urdf/blue_box/model.urdf",
             convexify=False,
         ),
         surface=gs.surfaces.Default(

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -928,7 +928,7 @@ def test_color_overwrite(overwrite, urdf_with_external_assets, show_viewer):
             assert_equal(color, (255, 0, 0, 255))
 
     texture_path = ET.fromstring(urdf_with_external_assets).find("material/texture").get("filename")
-    texture = np.array(Image.open(texture_path))
+    texture = np.array(Image.open(texture_path).convert("RGB"))
     sphere_vgeom, quad_vgeom = textured.vgeoms
     for vgeom in (sphere_vgeom, quad_vgeom):
         assert vgeom.vmesh.metadata["is_visual_overwritten"] == overwrite

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -79,7 +79,7 @@ def checkpoint_scene(mimic_hinges, requires_grad, show_viewer):
 @pytest.mark.parametrize("model_name", ["two_free_boxes"])
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_export_and_load_rigid(
-    n_envs, xml_path, mimic_hinges, urdf_with_external_mesh, xacro_robot, tmp_path, show_viewer, caplog
+    n_envs, xml_path, mimic_hinges, urdf_with_external_assets, xacro_robot, tmp_path, show_viewer, caplog
 ):
     scene = gs.Scene(
         sim_options=gs.options.SimOptions(
@@ -250,7 +250,7 @@ def test_export_and_load_rigid(
     # An asset may name a mesh outside its own directory, which the mesh states as an absolute path of its own
     far_mesh = scene.add_entity(
         morph=gs.morphs.URDF(
-            file=urdf_with_external_mesh,
+            file=urdf_with_external_assets,
             pos=(80.0, 80.0, 1.0),
         ),
     )
@@ -324,7 +324,7 @@ def test_export_and_load_rigid(
     # A mesh states the asset it was read from by name, wherever that asset stood
     assert restored.entities[16].geoms[0].mesh.metadata["mesh_path"] == "sphere.obj"
     # The document that entity was created from names that mesh as well, and the name travels without its directory
-    assert "external_meshes" not in restored.entities[16].morph.file
+    assert "external_assets" not in restored.entities[16].morph.file
     assert 'filename="sphere.obj"' in restored.entities[16].morph.file
     # A scale per axis comes back as the three factors it was given, and the geometry it produced with them
     assert_equal(restored.entities[14].morph.scale, stretched.morph.scale)


### PR DESCRIPTION
## Description

- Textures declared by a URDF material are applied to its visual geoms under the same rule as material colors: when the asset authors no material of its own, or when `prioritize_urdf_material` is set. A mesh holding texture coordinates and no material counts as authoring none, where trimesh hands it a placeholder material. The image replaces the material color, and a visual without texture coordinates takes the mean color of the image.
- Exporting an in-memory URDF model to XML leaves its texture files untouched. Every scene digest exports such models, so a scene build rewrote the texture images on disk.
- The color overwrite test names its box asset relative to the Genesis assets directory, so it loads from any working directory.
- A paletted texture image (PIL mode P) resolves to the colors its indices stand for, wherever an image becomes a texture: URDF materials, mesh-file materials, glTF and USD textures, and `ImageTexture(image_path=...)`.
- `urdfpy.URDF.save()` is removed together with the output path threaded through every unparse for it, and `URDF.to_xml()` exposes the document Genesis reads a model from.

## Motivation and Context

URDF material textures were parsed and then dropped, so a robot whose look is given by `<material><texture filename="..."/></material>` rendered untextured.

## How Has This Been / Can This Be Tested?

The URDF fixture naming its assets by absolute paths now carries a material with both a color and a paletted texture, shared by a sphere visual without texture coordinates and a quad visual with them. `test_color_overwrite` checks that the quad visual carries the image, that the sphere takes the mean color of the image, and that a surface color given by the user overrides both. The checkpoint round trip of `test_export_and_load_rigid` covers the texture named by an absolute path travelling by bare filename.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
