### PR TITLE
[BUG FIX] Honor the alpha cutoff of a masked glTF material.

### DIFF
--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -104,7 +104,6 @@ def parse_glb_material(glb, material_index, surface):
     normal_texture = None
     emissive_texture = None
 
-    alpha_cutoff = None
     double_sided = None
     ior = None
     uvs_used = 0
@@ -131,7 +130,7 @@ def parse_glb_material(glb, material_index, surface):
             occlusion_texture = mu.create_texture(occlusion_image, None, "linear")
 
     # parse alpha mode
-    alpha_cutoff = mu.adjust_alpha_cutoff(alpha_cutoff, alpha_modes[material.alphaMode])
+    alpha_cutoff = mu.adjust_alpha_cutoff(material.alphaCutoff, alpha_modes[material.alphaMode])
 
     # parse pbr roughness and metallic
     if material.pbrMetallicRoughness is not None:

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -447,6 +447,96 @@ def test_glb_parse_material(glb_file):
 
 
 @pytest.mark.required
+def test_glb_alpha_mode(tmp_path):
+    # Three materials share one base color texture whose alpha ramps up, the shape a cutout has along its edge. A
+    # masked material splits that ramp at its own cutoff, a blended one keeps it, and an opaque one discards it.
+    alpha = np.array([0, 64, 128, 192, 255], dtype=np.uint8)
+    rgba = np.full((1, len(alpha), 4), 255, dtype=np.uint8)
+    rgba[..., 3] = alpha
+    buffer = io.BytesIO()
+    Image.fromarray(rgba, mode="RGBA").save(buffer, format="PNG")
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    uvs = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    alpha_modes = {"masked": ("MASK", 0.6), "blended": ("BLEND", 0.5), "opaque": ("OPAQUE", 0.5)}
+    expected_opacities = {
+        # 0.6 of full opacity is 153, which falls between the third and the fourth texel
+        "masked": [0, 0, 0, 255, 255],
+        "blended": alpha,
+        "opaque": [255, 255, 255, 255, 255],
+    }
+
+    blob = b""
+    buffer_views = []
+    for data in (buffer.getvalue(), positions.tobytes(), uvs.tobytes()):
+        blob += b"\x00" * ((4 - len(blob) % 4) % 4)
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0)],
+        meshes=[
+            pygltflib.Mesh(
+                primitives=[
+                    pygltflib.Primitive(
+                        attributes=pygltflib.Attributes(POSITION=0, TEXCOORD_0=1), material=material_idx
+                    )
+                    for material_idx in range(len(alpha_modes))
+                ]
+            )
+        ],
+        materials=[
+            pygltflib.Material(
+                name=name,
+                pbrMetallicRoughness=pygltflib.PbrMetallicRoughness(
+                    baseColorTexture=pygltflib.TextureInfo(index=0, texCoord=0)
+                ),
+                alphaMode=alpha_mode,
+                alphaCutoff=alpha_cutoff,
+            )
+            for name, (alpha_mode, alpha_cutoff) in alpha_modes.items()
+        ],
+        textures=[pygltflib.Texture(source=0)],
+        images=[pygltflib.Image(bufferView=0, mimeType="image/png")],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=1,
+                componentType=pygltflib.FLOAT,
+                count=len(positions),
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(bufferView=2, componentType=pygltflib.FLOAT, count=len(uvs), type="VEC2"),
+        ],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    glb_path = tmp_path / "alpha_modes.glb"
+    gltf.save_binary(str(glb_path))
+
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        str(glb_path),
+        group_by_material=True,
+        scale=None,
+        is_mesh_zup=True,
+        surface=gs.surfaces.Default(),
+    )
+
+    assert {gs_mesh.metadata["name"] for gs_mesh in gs_meshes} == set(alpha_modes)
+    for gs_mesh in gs_meshes:
+        material_name = gs_mesh.metadata["name"]
+        opacity_texture = gs_mesh.surface.opacity_texture
+        assert_equal(
+            opacity_texture.image_array[0],
+            expected_opacities[material_name],
+            err_msg=f"Opacity match failed for material {material_name}.",
+        )
+
+
+@pytest.mark.required
 def test_glb_shared_texture_not_duplicated(tmp_path):
     from genesis.vis.batch_renderer import GenesisGeomRetriever
 


### PR DESCRIPTION
## Description

A glTF material with `alphaMode: "MASK"` asks for a hard cutout, every texel fully opaque or fully transparent at
`alphaCutoff`, which is what foliage, fences, grates and decals are authored with. Genesis imported it as if it were
`BLEND`: the authored alpha ramp survived, so the soft edge that the cutout exists to remove rendered as a
translucent fringe.

`parse_glb_material` initialised `alpha_cutoff` to `None` and passed that same `None` to `adjust_alpha_cutoff`, which
returns its argument for `MASK`, so `apply_cutoff` got `None` and returned immediately. The material's own
`alphaCutoff` (0.5 by default) is what belongs there, so it is passed instead and the dead initialisation goes.
`OPAQUE` and `BLEND` resolve to 0.0 and `None` inside `adjust_alpha_cutoff` regardless of the value handed to it, so
they keep the behaviour they had.

The USD importer already reads the same quantity off the shader and applies it the same way, through
`opacity_texture.apply_cutoff` with `opacityThreshold`.

`test_glb_alpha_mode` puts one alpha ramp behind three materials, one per alpha mode, and pins the opacity each mode
imports.

#3336 and #3337 touch the same two files in other places and merge cleanly against this one in either order.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3338

## Motivation and Context

Nothing warns and nothing fails, so the only sign is that a masked material shades exactly like a blended one. The
`MASK` branch of `adjust_alpha_cutoff` could never fire, which is why the two modes were indistinguishable.

## How Has This Been / Can This Be Tested?

```
pytest -n 0 --backend cpu tests/parsers/test_mesh.py -k "glb or mjcf or texture"
```

Windows 11, CPU backend, Python 3.12.

- On `b3c6c73` with only the test added, the masked material comes back with its authored ramp intact:

  ```
  FAILED tests/parsers/test_mesh.py::test_glb_alpha_mode
  E       Opacity match failed for material masked.
  E       Mismatched elements: 3 / 5 (60%)
  E        ACTUAL: array([  0,  64, 128, 192, 255], dtype=uint8)
  E        DESIRED: array([  0,   0,   0, 255, 255])
  ```

- With this commit the selection above is 23 passed, 0 failed, plus one setup error on
  `test_plane_texture_path_preservation`: `RuntimeError: Virtual memory allocation (1073741824 B) failed` raised by
  the quadrants host memory pool inside `gs.init`, before the test body. It passes on its own rerun, with and
  without this change, and that test loads no glTF.
- Pinned as unaffected: `adjust_alpha_cutoff` resolves `OPAQUE` to 0.0 and `BLEND` to `None` whatever it is handed,
  so only a `MASK` material can shade differently, and no glTF asset under `genesis/assets` or in the test dataset
  declares one (28 files scanned for `alphaMode`). The glb and mjcf cases of this selection pass on `b3c6c73`, as
  part of a wider `-k "glb or scale or yup or mjcf"` run of 24 that also passes.
- `ruff format --check` and `ruff check` report nothing on the two edited files.

Not run: the GPU backends and the rest of the suite.

## Screenshots (if appropriate):

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
