### PR TITLE
[BUG FIX] Keep separate glTF nodes from merging into one collision geom.

### DIFF
--- a/genesis/utils/gltf.py
+++ b/genesis/utils/gltf.py
@@ -320,7 +320,7 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
     materials = {}
     is_visual_overwritten = surface.texture is not None
 
-    for i, (mesh_index, mesh_transform) in enumerate(mesh_list):
+    for i_node, (mesh_index, mesh_transform) in enumerate(mesh_list):
         mesh_glb = glb.meshes[mesh_index]
         mesh_name = mesh_glb.name
 
@@ -402,14 +402,14 @@ def parse_mesh_glb(path, group_by_material, scale, is_mesh_zup, surface):
             # A single glTF mesh may hold several primitives with distinct materials. When not grouping by material,
             # primitives must still be separated by material so each keeps its own surface and texture; otherwise
             # primitives sharing a mesh would be merged under the first primitive's material and the rest lost.
-            group_idx = primitive.material if group_by_material else (i, primitive.material)
+            group_idx = primitive.material if group_by_material else (i_node, primitive.material)
             mesh_info, first_created = mesh_infos.get(group_idx)
             if first_created:
                 metadata = {"mesh_path": path, "name": material_name if group_by_material else mesh_name}
                 if not group_by_material:
                     # Record the source mesh node so per-material submeshes can be regrouped into one physical body
                     # (e.g. merged into a single collision geom) while still rendering with their own textures.
-                    metadata["node_index"] = i
+                    metadata["node_index"] = i_node
                 mesh_info.set_property(surface=material, metadata=metadata)
             mesh_info.append(points, triangles, normals, uvs)
     meshes = mesh_infos.export_meshes(scale=scale, is_mesh_zup=is_mesh_zup)

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -641,6 +641,60 @@ def emissive_material_variants_glb(asset_tmp_path):
     return str(path)
 
 
+@pytest.fixture(scope="session")
+def triangle_strip_nodes_glb(asset_tmp_path):
+    """Path to a GLB with two nodes a unit apart, each holding one TRIANGLE_STRIP primitive of the same material.
+
+    Sharing the material leaves the node each primitive comes from as the only thing separating the two meshes."""
+    positions = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]],
+        dtype=np.float32,
+    )
+    indices = np.arange(len(positions), dtype=np.uint32)
+
+    blob = b""
+    buffer_views = []
+    for data in (positions.tobytes(), indices.tobytes()):
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0, 1])],
+        nodes=[
+            pygltflib.Node(mesh=0, name="near_strip"),
+            pygltflib.Node(mesh=1, name="far_strip", translation=[10.0, 0.0, 0.0]),
+        ],
+        meshes=[
+            pygltflib.Mesh(
+                name=name,
+                primitives=[
+                    pygltflib.Primitive(attributes=pygltflib.Attributes(POSITION=0), indices=1, mode=5, material=0)
+                ],
+            )
+            for name in ("near_strip", "far_strip")
+        ],
+        materials=[pygltflib.Material(name="shared")],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=0,
+                componentType=pygltflib.FLOAT,
+                count=len(positions),
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(bufferView=1, componentType=pygltflib.UNSIGNED_INT, count=len(indices), type="SCALAR"),
+        ],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    path = str(asset_tmp_path / "triangle_strip_nodes.glb")
+    gltf.save_binary(path)
+    return path
+
+
 @pytest.fixture
 def material_mjcf(tmp_path):
     """Generate an MJCF model with materials and geom-level colors."""

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -327,6 +327,20 @@ def test_glb_parse_geometry(request, glb_file, tol):
 
 
 @pytest.mark.required
+def test_glb_strip_nodes_stay_separate(triangle_strip_nodes_glb):
+    # Two nodes are two meshes, and one collision geom each, whatever primitive mode they declare
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        triangle_strip_nodes_glb,
+        group_by_material=False,
+        scale=None,
+        is_mesh_zup=True,
+        surface=gs.surfaces.Default(),
+    )
+    assert {gs_mesh.metadata["name"] for gs_mesh in gs_meshes} == {"near_strip", "far_strip"}
+    assert {gs_mesh.metadata["node_index"] for gs_mesh in gs_meshes} == {0, 1}
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/tycoon_draco_no_normal.glb", "glb/tycoon_with_normal_draco.glb"])
 def test_glb_draco_missing_normals_texcoord(glb_file):
     # Normals and tex_coord are not always present in GLB files, typically for Draco-compressed ones.


### PR DESCRIPTION
## Description

The loops expanding a `TRIANGLE_STRIP` and a `TRIANGLE_FAN` in `parse_mesh_glb` reuse `i`, the index of the loop over nodes. By the time `group_idx` and `metadata["node_index"]` read it, it holds a triangle counter, so two nodes whose primitives share a material land in the same group and merge into one mesh, and with it one collision geom.

Renaming the outer index to `i_node` leaves the inner counters alone.

Supersedes #3337, reworked against `CODING_GUIDELINES.md`.

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3335

## Motivation and Context

Strips and fans are what an exporter emits for terrain, cloth panels and UI-like quads, and the merge is silent: the entity comes back with fewer geoms than it has nodes, so parts that should collide separately move as one body.

## How Has This Been / Can This Be Tested?

```
pytest --backend cpu tests/parsers/test_mesh.py -k "glb or texture"
```

Windows 11, CPU backend, Python 3.12: 22 passed.

On `b3c6c73` with only `test_glb_strip_nodes_stay_separate` and its fixture added, the two nodes come back as one mesh:

```
E  AssertionError: assert {'near_strip'} == {'far_strip', 'near_strip'}
```

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
