### PR TITLE
[BUG FIX] Open an exported scene on any platform and through gs launch.

### DIFF
--- a/genesis/_main.py
+++ b/genesis/_main.py
@@ -17,65 +17,70 @@ def launch(filename=None, collision=False, rotate=False, scale=1.0, show_link_fr
     if deprecated:
         gs.logger.warning("'gs view' is deprecated and will be removed in a future release. Use 'gs launch' instead.")
 
-    scene = gs.Scene(
-        viewer_options=gs.options.ViewerOptions(
-            camera_pos=(3.5, 0.0, 2.5),
-            camera_lookat=(0.0, 0.0, 0.5),
-            camera_fov=40,
-            enable_gui=True,
-        ),
-        vis_options=gs.options.VisOptions(
-            show_link_frame=show_link_frame,
-            show_world_frame=True,
-        ),
-        show_viewer=True,
+    viewer_options = gs.options.ViewerOptions(
+        camera_pos=(3.5, 0.0, 2.5),
+        camera_lookat=(0.0, 0.0, 0.5),
+        camera_fov=40,
+        enable_gui=True,
+    )
+    vis_options = gs.options.VisOptions(
+        show_link_frame=show_link_frame,
+        show_world_frame=True,
     )
 
-    # With no file given, open an empty interactive scene; entities can be added live through the overlay's
-    # "Add Entity / Stage" panel and applied with "Rebuild Scene".
-    entities = []
-    if filename is not None:
-        filename_lower = filename.lower()
-        material = gs.materials.Rigid()
-        # Morphs load collision geometry by default, so the overlay's collision vis-mode has something to show; the -c
-        # flag only selects which representation is displayed first.
-        surface = gs.surfaces.Default(vis_mode="visual" if not collision else "collision")
+    # An exported scene carries its entities and physics options, so it is opened as it stands under the inspector's
+    # viewer rather than placed in a scene made here.
+    if filename is not None and filename.lower().endswith(SCENE_FORMAT):
+        scene = gs.Scene.load(filename, show_viewer=True, viewer_options=viewer_options, vis_options=vis_options)
+        entities = scene.entities
+    else:
+        scene = gs.Scene(viewer_options=viewer_options, vis_options=vis_options, show_viewer=True)
 
-        if filename_lower.endswith(USD_FORMATS):
-            morph = gs.morphs.USD(file=filename, scale=scale)
-            entities = scene.add_stage(morph=morph, vis_mode=surface.vis_mode)
-        elif filename_lower.endswith((URDF_FORMAT, XACRO_FORMAT)):
-            morph_cls = gs.morphs.URDF
-            entities = [
-                scene.add_entity(
-                    morph_cls(file=filename, scale=scale),
-                    material=material,
-                    surface=surface,
+        # With no file given, open an empty interactive scene; entities can be added live through the overlay's
+        # "Add Entity / Stage" panel and applied with "Rebuild Scene".
+        entities = []
+        if filename is not None:
+            filename_lower = filename.lower()
+            material = gs.materials.Rigid()
+            # Morphs load collision geometry by default, so the overlay's collision vis-mode has something to show; the
+            # -c flag only selects which representation is displayed first.
+            surface = gs.surfaces.Default(vis_mode="visual" if not collision else "collision")
+
+            if filename_lower.endswith(USD_FORMATS):
+                morph = gs.morphs.USD(file=filename, scale=scale)
+                entities = scene.add_stage(morph=morph, vis_mode=surface.vis_mode)
+            elif filename_lower.endswith((URDF_FORMAT, XACRO_FORMAT)):
+                morph_cls = gs.morphs.URDF
+                entities = [
+                    scene.add_entity(
+                        morph_cls(file=filename, scale=scale),
+                        material=material,
+                        surface=surface,
+                    )
+                ]
+            elif filename_lower.endswith(MJCF_FORMAT):
+                morph_cls = gs.morphs.MJCF
+                entities = [
+                    scene.add_entity(
+                        morph_cls(file=filename, scale=scale),
+                        material=material,
+                        surface=surface,
+                    )
+                ]
+            elif filename_lower.endswith(MESH_FORMATS):
+                morph_cls = gs.morphs.Mesh
+                entities = [
+                    scene.add_entity(
+                        morph_cls(file=filename, scale=scale),
+                        material=material,
+                        surface=surface,
+                    )
+                ]
+            else:
+                gs.raise_exception(
+                    f"Unsupported file format for 'gs launch'. Expected {URDF_FORMAT}, {XACRO_FORMAT}, "
+                    f"{MJCF_FORMAT}, {MESH_FORMATS}, {USD_FORMATS}, or {SCENE_FORMAT}."
                 )
-            ]
-        elif filename_lower.endswith(MJCF_FORMAT):
-            morph_cls = gs.morphs.MJCF
-            entities = [
-                scene.add_entity(
-                    morph_cls(file=filename, scale=scale),
-                    material=material,
-                    surface=surface,
-                )
-            ]
-        elif filename_lower.endswith(MESH_FORMATS):
-            morph_cls = gs.morphs.Mesh
-            entities = [
-                scene.add_entity(
-                    morph_cls(file=filename, scale=scale),
-                    material=material,
-                    surface=surface,
-                )
-            ]
-        else:
-            gs.raise_exception(
-                f"Unsupported file format for 'gs launch'. Expected {URDF_FORMAT}, {XACRO_FORMAT}, "
-                f"{MJCF_FORMAT}, {MESH_FORMATS}, or {USD_FORMATS}."
-            )
 
     scene.build()
 
@@ -99,43 +104,38 @@ def launch(filename=None, collision=False, rotate=False, scale=1.0, show_link_fr
 def play(filename=None, collision=False, scale=1.0):
     gs.init()
 
-    # An exported scene carries the options it is viewed with, so it is opened as it stands rather than placed in a
-    # scene made here.
-    if filename is not None and filename.lower().endswith(SCENE_FORMAT):
-        scene = gs.Scene.load(filename, show_viewer=True)
+    scene = gs.Scene(
+        viewer_options=gs.options.ViewerOptions(
+            camera_pos=(2.0, 2.0, 1.5),
+            camera_lookat=(0.0, 0.0, 0.5),
+            enable_gui=True,
+        ),
+        show_viewer=True,
+    )
+
+    if filename is None:
+        scene.add_entity(gs.morphs.Plane())
+        scene.add_entity(gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"))
     else:
-        scene = gs.Scene(
-            viewer_options=gs.options.ViewerOptions(
-                camera_pos=(2.0, 2.0, 1.5),
-                camera_lookat=(0.0, 0.0, 0.5),
-                enable_gui=True,
-            ),
-            show_viewer=True,
-        )
+        filename_lower = filename.lower()
+        surface = gs.surfaces.Default(vis_mode="visual" if not collision else "collision")
 
-        if filename is None:
-            scene.add_entity(gs.morphs.Plane())
-            scene.add_entity(gs.morphs.MJCF(file="xml/franka_emika_panda/panda.xml"))
+        if filename_lower.endswith(USD_FORMATS):
+            scene.add_stage(
+                morph=gs.morphs.USD(file=filename, scale=scale),
+                vis_mode=surface.vis_mode,
+            )
+        elif filename_lower.endswith(URDF_FORMAT):
+            scene.add_entity(gs.morphs.URDF(file=filename, scale=scale), surface=surface)
+        elif filename_lower.endswith(MJCF_FORMAT):
+            scene.add_entity(gs.morphs.MJCF(file=filename, scale=scale), surface=surface)
+        elif filename_lower.endswith(MESH_FORMATS):
+            scene.add_entity(gs.morphs.Mesh(file=filename, scale=scale), surface=surface)
         else:
-            filename_lower = filename.lower()
-            surface = gs.surfaces.Default(vis_mode="visual" if not collision else "collision")
-
-            if filename_lower.endswith(USD_FORMATS):
-                scene.add_stage(
-                    morph=gs.morphs.USD(file=filename, scale=scale),
-                    vis_mode=surface.vis_mode,
-                )
-            elif filename_lower.endswith(URDF_FORMAT):
-                scene.add_entity(gs.morphs.URDF(file=filename, scale=scale), surface=surface)
-            elif filename_lower.endswith(MJCF_FORMAT):
-                scene.add_entity(gs.morphs.MJCF(file=filename, scale=scale), surface=surface)
-            elif filename_lower.endswith(MESH_FORMATS):
-                scene.add_entity(gs.morphs.Mesh(file=filename, scale=scale), surface=surface)
-            else:
-                gs.raise_exception(
-                    f"Unsupported file format for 'gs play'. Expected {URDF_FORMAT}, "
-                    f"{MJCF_FORMAT}, {MESH_FORMATS}, {USD_FORMATS}, or {SCENE_FORMAT}."
-                )
+            gs.raise_exception(
+                f"Unsupported file format for 'gs play'. Expected {URDF_FORMAT}, "
+                f"{MJCF_FORMAT}, {MESH_FORMATS}, or {USD_FORMATS}."
+            )
 
     scene.build()
 
@@ -173,7 +173,8 @@ def main():
         type=str,
         nargs="?",
         default=None,
-        help="Optional asset file (Mesh/URDF/MJCF/USD). Defaults to an empty interactive scene.",
+        help="Optional asset file (Mesh/URDF/MJCF/USD) or exported scene (.gscene). Defaults to an empty "
+        "interactive scene.",
     )
     launch_args.add_argument(
         "-c", "--collision", action="store_true", default=False, help="Whether to visualize collision geometry"

--- a/genesis/options/vis.py
+++ b/genesis/options/vis.py
@@ -1,9 +1,12 @@
+import sys
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, Sequence, Union
-from pydantic import StrictBool, StrictInt, Field, model_validator
+
+from pydantic import Field, StrictBool, StrictInt, model_validator
 
 import genesis as gs
 from genesis.datatypes import List
-from genesis.typing import IArrayType, PositiveFloat, PositiveInt, PositiveVec2IType, Vec3FType, UnitIntervalVec3Type
+from genesis.typing import IArrayType, PositiveFloat, PositiveInt, PositiveVec2IType, UnitIntervalVec3Type, Vec3FType
+from genesis.utils.serialization import ignore_invalid_load
 
 from .options import Options
 
@@ -29,8 +32,10 @@ class ViewerOptions(Options):
     res : tuple, shape (2,), optional
         The resolution of the viewer. If not set, will auto-compute using resolution of the connected display.
     run_in_thread : bool
-        Whether to run the viewer in a background thread. This option is not supported on MacOS. True by default if
-        available.
+        Whether to run the viewer in a background thread, where it stays responsive while the simulation is idle. If
+        None, it runs in a background thread wherever the platform supports it. MacOS only supports the main thread,
+        so asking for a background thread there raises an error. A scene file recording such a request is loaded
+        as asking for the platform default, so it opens on every platform.
     refresh_rate : int
         The rate (in frames per second) at which the viewer repaints on screen, and the framerate the video recorded
         from the viewer window is encoded at. Independent of the physics timestep, and of the framerate passed to
@@ -63,7 +68,10 @@ class ViewerOptions(Options):
     """
 
     res: PositiveVec2IType | None = None
-    run_in_thread: StrictBool | None = None
+    # MacOS serves the viewer window from its main thread only (see Visualizer).
+    run_in_thread: Annotated[
+        StrictBool | None, ignore_invalid_load((None, False) if sys.platform == "darwin" else (None, False, True))
+    ] = None
     refresh_rate: PositiveInt = 60
     realtime_factor: PositiveFloat | None = 1.0
     camera_pos: Vec3FType = (3.5, 0.5, 2.5)

--- a/genesis/utils/serialization.py
+++ b/genesis/utils/serialization.py
@@ -23,7 +23,8 @@ from functools import lru_cache, partial
 from typing import Callable, NamedTuple
 
 import numpy as np
-from pydantic import TypeAdapter, ValidationError
+from frozendict import frozendict
+from pydantic import AfterValidator, TypeAdapter, ValidationError, ValidationInfo
 
 import genesis as gs
 from genesis.options.options import Options
@@ -125,6 +126,27 @@ def _class_codec(cls) -> tuple[Callable, Callable] | None:
         if parent in _REGISTERED:
             return _REGISTERED[parent]
     return None
+
+
+# Validators receive it as 'info.context' while a value read from a file is checked (see 'ignore_invalid_load').
+_FROM_FILE = frozendict({"from_file": True})
+
+
+def ignore_invalid_load(accepted: Iterable) -> AfterValidator:
+    """Returns a validator loading a recorded value outside 'accepted' as None, the unset state of an optional field.
+
+    A value a file records holds wherever the file was written. A field whose values hold there and nowhere else
+    declares beside its type, through this, which of them hold on this machine, so the file opens here whatever it
+    asked for. What a caller gives is left as given, to be rejected where it is used.
+    """
+    accepted = tuple(accepted)
+
+    def settle(value, info: ValidationInfo):
+        if value in accepted or info.context is None or not info.context.get("from_file", False):
+            return value
+        return None
+
+    return AfterValidator(settle)
 
 
 @lru_cache(maxsize=None)
@@ -491,7 +513,7 @@ def _load_value(raw, expect, loaded: "Loaded"):
                 ):
                     continue
                 try:
-                    _field_check(cls, name).validate_python(value)
+                    values[name] = _field_check(cls, name).validate_python(value, context=_FROM_FILE)
                 except ValidationError as e:
                     gs.raise_exception_from(f"A Genesis file states a '{name}' that {cls.__name__} rejects.", e)
             return cls.model_construct(_fields_set=set(raw["given"]), **values)

--- a/genesis/vis/visualizer.py
+++ b/genesis/vis/visualizer.py
@@ -38,6 +38,7 @@ class Visualizer(RBC):
         self._rasterizer = None
         self._raytracer = None
         self._batch_renderer = None
+        self._cameras = gs.List()
         self.viewer_lock = DummyViewerLock()
 
         # Rasterizer context is shared by viewer and rasterizer
@@ -70,22 +71,22 @@ class Visualizer(RBC):
                     "or call `del scene`."
                 )
 
+            # The platform defaults are resolved into a copy handed to the viewer, so the options the scene was authored
+            # with stay as written and an export of the scene opens on any display and platform.
+            resolved = {}
             if viewer_options.res is None:
                 viewer_height = (screen_height * screen_scale) * VIEWER_DEFAULT_HEIGHT_RATIO
                 viewer_width = viewer_height / VIEWER_DEFAULT_ASPECT_RATIO
-                viewer_options.res = (int(viewer_width), int(viewer_height))
-            if viewer_options.run_in_thread is None:
-                if sys.platform == "linux":
-                    viewer_options.run_in_thread = True
-                elif sys.platform == "darwin":
-                    viewer_options.run_in_thread = False
-                elif sys.platform == "win32":
-                    viewer_options.run_in_thread = True
-            if sys.platform == "darwin" and viewer_options.run_in_thread:
+                resolved["res"] = (int(viewer_width), int(viewer_height))
+            run_in_thread = viewer_options.run_in_thread
+            if run_in_thread is None:
+                run_in_thread = sys.platform != "darwin"
+            elif run_in_thread and sys.platform == "darwin":
                 gs.raise_exception("Running viewer in background thread is not supported on MacOS.")
+            resolved["run_in_thread"] = run_in_thread
 
-            self._viewer = Viewer(viewer_options, self._context)
-            if not viewer_options.run_in_thread:
+            self._viewer = Viewer(viewer_options.model_copy(update=resolved), self._context)
+            if not run_in_thread:
                 gs.logger.warning(
                     "Interactive viewer running in main thread. It will only be responsive if a simulation is running."
                 )
@@ -103,8 +104,6 @@ class Visualizer(RBC):
             self._renderer = self._raytracer = Raytracer(renderer_options, vis_options)
         elif isinstance(renderer_options, gs.renderers.Rasterizer):
             self._renderer = self._rasterizer
-
-        self._cameras = gs.List()
 
     def __del__(self):
         self.destroy()

--- a/tests/rigid/test_serialization.py
+++ b/tests/rigid/test_serialization.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import pickle
+import sys
 import xml.etree.ElementTree as ET
 import zipfile
 from copy import deepcopy
@@ -431,6 +432,9 @@ def test_export_before_build(n_envs, checkpoint_scene, tmp_path, caplog):
     restored = gs.Scene.load(exported, vis_options=gs.options.VisOptions(show_world_frame=False))
     assert not restored.is_built
     assert not restored.options.vis.show_world_frame
+    # The viewer options are recorded as authored, whatever display and platform the scene was viewed with
+    assert restored.options.viewer.res is None
+    assert restored.options.viewer.run_in_thread is None
     assert restored.options.sim.dt == scene.options.sim.dt
     assert [entity.name for entity in restored.entities] == [entity.name for entity in scene.entities]
     # A scene destroyed while it records closes its log on the state it stopped at
@@ -454,6 +458,12 @@ def test_export_before_build(n_envs, checkpoint_scene, tmp_path, caplog):
     scene.export(built)
     assert scene.options.rigid.max_contacts is not None
     assert gs.Scene.load(built).options.rigid.max_contacts == scene.options.rigid.max_contacts
+
+    # A file asking for a viewer thread opens on every platform, in the main thread where that is the only one
+    threaded_scene = gs.Scene(viewer_options=gs.options.ViewerOptions(run_in_thread=True))
+    threaded = tmp_path / f"threaded{SCENE_FORMAT}"
+    threaded_scene.export(threaded)
+    assert gs.Scene.load(threaded).options.viewer.run_in_thread is (None if sys.platform == "darwin" else True)
 
 
 @pytest.mark.required


### PR DESCRIPTION
## Description

* The visualizer resolves the platform defaults of `res` and `run_in_thread` into a copy handed to the viewer, so the authored `ViewerOptions` stay as written and an export records `None` for both. An explicit `run_in_thread=True` from a caller still raises on macOS.
* `serialization.ignore_invalid_load(accepted)` returns a pydantic `AfterValidator` loading a recorded value outside the accepted ones as `None`, and leaving a caller's value as given: the loader passes a from-file validation context and keeps what the field makes of the value. `ViewerOptions.run_in_thread` declares through it which values hold on the loading platform, so a file recording a thread request opens on macOS in the main thread.
* The visualizer initializes its cameras list with its other members, so a failed init destroys cleanly.
* `.gscene` files open through `gs launch` (and its `gs view` alias) under the inspector's viewer and vis options, with the recorded entities and physics options. `gs play` rejects them.

## Motivation and Context

A `.gscene` exported on Linux failed to open on macOS with `Running viewer in background thread is not supported on MacOS`, followed by an `AttributeError` on `_cameras` while the half-built visualizer was destroyed: the visualizer wrote the exporting machine's window size and threading back into the scene's own options, and the export recorded them.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_serialization.py::test_export_before_build` asserts that an exported file records the viewer options as authored and that a file asking for a viewer thread loads on every platform. It fails on `main` on macOS. Opening the file that surfaced the failure: `gs launch scene.gscene`.

Documentation: Genesis-Embodied-AI/genesis-doc#153 (merged, submodule bumped).

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
