### PR TITLE
DO NOT MERGE: run production.yml on the ARC runners

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -63,7 +63,7 @@ jobs:
     name: production-unit_tests-${{ matrix.GS_ENABLE_NDARRAY == '0' && 'field' || 'ndarray' }}
 
     needs: image-version
-    runs-on: [self-hosted, coreweave, genesis-world]
+    runs-on: arc-genesis-world
 
     strategy:
       fail-fast: true
@@ -152,7 +152,7 @@ jobs:
     name: production-benchmarks-${{ matrix.GS_ENABLE_NDARRAY == '0' && 'field' || 'ndarray' }}
 
     needs: [image-version, unit-tests]
-    runs-on: [self-hosted, coreweave, genesis-world]
+    runs-on: arc-genesis-world
 
     strategy:
       matrix:


### PR DESCRIPTION
Throwaway pull request, opened to exercise the ARC runner pool declared in https://github.com/Genesis-Embodied-AI/infra/pull/1487. It will be closed once the run has been observed, and must not be merged.

The only change is the `runs-on` of the two self-hosted jobs, pointing them at `arc-genesis-world`. That label belongs to the new pool and nothing else targets it, so this is the only way a job can reach it. Everything else is untouched: those runners are Slurm submit clients like the current ones, so `salloc`, `srun` and the container mounts stay exactly as they are.

What this checks, in order: that a pod comes up and registers with GitHub, that munge lets it reach `slurmctld`, that `salloc --partition=rtx-high --exclusive` succeeds, that `production_build.sh` finds the existing `uv` and HuggingFace caches under `actions-runner-0`'s home rather than refetching torch, and that `benchmarks` can write to `/mnt/data/artifacts`.

If any of it fails, nothing else is affected: every other pull request keeps using the runners that serve this workflow today, and they are untouched.