### PR TITLE
[BUG FIX] Honor joint equality polynomials in SAPCoupler.

### DIFF
--- a/genesis/engine/couplers/sap_coupler.py
+++ b/genesis/engine/couplers/sap_coupler.py
@@ -212,6 +212,7 @@ class SAPCoupler(RBC):
             )
 
         self._rigid_compliant = False
+        self._has_equality_constraints = False
 
     # ------------------------------------------------------------------------------------
     # --------------------------------- Initialization -----------------------------------
@@ -222,10 +223,6 @@ class SAPCoupler(RBC):
         self.contact_handlers = []
         self._enable_rigid_fem_contact &= self.rigid_solver.is_active and self.fem_solver.is_active
         self._enable_fem_self_tet_contact &= self.fem_solver.is_active
-
-        for equality in self.rigid_solver.equalities:
-            if equality.type == gs.EQUALITY_TYPE.JOINT and equality.eq_obj2id < 0:
-                gs.raise_exception("SAPCoupler does not support JOINT equality constraints without `joint2`.")
 
         init_tet_tables = False
 
@@ -276,6 +273,9 @@ class SAPCoupler(RBC):
             # TODO: Dynamically added constraints are not supported for now
             if self.rigid_solver.n_equalities > 0:
                 self._init_equality_constraint()
+                self._has_equality_constraints = any(
+                    equality.type == gs.EQUALITY_TYPE.JOINT for equality in self.rigid_solver.equalities
+                )
 
         if self._enable_rigid_fem_contact:
             self.rigid_fem_contact = RigidFemTriTetContactHandler(self.sim)
@@ -585,6 +585,7 @@ class SAPCoupler(RBC):
         self.compute_regularization(
             dofs_state=self.rigid_solver.dyn_state.dofs,
             entities_info=self.rigid_solver.dyn_info.entities,
+            equalities_info=self.rigid_solver.dyn_info.equalities,
             rigid_info=self.rigid_solver.rigid_info,
         )
 
@@ -633,7 +634,7 @@ class SAPCoupler(RBC):
         return has_contact, overflow
 
     def couple(self, i_step):
-        if self.has_contact:
+        if self.has_contact or self._has_equality_constraints:
             self.sap_solve(i_step)
             self.update_vel(i_step, dofs_state=self.rigid_solver.dyn_state.dofs)
 
@@ -847,12 +848,18 @@ class SAPCoupler(RBC):
         self,
         dofs_state: array_class.DofsState,
         entities_info: array_class.EntitiesInfo,
+        equalities_info: array_class.EqualitiesInfo,
         rigid_info: array_class.RigidInfo,
     ):
         for contact in qd.static(self.contact_handlers):
             contact.compute_regularization(entities_info=entities_info, rigid_info=rigid_info)
         if qd.static(self.rigid_solver.is_active and self.rigid_solver.n_equalities > 0):
-            self.equality_constraint_handler.compute_regularization(dofs_state=dofs_state)
+            self.equality_constraint_handler.compute_regularization(
+                dofs_state=dofs_state,
+                entities_info=entities_info,
+                equalities_info=equalities_info,
+                rigid_info=rigid_info,
+            )
 
     @qd.kernel
     def _init_sap_solve(self, i_step: qd.i32, dofs_state: array_class.DofsState):
@@ -1868,13 +1875,15 @@ class RigidConstraintHandler(BaseConstraintHandler):
         self.n_constraints = qd.field(gs.qd_int, shape=())
         self.constraint_type = qd.types.struct(
             batch_idx=gs.qd_int,  # batch index
+            equality_idx=gs.qd_int,  # index of the equality constraint
             i_dof1=gs.qd_int,  # index of the first DOF in the constraint
             i_dof2=gs.qd_int,  # index of the second DOF in the constraint
             sap_info=self.sap_constraint_info_type,  # SAP info for the constraint
         )
         self.constraints = self.constraint_type.field(shape=(self.max_constraints,))
-        self.Jt = qd.field(gs.qd_float, shape=(self.max_constraints, self.rigid_solver.n_dofs))
-        self.M_inv_Jt = qd.field(gs.qd_float, shape=(self.max_constraints, self.rigid_solver.n_dofs))
+        # One-component vectors let scalar equalities reuse the contact Jacobian mass solve.
+        self.Jt = qd.Vector.field(1, dtype=gs.qd_float, shape=(self.max_constraints, self.rigid_solver.n_dofs))
+        self.M_inv_Jt = qd.Vector.field(1, dtype=gs.qd_float, shape=(self.max_constraints, self.rigid_solver.n_dofs))
         self.W = qd.field(gs.qd_float, shape=(self.max_constraints,))
 
     @qd.kernel
@@ -1893,36 +1902,61 @@ class RigidConstraintHandler(BaseConstraintHandler):
             if equalities_info.eq_type[i_e, i_b] == gs.EQUALITY_TYPE.JOINT:
                 i_c = qd.atomic_add(self.n_constraints[None], 1)
                 self.constraints[i_c].batch_idx = i_b
+                self.constraints[i_c].equality_idx = i_e
                 I_joint1 = (
                     [equalities_info.eq_obj1id[i_e, i_b], i_b]
                     if qd.static(rigid_config.batch_joints_info)
                     else equalities_info.eq_obj1id[i_e, i_b]
                 )
-                I_joint2 = (
-                    [equalities_info.eq_obj2id[i_e, i_b], i_b]
-                    if qd.static(rigid_config.batch_joints_info)
-                    else equalities_info.eq_obj2id[i_e, i_b]
-                )
                 i_dof1 = joints_info.dof_start[I_joint1]
-                i_dof2 = joints_info.dof_start[I_joint2]
+                i_joint2 = equalities_info.eq_obj2id[i_e, i_b]
+                i_dof2 = -1
+                if i_joint2 >= 0:
+                    I_joint2 = [i_joint2, i_b] if qd.static(rigid_config.batch_joints_info) else i_joint2
+                    i_dof2 = joints_info.dof_start[I_joint2]
                 self.constraints[i_c].i_dof1 = i_dof1
                 self.constraints[i_c].i_dof2 = i_dof2
                 self.constraints[i_c].sap_info.k = self.stiffness
                 self.constraints[i_c].sap_info.R_inv = dt2 * self.stiffness
                 self.constraints[i_c].sap_info.R = 1.0 / self.constraints[i_c].sap_info.R_inv
                 self.constraints[i_c].sap_info.v_hat = 0.0
-                self.Jt[i_c, i_dof1] = 1.0
-                self.Jt[i_c, i_dof2] = -1.0
 
     @qd.func
-    def compute_regularization(self, dofs_state: array_class.DofsState):
+    def compute_regularization(
+        self,
+        dofs_state: array_class.DofsState,
+        entities_info: array_class.EntitiesInfo,
+        equalities_info: array_class.EqualitiesInfo,
+        rigid_info: array_class.RigidInfo,
+    ):
         dt_inv = 1.0 / self.sim._substep_dt
         q = qd.static(dofs_state.pos)
-        sap_info = qd.static(self.constraints.sap_info)
+        constraints = qd.static(self.constraints)
+        sap_info = qd.static(constraints.sap_info)
         for i_c in range(self.n_constraints[None]):
-            i_b = self.constraints[i_c].batch_idx
-            g0 = q[self.constraints[i_c].i_dof1, i_b] - q[self.constraints[i_c].i_dof2, i_b]
-            self.constraints[i_c].sap_info.v_hat = -g0 * dt_inv
+            i_b = constraints[i_c].batch_idx
+            i_e = constraints[i_c].equality_idx
+            i_dof1 = constraints[i_c].i_dof1
+            i_dof2 = constraints[i_c].i_dof2
+            diff = gs.qd_float(0.0)
+            if i_dof2 >= 0:
+                diff = q[i_dof2, i_b]
+
+            g0 = q[i_dof1, i_b]
+            deriv = gs.qd_float(0.0)
+            for i_5 in range(5):
+                diff_power = diff**i_5
+                g0 -= diff_power * equalities_info.eq_data[i_e, i_b][i_5]
+                if i_5 < 4:
+                    deriv += equalities_info.eq_data[i_e, i_b][i_5 + 1] * diff_power * (i_5 + 1)
+
+            self.Jt[i_c, i_dof1][0] = 1.0
+            if i_dof2 >= 0:
+                self.Jt[i_c, i_dof2][0] = -deriv
+            sap_info[i_c].v_hat = -g0 * dt_inv
+
+        self.compute_delassus_world_frame(entities_info=entities_info, rigid_info=rigid_info)
+        for i_c in range(self.n_constraints[None]):
             W = self.compute_delassus(i_c)
             self.compute_constraint_regularization(sap_info, i_c, W, self.sim._substep_dt)
 
@@ -1939,7 +1973,7 @@ class RigidConstraintHandler(BaseConstraintHandler):
         )
         self.W.fill(0.0)
         for i_c, i_d in qd.ndrange(self.n_constraints[None], self.rigid_solver.n_dofs):
-            self.W[i_c] += self.M_inv_Jt[i_c, i_d] * self.Jt[i_c, i_d]
+            self.W[i_c] += self.M_inv_Jt[i_c, i_d][0] * self.Jt[i_c, i_d][0]
 
     @qd.func
     def compute_delassus(self, i_c):
@@ -1950,15 +1984,19 @@ class RigidConstraintHandler(BaseConstraintHandler):
         i_b = self.constraints[i_c].batch_idx
         i_dof1 = self.constraints[i_c].i_dof1
         i_dof2 = self.constraints[i_c].i_dof2
-        return x[i_b, i_dof1] - x[i_b, i_dof2]
+        value = self.Jt[i_c, i_dof1][0] * x[i_b, i_dof1]
+        if i_dof2 >= 0:
+            value += self.Jt[i_c, i_dof2][0] * x[i_b, i_dof2]
+        return value
 
     @qd.func
     def add_Jt_x(self, y, i_c, x):
         i_b = self.constraints[i_c].batch_idx
         i_dof1 = self.constraints[i_c].i_dof1
         i_dof2 = self.constraints[i_c].i_dof2
-        y[i_b, i_dof1] += x
-        y[i_b, i_dof2] -= x
+        y[i_b, i_dof1] += self.Jt[i_c, i_dof1][0] * x
+        if i_dof2 >= 0:
+            y[i_b, i_dof2] += self.Jt[i_c, i_dof2][0] * x
 
     @qd.func
     def compute_vc(self, i_c):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+import xml.etree.ElementTree as ET
 from argparse import SUPPRESS
 from enum import Enum
 from io import BytesIO
@@ -70,6 +71,40 @@ IS_INTERACTIVE_VIEWER_AVAILABLE = has_display or has_egl
 
 TOL_SINGLE = 5e-5
 TOL_DOUBLE = 1e-9
+
+
+@pytest.fixture(scope="session")
+def scaled_mjcf_joint_equalities():
+    mjcf = ET.Element("mujoco", model="scaled_mjcf_joint_equalities")
+    worldbody = ET.SubElement(mjcf, "worldbody")
+    equality = ET.SubElement(mjcf, "equality")
+    for driver_type, follower_type, position_y in (
+        ("hinge", "hinge", -0.25),
+        ("slide", "slide", -0.5),
+        ("slide", "hinge", -0.75),
+        ("hinge", "slide", -1.0),
+    ):
+        pair_name = f"{driver_type}_{follower_type}"
+        driver_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_driver_body", pos=f"0 {position_y} 0")
+        ET.SubElement(driver_body, "joint", name=f"{pair_name}_driver", type=driver_type, axis="1 0 0")
+        ET.SubElement(driver_body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
+        follower_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_follower_body", pos=f"0.15 {position_y} 0")
+        ET.SubElement(follower_body, "joint", name=f"{pair_name}_follower", type=follower_type, axis="1 0 0")
+        ET.SubElement(follower_body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
+        ET.SubElement(
+            equality,
+            "joint",
+            name=f"{pair_name}_coupling",
+            joint1=f"{pair_name}_follower",
+            joint2=f"{pair_name}_driver",
+            polycoef="0.2 0.4 -0.3 0.2 -0.1",
+        )
+    for name, position_y in (("target", 0.0), ("unrelated", 0.25)):
+        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=f"0 {position_y} 0")
+        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
+        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
+    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
+    return mjcf
 
 
 # Canonical skip reason registry.

--- a/tests/coupling/test_hybrid.py
+++ b/tests/coupling/test_hybrid.py
@@ -441,6 +441,129 @@ def test_sap_rigid_rigid_hydroelastic_contact(show_viewer):
     assert robot_2_max_corner[2] > robot_1_max_corner[2] + 0.05
 
 
+@pytest.mark.required
+@pytest.mark.parametrize("precision", ["64"])
+@pytest.mark.parametrize("n_envs, is_batched", [(0, False), (2, True)])
+def test_sap_joint_equality_polynomial(show_viewer, scaled_mjcf_joint_equalities, n_envs, is_batched, tol):
+    DT = 1e-2
+    SCALE = 2.0
+    COEFFICIENTS = (0.2, 0.4, -0.3, 0.2, -0.1)
+    DRIVER_POSITION = 0.5
+    DRIVER_VELOCITY = 0.4
+    FOLLOWER_POSITION = sum(coefficient * DRIVER_POSITION**degree for degree, coefficient in enumerate(COEFFICIENTS))
+    DERIVATIVE = sum(
+        degree * coefficient * DRIVER_POSITION ** (degree - 1)
+        for degree, coefficient in enumerate(COEFFICIENTS[1:], start=1)
+    )
+    FOLLOWER_VELOCITY = DRIVER_VELOCITY * DERIVATIVE
+    TARGET_POSITION = 0.25
+    UNRELATED_POSITION = 1.0
+    MAX_RESIDUAL_RATIO = 1e-3
+    JOINT_PAIRS = (
+        ("hinge_hinge", "hinge", "hinge"),
+        ("slide_slide", "slide", "slide"),
+        ("slide_hinge", "slide", "hinge"),
+        ("hinge_slide", "hinge", "slide"),
+    )
+    scene = gs.Scene(
+        sim_options=gs.options.SimOptions(
+            dt=DT,
+            gravity=(0.0, 0.0, 0.0),
+        ),
+        rigid_options=gs.options.RigidOptions(
+            batch_joints_info=is_batched,
+            batch_dofs_info=is_batched,
+        ),
+        coupler_options=gs.options.SAPCouplerOptions(
+            rigid_floor_contact_type="none",
+            rigid_rigid_contact_type="none",
+        ),
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(1.0, -0.75, 4.0),
+            camera_lookat=(1.0, -0.75, 0.0),
+            camera_up=(0.0, 1.0, 0.0),
+        ),
+        show_viewer=show_viewer,
+    )
+    entity = scene.add_entity(
+        morph=gs.morphs.MJCF(
+            file=scaled_mjcf_joint_equalities,
+            scale=SCALE,
+        ),
+    )
+    scene.build(n_envs=n_envs)
+
+    # A velocity tangent to the polynomial must not trigger a constraint impulse.
+    qpos = entity.get_qpos()
+    velocity = entity.get_dofs_velocity()
+    for name, driver_type, follower_type in JOINT_PAIRS:
+        (i_driver_q,) = entity.get_joint(f"{name}_driver").qs_idx_local
+        (i_follower_q,) = entity.get_joint(f"{name}_follower").qs_idx_local
+        (i_driver_d,) = entity.get_joint(f"{name}_driver").dofs_idx_local
+        (i_follower_d,) = entity.get_joint(f"{name}_follower").dofs_idx_local
+        qpos[..., i_driver_q] = DRIVER_POSITION * (SCALE if driver_type == "slide" else 1.0)
+        qpos[..., i_follower_q] = FOLLOWER_POSITION * (SCALE if follower_type == "slide" else 1.0)
+        velocity[..., i_driver_d] = DRIVER_VELOCITY * (SCALE if driver_type == "slide" else 1.0)
+        velocity[..., i_follower_d] = FOLLOWER_VELOCITY * (SCALE if follower_type == "slide" else 1.0)
+    (i_target_q,) = entity.get_joint("target").qs_idx_local
+    (i_unrelated_q,) = entity.get_joint("unrelated").qs_idx_local
+    qpos[..., i_target_q] = TARGET_POSITION * SCALE
+    qpos[..., i_unrelated_q] = UNRELATED_POSITION * SCALE
+    entity.set_qpos(qpos)
+    entity.set_dofs_velocity(velocity)
+    expected_qpos = qpos + velocity * DT
+    scene.step()
+    assert_allclose(entity.get_qpos(), expected_qpos, tol=tol)
+
+    # From rest, SAP reduces the linearized residual by R / (R + J M^-1 J^T).
+    # With default regularization, the largest effective inertia (8.1, including armature) gives a ratio below 8.1e-4.
+    # Move the driver to its reference pose to check the updated Jacobian: poly(0) = a0 and poly'(0) = a1.
+    qpos = entity.get_qpos()
+    for name, _, _ in JOINT_PAIRS:
+        (i_driver_q,) = entity.get_joint(f"{name}_driver").qs_idx_local
+        (i_follower_q,) = entity.get_joint(f"{name}_follower").qs_idx_local
+        qpos[..., i_driver_q] = 0.0
+        qpos[..., i_follower_q] = 0.0
+    qpos[..., i_target_q] = 0.0
+    qpos[..., i_unrelated_q] = UNRELATED_POSITION * SCALE
+    entity.set_qpos(qpos)
+    mass_mat = entity.get_mass_mat()
+    scene.step()
+
+    qpos_after = entity.get_qpos()
+    for name, driver_type, follower_type in JOINT_PAIRS:
+        (i_driver_q,) = entity.get_joint(f"{name}_driver").qs_idx_local
+        (i_follower_q,) = entity.get_joint(f"{name}_follower").qs_idx_local
+        (i_driver_d,) = entity.get_joint(f"{name}_driver").dofs_idx_local
+        (i_follower_d,) = entity.get_joint(f"{name}_follower").dofs_idx_local
+        driver_scale = SCALE if driver_type == "slide" else 1.0
+        follower_scale = SCALE if follower_type == "slide" else 1.0
+        driver_displacement = (qpos_after[..., i_driver_q] - qpos[..., i_driver_q]) / driver_scale
+        expected_follower_position = COEFFICIENTS[0] + COEFFICIENTS[1] * driver_displacement
+        assert_allclose(
+            qpos_after[..., i_follower_q] / follower_scale,
+            expected_follower_position,
+            atol=MAX_RESIDUAL_RATIO * abs(COEFFICIENTS[0]),
+        )
+
+        # Each joint has its own root link, so its generalized impulse is M_ii * delta_q / dt.
+        # The two impulses must have the ratio -poly'(driver), including coordinate scaling.
+        driver_impulse = (
+            mass_mat[..., i_driver_d, i_driver_d] * (qpos_after[..., i_driver_q] - qpos[..., i_driver_q]) / DT
+        )
+        follower_impulse = (
+            mass_mat[..., i_follower_d, i_follower_d] * (qpos_after[..., i_follower_q] - qpos[..., i_follower_q]) / DT
+        )
+        assert_allclose(driver_impulse, -COEFFICIENTS[1] * follower_scale / driver_scale * follower_impulse, tol=tol)
+
+    assert_allclose(
+        qpos_after[..., i_target_q] / SCALE,
+        TARGET_POSITION,
+        atol=MAX_RESIDUAL_RATIO * abs(TARGET_POSITION),
+    )
+    assert_allclose(qpos_after[..., i_unrelated_q] / SCALE, UNRELATED_POSITION, tol=tol)
+
+
 @pytest.mark.slow  # ~200s
 @pytest.mark.required
 @pytest.mark.parametrize("precision", ["64"])

--- a/tests/rigid/conftest.py
+++ b/tests/rigid/conftest.py
@@ -238,40 +238,6 @@ def mimic_hinges():
 
 
 @pytest.fixture(scope="session")
-def scaled_mjcf_joint_equalities():
-    mjcf = ET.Element("mujoco", model="scaled_mjcf_joint_equalities")
-    worldbody = ET.SubElement(mjcf, "worldbody")
-    equality = ET.SubElement(mjcf, "equality")
-    for driver_type, follower_type, position_y in (
-        ("hinge", "hinge", -0.25),
-        ("slide", "slide", -0.5),
-        ("slide", "hinge", -0.75),
-        ("hinge", "slide", -1.0),
-    ):
-        pair_name = f"{driver_type}_{follower_type}"
-        driver_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_driver_body", pos=f"0 {position_y} 0")
-        ET.SubElement(driver_body, "joint", name=f"{pair_name}_driver", type=driver_type, axis="1 0 0")
-        ET.SubElement(driver_body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
-        follower_body = ET.SubElement(worldbody, "body", name=f"{pair_name}_follower_body", pos=f"0.15 {position_y} 0")
-        ET.SubElement(follower_body, "joint", name=f"{pair_name}_follower", type=follower_type, axis="1 0 0")
-        ET.SubElement(follower_body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
-        ET.SubElement(
-            equality,
-            "joint",
-            name=f"{pair_name}_coupling",
-            joint1=f"{pair_name}_follower",
-            joint2=f"{pair_name}_driver",
-            polycoef="0.2 0.4 -0.3 0.2 -0.1",
-        )
-    for name, position_y in (("target", 0.0), ("unrelated", 0.25)):
-        body = ET.SubElement(worldbody, "body", name=f"{name}_body", pos=f"0 {position_y} 0")
-        ET.SubElement(body, "joint", name=name, type="slide", axis="1 0 0")
-        ET.SubElement(body, "geom", type="sphere", size="0.05", mass="1", contype="0", conaffinity="0")
-    ET.SubElement(equality, "joint", name="fixed_target", joint1="target", polycoef="0.25 1 0 0 0")
-    return mjcf
-
-
-@pytest.fixture(scope="session")
 def scaled_urdf_mimic():
     robot = ET.Element("robot", name="scaled_urdf_mimic")
     ET.SubElement(robot, "link", name="base")


### PR DESCRIPTION
## Description

Honor the full joint-equality polynomial in SAPCoupler, updating its residual and Jacobian every substep. Support omitted `joint2` instead of rejecting it at build time. This also applies to URDF mimic multipliers and offsets.

Equality constraints now trigger the SAP solve without contacts, adding per-substep solve overhead: about 69 ms versus 0.12 ms per step on macOS CPU for the 10-DOF test scene, because the SAP Newton, PCG, and line-search launches now run every substep. Regularization now uses the computed Delassus term, which also changes the regularization of existing identity-polynomial equalities.

## Related Issue

Resolves #3324.

Rebased on `main` after #3290 merged.

## Motivation and Context

SAP previously assumed an identity polynomial and skipped equality-only scenes without contacts, leaving valid joint constraints unenforced.

## How Has This Been / Can This Be Tested?

```bash
PYTHONPATH="$PWD" QD_OFFLINE_CACHE=0 uv run pytest \
  tests/coupling/test_hybrid.py::test_sap_joint_equality_polynomial \
  tests/coupling/test_hybrid.py::test_sap_rigid_rigid_hydroelastic_contact \
  tests/rigid/test_constraints.py::test_equality_joint_scaling \
  -p no:pytest-retry -p no:rerunfailures -q
```

5 passed on macOS CPU (fp64, since SAPCoupler rejects fp32). Pinned Ruff lint and format pass. CUDA and the full suite were not run.

The base fails it: the omitted-joint2 scene is rejected at build, restoring the contact-only gate fails both variants at the correction assertion, and freezing the derivative fails both at the impulse-ratio assertion.

Covered: batched and unbatched, all hinge/slide combinations, scaling, constant offset (a0), all coefficients, derivative updates, omitted `joint2`, an unrelated joint. The Delassus path runs but its value is not asserted.

`scaled_mjcf_joint_equalities` moves to `tests/conftest.py` because `tests/rigid` and `tests/coupling` both use it. Exact checks use the `tol` fixture; the one-step residual-ratio bound reflects SAP's constraint regularization, not floating-point error.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

