### PR TITLE
[BUG FIX] Fix convex collision detection on geom pairs of very different sizes.

### DIFF
--- a/genesis/engine/solvers/rigid/collider/mpr.py
+++ b/genesis/engine/solvers/rigid/collider/mpr.py
@@ -140,12 +140,16 @@ def mpr_portal_can_encapsule_origin(v, direction, collider_info: array_class.Col
 def mpr_portal_reach_tolerance(
     i_ga, i_gb, i_b, ccd_tol, v, direction, mpr_state: array_class.MPRState, collider_info: array_class.ColliderInfo
 ):
-    dv1 = mpr_state.simplex_support.v[1, i_b].dot(direction)
-    dv2 = mpr_state.simplex_support.v[2, i_b].dot(direction)
-    dv3 = mpr_state.simplex_support.v[3, i_b].dot(direction)
-    dv4 = v.dot(direction)
-    dot1 = qd.min(dv4 - dv1, dv4 - dv2, dv4 - dv3)
-    return dot1 < ccd_tol + collider_info.mpr.CCD_EPS[None] * qd.abs(dv4)
+    pv1 = mpr_state.simplex_support.v[1, i_b]
+    pv2 = mpr_state.simplex_support.v[2, i_b]
+    pv3 = mpr_state.simplex_support.v[3, i_b]
+    dv = v.dot(direction)
+    dot1 = qd.min(dv - pv1.dot(direction), dv - pv2.dot(direction), dv - pv3.dot(direction))
+    # A portal plane through the origin makes dv and the three pv projections pure rounding noise.
+    # The rounding error of a dot product scales with its operands, so the tolerance floor scales with the vertices.
+    # Without the floor a noise gap counts as progress, the portal re-adds a held vertex, and refinement never ends.
+    scale = qd.max(qd.abs(v).sum(), qd.abs(pv1).sum(), qd.abs(pv2).sum(), qd.abs(pv3).sum())
+    return dot1 < ccd_tol + collider_info.mpr.CCD_EPS[None] * scale
 
 
 @qd.func

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -420,6 +420,77 @@ def test_mpr_thin_box_stack_no_lateral_phantom(show_viewer, tol):
     assert_allclose(pos[..., 2], 0.015, atol=1e1 * tol)
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["32"])
+@pytest.mark.parametrize("gjk_collision", [True, False])
+def test_convex_collision_across_geom_scales(gjk_collision, show_viewer, tol):
+    YAW = 1.1
+    BOX_SIZE = 16.0
+    GEOM_SIZE = 0.016
+    # Collision tolerances scale with the smaller geom of a pair, rounding errors with its coordinates. A large size
+    # ratio thus drives the tolerance below the rounding error. The grazing box sits where its separation from the face
+    # is rounding noise, so contact detection must resolve the pair without any measurable depth to converge on. The
+    # pressed box checks that such a pair still yields a contact.
+    GRAZING_SPOT = (-3.36, 0.8)
+    PRESSED_SPOT = (-3.3, 0.8)
+    PRESSED_DEPTH = 0.25 * GEOM_SIZE
+
+    scene = gs.Scene(
+        rigid_options=gs.options.RigidOptions(
+            use_gjk_collision=gjk_collision,
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(6.6, 5.74, 8.85),
+            camera_lookat=(6.6, 5.63, 8.8),
+            camera_fov=30,
+        ),
+        show_viewer=show_viewer,
+    )
+    box = scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 0.5 * BOX_SIZE),
+            euler=(0.0, 0.0, math.degrees(YAW)),
+            size=(BOX_SIZE, BOX_SIZE, BOX_SIZE),
+            fixed=True,
+        ),
+    )
+    geom_grazing = scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 2.0 * BOX_SIZE),
+            size=(GEOM_SIZE, GEOM_SIZE, GEOM_SIZE),
+        ),
+        visualize_contact=True,
+        vis_mode="collision",
+    )
+    geom_pressed = scene.add_entity(
+        gs.morphs.Box(
+            pos=(0.0, 0.0, 3.0 * BOX_SIZE),
+            size=(GEOM_SIZE, GEOM_SIZE, GEOM_SIZE),
+        ),
+        visualize_contact=True,
+        vis_mode="collision",
+    )
+    scene.build()
+
+    face_offset = 0.5 * (BOX_SIZE + GEOM_SIZE)
+    face_normal = torch.tensor([math.cos(YAW), math.sin(YAW), 0.0], dtype=gs.tc_float, device=gs.device)
+    for geom, spot, depth in ((geom_grazing, GRAZING_SPOT, 0.0), (geom_pressed, PRESSED_SPOT, PRESSED_DEPTH)):
+        pos_local = torch.tensor([face_offset - depth, *spot], dtype=gs.tc_float, device=gs.device)
+        geom.set_pos(gu.transform_by_quat(pos_local, box.get_quat()) + box.get_pos())
+        geom.set_quat(box.get_quat())
+
+    scene.step()
+    contacts = scene.rigid_solver.collider.get_contacts()
+    assert_allclose((contacts["normal"] @ face_normal).abs(), 1.0, tol=tol)
+    is_pressed = contacts["geom_b"] == geom_pressed.geoms[0].idx
+    assert is_pressed.any()
+    assert_allclose(contacts["penetration"][is_pressed], PRESSED_DEPTH, tol=tol)
+    assert (contacts["penetration"][~is_pressed] >= 0.0).all()
+    assert (contacts["penetration"][~is_pressed] <= GEOM_SIZE).all()
+    offset = (geom_grazing.get_pos() - box.get_pos()) @ face_normal
+    assert face_offset - tol <= offset <= face_offset + GEOM_SIZE
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 def test_robot_scaling_primitive_collision(show_viewer):


### PR DESCRIPTION
## Description

`mpr_portal_reach_tolerance` floors the tolerance of the portal refinement with a term proportional to the projection of the new support point onto the portal normal. When the portal plane passes through the origin that projection is rounding noise, so the floor vanishes: a gap made of rounding noise counts as progress, `mpr_refine_portal` re-inserts the vertex it already holds, and the loop never ends. On the GPU one lane never leaves the narrowphase kernel and the host blocks at its next synchronisation. The floor now scales with the magnitude of the portal vertices and of the support point, which bounds the rounding error of their projections.

## Related Issue

Resolves Genesis-Embodied-AI/genesis-world#3314

Addresses Genesis-Embodied-AI/genesis-world#3310 (the same hang, first attributed to the constraint solver).

## Motivation and Context

The tolerance is relative to the smaller geom of the pair, so for a small geom touching a large one (a 1 mm box on the Go1 base against a pushed box in the report) it falls below single-precision resolution of the portal vertices, and the same dot product evaluates on both sides of zero at different sites of the loop.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_collision.py::test_convex_collision_across_geom_scales` places a small box exactly touching the side face of a large yawed box at a spot where their separation sits below floating-point resolution, and checks the contact it yields. The reporter's checkpoint replay from #3314 completes with this change.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
