### PR TITLE
[BUG FIX] Keep the imported normals perpendicular to a non-uniformly scaled glTF node.

### DIFF
--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -909,12 +909,16 @@ def apply_transform(transform, positions, normals=None):
 
     transformed_normals = normals
     if normals is not None:
-        rot_mat = transform[:3, :3]
-        if np.abs(3.0 - np.trace(rot_mat)) > gs.EPS**2:  # has rotation or scaling
-            transformed_normals = normals @ rot_mat
-            scale = np.linalg.norm(rot_mat, axis=1, keepdims=True)
-            if np.any(np.abs(scale - 1.0) > gs.EPS):  # has scale
-                transformed_normals /= np.linalg.norm(transformed_normals, axis=1, keepdims=True)
+        lin_mat = transform[:3, :3]
+        if not np.allclose(lin_mat, np.identity(3), atol=gs.EPS):  # has rotation or scaling
+            # A normal is a covector, so it maps through the cofactor matrix of the linear part, whose rows are the
+            # cross products of the other two rows. That matrix sends the cross product of two edges to the cross
+            # product of the transformed edges, keeping every normal perpendicular to its own triangle. The linear
+            # part itself agrees with it only for a rotation, and tilts the normals off the surface under a
+            # non-uniform scaling.
+            cofactor_mat = np.cross(np.roll(lin_mat, -1, axis=0), np.roll(lin_mat, -2, axis=0))
+            transformed_normals = normals @ cofactor_mat
+            transformed_normals /= np.linalg.norm(transformed_normals, axis=1, keepdims=True)
 
     return transformed_positions, transformed_normals
 

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -557,6 +557,52 @@ def texcoord_1_accessor_zero_glb(asset_tmp_path):
 
 
 @pytest.fixture(scope="session")
+def non_uniform_node_scale_glb(asset_tmp_path):
+    """Path to a GLB whose node scales its triangle by a different factor along each axis.
+
+    The authored normals are the triangle's own geometric normal, which points diagonally, so the node scale has to
+    tilt them to keep them perpendicular to the scaled triangle."""
+    positions = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+    normal = np.cross(positions[1] - positions[0], positions[2] - positions[0])
+    normals = np.tile(normal / np.linalg.norm(normal), (3, 1)).astype(np.float32)
+
+    blob = b""
+    buffer_views = []
+    for data in (positions.tobytes(), normals.tobytes()):
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0, scale=[2.0, 0.5, 0.5])],
+        meshes=[
+            pygltflib.Mesh(
+                name="scaled_triangle",
+                primitives=[pygltflib.Primitive(attributes=pygltflib.Attributes(POSITION=0, NORMAL=1))],
+            )
+        ],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=0,
+                componentType=pygltflib.FLOAT,
+                count=len(positions),
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(bufferView=1, componentType=pygltflib.FLOAT, count=len(normals), type="VEC3"),
+        ],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    path = str(asset_tmp_path / "non_uniform_node_scale.glb")
+    gltf.save_binary(path)
+    return path
+
+
+@pytest.fixture(scope="session")
 def emissive_material_variants_glb(asset_tmp_path):
     """Path to a GLB with three materials on distinct base/emissive texCoord sets and a triangle carrying two of them.
 

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -295,6 +295,7 @@ def test_urdf_mesh_processing(mesh_path, mesh_urdf, show_viewer):
         "normal_accessor_zero_glb",
         "texcoord_0_accessor_zero_glb",
         "texcoord_1_accessor_zero_glb",
+        "non_uniform_node_scale_glb",
     ],
 )
 def test_glb_parse_geometry(request, glb_file, tol):
@@ -312,11 +313,25 @@ def test_glb_parse_geometry(request, glb_file, tol):
     )
 
     tm_scene = trimesh.load(glb_path, process=False)
+    # A mesh whose primitives all declare NORMAL carries authored normals, which map through the inverse transpose
+    # of the node transform's linear part. 'apply_transform' maps the normals it holds through the linear part
+    # itself, so the authored ones are mapped here and written back over its result. A mesh declaring none leaves
+    # its normals to be derived from the geometry, which both parsers do once the node transform is applied.
+    glb = pygltflib.GLTF2().load(glb_path)
+    authored_normals_names = {
+        mesh.name for mesh in glb.meshes if all(prim.attributes.NORMAL is not None for prim in mesh.primitives)
+    }
     tm_meshes = {}
     for node_name in tm_scene.graph.nodes_geometry:
         transform, geometry_name = tm_scene.graph[node_name]
         ts_mesh = tm_scene.geometry[geometry_name].copy(include_cache=True)
+        normals = None
+        if geometry_name in authored_normals_names:
+            normals = ts_mesh.vertex_normals @ np.linalg.inv(transform[:3, :3])
+            normals /= np.linalg.norm(normals, axis=1, keepdims=True)
         ts_mesh = ts_mesh.apply_transform(transform)
+        if normals is not None:
+            ts_mesh.vertex_normals = normals
         tm_meshes[geometry_name] = ts_mesh
     assert len(tm_meshes) == len(gs_meshes)
 


### PR DESCRIPTION
## Description

A glTF node may scale its mesh by a different factor along each axis, and exporters use it routinely (a crate
stretched into a plank, a sphere squashed into an ellipsoid). Importing such a node scaled the geometry correctly but
left the shading normals pointing the wrong way, so the mesh rendered as if lit from somewhere else. On the sphere of
the `glb/combined_srt.glb` test asset the imported normals are up to 33 degrees off.

`apply_transform` mapped the normals through the linear part of the node transform:

```python
transformed_normals = normals @ rot_mat
```

A normal is a covector, so it maps through the cofactor matrix of that linear part, which is its inverse transpose up
to a factor the renormalisation drops. The two agree for a rotation and for a uniform scale, and part ways as soon as
the scaling is non-uniform. The guard in front of that branch tested the trace against 3, so a scale like
`(2.0, 0.5, 0.5)` also slipped through untransformed.

The cofactor matrix is built from the cross products of the linear part's rows, which is also what makes it the right
map here: it sends the cross product of two edges to the cross product of the transformed edges, so every normal
stays perpendicular to its own triangle. It stays defined when the linear part is singular, where an explicit inverse
would not.

`apply_transform` is called only from `parse_mesh_glb`, so the change is confined to the glTF importer, and within it
to nodes whose scaling is non-uniform.

### The trimesh oracle in `test_glb_parse_geometry`

`trimesh.Trimesh.apply_transform` maps the normals it holds through the linear part too, so its output cannot be the
oracle for a non-uniformly scaled node. The test now maps the authored normals itself and writes them back over
`apply_transform`'s result. A mesh that declares no `NORMAL` accessor keeps the old path: its normals are derived from
the geometry once the transform is applied, which is what both parsers do, and deriving them before the transform
and mapping them afterwards is measurably different (0.016 on `glb/combined_transform.glb`, whose normals are all
derived).

This changes what the test expects rather than loosening it: with the corrected oracle
`test_glb_parse_geometry[glb/combined_srt.glb]` fails on `b3c6c73` and passes here.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3334

## Motivation and Context

Nothing warns, the file loads, and the geometry is right, so the only sign is that the object is shaded wrong. The
imported mesh also disagrees with itself: the authored normals of the fixture triangle are its own geometric normal,
and after the node scale the imported normals are no longer perpendicular to the imported triangle.

## How Has This Been / Can This Be Tested?

```
pytest -n 0 --backend cpu tests/parsers/test_mesh.py -k "glb or scale or yup or mjcf"
```

Windows 11, CPU backend, Python 3.12, `--backend cpu`.

- On `b3c6c73` with only the test changes applied, `test_glb_parse_geometry` fails on two of its six cases and passes
  on the other four:

  ```
  FAILED tests/parsers/test_mesh.py::test_glb_parse_geometry[glb/combined_srt.glb-32]
  E       Normals match failed in mesh Sphere.
  E       Mismatched elements: 6060 / 6060 (100%)
  E        [0, 1]: 0.9608578687881945 (ACTUAL), 0.7060219645500183 (DESIRED)
  E       Max absolute difference among violations: 0.43590218

  FAILED tests/parsers/test_mesh.py::test_glb_parse_geometry[non_uniform_node_scale_glb-32]
  E       Normals match failed in mesh scaled_triangle.
  E       Mismatched elements: 9 / 9 (100%)
  E        [0, 0]: 0.17407765595569785 (ACTUAL), 0.5773502588272095 (DESIRED)
  ```

  The second case is the `(2.0, 0.5, 0.5)` scale the trace test let through: Genesis returned the authored
  `[0.577, 0.577, 0.577]` unchanged where the scaled triangle's normal is `[0.174, 0.696, 0.696]`.
- With this commit all 6 cases pass.
- Pinned as unaffected: the 24 cases the selection above collects pass on `b3c6c73`, and the 25 (the added
  parametrization) pass here.
- `ruff format --check` and `ruff check` report nothing on the three edited files.

Not run: the GPU backends and the rest of the suite.

The standalone reproduction in the issue prints, on `b3c6c73`, an imported normal of
`[0.69631064 0.69631064 0.17407766]` where the imported triangle's own geometric normal is
`[0.23570226 0.23570226 0.94280904]`, and prints them equal here.

## Screenshots (if appropriate):

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
