### PR TITLE
[MISC] Support heterogeneous default armature and honor joint actuator force range for MJCF.

### DIFF
--- a/genesis/engine/entities/rigid_entity/description.py
+++ b/genesis/engine/entities/rigid_entity/description.py
@@ -235,12 +235,19 @@ class KinematicVariantDescription:
 
     A heterogeneous entity holds one set of links and dispatches a variant per environment, so a variant is described
     beside those links rather than as an entity of its own.
+
+    'default_armature' is the default rotor inertia of its morph, None for a morph without one. Every joint a motor
+    could drive gets one, a revolute or prismatic joint moving a link on its own: a motor's rotor is real inertia, and
+    the constraint solve needs the armature for its stability anyway, so whether a joint is truly actuated, which the
+    asset file often leaves unspecified, is of no consequence. At build, every such degree of freedom whose armature
+    the asset leaves at zero receives it. Each variant asks its own, per environment.
     """
 
     init_qpos: np.ndarray
     offset_pos: np.ndarray
     offset_quat: np.ndarray
     links: list[KinematicVariantLinkDescription] = field(default_factory=list)
+    default_armature: float | None = None
 
 
 @dataclass
@@ -421,6 +428,8 @@ class KinematicEntityDescription(EntityDescription):
                 init_qpos=np.concatenate(init_qpos_chunks) if init_qpos_chunks else np.array([], dtype=gs.np_float),
                 offset_pos=self.links[0].offset_pos,
                 offset_quat=self.links[0].offset_quat,
+                # Only a scene or robot description file yields a robot link, and those morphs state a default armature.
+                default_armature=self.morphs[0].default_armature if any(l.is_robot for l in self.links) else None,
             )
         )
 
@@ -514,6 +523,7 @@ class KinematicEntityDescription(EntityDescription):
                         offset_pos=offset_pos,
                         offset_quat=offset_quat,
                         links=variant_links,
+                        default_armature=morph.default_armature,
                     )
                 )
 
@@ -806,14 +816,6 @@ class KinematicEntityDescription(EntityDescription):
                                 j_info_mj[name] = j_info_gs[name]
                             break
                 links_j_infos = links_j_infos_mj
-
-                # Must invalidate invweight if default rotor armature inertia has been specified
-                if morph.default_armature is not None:
-                    for link_j_infos in links_j_infos:
-                        for j_info in link_j_infos:
-                            if j_info["type"] not in (gs.JOINT_TYPE.FREE, gs.JOINT_TYPE.FIXED):
-                                is_inertia_invalid = True
-                                break
 
                 # Take into account 'world' body if it was added automatically for our legacy URDF parser
                 if len(links_g_infos_mj) == len(links_g_infos) + 1:

--- a/genesis/engine/solvers/rigid/rigid_solver.py
+++ b/genesis/engine/solvers/rigid/rigid_solver.py
@@ -36,6 +36,7 @@ from genesis.utils.sdf import SDF
 from ..base_solver import GravityMixin, MutatedLinks, Solver, StateChange, TimeBasedMixin, mutates
 from ..kinematic_solver import (
     KinematicSolver,
+    _balanced_variant_mapping,
     _fill_base_link_geom_offsets,
     _offset_world_shift,
     _select_links_offset,
@@ -397,6 +398,50 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         self._init_constraint_solver()
         self._refresh_invweight_and_meaninertia(force_update=False, in_place=True)
 
+        # Fill in the default rotor inertia (see 'KinematicVariantDescription'), one variant per environment. It is
+        # written to the armature field from the host once the parsed inverse weights stand, and a second refresh
+        # recomputes the ones it changes: those of every degree of freedom and link of the kinematic trees holding a
+        # defaulted joint. The parsed inverse weights stand everywhere else.
+        dofs_idx, dofs_default, dofs_link = [], [], []
+        for entity in self._entities:
+            rotor_links = [
+                link
+                for link in entity.links
+                if link.n_dofs == 1 and link.joints[0].type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC)
+            ]
+            if not rotor_links:
+                continue
+            # Only a scene or robot description file yields a rotor link, and those morphs state a default armature.
+            if entity.desc.variants:
+                variants_default = np.array([variant.default_armature or 0.0 for variant in entity.desc.variants])
+            else:
+                variants_default = np.array([entity.main_morph.default_armature or 0.0])
+            envs_default = variants_default[_balanced_variant_mapping(variants_default.size, self._B)]
+            if (envs_default <= 0.0).all():
+                continue
+            dofs_idx.extend(link.dof_start for link in rotor_links)
+            dofs_default.extend([envs_default] * len(rotor_links))
+            dofs_link.extend(rotor_links)
+        if dofs_idx:
+            # Field layout, batch last, since the arrays are written back as fields.
+            dofs_armature = qd_to_numpy(self.dyn_info.dofs.armature, transpose=False, copy=True)
+            is_default = (np.atleast_2d(dofs_armature[dofs_idx].T) <= 0.0).all(axis=0)
+            if is_default.any():
+                dofs_idx = np.array(dofs_idx)[is_default]
+                default_armature = np.stack(dofs_default, axis=1)[:, is_default]
+                dofs_armature[dofs_idx] = default_armature.T if self._options.batch_dofs_info else default_armature[0]
+                self.dyn_info.dofs.armature.from_numpy(dofs_armature)
+                roots_idx = {link.root_idx for link, is_dof_default in zip(dofs_link, is_default) if is_dof_default}
+                trees_links = [link for link in self.links if link.root_idx in roots_idx]
+                dofs_invweight = qd_to_numpy(self.dyn_info.dofs.invweight, transpose=False, copy=True)
+                dofs_invweight[[i_d for link in trees_links for i_d in range(link.dof_start, link.dof_end)]] = -1.0
+                self.dyn_info.dofs.invweight.from_numpy(dofs_invweight)
+                links_idx = [link.idx for link in trees_links]
+                links_invweight = qd_to_numpy(self.dyn_info.links.invweight, transpose=False, copy=True)
+                links_invweight[links_idx] = -1.0
+                self.dyn_info.links.invweight.from_numpy(links_invweight)
+                self._refresh_invweight_and_meaninertia(force_update=False, in_place=True)
+
         # The constraint solver decides it has converged from quantities summed over the whole scene, and every DOF of
         # a link contributes a cost of the order of the link's mass. A link whose mass is a tolerance-fraction of the
         # scene total therefore contributes less than the tolerance, and the solve stops while that link still carries
@@ -488,6 +533,18 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         # get_dofs_info reads from solver._options.batch_dofs_info.
         if self._enable_heterogeneous and self._use_hibernation:
             self._options.batch_dofs_info = True
+        # Likewise, the variants of a heterogeneous entity each state their own default armature (see build), which is
+        # per-env on every joint carrying a rotor whenever those defaults differ.
+        for entity in self._entities:
+            variants_default = np.array([variant.default_armature or 0.0 for variant in entity.desc.variants])
+            if variants_default.size < 2 or np.ptp(variants_default) <= gs.EPS:
+                continue
+            has_rotor = any(
+                link.n_dofs == 1 and link.joints[0].type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC)
+                for link in entity.links
+            )
+            if has_rotor:
+                self._options.batch_dofs_info = True
 
         # sparse_solve=None resolves automatically: the skyline-envelope solver pays off on CPU only when the scene
         # has block structure, whereas a single dense-coupled tree gains nothing and pays the per-step envelope tax. An
@@ -810,88 +867,127 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
     def _jacobi_mass_spread_bound(self):
         """Upper-bound the spread of the mass matrix diagonal over every configuration, from the model alone.
 
-        Each DOF's diagonal entry is bracketed without kinematics. A translational entry is exactly its per-DOF
-        armature plus the subtree mass. A rotational entry is the link the joint carries plus its descendants: with a
-        single joint the link's axis, anchor and centre of mass (COM) are fixed in its frame, so its own term
-        armature + a^T I_anchor a is exact for a revolute axis and bracketed by the principal inertias about the
-        anchor for free/spherical DOFs whose axes turn with the configuration; descendants add at least nothing, at
-        most their largest principal inertia plus their mass carried at an anchor-to-COM distance no configuration
-        exceeds (frame offsets summed along the chain, each joint anchor counted twice since a joint rotation swings
-        the child origin around it, and each prismatic descendant's full travel span, infinite when unlimited). The
-        largest upper bracket over the smallest lower one thus bounds the true diagonal spread at every configuration:
-        equilibration may enable for scenes whose reachable configurations stay better conditioned, never the reverse.
+        Each entry gets a lower and an upper bound that hold in every configuration. A translational entry is armature
+        plus subtree mass exactly. A rotational entry is at least armature plus the link inertia about its axis (the
+        smallest principal inertia for free and spherical DOFs), and at most the same with the largest principal inertia
+        plus, per descendant, its largest principal inertia and its mass times the squared anchor-to-COM distance no
+        configuration exceeds (frame offsets along the chain, each anchor twice, prismatic spans, infinite when
+        unlimited). A build-time default armature adds the value of the variant an entity takes to the entries it fills
+        in, and any variant may be dispatched to any environment, so the bounds are kept per variant of each entity and
+        the spread is the largest over every combination of variants across entities. That spread is at least the true
+        one, so the gate never leaves a scene that needs equilibration without it; its only error is to enable it for a
+        scene that does not, at a small runtime cost.
         """
-        links = [link for entity in self._entities for link in entity.links]
         children = {}
-        for link in links:
-            children.setdefault(link.parent_idx, []).append(link)
+        for entity in self._entities:
+            for link in entity.links:
+                children.setdefault(link.parent_idx, []).append(link)
 
-        lower, upper = [], []
-        for link in links:
-            if link.is_fixed:
-                continue
-            for joint in link.joints:
-                if joint.type == gs.JOINT_TYPE.FIXED:
+        # Per entity, the smallest lower bound and the largest upper bound over its entries, per variant.
+        entities_lower, entities_upper = [], []
+        for entity in self._entities:
+            rotor_links = [
+                link
+                for link in entity.links
+                if link.n_dofs == 1 and link.joints[0].type in (gs.JOINT_TYPE.REVOLUTE, gs.JOINT_TYPE.PRISMATIC)
+            ]
+            # Only a scene or robot description file yields a rotor link, and those morphs state a default armature.
+            if entity.desc.variants:
+                variants_default = np.array([variant.default_armature or 0.0 for variant in entity.desc.variants])
+            elif rotor_links:
+                variants_default = np.array([entity.main_morph.default_armature or 0.0])
+            else:
+                variants_default = np.zeros(1)
+            lower, upper = [], []
+            for link in entity.links:
+                if link.is_fixed:
                     continue
-                anchor = joint.pos
-                # Anchor-to-COM distance bound per subtree link (see the docstring); the carrying link's own term is
-                # exact only when this joint is its sole joint, since later chained joints re-rotate the link about
-                # their own anchors.
-                is_sole_joint = len(link.joints) == 1
-                if is_sole_joint:
-                    dist_com = {link.idx: np.linalg.norm(link.desc.inertial_pos - anchor)}
-                else:
-                    dist_com = {link.idx: np.linalg.norm(anchor) + np.linalg.norm(link.desc.inertial_pos)}
-                dist_origin = {link.idx: np.linalg.norm(anchor)}
-                sub, stack = [], [link]
-                while stack:
-                    cur = stack.pop()
-                    sub.append(cur)
-                    for child in children.get(cur.idx, []):
-                        hop = np.linalg.norm(child.desc.pos) + 2.0 * sum(np.linalg.norm(j.pos) for j in child.joints)
-                        # A prismatic descendant carries the subtree outward by up to its full travel span (which
-                        # covers the offset from any zero configuration within limits); an unlimited slide makes the
-                        # upper bracket infinite and the gate enables.
-                        hop += sum(np.ptp(j.desc.dofs_limit) for j in child.joints if j.type == gs.JOINT_TYPE.PRISMATIC)
-                        dist_origin[child.idx] = dist_origin[cur.idx] + hop
-                        dist_com[child.idx] = dist_origin[child.idx] + np.linalg.norm(child.desc.inertial_pos)
-                        stack.append(child)
-                sub_mass = sum(l.desc.mass for l in sub)
-                eigvals = np.linalg.eigvalsh(link.desc.inertia)
-                rot_desc_upper = sum(
-                    np.linalg.eigvalsh(l.desc.inertia)[-1] + l.desc.mass * dist_com[l.idx] ** 2
-                    for l in sub
-                    if l is not link
-                )
-                # Carrying link's inertia about the anchor: exact along a fixed axis, principal bracket otherwise.
-                if is_sole_joint:
-                    R_inertial = gu.quat_to_R(link.desc.inertial_quat)
-                    inertia_com = R_inertial @ link.desc.inertia @ R_inertial.T
-                    offset_com = link.desc.inertial_pos - anchor
-                    rot_self_lower = eigvals[0]
-                    rot_self_upper = eigvals[-1] + link.desc.mass * np.dot(offset_com, offset_com)
-                else:
-                    inertia_com = None
-                    offset_com = None
-                    rot_self_lower = eigvals[0]
-                    rot_self_upper = eigvals[-1] + link.desc.mass * dist_com[link.idx] ** 2
-                for i_d, armature_d in enumerate(joint.desc.dofs_armature):
-                    if joint.type == gs.JOINT_TYPE.PRISMATIC or (joint.type == gs.JOINT_TYPE.FREE and i_d < 3):
-                        lower.append(armature_d + sub_mass)
-                        upper.append(armature_d + sub_mass)
-                    elif joint.type == gs.JOINT_TYPE.REVOLUTE and is_sole_joint:
-                        axis = joint.desc.dofs_motion_ang[i_d]
-                        lever = np.cross(axis, offset_com)
-                        rot_self = axis @ inertia_com @ axis + link.desc.mass * np.dot(lever, lever)
-                        lower.append(armature_d + rot_self)
-                        upper.append(armature_d + rot_self + rot_desc_upper)
+                is_rotor = link in rotor_links
+                for joint in link.joints:
+                    if joint.type == gs.JOINT_TYPE.FIXED:
+                        continue
+                    anchor = joint.pos
+                    # Anchor-to-COM distance bound per subtree link (see the docstring); the carrying link's own term is
+                    # exact only when this joint is its sole joint, since later chained joints re-rotate the link about
+                    # their own anchors.
+                    is_sole_joint = len(link.joints) == 1
+                    if is_sole_joint:
+                        dist_com = {link.idx: np.linalg.norm(link.desc.inertial_pos - anchor)}
                     else:
-                        lower.append(armature_d + max(rot_self_lower, 0.0))
-                        upper.append(armature_d + rot_self_upper + rot_desc_upper)
-        lower = [val for val in lower if val > 0.0]
-        if not lower or not upper:
+                        dist_com = {link.idx: np.linalg.norm(anchor) + np.linalg.norm(link.desc.inertial_pos)}
+                    dist_origin = {link.idx: np.linalg.norm(anchor)}
+                    sub, stack = [], [link]
+                    while stack:
+                        cur = stack.pop()
+                        sub.append(cur)
+                        for child in children.get(cur.idx, []):
+                            hop = np.linalg.norm(child.desc.pos) + 2.0 * sum(
+                                np.linalg.norm(j.pos) for j in child.joints
+                            )
+                            # A prismatic descendant carries the subtree outward by up to its full travel span (which
+                            # covers the offset from any zero configuration within limits); an unlimited slide makes the
+                            # upper bound infinite and the gate enables.
+                            hop += sum(
+                                np.ptp(j.desc.dofs_limit) for j in child.joints if j.type == gs.JOINT_TYPE.PRISMATIC
+                            )
+                            dist_origin[child.idx] = dist_origin[cur.idx] + hop
+                            dist_com[child.idx] = dist_origin[child.idx] + np.linalg.norm(child.desc.inertial_pos)
+                            stack.append(child)
+                    sub_mass = sum(l.desc.mass for l in sub)
+                    eigvals = np.linalg.eigvalsh(link.desc.inertia)
+                    rot_desc_upper = sum(
+                        np.linalg.eigvalsh(l.desc.inertia)[-1] + l.desc.mass * dist_com[l.idx] ** 2
+                        for l in sub
+                        if l is not link
+                    )
+                    # Carrying link's inertia about the anchor: exact along a fixed axis, otherwise between its smallest
+                    # and largest principal inertia.
+                    if is_sole_joint:
+                        R_inertial = gu.quat_to_R(link.desc.inertial_quat)
+                        inertia_com = R_inertial @ link.desc.inertia @ R_inertial.T
+                        offset_com = link.desc.inertial_pos - anchor
+                        rot_self_lower = eigvals[0]
+                        rot_self_upper = eigvals[-1] + link.desc.mass * np.dot(offset_com, offset_com)
+                    else:
+                        inertia_com = None
+                        offset_com = None
+                        rot_self_lower = eigvals[0]
+                        rot_self_upper = eigvals[-1] + link.desc.mass * dist_com[link.idx] ** 2
+                    for i_d, armature_d in enumerate(joint.desc.dofs_armature):
+                        if is_rotor and armature_d <= 0.0:
+                            armature = variants_default
+                        else:
+                            armature = np.full(variants_default.size, armature_d)
+                        if joint.type == gs.JOINT_TYPE.PRISMATIC or (joint.type == gs.JOINT_TYPE.FREE and i_d < 3):
+                            lower.append(armature + sub_mass)
+                            upper.append(armature + sub_mass)
+                        elif joint.type == gs.JOINT_TYPE.REVOLUTE and is_sole_joint:
+                            axis = joint.desc.dofs_motion_ang[i_d]
+                            lever = np.cross(axis, offset_com)
+                            rot_self = axis @ inertia_com @ axis + link.desc.mass * np.dot(lever, lever)
+                            lower.append(armature + rot_self)
+                            upper.append(armature + rot_self + rot_desc_upper)
+                        else:
+                            lower.append(armature + max(rot_self_lower, 0.0))
+                            upper.append(armature + rot_self_upper + rot_desc_upper)
+            if lower:
+                lower, upper = np.array(lower), np.array(upper)
+                entities_lower.append(np.where(lower > 0.0, lower, np.inf).min(axis=0))
+                entities_upper.append(upper.max(axis=0))
+        if not entities_lower:
             return 0.0
-        return max(upper) / min(lower)
+
+        # The largest upper bound of a variant pairs with the smallest lower bound reachable alongside it: its own, or
+        # the one of any variant of another entity. A variant without a positive lower bound has no spread to speak of.
+        lower_min = np.array([entity_lower.min() for entity_lower in entities_lower])
+        mass_spread = 0.0
+        for i_e, (entity_lower, entity_upper) in enumerate(zip(entities_lower, entities_upper)):
+            lower_paired = np.minimum(entity_lower, np.delete(lower_min, i_e).min(initial=np.inf))
+            is_bounded = np.isfinite(lower_paired)
+            mass_spread_entity = np.zeros_like(entity_upper)
+            np.divide(entity_upper, lower_paired, out=mass_spread_entity, where=is_bounded)
+            mass_spread = max(mass_spread, mass_spread_entity.max())
+        return mass_spread
 
     def _refresh_invweight_and_meaninertia(self, envs_idx=None, *, force_update=True, in_place=False):
         # Every kinematic tree of the solver is recomputed. A change limited to some links is handled by the setter
@@ -1010,8 +1106,6 @@ class RigidSolver(GravityMixin, TimeBasedMixin, KinematicSolver):
         ranges and per-variant inertial properties. Per-variant inertial is pre-computed during
         link._build() from actual geom objects, using analytic formulas for primitives.
         """
-        from genesis.engine.solvers.kinematic_solver import _balanced_variant_mapping
-
         for link in self.links:
             if link._variant_vgeom_ranges is None:
                 continue

--- a/genesis/options/morphs.py
+++ b/genesis/options/morphs.py
@@ -971,9 +971,11 @@ class MJCF(FileMorph):
         aligned with the principal axes of inertia. Only applies to root (floating-base) links. Default to False.
         **This is only used for RigidEntity.**
     default_armature : float, optional
-        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
-        file, regardless of whether it is actuated. None to disable. Defaults to 0.1 if MuJoCo compatibility is
-        disabled on the rigid solver, None otherwise.
+        Default rotor inertia of the actuators. It applies to every revolute or prismatic joint moving a link on its own
+        whose armature the model file leaves at zero, regardless of whether it is actuated, and an authored armature is
+        kept as it is. The rotor inertia stabilises the constraint solve and damps the joint response, at the cost of
+        inertia the real actuator may lack, which slows every such joint down. None to disable. Defaults to 0.1 if
+        MuJoCo compatibility is disabled on the rigid solver, None otherwise.
     exclude_ground_plane : bool, optional
         Whether to exclude plane geometries authored directly under the MJCF worldbody if any. Defaults to False.
     """
@@ -1116,9 +1118,11 @@ class URDF(FileMorph):
         aligned with the principal axes of inertia. Only applies to root (floating-base) links. Default to False.
         **This is only used for RigidEntity.**
     default_armature : float, optional
-        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
-        file, regardless of whether it is actuated. None to disable. Defaults to 0.1 if MuJoCo compatibility is
-        disabled on the rigid solver, None otherwise.
+        Default rotor inertia of the actuators. It applies to every revolute or prismatic joint moving a link on its own
+        whose armature the model file leaves at zero, regardless of whether it is actuated, and an authored armature is
+        kept as it is. The rotor inertia stabilises the constraint solve and damps the joint response, at the cost of
+        inertia the real actuator may lack, which slows every such joint down. None to disable. Defaults to 0.1 if
+        MuJoCo compatibility is disabled on the rigid solver, None otherwise.
     xacro_args : dict, optional
         Key-value pairs to override ``xacro:arg`` declarations in the xacro file
         (e.g. ``{"use_sim": "true", "arm_length": "0.5"}``). Only used for ``.xacro`` files. Defaults to ``{}``.
@@ -1255,9 +1259,11 @@ class Drone(FileMorph):
     links_to_keep : list of str, optional
         A list of link names that should not be skipped during link merging. Defaults to ().
     default_armature : float, optional
-        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
-        file, regardless of whether it is actuated. None to disable. Defaults to 0.1 if MuJoCo compatibility is
-        disabled on the rigid solver, None otherwise.
+        Default rotor inertia of the actuators. It applies to every revolute or prismatic joint moving a link on its own
+        whose armature the model file leaves at zero, regardless of whether it is actuated, and an authored armature is
+        kept as it is. The rotor inertia stabilises the constraint solve and damps the joint response, at the cost of
+        inertia the real actuator may lack, which slows every such joint down. None to disable. Defaults to 0.1 if
+        MuJoCo compatibility is disabled on the rigid solver, None otherwise.
     default_base_ang_damping_scale : float, optional
         Default angular damping applied on the floating base that will be rescaled by the total mass.
         None to disable. Default to 1e-5.
@@ -1588,8 +1594,10 @@ class USD(FileMorph):
         Whether to batch fixed vertices. This will allow setting env-specific poses to fixed geometries, at the cost of
         significantly increasing memory usage. Default to true. **This is only used for RigidEntity.**
     default_armature : float, optional
-        Default rotor inertia of the actuators, applied to every joint whose armature is not specified in the model
-        file, regardless of whether it is actuated. None to disable. Default to 0.1.
+        Default rotor inertia of the actuators. It applies to every revolute or prismatic joint moving a link on its own
+        whose armature the model file leaves at zero, regardless of whether it is actuated, and an authored armature is
+        kept as it is. The rotor inertia stabilises the constraint solve and damps the joint response, at the cost of
+        inertia the real actuator may lack, which slows every such joint down. None to disable. Defaults to 0.1.
 
     Joint Dynamics Options
     ----------------------

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -65,7 +65,6 @@ def get_model_name(file_path):
 def build_model(
     xml,
     discard_visual,
-    default_armature=None,
     merge_fixed_links=False,
     exclude_ground_plane=False,
     links_to_keep=(),
@@ -136,7 +135,7 @@ def build_model(
         for name in ("assetdir", "meshdir", "texturedir"):
             compiler.attrib[name] = str(Path(asset_path) / compiler.attrib.get(name, ""))
 
-        # Set default constraint solver time constant and motor armature.
+        # Set default constraint solver time constant.
         # Note that these default options are ignored when parsing URDF files.
         default = mjcf.find("default")
         if default is None:
@@ -153,41 +152,6 @@ def build_model(
                 # 0.0 cannot be used because it is considered as an error, so that it will fallback to the original
                 # default value...
                 group.attrib.setdefault(param_name, str(MIN_TIMECONST))
-        if default_armature is not None:
-            # The default rotor armature only fills in joints whose armature is authored neither on the element nor
-            # anywhere in their default class chain, so the values authored in the model file are always preserved.
-            # First scan the nested default classes: a class authors armature if itself or any ancestor class sets it.
-            has_armature_by_class = {}
-            default_stack = [(elem, False) for elem in mjcf.findall("default")]
-            while default_stack:
-                default_elem, has_armature = default_stack.pop()
-                joint_elem = default_elem.find("joint")
-                has_armature |= joint_elem is not None and "armature" in joint_elem.attrib
-                has_armature_by_class[default_elem.attrib.get("class", "main")] = has_armature
-                default_stack.extend((child, has_armature) for child in default_elem.findall("default"))
-            # Then walk the kinematic tree while tracking the childclass in effect to resolve each joint's class.
-            # Bodies may be nested under grouping meta-elements (frame, replicate) at any depth, and composite
-            # elements hold joint configuration subelements that take armature like regular joints.
-            for worldbody in mjcf.findall("worldbody"):
-                body_stack = [
-                    (elem, "main")
-                    for tag in ("body", "frame", "replicate", "composite")
-                    for elem in worldbody.findall(tag)
-                ]
-                while body_stack:
-                    body_elem, childclass = body_stack.pop()
-                    childclass = body_elem.attrib.get("childclass", childclass)
-                    for joint_elem in body_elem.findall("joint"):
-                        if joint_elem.attrib.get("type") == "free":
-                            continue
-                        joint_class = joint_elem.attrib.get("class", childclass)
-                        if not has_armature_by_class.get(joint_class, False):
-                            joint_elem.attrib.setdefault("armature", str(default_armature))
-                    body_stack.extend(
-                        (elem, childclass)
-                        for tag in ("body", "frame", "replicate", "composite")
-                        for elem in body_elem.findall(tag)
-                    )
 
         # Must pre-process URDF to overwrite default Mujoco compile flags
         if is_urdf_file:
@@ -274,7 +238,6 @@ def parse_xml(morph, surface, rigid_options=None):
     mj = build_model(
         file,
         not morph.visualization,
-        morph.default_armature,
         merge_fixed_links,
         exclude_ground_plane,
         links_to_keep,

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -441,8 +441,11 @@ def parse_link(mj, i_l, scale):
         # See: https://mujoco.readthedocs.io/en/stable/XMLreference.html#actuator-general
         j_info["dofs_act_gain"] = np.zeros((n_dofs,), dtype=gs.np_float)
         j_info["dofs_act_bias"] = np.zeros((n_dofs, 3), dtype=gs.np_float)
-        j_info["dofs_force_range"] = np.tile([-np.inf, np.inf], (n_dofs, 1))
 
+        # Every bound the file states on the actuator force of the joint applies, one after the other in the order
+        # MuJoCo clamps: a motor's control range through its gear, the actuator's own force range, and the joint-level
+        # 'actuatorfrcrange' clamping whatever drives the joint. They are collected here and composed below.
+        force_ranges = []
         i_a = -1
         try:
             actuator_mask_j = (mj.actuator_trnid[:, 0] == i_j) & (mj.actuator_trntype == mujoco.mjtTrn.mjTRN_JOINT)
@@ -489,14 +492,22 @@ def parse_link(mj, i_l, scale):
                 j_info["dofs_act_gain"] = np.full((n_dofs,), float(gear * gainprm[0] * scale**3), dtype=gs.np_float)
                 j_info["dofs_act_bias"] = np.tile(gear * biasprm[:3] * scale**3, (n_dofs, 1)).astype(gs.np_float)
 
-            if mj.actuator_forcelimited[i_a]:
-                j_info["dofs_force_range"] = np.tile(mj.actuator_forcerange[i_a], (n_dofs, 1))
             if mj.actuator_ctrllimited[i_a] and biastype == mujoco.mjtBias.mjBIAS_NONE:
-                j_info["dofs_force_range"] = np.minimum(
-                    j_info["dofs_force_range"], np.tile(gear * mj.actuator_ctrlrange[i_a], (n_dofs, 1))
-                )
+                # A negative gear swaps the bounds.
+                force_ranges.append(np.sort(gear * mj.actuator_ctrlrange[i_a]))
+            if mj.actuator_forcelimited[i_a]:
+                force_ranges.append(mj.actuator_forcerange[i_a])
         elif gs_type not in (gs.JOINT_TYPE.FIXED, gs.JOINT_TYPE.FREE):
             gs.logger.debug(f"(MJCF) No actuator found for joint `{j_info['name']}`")
+
+        if i_j != -1 and mj.jnt_actfrclimited[i_j]:
+            force_ranges.append(mj.jnt_actfrcrange[i_j])
+        # Clamping the bounds themselves composes the clamps: overlapping ranges intersect, and a range lying past the
+        # previous one collapses the force onto its nearest bound, as clamping twice does.
+        force_range = np.array([-np.inf, np.inf])
+        for lower, upper in force_ranges:
+            force_range = np.clip(force_range, lower, upper)
+        j_info["dofs_force_range"] = np.tile(force_range, (n_dofs, 1))
 
         j_infos.append(j_info)
 

--- a/genesis/utils/mjcf.py
+++ b/genesis/utils/mjcf.py
@@ -302,7 +302,10 @@ def parse_link(mj, i_l, scale):
     else:
         l_info["parent_idx"] = int(mj.body_parentid[i_l])
     l_info["root_idx"] = int(mj.body_rootid[i_l])
-    l_info["invweight"] = mj.body_invweight0[i_l]
+    # FIXME: MuJoCo 3.10 weighs a childless body sliding on the world along its own axes as 1 / mass, leaving out the
+    # armature and the two locked axes its general J M^-1 J^T path accounts for, so those weights are recomputed at build.
+    is_simple_slider = mj.body_simple[i_l] == 2
+    l_info["invweight"] = np.full((2,), -1.0) if is_simple_slider else mj.body_invweight0[i_l]
 
     jnt_adr = mj.body_jntadr[i_l]
     jnt_num = mj.body_jntnum[i_l]
@@ -348,7 +351,10 @@ def parse_link(mj, i_l, scale):
         j_info["quat"] = np.array([1.0, 0.0, 0.0, 0.0])
         j_info["init_qpos"] = np.array(mj.qpos0[mj_qpos_offset : (mj_qpos_offset + n_qs)])
         j_info["dofs_damping"] = mj.dof_damping[mj_dof_offset : (mj_dof_offset + n_dofs)]
-        j_info["dofs_invweight"] = mj.dof_invweight0[mj_dof_offset : (mj_dof_offset + n_dofs)]
+        if is_simple_slider:
+            j_info["dofs_invweight"] = np.full((n_dofs,), -1.0)
+        else:
+            j_info["dofs_invweight"] = mj.dof_invweight0[mj_dof_offset : (mj_dof_offset + n_dofs)]
         j_info["dofs_armature"] = mj.dof_armature[mj_dof_offset : (mj_dof_offset + n_dofs)]
         j_info["dofs_frictionloss"] = mj.dof_frictionloss[mj_dof_offset : (mj_dof_offset + n_dofs)]
         if mj.njnt > 0:

--- a/genesis/utils/urdf.py
+++ b/genesis/utils/urdf.py
@@ -403,8 +403,6 @@ def parse_urdf(morph, surface):
         j_info["dofs_frictionloss"] = np.full(j_info["n_dofs"], joint_friction)
         j_info["dofs_damping"] = np.full(j_info["n_dofs"], joint_damping)
         j_info["dofs_armature"] = np.zeros(j_info["n_dofs"])
-        if joint.joint_type not in ("floating", "fixed") and morph.default_armature is not None:
-            j_info["dofs_armature"] = np.full((j_info["n_dofs"],), morph.default_armature)
 
         kp = gu.default_dofs_kp(j_info["n_dofs"])
         kv = gu.default_dofs_kv(j_info["n_dofs"])

--- a/genesis/utils/usd/usd_rigid_entity.py
+++ b/genesis/utils/usd/usd_rigid_entity.py
@@ -422,7 +422,7 @@ def _parse_link(
                     joint_prim,
                     candidates=morph.joint_armature_attr_candidates,
                     attr_name="dofs_armature",
-                    default_value=morph.default_armature or 0.0,
+                    default_value=0.0,
                 ),
                 dtype=gs.np_float,
             )

--- a/tests/grad/conftest.py
+++ b/tests/grad/conftest.py
@@ -114,7 +114,11 @@ def grad_slider_limit():
     mjcf = ET.Element("mujoco", model="slider_limit")
     worldbody = ET.SubElement(mjcf, "worldbody")
     body = ET.SubElement(worldbody, "body", name="cart", pos="0 0 0")
-    ET.SubElement(body, "joint", name="slider", type="slide", axis="1 0 0", range="-4 4", damping="0.0")
+    # A limit close to the origin keeps the rounding of the position under a finite difference small, and a soft one
+    # keeps the final position sensitive to a force applied at any step of a rollout that ends on it.
+    ET.SubElement(
+        body, "joint", name="slider", type="slide", axis="1 0 0", range="-0.5 0.5", damping="0.0", solreflimit="0.15 1"
+    )
     ET.SubElement(body, "inertial", pos="0 0 0", mass="1.0", diaginertia="1.0 1.0 1.0")
     ET.SubElement(body, "geom", type="box", size="0.25 0.25 0.1", contype="0", conaffinity="0")
     return ET.tostring(mjcf, encoding="unicode")
@@ -229,7 +233,10 @@ def grad_cartpole():
     mjcf = ET.Element("mujoco", model="cartpole")
     worldbody = ET.SubElement(mjcf, "worldbody")
     cart = ET.SubElement(worldbody, "body", name="cart", pos="0 0 0")
-    ET.SubElement(cart, "joint", name="slider", type="slide", axis="1 0 0", range="-4 4", damping="0.0")
+    # Same limit as grad_slider_limit, for the same reasons.
+    ET.SubElement(
+        cart, "joint", name="slider", type="slide", axis="1 0 0", range="-0.5 0.5", damping="0.0", solreflimit="0.15 1"
+    )
     ET.SubElement(cart, "inertial", pos="0 0 0", mass="1.0", diaginertia="1.0 1.0 1.0")
     ET.SubElement(cart, "geom", type="box", size="0.25 0.25 0.1", contype="0", conaffinity="0", rgba="0 0 0.8 1")
     pole = ET.SubElement(cart, "body", name="pole", pos="0 0 0")

--- a/tests/grad/test_rigid_constraints.py
+++ b/tests/grad/test_rigid_constraints.py
@@ -44,17 +44,17 @@ def test_joint_limit_grad_matches_fd(grad_slider_limit, precision, show_viewer):
     on.entity_fd.set_dofs_velocity(100.0)
     for _ in range(60):
         on.scene_fd.step()
-    assert (on.scene_fd.rigid_solver.get_state().qpos[:, 0].abs() <= 4.5).all()
+    assert (on.scene_fd.rigid_solver.get_state().qpos[:, 0].abs() <= 1.5).all()
 
-    # Backward, with mixed per-environment activity: env 0 drives into the active |x|=4 limit while env 1 stays well
+    # Backward, with mixed per-environment activity: env 0 drives past the active |x|=0.5 limit while env 1 stays
     # inside it, so the adjoint solve faces different constraint counts in the same batch. Sanity-check the split.
     on.scene_fd.reset()
     on.entity_fd.set_dofs_velocity([[100.0], [2.0]])
     for _ in range(5):
         on.scene_fd.step()
     qpos_end = on.scene_fd.rigid_solver.get_state().qpos
-    assert abs(qpos_end[0, 0]) > 3.5
-    assert abs(qpos_end[1, 0]) < 1.0
+    assert abs(qpos_end[0, 0]) > 0.5
+    assert abs(qpos_end[1, 0]) < 0.5
 
     assert_grad_matches_fd(
         on,
@@ -105,8 +105,8 @@ def test_per_step_force_into_limit_grad_matches_fd(model_name, request, precisio
     # (gravity, n_steps, per-step force, loss reads links_pos, sanity dof, sanity threshold, initial dof pose,
     # fp32 tolerance).
     gravity, n_steps, per_step_force, is_links_loss, sanity_dof, sanity_thresh, init_pos, fp32_tol = {
-        "grad_slider_limit": ((0.0, 0.0, 0.0), 10, [500.0], False, 0, 3.5, None, 1e-4),
-        "grad_cartpole": ((0.0, 0.0, -9.81), 15, [2000.0, 0.0], False, 0, 3.5, [0.0, -math.pi], 2e-4),
+        "grad_slider_limit": ((0.0, 0.0, 0.0), 10, [500.0], False, 0, 0.5, None, 1e-4),
+        "grad_cartpole": ((0.0, 0.0, -9.81), 15, [2000.0, 0.0], False, 0, 0.5, [0.0, -math.pi], 2e-4),
         "grad_hopper": ((0.0, 0.0, 0.0), 10, [0.0, 0.0, 0.0, 0.0, 0.0, 200.0], True, 5, 0.7, None, 5e-5),
     }[model_name]
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -84,25 +84,22 @@ def box_plan():
     return mjcf
 
 
-def _build_free_box_model(model_name, boxes):
-    """Generate an MJCF model holding the given free boxes and nothing else, as (name, pos) pairs."""
-    mjcf = ET.Element("mujoco", model=model_name)
+@pytest.fixture(scope="session")
+def free_boxes_and_slider():
+    """Generate an MJCF model for two free boxes with an off-center inertial frame and a box sliding on the world along
+    one axis with a rotor armature, which Mujoco holds as one model."""
+    mjcf = ET.Element("mujoco", model="free_boxes_and_slider")
     ET.SubElement(mjcf, "option", timestep="0.01")
     worldbody = ET.SubElement(mjcf, "worldbody")
-    for name, pos in boxes:
+    for name, pos in (("box_left", "-0.5 0. 1."), ("box_right", "0.5 0. 1.")):
         body = ET.SubElement(worldbody, "body", name=name, pos=pos)
         ET.SubElement(body, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.")
+        ET.SubElement(body, "inertial", pos="0.01 -0.02 0.03", mass="64.", diaginertia="1.7 1.7 1.7")
         ET.SubElement(body, "joint", name=f"{name}_root", type="free")
+    body = ET.SubElement(worldbody, "body", name="box_slider", pos="0. 1. 1.")
+    ET.SubElement(body, "geom", type="box", size="0.2 0.2 0.2", pos="0. 0. 0.")
+    ET.SubElement(body, "joint", name="box_slider_root", type="slide", axis="1 0 0", armature="0.1")
     return mjcf
-
-
-FREE_BOXES = (("box_left", "-0.5 0. 1."), ("box_right", "0.5 0. 1."))
-
-
-@pytest.fixture(scope="session")
-def two_free_boxes():
-    """Generate an MJCF model for two free boxes, which Mujoco holds as one model."""
-    return _build_free_box_model("two_free_boxes", FREE_BOXES)
 
 
 @pytest.fixture(scope="session")
@@ -1077,10 +1074,10 @@ def freeflyer_mjcf():
 
 
 @pytest.fixture(scope="session")
-def two_trees_mjcf():
-    """Generate an MJCF model holding two kinematic trees, a free body with a hinged child each, the second hinge with
-    an authored armature."""
-    mjcf = ET.Element("mujoco", model="two_trees")
+def trees_and_slider_mjcf():
+    """Generate an MJCF model holding three kinematic trees: a free body with a hinged child twice, the second hinge
+    with an authored armature, and a body sliding on the world along one axis with an authored armature."""
+    mjcf = ET.Element("mujoco", model="trees_and_slider")
     worldbody = ET.SubElement(mjcf, "worldbody")
     for name, pos, joint_attrs in (("tree_a", "0 0 1", {}), ("tree_b", "1 0 1", {"armature": "0.3"})):
         body = ET.SubElement(worldbody, "body", name=name, pos=pos)
@@ -1091,6 +1088,10 @@ def two_trees_mjcf():
         ET.SubElement(child, "joint", type="hinge", axis="0 1 0", **joint_attrs)
         ET.SubElement(child, "inertial", pos="0 0 0", mass="0.5", diaginertia="0.001 0.001 0.001")
         ET.SubElement(child, "geom", type="sphere", size="0.02")
+    slider = ET.SubElement(worldbody, "body", name="slider", pos="2 0 1")
+    ET.SubElement(slider, "joint", type="slide", axis="1 0 0", armature="0.3")
+    ET.SubElement(slider, "inertial", pos="0 0 0", mass="1.0", diaginertia="0.01 0.01 0.01")
+    ET.SubElement(slider, "geom", type="sphere", size="0.05")
     return ET.tostring(mjcf, encoding="unicode")
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -899,16 +899,18 @@ def general_actuator():
     ET.SubElement(mjcf, "option", timestep="0.01")
     worldbody = ET.SubElement(mjcf, "worldbody")
     body1 = ET.SubElement(worldbody, "body", name="link1", pos="0 0 1")
-    ET.SubElement(body1, "joint", name="hinge_pd", type="hinge", axis="0 1 0", damping="0.5")
+    ET.SubElement(body1, "joint", name="hinge_pd", type="hinge", axis="0 1 0", damping="0.5", actuatorfrcrange="-20 20")
     ET.SubElement(body1, "geom", type="capsule", size="0.05 0.3", mass="1.0")
     body2 = ET.SubElement(body1, "body", name="link2", pos="0 0 -0.6")
     ET.SubElement(body2, "joint", name="hinge_general", type="hinge", axis="0 1 0", damping="0.3")
     ET.SubElement(body2, "geom", type="capsule", size="0.04 0.2", mass="0.5")
     body3 = ET.SubElement(body2, "body", name="link3", pos="0 0 -0.4")
-    ET.SubElement(body3, "joint", name="hinge_motor", type="hinge", axis="0 1 0", damping="0.2")
+    ET.SubElement(
+        body3, "joint", name="hinge_motor", type="hinge", axis="0 1 0", damping="0.2", actuatorfrcrange="-4 4"
+    )
     ET.SubElement(body3, "geom", type="capsule", size="0.03 0.15", mass="0.3")
     actuator = ET.SubElement(mjcf, "actuator")
-    ET.SubElement(actuator, "position", name="act_pd", joint="hinge_pd", kp="100")
+    ET.SubElement(actuator, "position", name="act_pd", joint="hinge_pd", kp="100", kv="2")
     ET.SubElement(
         actuator,
         "general",
@@ -918,7 +920,9 @@ def general_actuator():
         biastype="affine",
         biasprm="0.5 -10 -1",
     )
-    ET.SubElement(actuator, "motor", name="act_motor", joint="hinge_motor", gear="5")
+    ET.SubElement(
+        actuator, "motor", name="act_motor", joint="hinge_motor", gear="5", ctrlrange="-1 1", forcerange="6 8"
+    )
     return mjcf
 
 

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -1077,6 +1077,24 @@ def freeflyer_mjcf():
 
 
 @pytest.fixture(scope="session")
+def two_trees_mjcf():
+    """Generate an MJCF model holding two kinematic trees, a free body with a hinged child each, the second hinge with
+    an authored armature."""
+    mjcf = ET.Element("mujoco", model="two_trees")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    for name, pos, joint_attrs in (("tree_a", "0 0 1", {}), ("tree_b", "1 0 1", {"armature": "0.3"})):
+        body = ET.SubElement(worldbody, "body", name=name, pos=pos)
+        ET.SubElement(body, "joint", type="free")
+        ET.SubElement(body, "inertial", pos="0 0 0", mass="1.0", diaginertia="0.01 0.01 0.01")
+        ET.SubElement(body, "geom", type="sphere", size="0.05")
+        child = ET.SubElement(body, "body", name=f"{name}_child", pos="0 0 0.1")
+        ET.SubElement(child, "joint", type="hinge", axis="0 1 0", **joint_attrs)
+        ET.SubElement(child, "inertial", pos="0 0 0", mass="0.5", diaginertia="0.001 0.001 0.001")
+        ET.SubElement(child, "geom", type="sphere", size="0.02")
+    return ET.tostring(mjcf, encoding="unicode")
+
+
+@pytest.fixture(scope="session")
 def freeflyer_urdf():
     robot = ET.Element("robot", name="freeflyer")
     ET.SubElement(robot, "link", name="world")

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -739,7 +739,7 @@ def test_urdf_joint_dynamics(joint_damping, joint_friction, xml_path):
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 @pytest.mark.parametrize("model_name", ["freeflyer_mjcf", "freeflyer_urdf"])
-def test_default_armature_freeflyer(xml_path):
+def test_default_armature(xml_path, two_trees_mjcf):
     DEFAULT_ARMATURE = 1000.0
 
     morph_class = gs.morphs.URDF if xml_path.endswith(".urdf") else gs.morphs.MJCF
@@ -750,24 +750,86 @@ def test_default_armature_freeflyer(xml_path):
     morph_without_armature = morph_class(
         file=xml_path,
         pos=(1.0, 0.0, 0.0),
+        default_armature=None,
     )
+    # One variant per environment, each weighing differently and asking its own default.
+    morphs_heterogeneous = [
+        morph_class(
+            file=xml_path,
+            pos=(2.0, 0.0, 0.0),
+            scale=1.0,
+            default_armature=DEFAULT_ARMATURE,
+        ),
+        morph_class(
+            file=xml_path,
+            pos=(2.0, 0.0, 0.0),
+            scale=2.0,
+            default_armature=None,
+        ),
+    ]
+
+    # An attached pair is one kinematic tree spanning two entities, only the mounted one asking a default, beside the
+    # same pair without any default.
+    carriers = []
+    for i_pair, default_armature in enumerate((DEFAULT_ARMATURE, None)):
+        carrier = morph_class(
+            file=xml_path,
+            pos=(3.0 + i_pair, 0.0, 0.0),
+            default_armature=None,
+        )
+        mounted = morph_class(
+            file=xml_path,
+            pos=(3.0 + i_pair, 0.0, 0.5),
+            default_armature=default_armature,
+        )
+        carriers.append((carrier, mounted))
 
     scene = gs.Scene()
     robot = scene.add_entity(morph)
     robot_without_armature = scene.add_entity(morph_without_armature)
-    scene.build()
+    robot_heterogeneous = scene.add_entity(morphs_heterogeneous)
+    # One entity holding two kinematic trees, only the first with a joint the default applies to.
+    robot_two_trees = scene.add_entity(
+        gs.morphs.MJCF(
+            file=two_trees_mjcf,
+            pos=(0.0, 3.0, 0.0),
+            default_armature=DEFAULT_ARMATURE,
+        )
+    )
+    robot_two_trees_reference = scene.add_entity(
+        gs.morphs.MJCF(
+            file=two_trees_mjcf,
+            pos=(0.0, 4.0, 0.0),
+            default_armature=None,
+        )
+    )
+    carrier, carrier_reference = [], []
+    for (carrier_morph, mounted_morph), pair in zip(carriers, (carrier, carrier_reference)):
+        pair.append(scene.add_entity(carrier_morph))
+        mounted_entity = scene.add_entity(mounted_morph)
+        mounted_entity.attach(pair[0], parent_link_name=pair[0].base_link.name, pos=(0.0, 0.0, 0.5))
+    (carrier,), (carrier_reference,) = carrier, carrier_reference
+    scene.build(n_envs=2)
 
     armature = robot.get_dofs_armature()
-    assert_allclose(armature[:6], 0.0, tol=gs.EPS)
-    assert_allclose(armature[6], DEFAULT_ARMATURE, tol=gs.EPS)
+    assert_allclose(armature[:, :6], 0.0, tol=gs.EPS)
+    assert_allclose(armature[:, 6], DEFAULT_ARMATURE, tol=gs.EPS)
+    assert_allclose(robot_without_armature.get_dofs_armature()[:, 6], 0.0, tol=gs.EPS)
     if xml_path.endswith(".xml"):
-        assert_allclose(armature[7], 42.0, tol=gs.EPS)
-        assert_allclose(armature[8], 0.0002, tol=gs.EPS)
+        assert_allclose(armature[:, 7], 42.0, tol=gs.EPS)
+        assert_allclose(armature[:, 8], 0.0002, tol=gs.EPS)
+    armature_heterogeneous = robot_heterogeneous.get_dofs_armature()
+    assert_allclose(armature_heterogeneous[0, 6], DEFAULT_ARMATURE, tol=gs.EPS)
+    assert_allclose(armature_heterogeneous[1, 6], 0.0, tol=gs.EPS)
 
-    # Rotor inertia adds to the effective inertia of the joint it is applied to, so it must lower the inverse weight
-    # the solver derives from it. An inverse weight parsed before the armature was applied leaves the rotor inertia
-    # out of every constraint it scales.
-    assert robot.get_dofs_invweight()[6] < robot_without_armature.get_dofs_invweight()[6]
+    # Rotor inertia lowers the inverse weight of its own joint and, through the inverse mass matrix of the tree, of
+    # every joint coupled to it, across attached entities included. An inverse weight parsed before the default was
+    # applied would miss it.
+    assert (robot.get_dofs_invweight()[:, 6:8] < robot_without_armature.get_dofs_invweight()[:, 6:8]).all()
+    assert (carrier.get_dofs_invweight()[:, 6:8] < carrier_reference.get_dofs_invweight()[:, 6:8]).all()
+    # The default reaches its own tree alone: the other tree of the entity keeps the parsed inverse weights.
+    assert (robot_two_trees.get_dofs_invweight()[:, 6] < robot_two_trees_reference.get_dofs_invweight()[:, 6]).all()
+    assert_equal(robot_two_trees.get_dofs_invweight()[:, 7:], robot_two_trees_reference.get_dofs_invweight()[:, 7:])
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_asset_loading.py
+++ b/tests/rigid/test_asset_loading.py
@@ -739,7 +739,7 @@ def test_urdf_joint_dynamics(joint_damping, joint_friction, xml_path):
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 @pytest.mark.parametrize("model_name", ["freeflyer_mjcf", "freeflyer_urdf"])
-def test_default_armature(xml_path, two_trees_mjcf):
+def test_default_armature(xml_path, trees_and_slider_mjcf, tol):
     DEFAULT_ARMATURE = 1000.0
 
     morph_class = gs.morphs.URDF if xml_path.endswith(".urdf") else gs.morphs.MJCF
@@ -788,17 +788,17 @@ def test_default_armature(xml_path, two_trees_mjcf):
     robot = scene.add_entity(morph)
     robot_without_armature = scene.add_entity(morph_without_armature)
     robot_heterogeneous = scene.add_entity(morphs_heterogeneous)
-    # One entity holding two kinematic trees, only the first with a joint the default applies to.
-    robot_two_trees = scene.add_entity(
+    # One entity holding three kinematic trees, only the first with a joint the default applies to.
+    robot_trees = scene.add_entity(
         gs.morphs.MJCF(
-            file=two_trees_mjcf,
+            file=trees_and_slider_mjcf,
             pos=(0.0, 3.0, 0.0),
             default_armature=DEFAULT_ARMATURE,
         )
     )
-    robot_two_trees_reference = scene.add_entity(
+    robot_trees_reference = scene.add_entity(
         gs.morphs.MJCF(
-            file=two_trees_mjcf,
+            file=trees_and_slider_mjcf,
             pos=(0.0, 4.0, 0.0),
             default_armature=None,
         )
@@ -822,14 +822,18 @@ def test_default_armature(xml_path, two_trees_mjcf):
     assert_allclose(armature_heterogeneous[0, 6], DEFAULT_ARMATURE, tol=gs.EPS)
     assert_allclose(armature_heterogeneous[1, 6], 0.0, tol=gs.EPS)
 
-    # Rotor inertia lowers the inverse weight of its own joint and, through the inverse mass matrix of the tree, of
-    # every joint coupled to it, across attached entities included. An inverse weight parsed before the default was
-    # applied would miss it.
+    # Rotor inertia lowers the inverse weight of its own joint and, through the inverse mass matrix of the tree, of every
+    # joint coupled to it, attached entities included: a weight parsed before the default was applied would miss it.
     assert (robot.get_dofs_invweight()[:, 6:8] < robot_without_armature.get_dofs_invweight()[:, 6:8]).all()
     assert (carrier.get_dofs_invweight()[:, 6:8] < carrier_reference.get_dofs_invweight()[:, 6:8]).all()
-    # The default reaches its own tree alone: the other tree of the entity keeps the parsed inverse weights.
-    assert (robot_two_trees.get_dofs_invweight()[:, 6] < robot_two_trees_reference.get_dofs_invweight()[:, 6]).all()
-    assert_equal(robot_two_trees.get_dofs_invweight()[:, 7:], robot_two_trees_reference.get_dofs_invweight()[:, 7:])
+    # The default reaches its own tree alone: the other trees of the entity keep the inverse weights they were built with.
+    assert (robot_trees.get_dofs_invweight()[:, 6] < robot_trees_reference.get_dofs_invweight()[:, 6]).all()
+    assert_equal(robot_trees.get_dofs_invweight()[:, 7:], robot_trees_reference.get_dofs_invweight()[:, 7:])
+    # The slider is weighed like every other body (see the FIXME in genesis.utils.mjcf): 1 / (mass + armature) for its
+    # dof, a third of it for the translation of the link and none for its rotation.
+    slider_invweight = 1.0 / (1.0 + 0.3)
+    assert_allclose(robot_trees.get_dofs_invweight()[:, 14], slider_invweight, tol=tol)
+    assert_allclose(robot_trees.get_links_invweight()[:, 4], (slider_invweight / 3.0, 0.0), tol=tol)
 
 
 @pytest.mark.slow  # ~200s

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -249,6 +249,15 @@ def test_stickman(gs_sim, mj_sim, tol):
 def test_general_actuator(gs_sim, mj_sim, tol):
     (entity,) = gs_sim.entities
 
+    # The force range of a dof composes every bound the file states for it in the order MuJoCo clamps: for the motor
+    # its control range through the gear, then its own force range, which lies past the joint-level 'actuatorfrcrange'
+    # and so collapses the force onto that joint bound. The PD gains come from the actuator.
+    lower, upper = entity.get_dofs_force_range()
+    assert_allclose(lower, [-20.0, -np.inf, 4.0], tol=tol)
+    assert_allclose(upper, [20.0, np.inf, 4.0], tol=tol)
+    assert_allclose(entity.get_dofs_kp(dofs_idx_local=[0]), 100.0, tol=tol)
+    assert_allclose(entity.get_dofs_kv(dofs_idx_local=[0]), 2.0, tol=tol)
+
     # get_dofs_kp raises for all DOFs (joint 1 is non-PD-reducible from parser)
     with pytest.raises(gs.GenesisException):
         entity.get_dofs_kp()
@@ -282,9 +291,11 @@ def test_general_actuator(gs_sim, mj_sim, tol):
     check_mujoco_model_consistency(gs_sim, mj_sim, tol=tol)
     init_paired_simulators(gs_sim, mj_sim, qpos=[0.2, 0.1, 0.0], qvel=[0.1, -0.1, 0.0])
 
+    # Both the PD joint (kp(100) * 0.3 rad = 30 N.m against its 20 N.m joint bound) and the motor (gear(5) * ctrl(1) =
+    # 5 N.m raised to its 6 N.m force floor, past its 4 N.m joint bound) saturate, so the comparison exercises the clamp.
     mj_sim.data.ctrl[:] = [0.5, 0.3, 1.0]
     entity.control_dofs_position([0.5, 0.3, 0.0])
-    entity.control_dofs_force(5.0, dofs_idx_local=[2])  # motor: gear(5) * gainprm(1) * ctrl(1) = 5
+    entity.control_dofs_force(5.0, dofs_idx_local=[2])
 
     # Pre-step so that Genesis computes qf_applied (needed for data consistency checks)
     mj_sim.data.qpos[:] = gs_sim.rigid_solver.qpos.to_numpy()[:, 0]

--- a/tests/rigid/test_mujoco_parity.py
+++ b/tests/rigid/test_mujoco_parity.py
@@ -11,6 +11,7 @@ from ..utils.mujoco_parity import (
     check_mujoco_data_consistency,
     check_mujoco_model_consistency,
     init_paired_simulators,
+    set_paired_inertial_properties,
     simulate_and_check_mujoco_consistency,
 )
 
@@ -53,13 +54,21 @@ def test_box_plane_dynamics(gs_sim, mj_sim, tol):
 
 @pytest.mark.required
 @pytest.mark.split_entities
-@pytest.mark.parametrize("model_name", ["two_free_boxes"])
+@pytest.mark.parametrize("model_name", ["free_boxes_and_slider"])
 @pytest.mark.parametrize("gs_solver, gs_integrator", [(gs.constraint_solver.Newton, gs.integrator.implicitfast)])
 @pytest.mark.parametrize("backend", [gs.cpu])
 def test_scene_aggregates_hold_across_entities(gs_sim, mj_sim, tol):
-    # Mujoco holds the two boxes in one model while Genesis holds one entity per box. The mean inertia the constraint
+    # Mujoco holds the three boxes in one model while Genesis holds one entity per box. The mean inertia the constraint
     # solver scales its tolerances by is a scene aggregate, so it must come out the same however the same bodies are
-    # grouped into entities, which one entity per box is what tells apart.
+    # grouped into entities, which one entity per box is what tells apart. The sliding box carries an armature on a
+    # body MuJoCo weighs by a rule of its own, so its constraint weights hold the general rule both engines settle on.
+    simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=10, tol=tol)
+
+    # The runtime inertial setters derive the constraint weights and the mean inertia anew, which the model consistency
+    # check then holds against the constants MuJoCo recomputes for the same change.
+    set_paired_inertial_properties(
+        gs_sim, mj_sim, armature_ratio=3.0, mass_ratio=0.5, inertia_ratio=2.0, com_offset=(0.01, -0.02, 0.03)
+    )
     simulate_and_check_mujoco_consistency(gs_sim, mj_sim, num_steps=10, tol=tol)
 
 

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -76,7 +76,7 @@ def checkpoint_scene(mimic_hinges, requires_grad, show_viewer):
 
 
 @pytest.mark.required
-@pytest.mark.parametrize("model_name", ["two_free_boxes"])
+@pytest.mark.parametrize("model_name", ["free_boxes_and_slider"])
 @pytest.mark.parametrize("n_envs", [0, 2])
 def test_export_and_load_rigid(
     n_envs, xml_path, mimic_hinges, urdf_with_external_assets, xacro_robot, tmp_path, show_viewer, caplog
@@ -298,7 +298,7 @@ def test_export_and_load_rigid(
         stored = archive.read(MANIFEST_NAME).decode()
     assert str(tmp_path) not in stored
     assert str(get_assets_dir()) not in stored
-    assert '"two_free_boxes.xml"' in stored
+    assert '"free_boxes_and_slider.xml"' in stored
     # An entity's creation uses the description its build resolved, and that description carries the geometry.
     # Genesis therefore reads the asset file once and never again.
     Path(xml_path).unlink()

--- a/tests/sensors/test_joint_torque.py
+++ b/tests/sensors/test_joint_torque.py
@@ -36,13 +36,12 @@ def joint_torque_pendulums():
 
 @pytest.fixture(scope="session")
 def joint_torque_contact_pendulum():
-    # Single lossless pendulum; the wall it presses against is added separately in the test. armature is set to 0 to
-    # override the MJCF morph's nonzero default_armature.
+    # Single lossless pendulum; the wall it presses against is added separately in the test.
     mjcf = ET.Element("mujoco", model="joint_torque_contact_pendulum")
     ET.SubElement(mjcf, "compiler", angle="radian")
     worldbody = ET.SubElement(mjcf, "worldbody")
     arm = ET.SubElement(worldbody, "body", name="arm")
-    ET.SubElement(arm, "joint", name="hinge", type="hinge", axis="0 1 0", armature="0")
+    ET.SubElement(arm, "joint", name="hinge", type="hinge", axis="0 1 0")
     mass = ET.SubElement(arm, "body", pos="0 0 -1.0")
     ET.SubElement(mass, "geom", type="sphere", size="0.05", mass="1.0")
     return ET.tostring(mjcf, encoding="unicode")
@@ -79,6 +78,7 @@ def test_joint_torque(joint_torque_pendulums, show_viewer, tol, n_envs):
     pendulums = scene.add_entity(
         morph=gs.morphs.MJCF(
             file=joint_torque_pendulums,
+            default_armature=0.0,
         ),
     )
     sensor = scene.add_sensor(
@@ -145,6 +145,7 @@ def test_joint_torque_with_contact(joint_torque_contact_pendulum, show_viewer, t
     pendulum = scene.add_entity(
         morph=gs.morphs.MJCF(
             file=joint_torque_contact_pendulum,
+            default_armature=0.0,
         ),
     )
     # Box face at x=0.75; the mass (sphere r=0.05) at theta=pi/4 sits at x=0.707, so contact is active from step 1.

--- a/tests/utils/mujoco_parity.py
+++ b/tests/utils/mujoco_parity.py
@@ -205,6 +205,43 @@ def init_paired_simulators(gs_sim, mj_sim, qpos=None, qvel=None):
     mujoco.mj_forward(mj_sim.model, mj_sim.data)
 
 
+def set_paired_inertial_properties(gs_sim, mj_sim, *, armature_ratio, mass_ratio, inertia_ratio, com_offset):
+    """Apply the same inertial change to both simulators, through the runtime setters on the Genesis side and through
+    the model fields and 'mj_setConst' on the MuJoCo side.
+
+    Every DOF armature and every body mass and inertia are scaled by the given ratios, and the center of mass of every
+    body MuJoCo compiled with a full mass matrix structure is shifted by 'com_offset' in its body frame. What the setters
+    derive from the change (inverse weights, mean inertia) can then be held against the constants MuJoCo recomputes.
+    """
+    gs_maps, mj_maps = _get_model_mappings(gs_sim, mj_sim)
+    gs_bodies_idx, _, _, gs_dofs_idx, _, _ = gs_maps
+    mj_bodies_idx, _, _, mj_dofs_idx, _, _ = mj_maps
+    model = mj_sim.model
+    # MuJoCo bakes a diagonal mass matrix structure for a body compiled with its inertial frame on the body frame, so a
+    # center of mass shifted at runtime has nowhere to couple: only the bodies compiled with the full structure take one.
+    gs_com_idx, mj_com_idx = [], []
+    for gs_i, mj_i in zip(gs_bodies_idx, mj_bodies_idx):
+        if not model.body_simple[mj_i]:
+            gs_com_idx.append(gs_i)
+            mj_com_idx.append(mj_i)
+
+    model.dof_armature[mj_dofs_idx] *= armature_ratio
+    model.body_mass[mj_bodies_idx] *= mass_ratio
+    model.body_inertia[mj_bodies_idx] *= inertia_ratio
+    model.body_ipos[mj_com_idx] += com_offset
+    # A body compiled with its inertial frame on the body frame keeps the flag that lets MuJoCo skip the offset.
+    model.body_sameframe[mj_com_idx] = mujoco.mjtSameFrame.mjSAMEFRAME_NONE
+    mujoco.mj_setConst(model, mj_sim.data)
+    align_mujoco_invweight0(model)
+
+    solver = gs_sim.rigid_solver
+    solver.set_dofs_armature(armature_ratio * solver.get_dofs_armature(dofs_idx=gs_dofs_idx), dofs_idx=gs_dofs_idx)
+    solver.set_links_mass(mass_ratio * solver.get_links_mass(links_idx=gs_bodies_idx), links_idx=gs_bodies_idx)
+    solver.set_links_inertia(inertia_ratio * solver.get_links_inertia(links_idx=gs_bodies_idx), links_idx=gs_bodies_idx)
+    links_com = tensor_to_array(solver.get_links_COM(links_idx=gs_com_idx)) + com_offset
+    solver.set_links_COM(links_com, links_idx=gs_com_idx)
+
+
 def get_mujoco_midpoint_dofs_mask(mj_sim):
     """Boolean mask over MuJoCo DOFs whose qacc / qvel are overwritten by midpoint integration this step.
 
@@ -249,6 +286,34 @@ def get_mujoco_midpoint_dofs_mask(mj_sim):
         start = 3 if (model.body_ipos[i_b] == 0.0).all() else 0
         mask[adr + start : adr + 6] = True
     return mask
+
+
+def align_mujoco_invweight0(model):
+    """Write into the model the constraint inverse weights of every body and DOF that MuJoCo's general rule gives.
+
+    That rule of 'mj_setConst' is the mean diagonal of J M^-1 J^T at the neutral configuration, over the translational
+    and the rotational rows of a body, and over the DOFs a joint moves together. MuJoCo leaves it aside for a body it
+    flags as simple (see the FIXME in genesis.utils.mjcf), so aligning the model on it has both engines simulate the
+    weights Genesis derives.
+    """
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    mass_mat_inv = np.zeros((model.nv, model.nv))
+    mujoco.mj_solveM(model, data, mass_mat_inv, np.eye(model.nv))
+    jac = np.zeros((6, model.nv))
+    for i_b in range(1, model.nbody):
+        mujoco.mj_jacBodyCom(model, data, jac[:3], jac[3:], i_b)
+        inv_inertia = jac @ mass_mat_inv @ jac.T
+        model.body_invweight0[i_b] = (np.trace(inv_inertia[:3, :3]) / 3.0, np.trace(inv_inertia[3:, 3:]) / 3.0)
+    dofs_invweight = np.diag(mass_mat_inv).copy()
+    for i_j in range(model.njnt):
+        i_d = model.jnt_dofadr[i_j]
+        if model.jnt_type[i_j] == mujoco.mjtJoint.mjJNT_FREE:
+            dofs_invweight[i_d : i_d + 3] = dofs_invweight[i_d : i_d + 3].mean()
+            dofs_invweight[i_d + 3 : i_d + 6] = dofs_invweight[i_d + 3 : i_d + 6].mean()
+        elif model.jnt_type[i_j] == mujoco.mjtJoint.mjJNT_BALL:
+            dofs_invweight[i_d : i_d + 3] = dofs_invweight[i_d : i_d + 3].mean()
+    model.dof_invweight0[:] = dofs_invweight
 
 
 def check_mujoco_model_consistency(

--- a/tests/utils/simulators.py
+++ b/tests/utils/simulators.py
@@ -46,9 +46,7 @@ def build_mujoco_sim(
         asset_path = get_hf_dataset(pattern=xml_path)
         file = os.path.join(asset_path, xml_path)
 
-    model = mju.build_model(
-        file, discard_visual=True, default_armature=None, merge_fixed_links=merge_fixed_links, links_to_keep=()
-    )
+    model = mju.build_model(file, discard_visual=True, merge_fixed_links=merge_fixed_links, links_to_keep=())
 
     model.opt.solver = mj_solver
     model.opt.integrator = mj_integrator

--- a/tests/utils/simulators.py
+++ b/tests/utils/simulators.py
@@ -9,6 +9,7 @@ from genesis.utils import mjcf as mju
 from genesis.utils.mesh import get_assets_dir
 
 from .assets import get_hf_dataset
+from .mujoco_parity import align_mujoco_invweight0
 
 
 @dataclass
@@ -74,6 +75,7 @@ def build_mujoco_sim(
     # meshes exactly. Midpoint integration branches on an exact ipos == 0 test, so the residuals would silently
     # route the two engines through different update rules; canonicalize the dust to zero.
     model.body_ipos[np.abs(model.body_ipos) < 1e-12] = 0.0
+    align_mujoco_invweight0(model)
     if native_ccd:
         model.opt.disableflags &= ~np.uint32(mujoco.mjtDisableBit.mjDSBL_NATIVECCD)
     else:


### PR DESCRIPTION
## Description

Split out of #3325, whose relative default armature and solver tolerance defaults stay there.

The default rotor armature is applied at build instead of being injected by the parsers: every revolute or prismatic joint moving a link on its own whose armature the asset leaves at zero receives the morph's `default_armature`, authored values are kept, and the inverse weights of every degree of freedom and link of the kinematic trees involved are recomputed afterwards, attached entities included. Heterogeneous entities resolve the default per variant and environment. Ball joints and multi-joint links no longer receive it, and an authored zero counts as left at zero, so opting out goes through `default_armature=None`.

The MJCF parser honors the joint-level `actuatorfrcrange`, which it dropped before, so models stating their torque limits that way ran unclamped. Every stated bound applies at once: the actuator force range, a motor's control range through its gear, and the joint range.

MuJoCo weighs a body sliding on the world on axis-aligned slide joints alone, with no child and its inertial frame on the body frame, as `1 / mass`, leaving out the armature and the two locked axes its general `J M^-1 J^T` rule accounts for. The MJCF parser now leaves such weights to the build, which recomputes them by the general rule (a FIXME records the finding), and the parity harness aligns MuJoCo's stored weights on that rule, at load and after `mj_setConst`, so both engines simulate the same weights.

The force-into-limit gradient check gets its margin from its model: the slider and cart limits move to 0.5 m and soften to a 0.15 s time constant, which cuts the rounding noise of the finite difference on the position and keeps the final position sensitive to every step's force.

## Motivation and Context

Injecting the default into the model before MuJoCo compiles it left the inverse weights of the joints coupled to a defaulted one, and those of attached entities, computed without the rotor inertia, so the impedance of their joint limits, friction loss and equality constraints missed it. The joint-level `actuatorfrcrange` is how many models state their torque limits.

## How Has This Been / Can This Be Tested?

`test_default_armature` checks the kept authored values, the per-variant resolution, the inverse weights across an attached pair and the untouched second tree of an entity. `test_general_actuator` states joint-level force ranges on a saturating PD joint and a geared motor, asserts the parsed ranges and gains, and compares the clamped actuator forces against MuJoCo step by step. `test_scene_aggregates_hold_across_entities` runs on a model holding a sliding armature box and checks the inverse weights and the mean inertia against MuJoCo at init and after scaling armatures, masses and inertias and shifting centers of mass at runtime on both sides. `test_default_armature` asserts the slider's weights against their closed form.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
