### PR TITLE
[BUG FIX] Preserve glTF normals and texture coordinates.

### DIFF
--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -378,17 +378,17 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
                     continue  # Skip unsupported modes
 
                 # parse normals
-                if primitive.attributes.NORMAL:
+                if primitive.attributes.NORMAL is not None:
                     normals = get_glb_data_from_accessor(glb, primitive.attributes.NORMAL).astype(np.float32)
                 else:
                     normals = None
 
                 # parse uvs
                 if uv_used == 0:
-                    if primitive.attributes.TEXCOORD_0:
+                    if primitive.attributes.TEXCOORD_0 is not None:
                         uvs = get_glb_data_from_accessor(glb, primitive.attributes.TEXCOORD_0).astype(np.float32)
                 elif uv_used == 1:
-                    if primitive.attributes.TEXCOORD_1:
+                    if primitive.attributes.TEXCOORD_1 is not None:
                         uvs = get_glb_data_from_accessor(glb, primitive.attributes.TEXCOORD_1).astype(np.float32)
 
             points, normals = mu.apply_transform(mesh_transform, points, normals)

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -42,6 +42,43 @@ def mesh_urdf(mesh_path):
     return ET.tostring(robot, encoding="unicode")
 
 
+@pytest.fixture
+def glb_path(glb_file, accessor_zero_attribute, asset_tmp_path):
+    """Path to an existing GLB or a generated mesh with the selected attribute at accessor zero."""
+    if accessor_zero_attribute is None:
+        return os.path.join(get_hf_dataset(pattern=glb_file), glb_file)
+
+    # Authored shading normals differ from the triangle's geometric normal
+    mesh = trimesh.Trimesh(
+        vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        faces=[[0, 1, 2]],
+        vertex_normals=[[1.0, 0.0, 0.0]] * 3,
+        visual=trimesh.visual.TextureVisuals(
+            uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
+            material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
+        ),
+        process=False,
+    )
+    path = asset_tmp_path / f"accessor_zero_{accessor_zero_attribute}.glb"
+    mesh.export(path, include_normals=True)
+    glb = pygltflib.GLTF2().load(path)
+    primitive = glb.meshes[0].primitives[0]
+    attributes = primitive.attributes
+    first_accessor = attributes.NORMAL if accessor_zero_attribute == "NORMAL" else attributes.TEXCOORD_0
+    # Reorder the accessor table while keeping every reference attached to its authored data
+    order = [first_accessor] + [i for i in range(len(glb.accessors)) if i != first_accessor]
+    glb.accessors = [glb.accessors[i] for i in order]
+    attributes.POSITION = order.index(attributes.POSITION)
+    attributes.NORMAL = order.index(attributes.NORMAL)
+    attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
+    primitive.indices = order.index(primitive.indices)
+    if accessor_zero_attribute == "TEXCOORD_1":
+        attributes.TEXCOORD_1 = attributes.TEXCOORD_0
+        glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
+    glb.save_binary(str(path))
+    return str(path)
+
+
 # Conversion from .usd to .glb significantly affects precision
 USD_COLOR_TOL = 1e-07
 

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -508,13 +508,12 @@ def usd_scene(request, model_name, scale, fixed):
     return build_usd_scene(request.getfixturevalue(model_name), scale=scale, fixed=fixed)
 
 
-def _build_textured_triangle_glb(asset_tmp_path, name):
-    """Export a textured triangle whose authored normals differ from its geometric normal, so a parser that drops them
-    and recomputes them from the geometry fails the normals comparison. Returns the loaded glTF document and its
-    path."""
+def _build_textured_triangle_glb(asset_tmp_path, name, first_attribute):
+    """Build a textured triangle with NORMAL or TEXCOORD_0 at accessor zero, returning the glTF document and path."""
     mesh = trimesh.Trimesh(
         vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
         faces=[[0, 1, 2]],
+        # Authored shading normals differ from the triangle's geometric normal
         vertex_normals=[[1.0, 0.0, 0.0]] * 3,
         visual=trimesh.visual.TextureVisuals(
             uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
@@ -524,27 +523,24 @@ def _build_textured_triangle_glb(asset_tmp_path, name):
     )
     path = str(asset_tmp_path / f"{name}.glb")
     mesh.export(path, include_normals=True)
-    return pygltflib.GLTF2().load(path), path
-
-
-def _move_accessor_first(glb, accessor):
-    """Move the given accessor to index zero in the generated triangle, preserving its POSITION, NORMAL, TEXCOORD_0,
-    and indices references."""
-    order = [accessor] + [i for i in range(len(glb.accessors)) if i != accessor]
-    glb.accessors = [glb.accessors[i] for i in order]
+    glb = pygltflib.GLTF2().load(path)
     primitive = glb.meshes[0].primitives[0]
     attributes = primitive.attributes
+    accessor = attributes.NORMAL if first_attribute == "NORMAL" else attributes.TEXCOORD_0
+    # Keep the triangle's attribute and index references attached to their data
+    order = [accessor] + [i for i in range(len(glb.accessors)) if i != accessor]
+    glb.accessors = [glb.accessors[i] for i in order]
     attributes.POSITION = order.index(attributes.POSITION)
     attributes.NORMAL = order.index(attributes.NORMAL)
     attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
     primitive.indices = order.index(primitive.indices)
+    return glb, path
 
 
 @pytest.fixture(scope="session")
 def normal_accessor_zero_glb(asset_tmp_path):
     """Path to a GLB storing the vertex normals of its triangle at accessor zero."""
-    glb, path = _build_textured_triangle_glb(asset_tmp_path, "normal_accessor_zero")
-    _move_accessor_first(glb, glb.meshes[0].primitives[0].attributes.NORMAL)
+    glb, path = _build_textured_triangle_glb(asset_tmp_path, "normal_accessor_zero", first_attribute="NORMAL")
     glb.save_binary(path)
     return path
 
@@ -552,8 +548,7 @@ def normal_accessor_zero_glb(asset_tmp_path):
 @pytest.fixture(scope="session")
 def texcoord_0_accessor_zero_glb(asset_tmp_path):
     """Path to a GLB storing the first texture coordinate set of its triangle at accessor zero."""
-    glb, path = _build_textured_triangle_glb(asset_tmp_path, "texcoord_0_accessor_zero")
-    _move_accessor_first(glb, glb.meshes[0].primitives[0].attributes.TEXCOORD_0)
+    glb, path = _build_textured_triangle_glb(asset_tmp_path, "texcoord_0_accessor_zero", first_attribute="TEXCOORD_0")
     glb.save_binary(path)
     return path
 
@@ -561,9 +556,8 @@ def texcoord_0_accessor_zero_glb(asset_tmp_path):
 @pytest.fixture(scope="session")
 def texcoord_1_accessor_zero_glb(asset_tmp_path):
     """Path to a GLB whose base color texture reads the second texture coordinate set, stored at accessor zero."""
-    glb, path = _build_textured_triangle_glb(asset_tmp_path, "texcoord_1_accessor_zero")
+    glb, path = _build_textured_triangle_glb(asset_tmp_path, "texcoord_1_accessor_zero", first_attribute="TEXCOORD_0")
     primitive = glb.meshes[0].primitives[0]
-    _move_accessor_first(glb, primitive.attributes.TEXCOORD_0)
     # glTF requires set 0 wherever set 1 exists, so set 1 aliases the accessor of set 0
     primitive.attributes.TEXCOORD_1 = primitive.attributes.TEXCOORD_0
     glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -43,40 +43,12 @@ def mesh_urdf(mesh_path):
 
 
 @pytest.fixture
-def glb_path(glb_file, accessor_zero_attribute, asset_tmp_path):
-    """Path to an existing GLB or a generated mesh with the selected attribute at accessor zero."""
-    if accessor_zero_attribute is None:
+def glb_path(request, glb_file):
+    """The GLB a test parses. An asset-relative path resolves through the dataset. A bare name is the fixture
+    generating the file."""
+    if "/" in glb_file:
         return os.path.join(get_hf_dataset(pattern=glb_file), glb_file)
-
-    # Authored shading normals differ from the triangle's geometric normal
-    mesh = trimesh.Trimesh(
-        vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-        faces=[[0, 1, 2]],
-        vertex_normals=[[1.0, 0.0, 0.0]] * 3,
-        visual=trimesh.visual.TextureVisuals(
-            uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
-            material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
-        ),
-        process=False,
-    )
-    path = asset_tmp_path / f"accessor_zero_{accessor_zero_attribute}.glb"
-    mesh.export(path, include_normals=True)
-    glb = pygltflib.GLTF2().load(path)
-    primitive = glb.meshes[0].primitives[0]
-    attributes = primitive.attributes
-    first_accessor = attributes.NORMAL if accessor_zero_attribute == "NORMAL" else attributes.TEXCOORD_0
-    # Reorder the accessor table while keeping every reference attached to its authored data
-    order = [first_accessor] + [i for i in range(len(glb.accessors)) if i != first_accessor]
-    glb.accessors = [glb.accessors[i] for i in order]
-    attributes.POSITION = order.index(attributes.POSITION)
-    attributes.NORMAL = order.index(attributes.NORMAL)
-    attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
-    primitive.indices = order.index(primitive.indices)
-    if accessor_zero_attribute == "TEXCOORD_1":
-        attributes.TEXCOORD_1 = attributes.TEXCOORD_0
-        glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
-    glb.save_binary(str(path))
-    return str(path)
+    return request.getfixturevalue(glb_file)
 
 
 # Conversion from .usd to .glb significantly affects precision
@@ -534,6 +506,69 @@ def fixed():
 def usd_scene(request, model_name, scale, fixed):
     """Build a USD scene from the USD file provided by the fixture named 'model_name'."""
     return build_usd_scene(request.getfixturevalue(model_name), scale=scale, fixed=fixed)
+
+
+def _build_textured_triangle_glb(asset_tmp_path, name):
+    """Export a textured triangle whose authored normals differ from its geometric normal, so a parser that drops them
+    and recomputes them from the geometry fails the normals comparison. Returns the loaded glTF document and its
+    path."""
+    mesh = trimesh.Trimesh(
+        vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        faces=[[0, 1, 2]],
+        vertex_normals=[[1.0, 0.0, 0.0]] * 3,
+        visual=trimesh.visual.TextureVisuals(
+            uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
+            material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
+        ),
+        process=False,
+    )
+    path = str(asset_tmp_path / f"{name}.glb")
+    mesh.export(path, include_normals=True)
+    return pygltflib.GLTF2().load(path), path
+
+
+def _move_accessor_first(glb, accessor):
+    """Move the given accessor to index zero in the generated triangle, preserving its POSITION, NORMAL, TEXCOORD_0,
+    and indices references."""
+    order = [accessor] + [i for i in range(len(glb.accessors)) if i != accessor]
+    glb.accessors = [glb.accessors[i] for i in order]
+    primitive = glb.meshes[0].primitives[0]
+    attributes = primitive.attributes
+    attributes.POSITION = order.index(attributes.POSITION)
+    attributes.NORMAL = order.index(attributes.NORMAL)
+    attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
+    primitive.indices = order.index(primitive.indices)
+
+
+@pytest.fixture(scope="session")
+def normal_accessor_zero_glb(asset_tmp_path):
+    """Path to a GLB storing the vertex normals of its triangle at accessor zero."""
+    glb, path = _build_textured_triangle_glb(asset_tmp_path, "normal_accessor_zero")
+    _move_accessor_first(glb, glb.meshes[0].primitives[0].attributes.NORMAL)
+    glb.save_binary(path)
+    return path
+
+
+@pytest.fixture(scope="session")
+def texcoord_0_accessor_zero_glb(asset_tmp_path):
+    """Path to a GLB storing the first texture coordinate set of its triangle at accessor zero."""
+    glb, path = _build_textured_triangle_glb(asset_tmp_path, "texcoord_0_accessor_zero")
+    _move_accessor_first(glb, glb.meshes[0].primitives[0].attributes.TEXCOORD_0)
+    glb.save_binary(path)
+    return path
+
+
+@pytest.fixture(scope="session")
+def texcoord_1_accessor_zero_glb(asset_tmp_path):
+    """Path to a GLB whose base color texture reads the second texture coordinate set, stored at accessor zero."""
+    glb, path = _build_textured_triangle_glb(asset_tmp_path, "texcoord_1_accessor_zero")
+    primitive = glb.meshes[0].primitives[0]
+    _move_accessor_first(glb, primitive.attributes.TEXCOORD_0)
+    # glTF requires set 0 wherever set 1 exists, so set 1 aliases the accessor of set 0
+    primitive.attributes.TEXCOORD_1 = primitive.attributes.TEXCOORD_0
+    glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
+    glb.save_binary(path)
+    return path
 
 
 @pytest.fixture(scope="session")

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -42,15 +42,6 @@ def mesh_urdf(mesh_path):
     return ET.tostring(robot, encoding="unicode")
 
 
-@pytest.fixture
-def glb_path(request, glb_file):
-    """The GLB a test parses. An asset-relative path resolves through the dataset. A bare name is the fixture
-    generating the file."""
-    if "/" in glb_file:
-        return os.path.join(get_hf_dataset(pattern=glb_file), glb_file)
-    return request.getfixturevalue(glb_file)
-
-
 # Conversion from .usd to .glb significantly affects precision
 USD_COLOR_TOL = 1e-07
 

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -291,13 +291,13 @@ def test_urdf_mesh_processing(mesh_path, mesh_urdf, show_viewer):
 @pytest.mark.required
 @pytest.mark.parametrize("precision", ["32"])
 @pytest.mark.parametrize(
-    "glb_file, accessor_zero_attribute",
+    "glb_file",
     [
-        ("glb/combined_srt.glb", None),
-        ("glb/combined_transform.glb", None),
-        (None, "NORMAL"),
-        (None, "TEXCOORD_0"),
-        (None, "TEXCOORD_1"),
+        "glb/combined_srt.glb",
+        "glb/combined_transform.glb",
+        "normal_accessor_zero_glb",
+        "texcoord_0_accessor_zero_glb",
+        "texcoord_1_accessor_zero_glb",
     ],
 )
 def test_glb_parse_geometry(glb_path, tol):

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -1,5 +1,4 @@
 import io
-import os
 from contextlib import nullcontext
 
 import numpy as np
@@ -18,12 +17,9 @@ import genesis.utils.mesh as mu
 from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.assets import get_hf_dataset
 from .conftest import (
-    check_gs_meshes,
-    check_gs_surfaces,
     check_gs_textures,
     check_gs_tm_meshes,
     check_gs_tm_textures,
-    extract_mesh,
 )
 
 
@@ -326,10 +322,8 @@ def test_glb_parse_geometry(glb_path, tol):
 
 @pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/tycoon_draco_no_normal.glb", "glb/tycoon_with_normal_draco.glb"])
-def test_glb_draco_missing_normals_texcoord(glb_file):
+def test_glb_draco_missing_normals_texcoord(glb_path):
     # Normals and tex_coord are not always present in GLB files, typically for Draco-compressed ones.
-    asset_path = get_hf_dataset(pattern=glb_file)
-    glb_path = os.path.join(asset_path, glb_file)
     gs_meshes = gltf_utils.parse_mesh_glb(
         glb_path,
         group_by_material=False,
@@ -353,18 +347,16 @@ def test_glb_draco_missing_normals_texcoord(glb_file):
 
 @pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/chopper.glb"])
-def test_glb_parse_material(glb_file):
-    asset_path = get_hf_dataset(pattern=glb_file)
-    glb_file = os.path.join(asset_path, glb_file)
+def test_glb_parse_material(glb_path):
     gs_meshes = gltf_utils.parse_mesh_glb(
-        glb_file,
+        glb_path,
         group_by_material=True,
         scale=None,
         is_mesh_zup=True,
         surface=gs.surfaces.Default(),
     )
 
-    tm_scene = trimesh.load(glb_file, process=False)
+    tm_scene = trimesh.load(glb_path, process=False)
     tm_materials = {}
     for geometry_name in tm_scene.geometry:
         ts_mesh = tm_scene.geometry[geometry_name]

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -318,6 +318,44 @@ def test_glb_parse_geometry(glb_file, tol):
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("first_attribute", ["NORMAL", "TEXCOORD_0", "TEXCOORD_1"])
+def test_glb_parse_vertex_attributes(asset_tmp_path, tol, first_attribute):
+    # Authored shading normals differ from the triangle's geometric normal
+    mesh = trimesh.Trimesh(
+        vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        faces=[[0, 1, 2]],
+        vertex_normals=[[1.0, 0.0, 0.0]] * 3,
+        visual=trimesh.visual.TextureVisuals(
+            uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
+            material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
+        ),
+        process=False,
+    )
+    glb_path = asset_tmp_path / f"vertex_attributes_{first_attribute}.glb"
+    mesh.export(glb_path, include_normals=True)
+    glb = pygltflib.GLTF2().load(glb_path)
+    primitive = glb.meshes[0].primitives[0]
+    attributes = primitive.attributes
+    first_accessor = attributes.NORMAL if first_attribute == "NORMAL" else attributes.TEXCOORD_0
+    # Reorder the accessor table while keeping every reference attached to its authored data
+    order = [first_accessor] + [i for i in range(len(glb.accessors)) if i != first_accessor]
+    glb.accessors = [glb.accessors[i] for i in order]
+    attributes.POSITION = order.index(attributes.POSITION)
+    attributes.NORMAL = order.index(attributes.NORMAL)
+    attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
+    primitive.indices = order.index(primitive.indices)
+    if first_attribute == "TEXCOORD_1":
+        attributes.TEXCOORD_1 = attributes.TEXCOORD_0
+        glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
+    glb.save_binary(str(glb_path))
+
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        str(glb_path), group_by_material=False, scale=None, is_mesh_zup=True, surface=gs.surfaces.Default()
+    )
+    check_gs_tm_meshes(gs_meshes[0], mesh, first_attribute, tol, tol)
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/tycoon_draco_no_normal.glb", "glb/tycoon_with_normal_draco.glb"])
 def test_glb_draco_missing_normals_texcoord(glb_file):
     # Normals and tex_coord are not always present in GLB files, typically for Draco-compressed ones.

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -300,50 +300,16 @@ def test_urdf_mesh_processing(mesh_path, mesh_urdf, show_viewer):
         (None, "TEXCOORD_1"),
     ],
 )
-def test_glb_parse_geometry(glb_file, accessor_zero_attribute, asset_tmp_path, tol):
-    if accessor_zero_attribute is None:
-        asset_path = get_hf_dataset(pattern=glb_file)
-        glb_file = os.path.join(asset_path, glb_file)
-    else:
-        # Authored shading normals differ from the triangle's geometric normal
-        mesh = trimesh.Trimesh(
-            vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-            faces=[[0, 1, 2]],
-            vertex_normals=[[1.0, 0.0, 0.0]] * 3,
-            visual=trimesh.visual.TextureVisuals(
-                uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
-                material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
-            ),
-            process=False,
-        )
-        glb_path = asset_tmp_path / f"vertex_attributes_{accessor_zero_attribute}.glb"
-        mesh.export(glb_path, include_normals=True)
-        glb = pygltflib.GLTF2().load(glb_path)
-        primitive = glb.meshes[0].primitives[0]
-        attributes = primitive.attributes
-        first_accessor = attributes.NORMAL if accessor_zero_attribute == "NORMAL" else attributes.TEXCOORD_0
-        # Reorder the accessor table while keeping every reference attached to its authored data
-        order = [first_accessor] + [i for i in range(len(glb.accessors)) if i != first_accessor]
-        glb.accessors = [glb.accessors[i] for i in order]
-        attributes.POSITION = order.index(attributes.POSITION)
-        attributes.NORMAL = order.index(attributes.NORMAL)
-        attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
-        primitive.indices = order.index(primitive.indices)
-        if accessor_zero_attribute == "TEXCOORD_1":
-            attributes.TEXCOORD_1 = attributes.TEXCOORD_0
-            glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
-        glb.save_binary(str(glb_path))
-        glb_file = str(glb_path)
-
+def test_glb_parse_geometry(glb_path, tol):
     gs_meshes = gltf_utils.parse_mesh_glb(
-        glb_file,
+        glb_path,
         group_by_material=False,
         scale=None,
         is_mesh_zup=True,
         surface=gs.surfaces.Default(),
     )
 
-    tm_scene = trimesh.load(glb_file, process=False)
+    tm_scene = trimesh.load(glb_path, process=False)
     tm_meshes = {}
     for node_name in tm_scene.graph.nodes_geometry:
         transform, geometry_name = tm_scene.graph[node_name]

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -290,10 +290,51 @@ def test_urdf_mesh_processing(mesh_path, mesh_urdf, show_viewer):
 
 @pytest.mark.required
 @pytest.mark.parametrize("precision", ["32"])
-@pytest.mark.parametrize("glb_file", ["glb/combined_srt.glb", "glb/combined_transform.glb"])
-def test_glb_parse_geometry(glb_file, tol):
-    asset_path = get_hf_dataset(pattern=glb_file)
-    glb_file = os.path.join(asset_path, glb_file)
+@pytest.mark.parametrize(
+    "glb_file, accessor_zero_attribute",
+    [
+        ("glb/combined_srt.glb", None),
+        ("glb/combined_transform.glb", None),
+        (None, "NORMAL"),
+        (None, "TEXCOORD_0"),
+        (None, "TEXCOORD_1"),
+    ],
+)
+def test_glb_parse_geometry(glb_file, accessor_zero_attribute, asset_tmp_path, tol):
+    if accessor_zero_attribute is None:
+        asset_path = get_hf_dataset(pattern=glb_file)
+        glb_file = os.path.join(asset_path, glb_file)
+    else:
+        # Authored shading normals differ from the triangle's geometric normal
+        mesh = trimesh.Trimesh(
+            vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            faces=[[0, 1, 2]],
+            vertex_normals=[[1.0, 0.0, 0.0]] * 3,
+            visual=trimesh.visual.TextureVisuals(
+                uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
+                material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
+            ),
+            process=False,
+        )
+        glb_path = asset_tmp_path / f"vertex_attributes_{accessor_zero_attribute}.glb"
+        mesh.export(glb_path, include_normals=True)
+        glb = pygltflib.GLTF2().load(glb_path)
+        primitive = glb.meshes[0].primitives[0]
+        attributes = primitive.attributes
+        first_accessor = attributes.NORMAL if accessor_zero_attribute == "NORMAL" else attributes.TEXCOORD_0
+        # Reorder the accessor table while keeping every reference attached to its authored data
+        order = [first_accessor] + [i for i in range(len(glb.accessors)) if i != first_accessor]
+        glb.accessors = [glb.accessors[i] for i in order]
+        attributes.POSITION = order.index(attributes.POSITION)
+        attributes.NORMAL = order.index(attributes.NORMAL)
+        attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
+        primitive.indices = order.index(primitive.indices)
+        if accessor_zero_attribute == "TEXCOORD_1":
+            attributes.TEXCOORD_1 = attributes.TEXCOORD_0
+            glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
+        glb.save_binary(str(glb_path))
+        glb_file = str(glb_path)
+
     gs_meshes = gltf_utils.parse_mesh_glb(
         glb_file,
         group_by_material=False,
@@ -315,44 +356,6 @@ def test_glb_parse_geometry(glb_file, tol):
         mesh_name = gs_mesh.metadata["name"]
         tm_mesh = tm_meshes[mesh_name]
         check_gs_tm_meshes(gs_mesh, tm_mesh, mesh_name, tol, tol)
-
-
-@pytest.mark.required
-@pytest.mark.parametrize("first_attribute", ["NORMAL", "TEXCOORD_0", "TEXCOORD_1"])
-def test_glb_parse_vertex_attributes(asset_tmp_path, tol, first_attribute):
-    # Authored shading normals differ from the triangle's geometric normal
-    mesh = trimesh.Trimesh(
-        vertices=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-        faces=[[0, 1, 2]],
-        vertex_normals=[[1.0, 0.0, 0.0]] * 3,
-        visual=trimesh.visual.TextureVisuals(
-            uv=[[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]],
-            material=trimesh.visual.material.PBRMaterial(baseColorTexture=Image.new("RGB", (2, 2), "white")),
-        ),
-        process=False,
-    )
-    glb_path = asset_tmp_path / f"vertex_attributes_{first_attribute}.glb"
-    mesh.export(glb_path, include_normals=True)
-    glb = pygltflib.GLTF2().load(glb_path)
-    primitive = glb.meshes[0].primitives[0]
-    attributes = primitive.attributes
-    first_accessor = attributes.NORMAL if first_attribute == "NORMAL" else attributes.TEXCOORD_0
-    # Reorder the accessor table while keeping every reference attached to its authored data
-    order = [first_accessor] + [i for i in range(len(glb.accessors)) if i != first_accessor]
-    glb.accessors = [glb.accessors[i] for i in order]
-    attributes.POSITION = order.index(attributes.POSITION)
-    attributes.NORMAL = order.index(attributes.NORMAL)
-    attributes.TEXCOORD_0 = order.index(attributes.TEXCOORD_0)
-    primitive.indices = order.index(primitive.indices)
-    if first_attribute == "TEXCOORD_1":
-        attributes.TEXCOORD_1 = attributes.TEXCOORD_0
-        glb.materials[primitive.material].pbrMetallicRoughness.baseColorTexture.texCoord = 1
-    glb.save_binary(str(glb_path))
-
-    gs_meshes = gltf_utils.parse_mesh_glb(
-        str(glb_path), group_by_material=False, scale=None, is_mesh_zup=True, surface=gs.surfaces.Default()
-    )
-    check_gs_tm_meshes(gs_meshes[0], mesh, first_attribute, tol, tol)
 
 
 @pytest.mark.required

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -1,4 +1,5 @@
 import io
+import os
 from contextlib import nullcontext
 
 import numpy as np
@@ -296,7 +297,12 @@ def test_urdf_mesh_processing(mesh_path, mesh_urdf, show_viewer):
         "texcoord_1_accessor_zero_glb",
     ],
 )
-def test_glb_parse_geometry(glb_path, tol):
+def test_glb_parse_geometry(request, glb_file, tol):
+    # An asset-relative path resolves through the dataset. A bare name is the fixture generating the file.
+    if "/" in glb_file:
+        glb_path = os.path.join(get_hf_dataset(pattern=glb_file), glb_file)
+    else:
+        glb_path = request.getfixturevalue(glb_file)
     gs_meshes = gltf_utils.parse_mesh_glb(
         glb_path,
         group_by_material=False,
@@ -322,8 +328,10 @@ def test_glb_parse_geometry(glb_path, tol):
 
 @pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/tycoon_draco_no_normal.glb", "glb/tycoon_with_normal_draco.glb"])
-def test_glb_draco_missing_normals_texcoord(glb_path):
+def test_glb_draco_missing_normals_texcoord(glb_file):
     # Normals and tex_coord are not always present in GLB files, typically for Draco-compressed ones.
+    asset_path = get_hf_dataset(pattern=glb_file)
+    glb_path = os.path.join(asset_path, glb_file)
     gs_meshes = gltf_utils.parse_mesh_glb(
         glb_path,
         group_by_material=False,
@@ -347,16 +355,18 @@ def test_glb_draco_missing_normals_texcoord(glb_path):
 
 @pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/chopper.glb"])
-def test_glb_parse_material(glb_path):
+def test_glb_parse_material(glb_file):
+    asset_path = get_hf_dataset(pattern=glb_file)
+    glb_file = os.path.join(asset_path, glb_file)
     gs_meshes = gltf_utils.parse_mesh_glb(
-        glb_path,
+        glb_file,
         group_by_material=True,
         scale=None,
         is_mesh_zup=True,
         surface=gs.surfaces.Default(),
     )
 
-    tm_scene = trimesh.load(glb_path, process=False)
+    tm_scene = trimesh.load(glb_file, process=False)
     tm_materials = {}
     for geometry_name in tm_scene.geometry:
         ts_mesh = tm_scene.geometry[geometry_name]


### PR DESCRIPTION
## Description

The glTF parser tested the NORMAL, TEXCOORD_0 and TEXCOORD_1 accessor indices for truthiness. Accessor index `0` is valid but falsy, so normals or UVs stored in the first accessor were silently dropped: UVs came back as zeros and normals were recomputed from the geometry. The three checks now use `is not None`, like the `indices` and `material` checks in the same function. Absent attributes keep their existing fallback.

The existing `test_glb_parse_geometry` now covers NORMAL, TEXCOORD_0 and TEXCOORD_1 at accessor 0 alongside its existing asset cases. Each added case exports a small textured triangle and reorders the accessor table to put the selected attribute first. All cases share the existing geometry, normals and UV comparisons against trimesh.

## Related Issue

Resolves #3320

## Motivation and Context

Which accessor an attribute lands in is up to the exporter, so a perfectly valid glTF file could lose its texture mapping or shading normals on import with no warning.

## How Has This Been / Can This Be Tested?

```
pytest -n 0 --backend cpu tests/parsers/test_mesh.py -k "glb_parse_geometry or glb_draco_missing_normals_texcoord or glb_uv_set"
```

All eight selected tests pass on macOS (Apple M4), CPU backend. The three accessor-zero cases fail on the normals or UV comparison with the original parser from `351ffe03`; the two existing geometry cases pass. Ruff checks pass. Full suite and GPU backends not run.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
