### PR TITLE
[BUG FIX] Decode normalized integer glTF accessors instead of reading their raw values.

### DIFF
--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -79,7 +79,11 @@ def get_glb_data_from_accessor(glb, accessor_index):
             data_slice = buffer_data[start:end]
             array[i] = np.frombuffer(data_slice, dtype=dtype, count=num_components)
 
-    return array.reshape((count, *type_to_count[data_type][1]))
+    array = array.reshape((count, *type_to_count[data_type][1]))
+    if accessor.normalized:
+        # glTF stores normalized integer components as [0, 1] (unsigned) or [-1, 1] (signed) fixed point
+        array = np.maximum(array / np.iinfo(dtype).max, -1.0, dtype=np.float32)
+    return array
 
 
 def get_glb_image(glb, image_index, image_type=None):

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -48,9 +48,6 @@ USD_COLOR_TOL = 1e-07
 
 USD_NORMALS_TOL = 1e-02
 
-# Texture coordinates authored into the triangle of the emissive material variants GLB
-GLB_TEXCOORD_UVS = np.array([[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]], dtype=np.float32)
-
 
 # UsdPhysics declares every joint attribute as single precision, so an anchor, a limit or a drive gain authored in
 # double comes back rounded from a USD file and no parser can recover it. Comparing joints against the model they were
@@ -504,11 +501,13 @@ def usd_scene(request, model_name, scale, fixed):
 
 @pytest.fixture(scope="session")
 def emissive_material_variants_glb(asset_tmp_path):
-    """Path to a GLB with three materials, each on distinct base/emissive texCoord sets: a base-color atlas (red) on
-    texCoord 0 with an emissive atlas on texCoord 1, a flat base color with an emissive atlas on texCoord 1, and a
-    KHR_materials_unlit material whose red base atlas stands in for the unlit imagery. The red base atlas is index 0.
-    A triangle carries the first two materials as primitives, with the same texture coordinates stored as float in
-    set 0 and as normalized UNSIGNED_SHORT, an encoding glTF allows without any extension, in set 1."""
+    """Path to a GLB with three materials on distinct base/emissive texCoord sets and a triangle carrying two of them.
+
+    The materials are a base-color atlas (red) on texCoord 0 with an emissive atlas on texCoord 1, a flat base color
+    with an emissive atlas on texCoord 1, and a KHR_materials_unlit material whose red base atlas stands in for the
+    unlit imagery. The red base atlas is index 0. The triangle holds the first two materials as primitives, with the
+    same texture coordinates stored as float in set 0 and as normalized UNSIGNED_SHORT, an encoding core glTF allows,
+    in set 1."""
     images = []
     for color in (np.array([220, 30, 30], np.uint8), np.array([30, 220, 30], np.uint8)):
         buffer = io.BytesIO()
@@ -516,11 +515,12 @@ def emissive_material_variants_glb(asset_tmp_path):
         images.append(buffer.getvalue())
 
     positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
-    uvs_uint16 = np.round(GLB_TEXCOORD_UVS * np.iinfo(np.uint16).max).astype(np.uint16)
+    uvs = np.array([[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]], dtype=np.float32)
+    uvs_uint16 = np.round(uvs * np.iinfo(np.uint16).max).astype(np.uint16)
 
     blob = b""
     buffer_views = []
-    for data in (*images, positions.tobytes(), GLB_TEXCOORD_UVS.tobytes(), uvs_uint16.tobytes()):
+    for data in (*images, positions.tobytes(), uvs.tobytes(), uvs_uint16.tobytes()):
         blob += b"\x00" * ((4 - len(blob) % 4) % 4)
         buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
         blob += data

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -48,6 +48,9 @@ USD_COLOR_TOL = 1e-07
 
 USD_NORMALS_TOL = 1e-02
 
+# Texture coordinates authored into the normalized-integer GLB fixture
+NORMALIZED_TEXCOORD_UVS = np.array([[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]], dtype=np.float32)
+
 
 # UsdPhysics declares every joint attribute as single precision, so an anchor, a limit or a drive gain authored in
 # double comes back rounded from a USD file and no parser can recover it. Comparing joints against the model they were
@@ -545,6 +548,62 @@ def emissive_material_variants_glb(asset_tmp_path):
     )
     gltf.set_binary_blob(blob)
     path = asset_tmp_path / "emissive_material_variants.glb"
+    gltf.save_binary(str(path))
+    return str(path)
+
+
+@pytest.fixture(scope="session")
+def normalized_texcoord_glb(asset_tmp_path):
+    """Path to a GLB storing the texture coordinates of a textured triangle as normalized UNSIGNED_SHORT, one of the
+    integer encodings glTF allows for TEXCOORD_n without any extension."""
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    uvs = np.round(NORMALIZED_TEXCOORD_UVS * np.iinfo(np.uint16).max).astype(np.uint16)
+    image = io.BytesIO()
+    Image.new("RGB", (2, 2), "white").save(image, format="PNG")
+
+    blob = b""
+    buffer_views = []
+    for data in (positions.tobytes(), uvs.tobytes(), image.getvalue()):
+        blob += b"\x00" * ((4 - len(blob) % 4) % 4)
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0)],
+        meshes=[
+            pygltflib.Mesh(
+                primitives=[
+                    pygltflib.Primitive(attributes=pygltflib.Attributes(POSITION=0, TEXCOORD_0=1), material=0),
+                ]
+            )
+        ],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=0,
+                componentType=pygltflib.FLOAT,
+                count=3,
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(
+                bufferView=1, componentType=pygltflib.UNSIGNED_SHORT, normalized=True, count=3, type="VEC2"
+            ),
+        ],
+        materials=[
+            pygltflib.Material(
+                pbrMetallicRoughness=pygltflib.PbrMetallicRoughness(baseColorTexture=pygltflib.TextureInfo(index=0))
+            )
+        ],
+        textures=[pygltflib.Texture(source=0)],
+        images=[pygltflib.Image(bufferView=2, mimeType="image/png")],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    path = asset_tmp_path / "normalized_texcoord.glb"
     gltf.save_binary(str(path))
     return str(path)
 

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -48,8 +48,8 @@ USD_COLOR_TOL = 1e-07
 
 USD_NORMALS_TOL = 1e-02
 
-# Texture coordinates authored into the normalized-integer GLB fixture
-NORMALIZED_TEXCOORD_UVS = np.array([[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]], dtype=np.float32)
+# Texture coordinates authored into the triangle of the emissive material variants GLB
+GLB_TEXCOORD_UVS = np.array([[0.125, 0.25], [0.375, 0.5], [0.625, 0.75]], dtype=np.float32)
 
 
 # UsdPhysics declares every joint attribute as single precision, so an anchor, a limit or a drive gain authored in
@@ -506,21 +506,53 @@ def usd_scene(request, model_name, scale, fixed):
 def emissive_material_variants_glb(asset_tmp_path):
     """Path to a GLB with three materials, each on distinct base/emissive texCoord sets: a base-color atlas (red) on
     texCoord 0 with an emissive atlas on texCoord 1, a flat base color with an emissive atlas on texCoord 1, and a
-    KHR_materials_unlit material whose red base atlas stands in for the unlit imagery. The red base atlas is index 0."""
+    KHR_materials_unlit material whose red base atlas stands in for the unlit imagery. The red base atlas is index 0.
+    A triangle carries the first two materials as primitives, with the same texture coordinates stored as float in
+    set 0 and as normalized UNSIGNED_SHORT, an encoding glTF allows without any extension, in set 1."""
     images = []
     for color in (np.array([220, 30, 30], np.uint8), np.array([30, 220, 30], np.uint8)):
         buffer = io.BytesIO()
         Image.fromarray(np.broadcast_to(color, (8, 8, 3)).copy()).save(buffer, format="PNG")
         images.append(buffer.getvalue())
 
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    uvs_uint16 = np.round(GLB_TEXCOORD_UVS * np.iinfo(np.uint16).max).astype(np.uint16)
+
     blob = b""
     buffer_views = []
-    for data in images:
+    for data in (*images, positions.tobytes(), GLB_TEXCOORD_UVS.tobytes(), uvs_uint16.tobytes()):
         blob += b"\x00" * ((4 - len(blob) % 4) % 4)
         buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
         blob += data
 
     gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0)],
+        meshes=[
+            pygltflib.Mesh(
+                primitives=[
+                    pygltflib.Primitive(
+                        attributes=pygltflib.Attributes(POSITION=0, TEXCOORD_0=1, TEXCOORD_1=2), material=material
+                    )
+                    for material in range(2)
+                ]
+            )
+        ],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=2,
+                componentType=pygltflib.FLOAT,
+                count=3,
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(bufferView=3, componentType=pygltflib.FLOAT, count=3, type="VEC2"),
+            pygltflib.Accessor(
+                bufferView=4, componentType=pygltflib.UNSIGNED_SHORT, normalized=True, count=3, type="VEC2"
+            ),
+        ],
         materials=[
             pygltflib.Material(
                 pbrMetallicRoughness=pygltflib.PbrMetallicRoughness(
@@ -548,62 +580,6 @@ def emissive_material_variants_glb(asset_tmp_path):
     )
     gltf.set_binary_blob(blob)
     path = asset_tmp_path / "emissive_material_variants.glb"
-    gltf.save_binary(str(path))
-    return str(path)
-
-
-@pytest.fixture(scope="session")
-def normalized_texcoord_glb(asset_tmp_path):
-    """Path to a GLB storing the texture coordinates of a textured triangle as normalized UNSIGNED_SHORT, one of the
-    integer encodings glTF allows for TEXCOORD_n without any extension."""
-    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
-    uvs = np.round(NORMALIZED_TEXCOORD_UVS * np.iinfo(np.uint16).max).astype(np.uint16)
-    image = io.BytesIO()
-    Image.new("RGB", (2, 2), "white").save(image, format="PNG")
-
-    blob = b""
-    buffer_views = []
-    for data in (positions.tobytes(), uvs.tobytes(), image.getvalue()):
-        blob += b"\x00" * ((4 - len(blob) % 4) % 4)
-        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
-        blob += data
-
-    gltf = pygltflib.GLTF2(
-        scene=0,
-        scenes=[pygltflib.Scene(nodes=[0])],
-        nodes=[pygltflib.Node(mesh=0)],
-        meshes=[
-            pygltflib.Mesh(
-                primitives=[
-                    pygltflib.Primitive(attributes=pygltflib.Attributes(POSITION=0, TEXCOORD_0=1), material=0),
-                ]
-            )
-        ],
-        accessors=[
-            pygltflib.Accessor(
-                bufferView=0,
-                componentType=pygltflib.FLOAT,
-                count=3,
-                type="VEC3",
-                min=positions.min(axis=0).tolist(),
-                max=positions.max(axis=0).tolist(),
-            ),
-            pygltflib.Accessor(
-                bufferView=1, componentType=pygltflib.UNSIGNED_SHORT, normalized=True, count=3, type="VEC2"
-            ),
-        ],
-        materials=[
-            pygltflib.Material(
-                pbrMetallicRoughness=pygltflib.PbrMetallicRoughness(baseColorTexture=pygltflib.TextureInfo(index=0))
-            )
-        ],
-        textures=[pygltflib.Texture(source=0)],
-        images=[pygltflib.Image(bufferView=2, mimeType="image/png")],
-        bufferViews=buffer_views,
-        buffers=[pygltflib.Buffer(byteLength=len(blob))],
-    )
-    gltf.set_binary_blob(blob)
-    path = asset_tmp_path / "normalized_texcoord.glb"
     gltf.save_binary(str(path))
     return str(path)
 

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -18,7 +18,6 @@ import genesis.utils.mesh as mu
 from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.assets import get_hf_dataset
 from .conftest import (
-    GLB_TEXCOORD_UVS,
     check_gs_meshes,
     check_gs_surfaces,
     check_gs_textures,
@@ -344,8 +343,7 @@ def test_glb_draco_missing_normals_texcoord(glb_file):
 
 @pytest.mark.required
 def test_glb_texcoord(emissive_material_variants_glb):
-    # The first material samples the float set 0 and the second the normalized UNSIGNED_SHORT set 1, so both meshes
-    # must come back with the authored coordinates, V flipped to the image-space convention shared with trimesh
+    # Material 0 reads the float set 0 and material 1 the normalized set 1, so both meshes carry the authored UVs
     gs_meshes = gltf_utils.parse_mesh_glb(
         emissive_material_variants_glb,
         group_by_material=True,
@@ -354,7 +352,8 @@ def test_glb_texcoord(emissive_material_variants_glb):
         surface=gs.surfaces.Default(),
     )
     assert len(gs_meshes) == 2
-    expected_uvs = GLB_TEXCOORD_UVS * (1.0, -1.0) + (0.0, 1.0)
+    # V is flipped to the image-space convention
+    expected_uvs = np.array([[0.125, 0.75], [0.375, 0.5], [0.625, 0.25]], dtype=np.float32)
     for gs_mesh in gs_meshes:
         assert_allclose(gs_mesh.trimesh.visual.uv, expected_uvs, tol=1.0 / np.iinfo(np.uint16).max)
 

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -18,7 +18,7 @@ import genesis.utils.mesh as mu
 from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.assets import get_hf_dataset
 from .conftest import (
-    NORMALIZED_TEXCOORD_UVS,
+    GLB_TEXCOORD_UVS,
     check_gs_meshes,
     check_gs_surfaces,
     check_gs_textures,
@@ -343,18 +343,20 @@ def test_glb_draco_missing_normals_texcoord(glb_file):
 
 
 @pytest.mark.required
-def test_glb_normalized_texcoord(normalized_texcoord_glb):
-    # Integer texture coordinates flagged as normalized encode [0, 1] and must not be read back at their raw scale
-    (gs_mesh,) = gltf_utils.parse_mesh_glb(
-        normalized_texcoord_glb,
-        group_by_material=False,
+def test_glb_texcoord(emissive_material_variants_glb):
+    # The first material samples the float set 0 and the second the normalized UNSIGNED_SHORT set 1, so both meshes
+    # must come back with the authored coordinates, V flipped to the image-space convention shared with trimesh
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        emissive_material_variants_glb,
+        group_by_material=True,
         scale=None,
         is_mesh_zup=True,
         surface=gs.surfaces.Default(),
     )
-    # The parser flips V to the image-space convention shared with trimesh
-    expected_uvs = NORMALIZED_TEXCOORD_UVS * (1.0, -1.0) + (0.0, 1.0)
-    assert_allclose(gs_mesh.trimesh.visual.uv, expected_uvs, tol=1.0 / np.iinfo(np.uint16).max)
+    assert len(gs_meshes) == 2
+    expected_uvs = GLB_TEXCOORD_UVS * (1.0, -1.0) + (0.0, 1.0)
+    for gs_mesh in gs_meshes:
+        assert_allclose(gs_mesh.trimesh.visual.uv, expected_uvs, tol=1.0 / np.iinfo(np.uint16).max)
 
 
 # ==================== Material/Texture Parsing Tests ====================

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -18,6 +18,7 @@ import genesis.utils.mesh as mu
 from ..utils.assertions import assert_allclose, assert_equal
 from ..utils.assets import get_hf_dataset
 from .conftest import (
+    NORMALIZED_TEXCOORD_UVS,
     check_gs_meshes,
     check_gs_surfaces,
     check_gs_textures,
@@ -339,6 +340,21 @@ def test_glb_draco_missing_normals_texcoord(glb_file):
         assert verts.shape[1] == 3, "Vertices should be 3D"
         assert faces.shape[0] > 0, "Mesh has no faces"
         assert faces.shape[1] == 3, "Faces should be triangles"
+
+
+@pytest.mark.required
+def test_glb_normalized_texcoord(normalized_texcoord_glb):
+    # Integer texture coordinates flagged as normalized encode [0, 1] and must not be read back at their raw scale
+    (gs_mesh,) = gltf_utils.parse_mesh_glb(
+        normalized_texcoord_glb,
+        group_by_material=False,
+        scale=None,
+        is_mesh_zup=True,
+        surface=gs.surfaces.Default(),
+    )
+    # The parser flips V to the image-space convention shared with trimesh
+    expected_uvs = NORMALIZED_TEXCOORD_UVS * (1.0, -1.0) + (0.0, 1.0)
+    assert_allclose(gs_mesh.trimesh.visual.uv, expected_uvs, tol=1.0 / np.iinfo(np.uint16).max)
 
 
 # ==================== Material/Texture Parsing Tests ====================


### PR DESCRIPTION
## Description

`get_glb_data_from_accessor` returned the raw integers of an accessor even when `accessor.normalized` was set. glTF allows `TEXCOORD_n` to be stored as normalized `UNSIGNED_BYTE` or `UNSIGNED_SHORT` in core, and `KHR_mesh_quantization` extends the same encoding to normals. Those attributes now map back to `[0, 1]` (unsigned) or `[-1, 1]` (signed) as the spec defines, so a UV authored as `0.1` no longer loads as `6554`.

The new `test_glb_normalized_texcoord` builds a textured triangle with normalized `UNSIGNED_SHORT` texture coordinates and checks the loaded UVs against the authored values. trimesh reads such accessors raw as well, so the test compares against the authored array rather than a trimesh load.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3329

## Motivation and Context

gltfpack and other optimizers quantize texture coordinates to 16-bit by default, so any asset that went through them is textured wrongly in Genesis without a warning.

## How Has This Been / Can This Be Tested?

```
pytest -n 0 --backend cpu tests/parsers/test_mesh.py -k "glb"
```

The new test fails on `main` with UVs at their raw 16-bit scale and passes with the fix. The other glb parser tests pass before and after. Ran on macOS, CPU backend, with `ruff check` and `ruff format` clean on the touched files.

## Screenshots (if appropriate):

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
