### PR TITLE
[BUG FIX] Import a masked glTF material with its alpha cutout applied.

### DIFF
--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -104,7 +104,6 @@ def parse_glb_material(glb, material_index, surface):
     normal_texture = None
     emissive_texture = None
 
-    alpha_cutoff = None
     double_sided = None
     ior = None
     uvs_used = 0
@@ -131,7 +130,7 @@ def parse_glb_material(glb, material_index, surface):
             occlusion_texture = mu.create_texture(occlusion_image, None, "linear")
 
     # parse alpha mode
-    alpha_cutoff = mu.adjust_alpha_cutoff(alpha_cutoff, alpha_modes[material.alphaMode])
+    alpha_cutoff = mu.adjust_alpha_cutoff(material.alphaCutoff, alpha_modes[material.alphaMode])
 
     # parse pbr roughness and metallic
     if material.pbrMetallicRoughness is not None:

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -641,6 +641,76 @@ def emissive_material_variants_glb(asset_tmp_path):
     return str(path)
 
 
+@pytest.fixture(scope="session")
+def alpha_mode_variants_glb(asset_tmp_path):
+    """Path to a GLB whose three materials read one base color texture under the three alpha modes.
+
+    The texture is a single row whose alpha ramps from fully transparent to fully opaque, the gradient a cutout has
+    along its edge. The masked material cuts that ramp at 0.6, above the third texel of five, while the blended and
+    the opaque materials leave their own cutoff at the 0.5 default."""
+    alpha = np.array([0, 64, 128, 192, 255], dtype=np.uint8)
+    rgba = np.full((1, len(alpha), 4), 255, dtype=np.uint8)
+    rgba[..., 3] = alpha
+    buffer = io.BytesIO()
+    Image.fromarray(rgba, mode="RGBA").save(buffer, format="PNG")
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    uvs = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    alpha_modes = (("masked", "MASK", 0.6), ("blended", "BLEND", 0.5), ("opaque", "OPAQUE", 0.5))
+
+    blob = b""
+    buffer_views = []
+    for data in (buffer.getvalue(), positions.tobytes(), uvs.tobytes()):
+        blob += bytes(-len(blob) % 4)
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0)],
+        meshes=[
+            pygltflib.Mesh(
+                primitives=[
+                    pygltflib.Primitive(
+                        attributes=pygltflib.Attributes(POSITION=0, TEXCOORD_0=1), material=material_idx
+                    )
+                    for material_idx in range(len(alpha_modes))
+                ]
+            )
+        ],
+        materials=[
+            pygltflib.Material(
+                name=name,
+                pbrMetallicRoughness=pygltflib.PbrMetallicRoughness(
+                    baseColorTexture=pygltflib.TextureInfo(index=0, texCoord=0)
+                ),
+                alphaMode=alpha_mode,
+                alphaCutoff=alpha_cutoff,
+            )
+            for name, alpha_mode, alpha_cutoff in alpha_modes
+        ],
+        textures=[pygltflib.Texture(source=0)],
+        images=[pygltflib.Image(bufferView=0, mimeType="image/png")],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=1,
+                componentType=pygltflib.FLOAT,
+                count=len(positions),
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(bufferView=2, componentType=pygltflib.FLOAT, count=len(uvs), type="VEC2"),
+        ],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    path = str(asset_tmp_path / "alpha_mode_variants.glb")
+    gltf.save_binary(path)
+    return path
+
+
 @pytest.fixture
 def material_mjcf(tmp_path):
     """Generate an MJCF model with materials and geom-level colors."""

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -447,6 +447,31 @@ def test_glb_parse_material(glb_file):
 
 
 @pytest.mark.required
+def test_glb_alpha_mode(alpha_mode_variants_glb):
+    # A cutoff of 0.6 lands at an opacity of 153, between the third and the fourth texel of the ramp
+    expected_opacities = {
+        "masked": [0, 0, 0, 255, 255],
+        "blended": [0, 64, 128, 192, 255],
+        "opaque": [255, 255, 255, 255, 255],
+    }
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        alpha_mode_variants_glb,
+        group_by_material=True,
+        scale=None,
+        is_mesh_zup=True,
+        surface=gs.surfaces.Default(),
+    )
+    assert {gs_mesh.metadata["name"] for gs_mesh in gs_meshes} == set(expected_opacities)
+    for gs_mesh in gs_meshes:
+        material_name = gs_mesh.metadata["name"]
+        assert_equal(
+            gs_mesh.surface.opacity_texture.image_array[0],
+            expected_opacities[material_name],
+            err_msg=material_name,
+        )
+
+
+@pytest.mark.required
 def test_glb_shared_texture_not_duplicated(tmp_path):
     from genesis.vis.batch_renderer import GenesisGeomRetriever
 


### PR DESCRIPTION
## Description

`parse_glb_material` passed a local initialised to `None` into `adjust_alpha_cutoff` instead of `material.alphaCutoff`, so the `MASK` branch returned `None` and `apply_cutoff` returned immediately. A masked material imported with its authored alpha ramp, shading like a blended one. `OPAQUE` and `BLEND` resolve inside `adjust_alpha_cutoff` regardless of the value handed to it, so they keep the behaviour they had.

Supersedes #3339, reworked against `CODING_GUIDELINES.md`.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3338

## Motivation and Context

`MASK` is what foliage, fences, grates and decals are authored with, and nothing warns: the only sign is the translucent fringe the cutout exists to remove.

## How Has This Been / Can This Be Tested?

```
pytest --backend cpu tests/parsers/test_mesh.py -k "glb or texture"
```

Windows 11, CPU backend, Python 3.12: 22 passed.

On `b3c6c73` with only `test_glb_alpha_mode` and its fixture added, the masked material keeps its ramp:

```
E  Mismatched elements: 3 / 5 (60%)
E  Mismatch at indices:
E   [1]: 64 (ACTUAL), 0 (DESIRED)
E   [2]: 128 (ACTUAL), 0 (DESIRED)
E   [3]: 192 (ACTUAL), 255 (DESIRED)
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
