### PR TITLE
[BUG FIX] Keep imported glTF normals perpendicular under a non-uniform node scale.

### DIFF
--- a/genesis/utils/mesh.py
+++ b/genesis/utils/mesh.py
@@ -909,12 +909,14 @@ def apply_transform(transform, positions, normals=None):
 
     transformed_normals = normals
     if normals is not None:
-        rot_mat = transform[:3, :3]
-        if np.abs(3.0 - np.trace(rot_mat)) > gs.EPS**2:  # has rotation or scaling
-            transformed_normals = normals @ rot_mat
-            scale = np.linalg.norm(rot_mat, axis=1, keepdims=True)
-            if np.any(np.abs(scale - 1.0) > gs.EPS):  # has scale
-                transformed_normals /= np.linalg.norm(transformed_normals, axis=1, keepdims=True)
+        lin_mat = transform[:3, :3]
+        if not np.allclose(lin_mat, np.identity(3), atol=gs.EPS):  # has rotation or scaling
+            # A normal is a covector, so it maps through the cofactor matrix of the linear part, whose rows are the
+            # cross products of the other two rows. That matrix sends the cross product of two edges to the cross
+            # product of the transformed edges, keeping a normal perpendicular to its own triangle under any scaling.
+            cofactor_mat = np.cross(np.roll(lin_mat, -1, axis=0), np.roll(lin_mat, -2, axis=0))
+            transformed_normals = normals @ cofactor_mat
+            transformed_normals /= np.linalg.norm(transformed_normals, axis=1, keepdims=True)
 
     return transformed_positions, transformed_normals
 

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -641,6 +641,52 @@ def emissive_material_variants_glb(asset_tmp_path):
     return str(path)
 
 
+@pytest.fixture(scope="session")
+def non_uniform_node_scale_glb(asset_tmp_path):
+    """Path to a GLB whose node scales its one triangle by a different factor along each axis.
+
+    The authored normals are the triangle's own geometric normal, which points diagonally, so the node scale has to
+    tilt them for them to stay perpendicular to the scaled triangle."""
+    positions = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+    normal = np.cross(positions[1] - positions[0], positions[2] - positions[0])
+    normals = np.tile(normal / np.linalg.norm(normal), (3, 1)).astype(np.float32)
+
+    blob = b""
+    buffer_views = []
+    for data in (positions.tobytes(), normals.tobytes()):
+        buffer_views.append(pygltflib.BufferView(buffer=0, byteOffset=len(blob), byteLength=len(data)))
+        blob += data
+
+    gltf = pygltflib.GLTF2(
+        scene=0,
+        scenes=[pygltflib.Scene(nodes=[0])],
+        nodes=[pygltflib.Node(mesh=0, scale=[2.0, 0.5, 0.5])],
+        meshes=[
+            pygltflib.Mesh(
+                name="scaled_triangle",
+                primitives=[pygltflib.Primitive(attributes=pygltflib.Attributes(POSITION=0, NORMAL=1))],
+            )
+        ],
+        accessors=[
+            pygltflib.Accessor(
+                bufferView=0,
+                componentType=pygltflib.FLOAT,
+                count=len(positions),
+                type="VEC3",
+                min=positions.min(axis=0).tolist(),
+                max=positions.max(axis=0).tolist(),
+            ),
+            pygltflib.Accessor(bufferView=1, componentType=pygltflib.FLOAT, count=len(normals), type="VEC3"),
+        ],
+        bufferViews=buffer_views,
+        buffers=[pygltflib.Buffer(byteLength=len(blob))],
+    )
+    gltf.set_binary_blob(blob)
+    path = str(asset_tmp_path / "non_uniform_node_scale.glb")
+    gltf.save_binary(path)
+    return path
+
+
 @pytest.fixture
 def material_mjcf(tmp_path):
     """Generate an MJCF model with materials and geom-level colors."""

--- a/tests/parsers/test_mesh.py
+++ b/tests/parsers/test_mesh.py
@@ -327,6 +327,25 @@ def test_glb_parse_geometry(request, glb_file, tol):
 
 
 @pytest.mark.required
+def test_glb_node_scale_normals(non_uniform_node_scale_glb):
+    # The normal of a flat triangle is the geometric normal of that triangle, whatever the node scales it by
+    gs_meshes = gltf_utils.parse_mesh_glb(
+        non_uniform_node_scale_glb,
+        group_by_material=False,
+        scale=None,
+        is_mesh_zup=True,
+        surface=gs.surfaces.Default(),
+    )
+    assert len(gs_meshes) == 1
+    tm_mesh = gs_meshes[0].trimesh
+    triangle = tm_mesh.vertices[tm_mesh.faces[0]]
+    geometric_normal = np.cross(triangle[1] - triangle[0], triangle[2] - triangle[0])
+    geometric_normal /= np.linalg.norm(geometric_normal)
+    # The authored normals are stored in a float accessor, so they round to float32 in the file
+    assert_allclose(tm_mesh.vertex_normals, geometric_normal, tol=np.finfo(np.float32).eps)
+
+
+@pytest.mark.required
 @pytest.mark.parametrize("glb_file", ["glb/tycoon_draco_no_normal.glb", "glb/tycoon_with_normal_draco.glb"])
 def test_glb_draco_missing_normals_texcoord(glb_file):
     # Normals and tex_coord are not always present in GLB files, typically for Draco-compressed ones.


### PR DESCRIPTION
## Description

`apply_transform` maps normals through the linear part of the node transform, which is the map for positions. A normal is a covector: under the row-vector convention used here it maps through `M^-T`, which the cofactor matrix gives up to the factor the renormalisation drops. The guard in front of the branch also tested the trace, so a scale of `[2.0, 0.5, 0.5]` summed to 3 and left the normals untransformed entirely.

Supersedes #3336, reworked against `CODING_GUIDELINES.md`.

**This PR is a draft because it makes `test_glb_parse_geometry[glb/combined_srt.glb-32]` fail, and I would rather you decide how to resolve that than rewrite the assertion myself. Details in the last section.**

## Related Issue

Resolves Genesis-Embodied-AI/Genesis#3334

## Motivation and Context

Nothing warns. A non-uniformly scaled node imports with normals tilted off its surface, so it shades wrong everywhere the scale is not uniform, and the tilt grows with the anisotropy.

## How Has This Been / Can This Be Tested?

```
pytest --backend cpu tests/parsers/test_mesh.py -k "glb or texture"
```

Windows 11, CPU backend, Python 3.12: 21 passed, 1 failed (see below).

On `b3c6c73` with only `test_glb_node_scale_normals` and its fixture added, the authored normal arrives untouched, the trace guard having skipped the branch:

```
E  Mismatched elements: 9 / 9 (100%)
E   [0, 0]: 0.5773502588272095 (ACTUAL), 0.17407765595569785 (DESIRED)
E   [0, 1]: 0.5773502588272095 (ACTUAL), 0.6963106238227914 (DESIRED)
E   [0, 2]: 0.5773502588272095 (ACTUAL), 0.6963106238227914 (DESIRED)
```

## The failing test, and the decision I would like from you

`test_glb_parse_geometry` compares the import against trimesh, and trimesh maps authored normals through the linear part exactly as this code did. The parity held because both were wrong, and this change breaks it on the two meshes of `combined_srt.glb` that carry a non-uniform scale.

Measured on the `Sphere` node of that asset (scale `[1.0, 0.766, 1.433]`), against the closed-form `n @ inv(M).T` normalised:

```
cofactor  vs exact : max 2.2e-16
linear    vs exact : max 0.436
trimesh   vs exact : max 0.436
trimesh   vs linear: max 1.1e-16
```

So trimesh cannot serve as the oracle for normals under a non-uniform node scale, which is why the new test derives its expectation analytically instead.

Two ways I can see to resolve it, and I will take whichever you prefer:

1. Leave the normal comparison out of `test_glb_parse_geometry` for nodes whose scale is non-uniform, and let `test_glb_node_scale_normals` carry the property.
2. Map the authored normals through `inv(transform).T` in that test's harness before comparing, which makes the oracle correct but puts the formula under test into the expectation.

I have not touched the test either way.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
