### PR TITLE
[BUG FIX] Identify failed environments and clear their error flags on reset.

### DIFF
--- a/genesis/engine/solvers/rigid/abd/misc.py
+++ b/genesis/engine/solvers/rigid/abd/misc.py
@@ -906,7 +906,7 @@ def kernel_bit_reduction(tensor: qd.Tensor) -> qd.i32:
 @qd.kernel(fastcache=True)
 def kernel_set_zero(envs_idx: qd.types.ndarray(), tensor: qd.Tensor):
     for i_b_ in range(envs_idx.shape[0]):
-        tensor[i_b_] = 0
+        tensor[envs_idx[i_b_]] = 0
 
 
 @qd.func

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1325,8 +1325,7 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
 
     def check_errno(self):
         """Raise for a solver error and list the affected environments in batched scenes."""
-        # FIXME: qd.atomic_or return value is broken on Metal - always returns 0.
-        # See repro_metal_kernel_return.py. Falling back to numpy reduction.
+        # FIXME: qd.atomic_or return value is broken on Metal - always returns 0. Falling back to numpy reduction.
         errno_by_env = None
         if gs.use_zerocopy or sys.platform == "darwin":
             errno_by_env = qd_to_numpy(self._errno, transpose=True)

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1308,45 +1308,80 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
                 )
 
     def get_error_envs_mask(self):
+        """Return a mask selecting environments with a rigid-solver error.
+
+        An environment is flagged after the solver encounters an error such as a non-finite constraint force or
+        acceleration. The flag remains set until the environment state is reset.
+
+        If a flag remains set, a later `Scene.step` raises. For non-finite force and acceleration errors, batched
+        workloads can read this mask after each step and reset the affected environments before stepping again.
+
+        Returns
+        -------
+        error_envs_mask : torch.Tensor
+            Boolean tensor with one value per built environment. A non-parallelized scene returns one value.
+        """
         return qd_to_torch(self._errno) > 0
 
     def check_errno(self):
-        # FIXME: qd.atomic_or return value is broken on Metal — always returns 0.
+        """Raise if any environment is flagged as invalid."""
+        # FIXME: qd.atomic_or return value is broken on Metal - always returns 0.
         # See repro_metal_kernel_return.py. Falling back to numpy reduction.
         if gs.use_zerocopy or sys.platform == "darwin":
             errno = np.bitwise_or.reduce(qd_to_numpy(self._errno))
         else:
             errno = kernel_bit_reduction(self._errno)
+        if not errno:
+            return
+
+        envs_info = ""
+        if self.n_envs > 0:
+            envs_info = f" Environments in error: {np.nonzero(qd_to_numpy(self._errno))[0].tolist()}."
+
+        recovery_info = (
+            " Read RigidSolver.get_error_envs_mask() after each step and reset the environments it reports so the "
+            "rest of the batch can continue."
+            if self.n_envs > 0
+            else ""
+        )
 
         if errno & array_class.ErrorCode.OVERFLOW_CANDIDATE_CONTACTS:
             max_collision_pairs_broad = self.collider.collider_info.max_collision_pairs_broad[None]
             gs.raise_exception(
                 f"Exceeding max number of broad phase candidate contact pairs ({max_collision_pairs_broad}). "
-                f"Please increase the value of RigidSolver's option 'multiplier_collision_broad_phase'."
+                f"Please increase the value of RigidSolver's option 'multiplier_collision_broad_phase'.{envs_info}"
             )
         if errno & array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS:
             max_candidate_contacts = self.collider.collider_info.max_candidate_contacts[None]
             gs.raise_exception(
                 f"Exceeding max number of candidate contact points ({max_candidate_contacts}). Please increase the "
-                "value of RigidSolver's option 'max_collision_pairs'."
+                f"value of RigidSolver's option 'max_collision_pairs'.{envs_info}"
             )
         if errno & array_class.ErrorCode.OVERFLOW_CONTACTS:
             max_contacts = self.collider.collider_info.max_contacts[None]
             gs.raise_exception(
                 f"Exceeding max number of post-pruning contact points ({max_contacts}) supported by the constraint "
-                "solver. Please increase the value of RigidSolver's option 'max_contacts'."
+                f"solver. Please increase the value of RigidSolver's option 'max_contacts'.{envs_info}"
             )
         if errno & array_class.ErrorCode.INVALID_CONTACT_NAN:
             gs.raise_exception(
                 "Collision detection reported a contact whose position, normal or penetration is not finite. This is a "
-                "solver-internal error, please report it."
+                f"solver-internal error, please report it.{envs_info}"
             )
         if errno & array_class.ErrorCode.INVALID_FORCE_NAN:
-            gs.raise_exception("Invalid constraint forces causing 'nan'. Please decrease Rigid simulation timestep.")
+            gs.raise_exception(
+                f"Invalid constraint forces causing 'nan'. Please decrease Rigid simulation timestep.{envs_info}"
+                f"{recovery_info}"
+            )
         if errno & array_class.ErrorCode.INVALID_ACC_NAN:
-            gs.raise_exception("Invalid accelerations causing 'nan'. Please decrease Rigid simulation timestep.")
+            gs.raise_exception(
+                f"Invalid accelerations causing 'nan'. Please decrease Rigid simulation timestep.{envs_info}"
+                f"{recovery_info}"
+            )
         if errno & array_class.ErrorCode.OVERFLOW_HIBERNATION_ISLANDS:
-            gs.raise_exception("Contact island buffer overflow. Please increase RigidOptions 'max_collision_pairs'.")
+            gs.raise_exception(
+                f"Contact island buffer overflow. Please increase RigidOptions 'max_collision_pairs'.{envs_info}"
+            )
 
     def _kernel_detect_collision(self):
         self.collider.clear()

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -1324,64 +1324,75 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         return qd_to_torch(self._errno) > 0
 
     def check_errno(self):
-        """Raise if any environment is flagged as invalid."""
+        """Raise for a solver error and list the affected environments in batched scenes."""
         # FIXME: qd.atomic_or return value is broken on Metal - always returns 0.
         # See repro_metal_kernel_return.py. Falling back to numpy reduction.
+        errno_by_env = None
         if gs.use_zerocopy or sys.platform == "darwin":
-            errno = np.bitwise_or.reduce(qd_to_numpy(self._errno))
+            errno_by_env = qd_to_numpy(self._errno, transpose=True)
+            errno = np.bitwise_or.reduce(errno_by_env)
         else:
             errno = kernel_bit_reduction(self._errno)
         if not errno:
             return
 
+        if errno & array_class.ErrorCode.OVERFLOW_CANDIDATE_CONTACTS:
+            code = array_class.ErrorCode.OVERFLOW_CANDIDATE_CONTACTS
+            max_collision_pairs_broad = self.collider.collider_info.max_collision_pairs_broad[None]
+            message = (
+                f"Exceeding max number of broad phase candidate contact pairs ({max_collision_pairs_broad}). "
+                "Please increase the value of RigidSolver's option 'multiplier_collision_broad_phase'."
+            )
+        elif errno & array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS:
+            code = array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS
+            max_candidate_contacts = self.collider.collider_info.max_candidate_contacts[None]
+            message = (
+                f"Exceeding max number of candidate contact points ({max_candidate_contacts}). Please increase the "
+                "value of RigidSolver's option 'max_collision_pairs'."
+            )
+        elif errno & array_class.ErrorCode.OVERFLOW_CONTACTS:
+            code = array_class.ErrorCode.OVERFLOW_CONTACTS
+            max_contacts = self.collider.collider_info.max_contacts[None]
+            message = (
+                f"Exceeding max number of post-pruning contact points ({max_contacts}) supported by the constraint "
+                "solver. Please increase the value of RigidSolver's option 'max_contacts'."
+            )
+        elif errno & array_class.ErrorCode.INVALID_CONTACT_NAN:
+            code = array_class.ErrorCode.INVALID_CONTACT_NAN
+            message = (
+                "Collision detection reported a contact whose position, normal or penetration is not finite. This is a "
+                "solver-internal error, please report it."
+            )
+        elif errno & array_class.ErrorCode.INVALID_FORCE_NAN:
+            code = array_class.ErrorCode.INVALID_FORCE_NAN
+            message = "Invalid constraint forces causing 'nan'. Please decrease Rigid simulation timestep."
+        elif errno & array_class.ErrorCode.INVALID_ACC_NAN:
+            code = array_class.ErrorCode.INVALID_ACC_NAN
+            message = "Invalid accelerations causing 'nan'. Please decrease Rigid simulation timestep."
+        elif errno & array_class.ErrorCode.OVERFLOW_HIBERNATION_ISLANDS:
+            code = array_class.ErrorCode.OVERFLOW_HIBERNATION_ISLANDS
+            message = "Contact island buffer overflow. Please increase RigidOptions 'max_collision_pairs'."
+        else:
+            return
+
         envs_info = ""
         if self.n_envs > 0:
-            envs_info = f" Environments in error: {np.nonzero(qd_to_numpy(self._errno))[0].tolist()}."
+            # One sweep can flag different errors, so associate each environment with the message that describes it
+            if errno_by_env is None:
+                errno_by_env = qd_to_numpy(self._errno, transpose=True)
+            envs_info = f" Environments reporting this error: {np.nonzero(errno_by_env & code)[0].tolist()}."
+            i_bs_other = np.nonzero((errno_by_env != 0) & ((errno_by_env & code) == 0))[0]
+            if i_bs_other.size:
+                envs_info += f" Environments reporting a different error: {i_bs_other.tolist()}."
 
         recovery_info = (
             " Read RigidSolver.get_error_envs_mask() after each step and reset the environments it reports so the "
             "rest of the batch can continue."
             if self.n_envs > 0
+            and code in (array_class.ErrorCode.INVALID_FORCE_NAN, array_class.ErrorCode.INVALID_ACC_NAN)
             else ""
         )
-
-        if errno & array_class.ErrorCode.OVERFLOW_CANDIDATE_CONTACTS:
-            max_collision_pairs_broad = self.collider.collider_info.max_collision_pairs_broad[None]
-            gs.raise_exception(
-                f"Exceeding max number of broad phase candidate contact pairs ({max_collision_pairs_broad}). "
-                f"Please increase the value of RigidSolver's option 'multiplier_collision_broad_phase'.{envs_info}"
-            )
-        if errno & array_class.ErrorCode.OVERFLOW_COLLISION_PAIRS:
-            max_candidate_contacts = self.collider.collider_info.max_candidate_contacts[None]
-            gs.raise_exception(
-                f"Exceeding max number of candidate contact points ({max_candidate_contacts}). Please increase the "
-                f"value of RigidSolver's option 'max_collision_pairs'.{envs_info}"
-            )
-        if errno & array_class.ErrorCode.OVERFLOW_CONTACTS:
-            max_contacts = self.collider.collider_info.max_contacts[None]
-            gs.raise_exception(
-                f"Exceeding max number of post-pruning contact points ({max_contacts}) supported by the constraint "
-                f"solver. Please increase the value of RigidSolver's option 'max_contacts'.{envs_info}"
-            )
-        if errno & array_class.ErrorCode.INVALID_CONTACT_NAN:
-            gs.raise_exception(
-                "Collision detection reported a contact whose position, normal or penetration is not finite. This is a "
-                f"solver-internal error, please report it.{envs_info}"
-            )
-        if errno & array_class.ErrorCode.INVALID_FORCE_NAN:
-            gs.raise_exception(
-                f"Invalid constraint forces causing 'nan'. Please decrease Rigid simulation timestep.{envs_info}"
-                f"{recovery_info}"
-            )
-        if errno & array_class.ErrorCode.INVALID_ACC_NAN:
-            gs.raise_exception(
-                f"Invalid accelerations causing 'nan'. Please decrease Rigid simulation timestep.{envs_info}"
-                f"{recovery_info}"
-            )
-        if errno & array_class.ErrorCode.OVERFLOW_HIBERNATION_ISLANDS:
-            gs.raise_exception(
-                f"Contact island buffer overflow. Please increase RigidOptions 'max_collision_pairs'.{envs_info}"
-            )
+        gs.raise_exception(f"{message}{envs_info}{recovery_info}")
 
     def _kernel_detect_collision(self):
         self.collider.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -751,23 +751,9 @@ def use_deterministic_algorithms(request):
     return use_deterministic_algorithms
 
 
-@pytest.fixture
-def use_zerocopy():
-    return None
-
-
 @pytest.fixture(scope="function", autouse=True)
 def initialize_genesis(
-    request,
-    monkeypatch,
-    tmp_path,
-    backend,
-    precision,
-    performance_mode,
-    use_zerocopy,
-    debug,
-    cache,
-    use_deterministic_algorithms,
+    request, monkeypatch, tmp_path, backend, precision, performance_mode, debug, cache, use_deterministic_algorithms
 ):
     import genesis as gs
 
@@ -786,9 +772,6 @@ def initialize_genesis(
         logging_level = logging.DEBUG if dev_mode else logging.INFO
     if debug is None:
         debug = dev_mode
-
-    if use_zerocopy is not None:
-        monkeypatch.setenv("GS_ENABLE_ZEROCOPY", str(int(use_zerocopy)))
 
     if not cache:
         monkeypatch.setenv("QD_OFFLINE_CACHE", "0")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -751,9 +751,23 @@ def use_deterministic_algorithms(request):
     return use_deterministic_algorithms
 
 
+@pytest.fixture
+def use_zerocopy():
+    return None
+
+
 @pytest.fixture(scope="function", autouse=True)
 def initialize_genesis(
-    request, monkeypatch, tmp_path, backend, precision, performance_mode, debug, cache, use_deterministic_algorithms
+    request,
+    monkeypatch,
+    tmp_path,
+    backend,
+    precision,
+    performance_mode,
+    use_zerocopy,
+    debug,
+    cache,
+    use_deterministic_algorithms,
 ):
     import genesis as gs
 
@@ -772,6 +786,9 @@ def initialize_genesis(
         logging_level = logging.DEBUG if dev_mode else logging.INFO
     if debug is None:
         debug = dev_mode
+
+    if use_zerocopy is not None:
+        monkeypatch.setenv("GS_ENABLE_ZEROCOPY", str(int(use_zerocopy)))
 
     if not cache:
         monkeypatch.setenv("QD_OFFLINE_CACHE", "0")

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -12,8 +12,6 @@ from scipy.spatial.qhull import QhullError
 
 import genesis as gs
 import genesis.utils.geom as gu
-from genesis.engine.simulator import RATE_CHECK_ERRNO
-from genesis.utils.array_class import RigidSimStaticConfig
 from genesis.utils.misc import tensor_to_array
 
 from ..utils.assertions import assert_allclose, assert_equal
@@ -1054,6 +1052,8 @@ def test_contact_pruning_degenerated_hull(model_name, xml_path, show_viewer):
 )
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
 def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, error_pattern, n_envs, show_viewer):
+    from genesis.engine.simulator import RATE_CHECK_ERRNO
+
     N_BOWLS = 4
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
@@ -1332,6 +1332,8 @@ def test_gpu_simulation_determinism(prefer_decomposed_solver, contact_pruning_to
     #   - contact set    -> narrowphase / pruning
     #   - contact order  -> contact sort
     #   - dofs velocity  -> constraint solve
+    from genesis.utils.array_class import RigidSimStaticConfig
+
     if prefer_decomposed_solver is not None:
         init_orig = RigidSimStaticConfig.__init__
 

--- a/tests/rigid/test_collision.py
+++ b/tests/rigid/test_collision.py
@@ -12,6 +12,8 @@ from scipy.spatial.qhull import QhullError
 
 import genesis as gs
 import genesis.utils.geom as gu
+from genesis.engine.simulator import RATE_CHECK_ERRNO
+from genesis.utils.array_class import RigidSimStaticConfig
 from genesis.utils.misc import tensor_to_array
 
 from ..utils.assertions import assert_allclose, assert_equal
@@ -1031,38 +1033,43 @@ def test_contact_pruning_degenerated_hull(model_name, xml_path, show_viewer):
 
 @pytest.mark.slow("gpu")  # gpu ~250s
 @pytest.mark.parametrize(
-    "scene_kind, max_collision_pairs, max_contacts, error_pattern",
+    "scene_kind, max_collision_pairs, max_contacts, error_pattern, n_envs",
     [
         # Post-pruning contact budget overflow, with the candidate buffer large enough (2x margin) that it cannot
         # trip first. The automatic budget resolves to 32 contact points per link pair floored at 512, far below
         # what the piled-up bowls produce.
-        pytest.param("bowls", 1_000, None, "max number of post-pruning contact points", marks=pytest.mark.required),
+        pytest.param("bowls", 1_000, None, "max number of post-pruning contact points", 0, marks=pytest.mark.required),
         # Candidate contact buffer overflow. The explicit contact budget is clamped down to the buffer size, so only
         # the buffer itself can overflow.
-        ("bowls", 150, 1_000, "max number of candidate contact points"),
+        ("bowls", 150, 1_000, "max number of candidate contact points", 0),
         # Buffers large enough for the whole pile: no overflow at all. Both values keep a 2x margin over the peaks
         # reached within the stepped window (about 500 colliding geom pairs and 1040 post-pruning contact points).
-        ("bowls", 1_000, 2_000, None),
+        ("bowls", 1_000, 2_000, None, 0),
         # Two contacts against a budget of one: the clamp must also run when the contact count is below the pruning
         # gate (n_contacts < 3), in both the serial and the GPU cooperative kernel variants.
-        ("spheres", 150, 1, "max number of post-pruning contact points"),
+        ("spheres", 150, 1, "max number of post-pruning contact points", 0),
+        # Infinite velocity produces a numerical failure independently of the contact budget
+        pytest.param("spheres", 150, 1, "max number of post-pruning contact points", 3, marks=pytest.mark.required),
     ],
 )
 @pytest.mark.parametrize("backend", [gs.cpu, gs.gpu])
-def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, error_pattern, show_viewer):
-    from genesis.engine.simulator import RATE_CHECK_ERRNO
-
+def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, error_pattern, n_envs, show_viewer):
     N_BOWLS = 4
     scene = gs.Scene(
         rigid_options=gs.options.RigidOptions(
             max_collision_pairs=max_collision_pairs,
             max_contacts=max_contacts,
         ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, -2.0, 2.0),
+            camera_lookat=(0.25, 0.0, 0.5),
+        ),
         renderer=gs.renderers.Rasterizer(),
         show_viewer=show_viewer,
     )
     scene.add_entity(
         morph=gs.morphs.Plane(),
+        vis_mode="collision",
     )
     if scene_kind == "bowls":
         asset_path = get_hf_dataset(pattern="glb/orange_plastic_bowl.glb")
@@ -1075,6 +1082,7 @@ def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, err
                     convexify=True,
                     file_meshes_are_zup=True,
                 ),
+                vis_mode="collision",
             )
     else:
         # Non-contacting nonconvex mesh: makes the scene prunable so that the GPU cooperative kernel is exercised.
@@ -1085,15 +1093,20 @@ def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, err
                 pos=(5.0, 5.0, 5.0),
                 convexify=False,
             ),
+            vis_mode="collision",
         )
         for i in range(2):
-            scene.add_entity(
+            sphere = scene.add_entity(
                 morph=gs.morphs.Sphere(
                     pos=(0.5 * i, 0.0, 0.0999),
                     radius=0.1,
                 ),
+                vis_mode="collision",
             )
-    scene.build()
+    scene.build(n_envs=n_envs, env_spacing=(1.0, 1.0))
+    if n_envs:
+        sphere.set_pos(pos=(0.5, 0.0, 1.0), envs_idx=[1, 2])
+        sphere.set_dofs_velocity(velocity=torch.inf, envs_idx=2)
     assert scene.rigid_solver.collider.collider_config.has_prunable_contacts
 
     # The resolved contact budget must match the documented resolution: 32 contact points per link pair floored at
@@ -1114,9 +1127,20 @@ def test_num_contact_overflow(scene_kind, max_collision_pairs, max_contacts, err
     # All overflows occur on the very first step (the bowls start fully overlapping, the spheres start resting on the
     # plane), but errno is only polled every RATE_CHECK_ERRNO substeps, so one extra step is required to guarantee
     # that the error gets raised.
-    with nullcontext() if error_pattern is None else pytest.raises(gs.GenesisException, match=error_pattern):
+    with (
+        nullcontext() if error_pattern is None else pytest.raises(gs.GenesisException, match=error_pattern) as exc_info
+    ):
         for _ in range(RATE_CHECK_ERRNO + 1):
             scene.step()
+
+    if error_pattern is not None:
+        error_message = str(exc_info.value)
+        if n_envs:
+            assert "Environments reporting this error: [0]." in error_message
+            assert "Environments reporting a different error: [2]." in error_message
+            assert_equal(solver.get_error_envs_mask(), [True, False, True])
+        else:
+            assert "Environments reporting" not in error_message
 
 
 @pytest.mark.slow  # ~200s
@@ -1308,8 +1332,6 @@ def test_gpu_simulation_determinism(prefer_decomposed_solver, contact_pruning_to
     #   - contact set    -> narrowphase / pruning
     #   - contact order  -> contact sort
     #   - dofs velocity  -> constraint solve
-    from genesis.utils.array_class import RigidSimStaticConfig
-
     if prefer_decomposed_solver is not None:
         init_orig = RigidSimStaticConfig.__init__
 

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -860,53 +860,61 @@ def test_cholesky_tiling(monkeypatch, tol):
 
 
 @pytest.mark.required
+@pytest.mark.parametrize("use_zerocopy", [False, None])
 def test_reset_envs_flagged_by_rigid_solver(show_viewer, tol):
+    DT = 0.01
     N_STEPS = 15
+    VELOCITY = 0.2
 
     scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+        ),
         viewer_options=gs.options.ViewerOptions(
-            camera_pos=(1.5, -1.5, 1.2),
-            camera_lookat=(0.0, 0.0, 0.4),
+            camera_pos=(1.2, -1.2, 1.6),
+            camera_lookat=(0.0, 0.0, 0.9),
         ),
         show_viewer=show_viewer,
     )
-    scene.add_entity(
-        morph=gs.morphs.Plane(),
-    )
-    robot = scene.add_entity(
-        morph=gs.morphs.MJCF(
-            file="xml/franka_emika_panda/panda.xml",
+    sphere = scene.add_entity(
+        morph=gs.morphs.Sphere(
+            pos=(0.0, 0.0, 1.0),
+            radius=0.1,
         ),
+        vis_mode="collision",
     )
-    scene.build(n_envs=4)
+    scene.build(n_envs=4, env_spacing=(0.5, 0.5))
     solver = scene.rigid_solver
 
     scene.step()
     assert not solver.get_error_envs_mask().any()
 
-    # Use the public velocity setter as a deterministic trigger for the error path. Contact-heavy rollouts can reach
-    # the same error flag statistically, depending on the scene and hardware.
-    robot.set_dofs_velocity(velocity=torch.inf, envs_idx=1)
+    sphere.set_pos(pos=(0.1, 0.0, 1.0), envs_idx=2)
+    sphere.set_dofs_velocity(velocity=VELOCITY, dofs_idx_local=0, envs_idx=2)
+    pos_healthy = sphere.get_pos(envs_idx=2)
+    sphere.set_dofs_velocity(velocity=torch.inf, envs_idx=1)
     scene.step()
     error_envs_mask = solver.get_error_envs_mask()
     assert_equal(error_envs_mask, torch.tensor([False, True, False, False], device=gs.device))
+    assert_allclose(sphere.get_pos(envs_idx=2)[..., 0] - pos_healthy[..., 0], VELOCITY * DT, tol=tol)
 
+    pos_healthy = sphere.get_pos(envs_idx=2)
     scene.reset(envs_idx=error_envs_mask)
     assert not solver.get_error_envs_mask().any()
-    # Advance beyond the periodic error-check interval to verify that the handled error does not raise later.
+    assert_allclose(sphere.get_pos(envs_idx=2), pos_healthy, tol=tol)
+    # Advance past the periodic error check to exercise continued simulation after recovery
     for _ in range(N_STEPS):
         scene.step()
     assert not solver.get_error_envs_mask().any()
 
-    qpos = robot.get_dofs_position()
-    assert torch.isfinite(qpos).all()
-    assert_allclose(qpos[2], qpos[0], tol=tol)
-    assert_allclose(qpos[3], qpos[0], tol=tol)
+    assert torch.isfinite(sphere.get_dofs_position()).all()
+    assert_allclose(sphere.get_pos(envs_idx=3), sphere.get_pos(envs_idx=0), tol=tol)
+    assert_allclose(sphere.get_pos(envs_idx=2)[..., 0] - pos_healthy[..., 0], VELOCITY * DT * N_STEPS, tol=tol)
 
-    robot.set_dofs_velocity(velocity=torch.inf, envs_idx=2)
+    sphere.set_dofs_velocity(velocity=torch.inf, envs_idx=2)
     with pytest.raises(
         gs.GenesisException,
-        match=r"Environments in error: \[2\]. Read RigidSolver.get_error_envs_mask\(\)",
+        match=r"Environments reporting this error: \[2\]. Read RigidSolver.get_error_envs_mask\(\)",
     ):
         for _ in range(N_STEPS):
             scene.step()

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -860,6 +860,59 @@ def test_cholesky_tiling(monkeypatch, tol):
 
 
 @pytest.mark.required
+def test_reset_envs_flagged_by_rigid_solver(show_viewer, tol):
+    N_STEPS = 15
+
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.5, -1.5, 1.2),
+            camera_lookat=(0.0, 0.0, 0.4),
+        ),
+        show_viewer=show_viewer,
+    )
+    scene.add_entity(
+        morph=gs.morphs.Plane(),
+    )
+    robot = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file="xml/franka_emika_panda/panda.xml",
+        ),
+    )
+    scene.build(n_envs=4)
+    solver = scene.rigid_solver
+
+    scene.step()
+    assert not solver.get_error_envs_mask().any()
+
+    # Use the public velocity setter as a deterministic trigger for the error path. Contact-heavy rollouts can reach
+    # the same error flag statistically, depending on the scene and hardware.
+    robot.set_dofs_velocity(velocity=torch.inf, envs_idx=1)
+    scene.step()
+    error_envs_mask = solver.get_error_envs_mask()
+    assert_equal(error_envs_mask, torch.tensor([False, True, False, False], device=gs.device))
+
+    scene.reset(envs_idx=error_envs_mask)
+    assert not solver.get_error_envs_mask().any()
+    # Advance beyond the periodic error-check interval to verify that the handled error does not raise later.
+    for _ in range(N_STEPS):
+        scene.step()
+    assert not solver.get_error_envs_mask().any()
+
+    qpos = robot.get_dofs_position()
+    assert torch.isfinite(qpos).all()
+    assert_allclose(qpos[2], qpos[0], tol=tol)
+    assert_allclose(qpos[3], qpos[0], tol=tol)
+
+    robot.set_dofs_velocity(velocity=torch.inf, envs_idx=2)
+    with pytest.raises(
+        gs.GenesisException,
+        match=r"Environments in error: \[2\]. Read RigidSolver.get_error_envs_mask\(\)",
+    ):
+        for _ in range(N_STEPS):
+            scene.step()
+
+
+@pytest.mark.required
 @pytest.mark.use_deterministic_algorithms(False)
 @pytest.mark.parametrize("backend", [gs.gpu])
 def test_solve_arm_equivalence(monkeypatch, show_viewer, tol):

--- a/tests/rigid/test_dynamics.py
+++ b/tests/rigid/test_dynamics.py
@@ -860,7 +860,6 @@ def test_cholesky_tiling(monkeypatch, tol):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("use_zerocopy", [False, None])
 def test_reset_envs_flagged_by_rigid_solver(show_viewer, tol):
     DT = 0.01
     N_STEPS = 15


### PR DESCRIPTION
## Description

Rigid-solver exceptions now identify environments reporting the displayed error separately from environments reporting other errors. For non-finite force and acceleration errors, batched workloads receive guidance to use `RigidSolver.get_error_envs_mask()`, whose recovery workflow is now documented in its docstring.

Selective resets through `set_state`, `set_qpos`, and `set_dofs_position` cleared the wrong environment's error flag on the kernel fallback path. With zero-copy disabled, a reset environment could remain flagged and trigger another exception. `kernel_set_zero` now clears flags using the selected environment indices.

  ## Related Issue

  Addresses #3179

  ## Motivation and Context

The existing boolean-mask workflow lets callers reset failing environments while preserving healthy episodes. This change makes that workflow discoverable in error messages and fixes selective flag clearing when zero-copy is disabled.


  ## How Has This Been / Can This Be Tested?

  ```bash
  pytest tests/rigid/test_dynamics.py -k test_reset_envs_flagged_by_rigid_solver --backend cpu
  pytest tests/rigid/test_collision.py -k "test_num_contact_overflow and spheres and cpu"
  ```

  - The required reset test runs with zero-copy disabled and at its default. It checks the failing-environment mask, healthy motion during the failing step, selective reset, continued motion after recovery, and reporting of a later unhandled failure. The disabled case fails before the indexing fix and passes afterward.
  - The required mixed-error case produces contact overflow in environment 0, keeps environment 1 healthy, and produces a numerical failure in environment 2. It checks error priority, separate diagnostic groups, and the public mask. Existing unbatched cases check that environment lists are omitted.
  - A non-finite velocity supplied through the public setter deterministically exercises the failure path.
  - Passed locally on macOS: reset cases on CPU and Metal, including Metal with CPU-side Torch tensors where zero-copy is unavailable; CPU spheres cases with zero-copy enabled and disabled; and the required bowls case on CPU.
  - Not run: the full suite, CUDA/ROCm, and the mixed-error collision case on Metal. The non-Darwin, zero-copy-disabled reduction path, unbatched numerical-error recovery-hint suppression, and Metal static-array mode with `torch<=2.9.1` remain unverified.

  ## Checklist:

  - [x] I read the **CONTRIBUTING** document.
  - [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
  - [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING).
  - [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
  - [x] I tested my changes and added instructions on how to test it for reviewers.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.