### PR TITLE
[MISC] Spare a copy of every rasterizer camera sensor image.

### DIFF
--- a/genesis/engine/sensors/camera.py
+++ b/genesis/engine/sensors/camera.py
@@ -546,17 +546,15 @@ class RasterizerCameraSensor(
         self._ensure_camera_registered()
 
         self._shared_metadata.renderer.update_scene()
-        rgb_arr, _, _, _ = self._shared_metadata.renderer.render_camera(
-            self._camera_wrapper, rgb=True, depth=False, segmentation=False, normal=False, split_envs=True
+        self._shared_metadata.renderer.render_camera(
+            self._camera_wrapper,
+            rgb=True,
+            depth=False,
+            segmentation=False,
+            normal=False,
+            split_envs=True,
+            rgb_out=self._shared_metadata.image_cache[self._idx],
         )
-
-        # Ensure contiguous layout because the rendered array may have negative strides.
-        rgb_tensor = torch.from_numpy(np.ascontiguousarray(rgb_arr)).to(dtype=torch.uint8, device=gs.device)
-
-        if len(rgb_tensor.shape) == 3:
-            # Single environment rendered - add batch dimension.
-            rgb_tensor = rgb_tensor.unsqueeze(0)
-        self._shared_metadata.image_cache[self._idx][:] = rgb_tensor
 
 
 # ========================== Raytracer Camera Sensor ==========================

--- a/genesis/ext/pyrender/jit_render.py
+++ b/genesis/ext/pyrender/jit_render.py
@@ -1248,15 +1248,10 @@ class JITRenderer:
                 depth_im = (z_near * z_far) / (z_far + z_near - depth_im * (z_far - z_near)) * 2
             return depth_im
 
-        @nb.jit(nb.uint8[:, :, :](nb.int32, nb.int32, nb.int32, self.gl.wrapper_type), cache=True)
-        def read_color_buf(width, height, rgba, gl):
-            if rgba:
-                buf = np.zeros((height, width, 4), np.uint8)
-                gl.glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, address_to_ptr(buf.ctypes.data))
-            else:
-                buf = np.zeros((height, width, 3), np.uint8)
-                gl.glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, address_to_ptr(buf.ctypes.data))
-            return buf[::-1, :, :]
+        @nb.jit(nb.none(nb.int32, nb.int32, nb.uint8[:, :, :], self.gl.wrapper_type), cache=True)
+        def read_color_buf(width, height, buf, gl):
+            gl_format = GL_RGBA if buf.shape[2] == 4 else GL_RGB
+            gl.glReadPixels(0, 0, width, height, gl_format, GL_UNSIGNED_BYTE, address_to_ptr(buf.ctypes.data))
 
         @nb.jit(nb.float32[:, :](nb.float32[:, :, :]), cache=True)
         def update_normal_flat(p):
@@ -1502,7 +1497,12 @@ class JITRenderer:
             self.gen_func_ptr()
         return self._read_depth_buf(weight, height, z_near, z_far, self.gl.wrapper_instance)
 
-    def read_color_buf(self, weight, height, rgba):
+    def read_color_buf(self, width, height, rgba, out=None):
+        """Read the color buffer of the bound framebuffer, into 'out' when given, a (height, width, 3 or 4) uint8 array
+        taking the rows bottom-up as the GL context delivers them, and return the image with its rows in order."""
+        if out is None:
+            out = np.empty((height, width, 4 if rgba else 3), np.uint8)
         if self._read_color_buf is None:
             self.gen_func_ptr()
-        return self._read_color_buf(weight, height, rgba, self.gl.wrapper_instance)
+        self._read_color_buf(width, height, out, self.gl.wrapper_instance)
+        return out[::-1]

--- a/genesis/ext/pyrender/offscreen.py
+++ b/genesis/ext/pyrender/offscreen.py
@@ -76,6 +76,7 @@ class OffscreenRenderer(object):
         plane_reflection=False,
         split_envs=False,
         skip_markers=False,
+        color_out=None,
     ):
         """Render a scene with the given set of flags.
 
@@ -85,6 +86,8 @@ class OffscreenRenderer(object):
             A scene to render.
         flags : int
             A bitwise or of one or more flags from :class:`.RenderFlags`.
+        color_out : ndarray, optional
+            The array the color buffer is read back into (see Renderer.render).
 
         Returns
         -------
@@ -137,7 +140,7 @@ class OffscreenRenderer(object):
         first_pass_done = False
         if rgb or depth or seg:
             flags |= RenderFlags.OFFSCREEN
-            retval = renderer.render(scene, flags, seg_node_map)
+            retval = renderer.render(scene, flags, seg_node_map, color_out=color_out)
             assert retval is not None
             first_pass_done = True
         else:

--- a/genesis/ext/pyrender/renderer.py
+++ b/genesis/ext/pyrender/renderer.py
@@ -115,7 +115,7 @@ class Renderer(object):
     def point_size(self, value):
         self._point_size = float(value)
 
-    def render(self, scene, flags, seg_node_map=None, *, is_first_pass=True, force_skip_shadows=False):
+    def render(self, scene, flags, seg_node_map=None, *, color_out=None, is_first_pass=True, force_skip_shadows=False):
         """Render a scene with the given set of flags.
 
         Parameters
@@ -128,6 +128,10 @@ class Renderer(object):
             A map from :class:`.Node` objects to (3,) colors for each.
             If specified along with flags set to :attr:`.RenderFlags.SEG`,
             the color image will be a segmentation image.
+        color_out : (n_envs, h, w, 3) uint8 or (n_envs, h, w, 4) uint8, optional
+            If :attr:`RenderFlags.OFFSCREEN` is set, the array the color buffer is read back into, one entry of the
+            leading axis per environment rendered, a single one when they are drawn together, with the rows bottom-up
+            as the GL context delivers them. The color image returned is then a view of it.
 
         Returns
         -------
@@ -199,7 +203,13 @@ class Renderer(object):
             if flags & RenderFlags.REFLECTIVE_FLOOR:
                 self._floor_pass(scene, flags, env_idx=env_idx)
 
-            retval = self._forward_pass(scene, flags, seg_node_map=seg_node_map, env_idx=env_idx)
+            retval = self._forward_pass(
+                scene,
+                flags,
+                seg_node_map=seg_node_map,
+                env_idx=env_idx,
+                color_out=None if color_out is None else color_out[i],
+            )
             if retval is not None:
                 if retval_list is None:
                     retval_list = tuple([val] for val in retval)
@@ -220,7 +230,12 @@ class Renderer(object):
             return
 
         if use_env_idx:
-            retval_list = tuple(np.stack(val_list, axis=0) for val_list in retval_list)
+            # The color images were read back one behind the other into 'color_out', which the view stands for
+            has_color_out = color_out is not None and not flags & RenderFlags.DEPTH_ONLY
+            retval_list = tuple(
+                color_out[:, ::-1] if has_color_out and idx == 0 else np.stack(val_list, axis=0)
+                for idx, val_list in enumerate(retval_list)
+            )
         else:
             retval_list = tuple(val_list[0] for val_list in retval_list)
         return retval_list
@@ -366,7 +381,7 @@ class Renderer(object):
             env_idx=env_idx,
         )
 
-    def _forward_pass(self, scene, flags, seg_node_map=None, env_idx=-1):
+    def _forward_pass(self, scene, flags, seg_node_map=None, env_idx=-1, color_out=None):
         # Set up viewport for render
         self._configure_forward_pass_viewport(flags)
 
@@ -445,7 +460,7 @@ class Renderer(object):
 
         # If doing offscreen render, copy result from framebuffer and return
         if flags & RenderFlags.OFFSCREEN:
-            return self._read_main_framebuffer(scene, flags)
+            return self._read_main_framebuffer(scene, flags, color_out)
 
     def _marker_xray_pass(self, V, P, cam_pos, flags, screen_size, env_idx):
         """Render markers behind geometry with darkened transparency (X-ray effect)."""
@@ -1032,7 +1047,7 @@ class Renderer(object):
         self._main_db_ms = None
         self._main_fb_dims = (None, None)
 
-    def _read_main_framebuffer(self, scene, flags):
+    def _read_main_framebuffer(self, scene, flags, color_out):
         width, height = self._main_fb_dims
 
         if not (flags & RenderFlags.SEG or flags & RenderFlags.DEPTH_ONLY):
@@ -1059,7 +1074,7 @@ class Renderer(object):
             return (depth_im,)
 
         # Read color
-        color_im = self.jit.read_color_buf(width, height, flags & RenderFlags.RGBA)
+        color_im = self.jit.read_color_buf(width, height, flags & RenderFlags.RGBA, out=color_out)
 
         # Resize
         color_im = self._resize_image(color_im, antialias=not flags & RenderFlags.SEG)

--- a/genesis/ext/pyrender/viewer.py
+++ b/genesis/ext/pyrender/viewer.py
@@ -733,6 +733,7 @@ class Viewer(pyglet.window.Window):
         normal=False,
         skip_markers=False,
         split_envs=False,
+        color_out=None,
     ):
         if not self.is_active:
             # A viewer in its own thread stores what ended it rather than raising it where nobody waits, so the call
@@ -744,7 +745,7 @@ class Viewer(pyglet.window.Window):
         self.render_flags["rgb"] = rgb
         self.render_flags["seg"] = seg
         self.render_flags["depth"] = depth
-        self._offscreen_pending_render = (camera_node, render_target, normal, skip_markers, split_envs)
+        self._offscreen_pending_render = (camera_node, render_target, normal, skip_markers, split_envs, color_out)
         if self._run_in_thread:
             # Send offscreen request
             self._offscreen_event.set()
@@ -783,7 +784,7 @@ class Viewer(pyglet.window.Window):
 
             if self._offscreen_pending_render is not None:
                 # Extract request right away
-                camera, target, normal, skip_markers, split_envs = self._offscreen_pending_render
+                camera, target, normal, skip_markers, split_envs, color_out = self._offscreen_pending_render
                 self._offscreen_pending_render = None
 
                 # Update context, just in case is not already done before
@@ -802,14 +803,14 @@ class Viewer(pyglet.window.Window):
                     target.viewport_width, target.viewport_height = self._offscreen_viewport_size
                     try:
                         self.clear()
-                        retval = self._render(camera, target, normal)
+                        retval = self._render(camera, target, normal, color_out)
                     finally:
                         target.viewport_width, target.viewport_height = saved_viewport
                 else:
                     # A per-camera offscreen FBO is already sized to that camera's own resolution and is independent of
                     # the window, so its viewport is authoritative and must not be overridden with the window size.
                     self.clear()
-                    retval = self._render(camera, target, normal)
+                    retval = self._render(camera, target, normal, color_out)
                 self._offscreen_result = retval if retval else (None, None)
                 self.render_flags["offscreen"] = False
                 self.render_flags["skip_markers"] = False
@@ -1053,7 +1054,7 @@ class Viewer(pyglet.window.Window):
         az = self.viewer_flags["rotate_rate"] / self.viewer_flags["refresh_rate"]
         self._trackball.rotate(az, self.viewer_flags["rotate_axis"])
 
-    def _render(self, camera_node=None, renderer=None, normal=False):
+    def _render(self, camera_node=None, renderer=None, normal=False, color_out=None):
         """Render the scene into the framebuffer and flip."""
         scene = self.scene
         self._camera_node.matrix = self._trackball.pose.copy()
@@ -1124,7 +1125,7 @@ class Viewer(pyglet.window.Window):
 
         first_pass_done = False
         if self.render_flags["rgb"] or self.render_flags["depth"] or self.render_flags["seg"]:
-            retval = renderer.render(self.scene, flags, seg_node_map=seg_node_map)
+            retval = renderer.render(self.scene, flags, seg_node_map=seg_node_map, color_out=color_out)
             first_pass_done = True
         else:
             retval = ()

--- a/genesis/vis/rasterizer.py
+++ b/genesis/vis/rasterizer.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import numpy as np
+import torch
 
 import OpenGL
 
@@ -22,12 +23,33 @@ from genesis.ext import pyrender
 from genesis.vis.camera import Camera
 
 
+class _CameraStaging:
+    """What the color readback of a camera goes through on its way to the cache tensor 'out' (see
+    Rasterizer.render_camera): the host buffer taking the rows bottom-up as the GL context delivers them, and for a
+    tensor on a device the scratch the buffer is transferred to, the row order reversing it, and the event of the last
+    transfer for a CUDA device."""
+
+    def __init__(self, out):
+        is_cuda = out.device.type == "cuda"
+        self.host = torch.empty(out.shape, dtype=torch.uint8, device="cpu", pin_memory=is_cuda)
+        self.scratch = None
+        self.rows_reversed = None
+        self.event = None
+        if out.device.type != "cpu":
+            self.scratch = torch.empty_like(out)
+            self.rows_reversed = torch.arange(out.shape[1] - 1, -1, -1, device=out.device)
+            if is_cuda:
+                self.event = torch.cuda.Event()
+
+
 class Rasterizer(RBC):
     def __init__(self, viewer, context):
         self._viewer = viewer
         self._context = context
         self._camera_nodes = dict()
         self._camera_targets = dict()
+        # Per camera, what the color readback goes through when the image goes to a cache tensor (see 'render_camera')
+        self._camera_staging = dict()
         self._offscreen = self._viewer is None
         self._renderer = None
         self._buffer_updates = None
@@ -65,15 +87,34 @@ class Rasterizer(RBC):
         else:
             self._viewer.close_offscreen(self._camera_targets[camera.uid])
         del self._camera_targets[camera.uid]
+        self._camera_staging.pop(camera.uid, None)
 
-    def render_camera(self, camera, rgb=True, depth=False, segmentation=False, normal=False, *, split_envs):
+    def render_camera(
+        self, camera, rgb=True, depth=False, segmentation=False, normal=False, *, split_envs, rgb_out=None
+    ):
         """Render a camera. With 'split_envs', the environments are rendered one by one from the pose the camera
-        holds in each, and stacked; otherwise one image is rendered of the environments laid out side by side."""
+        holds in each, and stacked; otherwise one image is rendered of the environments laid out side by side.
+
+        'rgb_out' is a tensor to write the RGB image into and return in its stead, with a leading environment axis, of
+        one environment when the scene has none. The readback lands in a persistent host buffer shaped like it, from
+        which the image goes to the tensor in one pass: a strided copy flipping the rows for a tensor on the host, a
+        transfer of the pinned buffer to a device scratch followed by a gather flipping the rows for a CUDA tensor.
+        """
         # Update camera
         self.update_camera(camera)
 
         rgb_arr, depth_arr, seg_idxc_arr, normal_arr = None, None, None, None
         skip_markers = not camera.debug if isinstance(camera, Camera) else True
+        color_out = None
+        if rgb and rgb_out is not None:
+            staging = self._camera_staging.get(camera.uid)
+            if staging is None:
+                staging = _CameraStaging(rgb_out)
+                self._camera_staging[camera.uid] = staging
+            elif staging.event is not None:
+                # The host buffer is written again once the last transfer out of it is done
+                staging.event.synchronize()
+            color_out = staging.host.numpy()
         if self._offscreen:
             # Set the context
             self._renderer.make_current()
@@ -92,6 +133,7 @@ class Rasterizer(RBC):
                         plane_reflection=rgb and self._context.plane_reflection,
                         shadow=rgb and self._context.shadow,
                         skip_markers=skip_markers,
+                        color_out=color_out,
                     )
 
                 if segmentation:
@@ -123,6 +165,7 @@ class Rasterizer(RBC):
                     seg=False,
                     skip_markers=skip_markers,
                     split_envs=split_envs,
+                    color_out=color_out,
                 )
 
             if segmentation:
@@ -142,6 +185,15 @@ class Rasterizer(RBC):
 
         if rgb:
             rgb_arr = retval[0]
+            if rgb_out is not None:
+                if rgb_out.device.type == "cpu":
+                    np.copyto(rgb_out.numpy(), rgb_arr)
+                else:
+                    staging.scratch.copy_(staging.host, non_blocking=True)
+                    torch.index_select(staging.scratch, 1, staging.rows_reversed, out=rgb_out)
+                    if staging.event is not None:
+                        staging.event.record()
+                rgb_arr = rgb_out
         if depth:
             depth_arr = retval[int(rgb)]
         if normal:
@@ -187,6 +239,7 @@ class Rasterizer(RBC):
                 except (OpenGL.error.NullFunctionError, OSError):
                     pass
         self._camera_targets.clear()
+        self._camera_staging.clear()
 
     @property
     def viewer(self):

--- a/genesis/vis/viewer.py
+++ b/genesis/vis/viewer.py
@@ -253,6 +253,7 @@ class Viewer(RBC):
         normal=False,
         skip_markers=False,
         split_envs=False,
+        color_out=None,
     ):
         return self._pyrender_viewer.render_offscreen(
             camera_node,
@@ -263,6 +264,7 @@ class Viewer(RBC):
             normal,
             skip_markers=skip_markers,
             split_envs=split_envs,
+            color_out=color_out,
         )
 
     def set_camera_pose(self, pose=None, pos=None, lookat=None):


### PR DESCRIPTION
## Description

A rasterizer camera sensor read copied the rendered image twice: once to flip its rows into a contiguous array, once into the sensor cache. The color buffer is now read back into a persistent host buffer shaped like the cache, and the image goes from there to the cache in one pass:

- cache on the host: one strided copy, which flips the rows;
- cache on a CUDA device: the pinned host buffer is transferred as is, asynchronously, and the rows are flipped on the device; the buffer is written again only once that transfer is done.

The environments of a split render are read back one behind the other into that buffer, which spares the stacking copy too. `Rasterizer.render_camera` takes the cache tensor as `rgb_out`, and the pyrender readback takes the destination array (`color_out`) down to `glReadPixels`.

## Related Issue

None.

## Motivation and Context

An image copy runs at the speed of cold memory on a server, so each avoided pass is a measurable part of a sensor read. All reads per step on an RTX PRO 6000, medians of 3 interleaved rounds against `main`:

| sensors | backend | main | this PR |
|---|---|---|---|
| 3 x 640x480 | CPU | 3.43 ms | 2.72 ms |
| 8 x 256x256 | CPU | 5.09 ms | 4.24 ms |
| 3 x 640x480 | GPU | 3.64 ms | 3.09 ms |
| 8 x 256x256 | GPU | 6.14 ms | 5.95 ms |

## How Has This Been / Can This Be Tested?

The sensor images are unchanged, so the existing sensor and snapshot tests cover the change.
