### PR TITLE
[BUG FIX] Keep every glTF node its own mesh when its primitives are triangle strips or fans.

### DIFF
--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -320,7 +320,7 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
     materials = {}
     is_visual_overwritten = surface.texture is not None
 
-    for i, (mesh_index, mesh_transform) in enumerate(mesh_list):
+    for i_node, (mesh_index, mesh_transform) in enumerate(mesh_list):
         mesh_glb = glb.meshes[mesh_index]
         mesh_name = mesh_glb.name
 
@@ -402,14 +402,14 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
             # A single glTF mesh may hold several primitives with distinct materials. When not grouping by material,
             # primitives must still be separated by material so each keeps its own surface and texture; otherwise
             # primitives sharing a mesh would be merged under the first primitive's material and the rest lost.
-            group_idx = primitive.material if group_by_material else (i, primitive.material)
+            group_idx = primitive.material if group_by_material else (i_node, primitive.material)
             mesh_info, first_created = mesh_infos.get(group_idx)
             if first_created:
                 metadata = {"mesh_path": path, "name": material_name if group_by_material else mesh_name}
                 if not group_by_material:
                     # Record the source mesh node so per-material submeshes can be regrouped into one physical body
                     # (e.g. merged into a single collision geom) while still rendering with their own textures.
-                    metadata["node_index"] = i
+                    metadata["node_index"] = i_node
                 mesh_info.set_property(surface=material, metadata=metadata)
             mesh_info.append(points, triangles, normals, uvs)
     meshes = mesh_infos.export_meshes(scale=scale, is_mesh_zup=is_mesh_zup)

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -351,6 +351,88 @@ def test_glb_draco_missing_normals_texcoord(glb_file):
 
 
 @pytest.mark.required
+def test_glb_primitive_modes(tmp_path):
+    # Four nodes read the same five positions: a lone triangle, that triangle as a one-triangle strip, a
+    # three-triangle strip whose second triangle is wound the other way round, and a three-triangle fan pivoting on
+    # the first index. Each node is a mesh of its own whatever mode it declares.
+    positions = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32
+    )
+    short_indices = np.array([0, 1, 2], dtype=np.uint32)
+    long_indices = np.array([0, 1, 2, 3, 4], dtype=np.uint32)
+    TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN = 4, 5, 6
+    primitives = {
+        "triangles": (TRIANGLES, 1),
+        "strip_one": (TRIANGLE_STRIP, 1),
+        "strip_three": (TRIANGLE_STRIP, 2),
+        "fan_three": (TRIANGLE_FAN, 2),
+    }
+    expected_faces = {
+        "triangles": [[0, 1, 2]],
+        "strip_one": [[0, 1, 2]],
+        "strip_three": [[0, 1, 2], [1, 3, 2], [2, 3, 4]],
+        "fan_three": [[0, 1, 2], [0, 2, 3], [0, 3, 4]],
+    }
+
+    blob = b""
+    buffer_views = []
+    for data in (positions.tobytes(), short_indices.tobytes(), long_indices.tobytes()):
+        blob += b"\x00" * ((4 - len(blob) % 4) % 4)
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=list(range(len(primitives))))],
+        nodes=[pygltflib.Node(mesh=i) for i in range(len(primitives))],
+        meshes=[
+            pygltflib.Mesh(
+                name=name,
+                primitives=[
+                    pygltflib.Primitive(attributes=pygltflib.Attributes(POSITION=0), indices=indices, mode=mode)
+                ],
+            )
+            for name, (mode, indices) in primitives.items()
+        ],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=0,
+                componentType=pygltflib.FLOAT,
+                count=len(positions),
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(
+                bufferView=1, componentType=pygltflib.UNSIGNED_INT, count=len(short_indices), type="SCALAR"
+            ),
+            pygltflib.Accessor(
+                bufferView=2, componentType=pygltflib.UNSIGNED_INT, count=len(long_indices), type="SCALAR"
+            ),
+        ],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    glb_path = tmp_path / "primitive_modes.glb"
+    gltf.save_binary(str(glb_path))
+
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        str(glb_path),
+        group_by_material=False,
+        scale=None,
+        is_mesh_zup=True,
+        surface=gs.surfaces.Default(),
+    )
+
+    assert {gs_mesh.metadata["name"] for gs_mesh in gs_meshes} == set(primitives)
+    for gs_mesh in gs_meshes:
+        mesh_name = gs_mesh.metadata["name"]
+        assert_allclose(gs_mesh.trimesh.vertices, positions, tol=gs.EPS)
+        assert_equal(gs_mesh.trimesh.faces, expected_faces[mesh_name])
+
+
+@pytest.mark.required
 def test_glb_texcoord(emissive_material_variants_glb):
     # Material 0 reads the float set 0 and material 1 the normalized set 1, so both meshes carry the authored UVs
     gs_meshes = gltf_utils.parse_mesh_glb(


### PR DESCRIPTION
## Description

Loading a `.glb` whose primitives use `TRIANGLE_STRIP` or `TRIANGLE_FAN` lost the node each primitive came from. Two
separate nodes came back as a single mesh holding the geometry of both, under the first one's name and material, and
downstream that one mesh is one collision geom, so two bodies that should collide separately became one.

The loop over nodes and the loops expanding a strip or a fan into triangles shared the name `i`:

```python
for i, (mesh_index, mesh_transform) in enumerate(mesh_list):
    ...
            for i in range(len(indices) - 2):
```

so after either expansion `i` held the last triangle counter. Two consumers read it afterwards: `group_idx`, which
decides what shares a mesh, and `metadata["node_index"]`, which decides what is merged into one collision geom (the
`groups_by_node` block of `RigidEntityDescription`). The outer loop now names its index `i_node`, which is what both
of them mean.

The geometry itself was decoded correctly, which is why nothing warned.

`test_glb_primitive_modes` reads four nodes off the same five positions: a `TRIANGLES` triangle, that triangle as a
one-triangle strip, a three-triangle strip and a three-triangle fan. It pins the mesh each node gets, its vertices,
and the triangles each mode expands to, including the alternating winding of a strip.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3335

## Motivation and Context

Strips and fans are what a `.glb` gets from a pipeline that optimises for vertex reuse, and neither mode had a test.
The file loads, the geometry is right, and the only sign is that the scene ends up with fewer meshes and fewer
collision geoms than the file describes.

## How Has This Been / Can This Be Tested?

```
pytest -n 0 --backend cpu tests/parsers/test_mesh.py -k glb
```

Windows 11, CPU backend, Python 3.12.

- On `b3c6c73` with only the test added, `test_glb_primitive_modes` fails on the four nodes coming back as three
  meshes, the strip node having been folded into the plain-triangle one:

  ```
  >       assert {gs_mesh.metadata["name"] for gs_mesh in gs_meshes} == set(primitives)
  E       AssertionError: assert {'fan_three',..., 'triangles'} == {'fan_three',..., 'triangles'}
  E         Extra items in the right set:
  E         'strip_one'
  ```

- With this commit the selection above is 17 passed, 0 failed.
- Pinned as unaffected: the 16 cases this selection collects on `b3c6c73` pass there, as part of a wider
  `-k "glb or scale or yup or mjcf"` run of 24 that also passes.
- `ruff format --check` and `ruff check` report nothing on the two edited files.

Not run: the GPU backends and the rest of the suite.

## Screenshots (if appropriate):

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
