### PR TITLE
[MISC] Fix rigid solver perf regressions (cont'd).

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/linesearch.py
+++ b/genesis/engine/solvers/rigid/constraint/linesearch.py
@@ -92,30 +92,13 @@ def func_row_p0_terms(
 ):
     """Linear and quadratic coefficients along the search direction, at alpha = 0, of one constraint row.
 
-    The equality rows count apart (they never deactivate) and the active rows of any kind contribute, an elliptic cone
-    through its head row only. row_kind names the row's class when the caller knows it (1 equality, 2 friction loss,
+    An equality row, which never deactivates, counts apart. Every other row contributes its candidate terms at alpha = 0
+    (see func_row_alpha_terms). row_kind names the row's class when the caller knows it (1 equality, 2 friction loss,
     3 elliptic cone head, 4 contact or limit), 0 when the row's class is tested at runtime.
 
     Returns the vector [linear, quadratic] of an equality row followed by [linear, quadratic] of a row of any kind.
     """
     terms = qd.Vector.zero(gs.qd_float, 4)
-    if qd.static(rigid_config.enable_elliptic_friction and row_kind in (0, 3)):
-        n_rows = qd.static(rigid_config.rows_per_contact)
-        is_cone_head = True
-        if qd.static(row_kind == 0):
-            is_cone_head = nef <= i_c and i_c < ncone and (i_c - nef) % n_rows == 0
-        if is_cone_head:
-            rows_efc_D, rows_friction, con_mu, rows_jaref = constraint_solver._func_cone_head_load(
-                i_c, i_b, constraint_state, rigid_config
-            )
-            rows_jv = qd.Vector.zero(gs.qd_float, n_rows)
-            for i_r in qd.static(range(n_rows)):
-                rows_jv[i_r] = constraint_state.jv[i_c + i_r, i_b]
-            _cost_c, grad_c, hess_c = constraint_solver._func_cone_cost_along_alpha(
-                rows_jaref, rows_jv, 0.0, rows_efc_D, con_mu, rows_friction, rigid_config
-            )
-            terms[2] = grad_c
-            terms[3] = 0.5 * hess_c
     if qd.static(row_kind in (0, 1)):
         is_equality_row = True
         if qd.static(row_kind == 0):
@@ -128,36 +111,12 @@ def func_row_p0_terms(
             terms[1] = D * (0.5 * jv_c * jv_c)
             terms[2] = terms[0]
             terms[3] = terms[1]
-    if qd.static(row_kind in (0, 2)):
-        is_friction_row = True
-        if qd.static(row_kind == 0):
-            is_friction_row = ne <= i_c and i_c < nef
-        if is_friction_row:
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            f = constraint_state.efc_frictionloss[i_c, i_b]
-            rf = constraint_state.diag[i_c, i_b] * f
-            qf_1 = D * (jv_c * Jaref_c)
-            qf_2 = D * (0.5 * jv_c * jv_c)
-            linear_neg = Jaref_c <= -rf
-            linear_pos = Jaref_c >= rf
-            if linear_neg or linear_pos:
-                qf_1 = linear_neg * (-f * jv_c) + linear_pos * (f * jv_c)
-                qf_2 = 0.0
-            terms[2] = qf_1
-            terms[3] = qf_2
-    if qd.static(row_kind in (0, 4)):
-        is_contact_row = True
-        if qd.static(row_kind == 0):
-            is_contact_row = i_c >= ncone
-        if is_contact_row:
-            Jaref_c = constraint_state.Jaref[i_c, i_b]
-            jv_c = constraint_state.jv[i_c, i_b]
-            D = constraint_state.efc_D[i_c, i_b]
-            active = Jaref_c < 0
-            terms[2] = D * (jv_c * Jaref_c) * active
-            terms[3] = D * (0.5 * jv_c * jv_c) * active
+    if qd.static(row_kind != 1):
+        terms_alpha = func_row_alpha_terms(
+            i_c, i_b, 1, qd.Vector.zero(gs.qd_float, 3), ne, nef, ncone, constraint_state, rigid_config, row_kind
+        )
+        terms[2] = terms[2] + terms_alpha[1]
+        terms[3] = terms[3] + terms_alpha[2]
     return terms
 
 
@@ -604,6 +563,274 @@ def func_mv_jv_islands(i_b, constraint_state: array_class.ConstraintState, rigid
 
 
 @qd.func
+def func_row_p0_sums_by_class(
+    i_b,
+    i_first,
+    stride,
+    ne,
+    nef,
+    ncone,
+    n_con,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+):
+    """Sum the initialization terms (func_row_p0_terms) of the rows i_first, i_first + stride, ... of each row class of
+    one env, class by class, the rows read by index. The env's one island holds every row in constraint order."""
+    sums_rows = qd.Vector.zero(gs.qd_float, 4)
+    i_c = i_first
+    while i_c < ne:
+        sums_rows = sums_rows + func_row_p0_terms(i_c, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=1)
+        i_c = i_c + stride
+    i_c = ne + i_first
+    while i_c < nef:
+        sums_rows = sums_rows + func_row_p0_terms(i_c, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=2)
+        i_c = i_c + stride
+    if qd.static(rigid_config.enable_elliptic_friction):
+        n_rows = qd.static(rigid_config.rows_per_contact)
+        i_cone = i_first
+        while i_cone < (ncone - nef) // n_rows:
+            sums_rows = sums_rows + func_row_p0_terms(
+                nef + i_cone * n_rows, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=3
+            )
+            i_cone = i_cone + stride
+    i_c = ncone + i_first
+    while i_c < n_con:
+        sums_rows = sums_rows + func_row_p0_terms(i_c, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=4)
+        i_c = i_c + stride
+    return sums_rows
+
+
+@qd.func
+def func_row_alpha_sums_by_class(
+    i_b,
+    i_first,
+    stride,
+    n_alphas,
+    alphas,
+    ne,
+    nef,
+    ncone,
+    n_con,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+):
+    """Sum the candidate terms (func_row_alpha_terms) of the rows i_first, i_first + stride, ... of each row class of
+    one env, class by class, the rows read by index as in func_row_p0_sums_by_class."""
+    acc = qd.Vector.zero(gs.qd_float, 9)
+    i_c = ne + i_first
+    while i_c < nef:
+        acc = acc + func_row_alpha_terms(
+            i_c, i_b, n_alphas, alphas, ne, nef, ncone, constraint_state, rigid_config, row_kind=2
+        )
+        i_c = i_c + stride
+    if qd.static(rigid_config.enable_elliptic_friction):
+        n_rows = qd.static(rigid_config.rows_per_contact)
+        i_cone = i_first
+        while i_cone < (ncone - nef) // n_rows:
+            acc = acc + func_row_alpha_terms(
+                nef + i_cone * n_rows, i_b, n_alphas, alphas, ne, nef, ncone, constraint_state, rigid_config, row_kind=3
+            )
+            i_cone = i_cone + stride
+    i_c = ncone + i_first
+    while i_c < n_con:
+        acc = acc + func_row_alpha_terms(
+            i_c, i_b, n_alphas, alphas, ne, nef, ncone, constraint_state, rigid_config, row_kind=4
+        )
+        i_c = i_c + stride
+    return acc
+
+
+@qd.func
+def func_search_single_island(
+    i_b,
+    tid,
+    stride,
+    dyn_state: array_class.DynState,
+    constraint_state: array_class.ConstraintState,
+    dyn_info: array_class.DynInfo,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+    is_coop: qd.template(),
+):
+    """Search the step of the one island of an env of a single-island scene and apply it.
+
+    Lane tid sweeps the dofs and rows tid, tid + stride, ... of the env. Serially one lane holds the env (tid 0, stride
+    1). Under is_coop the _K lanes of the env's block share the sweeps, their sums reduced across the block, and every
+    lane holds the island's search state. The dofs and rows are read by index, the island holding every one of them in
+    order, the CPU skyline path reading the dofs through its reordered list. mv and jv hold M @ search and J @ search
+    on entry.
+
+    Returns whether the island moved.
+    """
+    n_dofs = constraint_state.search.shape[0]
+    ne = constraint_state.n_constraints_equality[i_b]
+    nef = ne + constraint_state.n_constraints_frictionloss[i_b]
+    ncone = nef
+    if qd.static(rigid_config.enable_elliptic_friction):
+        ncone = ncone + constraint_state.n_constraints_cone[i_b]
+    n_con = constraint_state.n_constraints[i_b]
+
+    is_moved = False
+    if constraint_state.island.improved[0, i_b]:
+        sums_dofs = qd.Vector.zero(gs.qd_float, 4)
+        i_pos = tid
+        while i_pos < n_dofs:
+            i_d = i_pos
+            if qd.static(rigid_config.sparse_solve):
+                i_d = constraint_state.island.dof_id[i_pos, i_b]
+            sums_dofs = sums_dofs + func_dof_p0_terms(i_d, i_b, dyn_state, constraint_state)
+            i_pos = i_pos + stride
+        sums_rows = func_row_p0_sums_by_class(i_b, tid, stride, ne, nef, ncone, n_con, constraint_state, rigid_config)
+        if qd.static(is_coop):
+            for k in qd.static(range(4)):
+                sums_dofs[k] = qd.simt.subgroup.reduce_all_add_tiled(sums_dofs[k], 5)
+                sums_rows[k] = qd.simt.subgroup.reduce_all_add_tiled(sums_rows[k], 5)
+        phase, ls_result, gtol, base_1, base_2, p0_deriv_0, p0_deriv_1, alpha_0 = func_ls_state_init(
+            sums_dofs, sums_rows, constraint_state.island.inertia[0, i_b], rigid_info, rigid_config
+        )
+        n_alphas = 1
+        alphas = qd.Vector.zero(gs.qd_float, 3)
+        alphas[0] = alpha_0
+        p1 = qd.Vector.zero(gs.qd_float, 4)
+        p2 = qd.Vector.zero(gs.qd_float, 4)
+        p2update = 0
+        direction = 0
+        ls_it = 1
+        res_alpha = gs.qd_float(0.0)
+        improvement = gs.qd_float(0.0)
+        # Under is_coop the lanes hold identical state, the reductions handing every lane the same sums, so the
+        # rounds are uniform across the block
+        while phase < 3:
+            acc = func_row_alpha_sums_by_class(
+                i_b, tid, stride, n_alphas, alphas, ne, nef, ncone, n_con, constraint_state, rigid_config
+            )
+            if qd.static(is_coop):
+                for k in qd.static(range(9)):
+                    if k < 3 * n_alphas:
+                        acc[k] = qd.simt.subgroup.reduce_all_add_tiled(acc[k], 5)
+            (
+                phase,
+                n_alphas,
+                alphas,
+                p1,
+                p2,
+                p2update,
+                direction,
+                ls_it,
+                res_alpha,
+                improvement,
+                ls_result,
+            ) = func_ls_state_advance(
+                acc,
+                n_alphas,
+                alphas,
+                phase,
+                p1,
+                p2,
+                p2update,
+                direction,
+                ls_it,
+                gtol,
+                base_1,
+                base_2,
+                p0_deriv_0,
+                p0_deriv_1,
+                rigid_info,
+            )
+        # A null step converges the island; otherwise its dofs and rows take the step
+        if qd.abs(res_alpha) < rigid_info.EPS[None]:
+            if tid == 0:
+                constraint_state.island.improved[0, i_b] = False
+        else:
+            is_moved = True
+            i_pos = tid
+            while i_pos < n_dofs:
+                i_d = i_pos
+                if qd.static(rigid_config.sparse_solve):
+                    i_d = constraint_state.island.dof_id[i_pos, i_b]
+                constraint_state.qacc[i_d, i_b] = (
+                    constraint_state.qacc[i_d, i_b] + constraint_state.search[i_d, i_b] * res_alpha
+                )
+                constraint_state.Ma[i_d, i_b] = (
+                    constraint_state.Ma[i_d, i_b] + constraint_state.mv[i_d, i_b] * res_alpha
+                )
+                if qd.static(rigid_config.solver_type == gs.constraint_solver.CG):
+                    constraint_state.cg_prev_grad[i_d, i_b] = constraint_state.grad[i_d, i_b]
+                    constraint_state.cg_prev_Mgrad[i_d, i_b] = constraint_state.Mgrad[i_d, i_b]
+                i_pos = i_pos + stride
+            i_c = tid
+            while i_c < n_con:
+                constraint_state.Jaref[i_c, i_b] = (
+                    constraint_state.Jaref[i_c, i_b] + constraint_state.jv[i_c, i_b] * res_alpha
+                )
+                i_c = i_c + stride
+        if tid == 0:
+            constraint_state.island.ls_improvement[0, i_b] = improvement
+    return is_moved
+
+
+@qd.func
+def func_exit_single_island(
+    i_b,
+    tid,
+    stride,
+    constraint_state: array_class.ConstraintState,
+    rigid_info: array_class.RigidInfo,
+    rigid_config: qd.template(),
+    is_coop: qd.template(),
+    certify: qd.template(),
+):
+    """Test the convergence of the one island of an env of a single-island scene, or under certify its warm-start
+    certificate, and set the search direction of its dofs.
+
+    The lanes sweep the dofs as in func_search_single_island, the exit terms reduced across the block under is_coop,
+    every lane deciding alike.
+
+    Returns whether the island iterates on.
+    """
+    n_dofs = constraint_state.search.shape[0]
+    improved = False
+    if constraint_state.island.improved[0, i_b]:
+        terms = qd.Vector.zero(gs.qd_float, 7)
+        i_pos = tid
+        while i_pos < n_dofs:
+            i_d = i_pos
+            if qd.static(rigid_config.sparse_solve):
+                i_d = constraint_state.island.dof_id[i_pos, i_b]
+            terms = terms + func_dof_exit_terms(i_d, i_b, constraint_state, rigid_config)
+            i_pos = i_pos + stride
+        if qd.static(is_coop):
+            # The Hager-Zhang terms stay zero under Newton, see func_dof_exit_terms
+            for k in qd.static(range(7 if rigid_config.solver_type == gs.constraint_solver.CG else 2)):
+                terms[k] = qd.simt.subgroup.reduce_all_add_tiled(terms[k], 5)
+        inertia = constraint_state.island.inertia[0, i_b]
+        cg_beta = gs.qd_float(0.0)
+        if qd.static(certify):
+            improved = not func_certify_decision(terms, inertia, rigid_info, rigid_config)
+        else:
+            improved, cg_beta = func_exit_decision(
+                terms, constraint_state.island.ls_improvement[0, i_b], inertia, rigid_info, rigid_config
+            )
+        if tid == 0:
+            constraint_state.island.improved[0, i_b] = improved
+        if improved:
+            if qd.static(not certify):
+                i_pos = tid
+                while i_pos < n_dofs:
+                    i_d = i_pos
+                    if qd.static(rigid_config.sparse_solve):
+                        i_d = constraint_state.island.dof_id[i_pos, i_b]
+                    if qd.static(rigid_config.solver_type == gs.constraint_solver.Newton):
+                        constraint_state.search[i_d, i_b] = -constraint_state.Mgrad[i_d, i_b]
+                    else:
+                        constraint_state.search[i_d, i_b] = (
+                            -constraint_state.Mgrad[i_d, i_b] + cg_beta * constraint_state.search[i_d, i_b]
+                        )
+                    i_pos = i_pos + stride
+    return improved
+
+
+@qd.func
 def func_linesearch_islands_serial(
     i_b,
     dyn_state: array_class.DynState,
@@ -615,70 +842,44 @@ def func_linesearch_islands_serial(
     """Line search of every island of one env by a single thread, then the step applied.
 
     mv and jv are formed over the env, then each awake island is searched in turn, its state in registers, its sums and
-    evaluations sweeping its own dofs and rows through the island-ordered dof_id / constraint_id lists, or by index in
-    a scene whose envs hold one island (is_single_island).
+    evaluations sweeping its own dofs and rows through the island-ordered dof_id / constraint_id lists. A single-island
+    scene searches its one island by index (func_search_single_island).
 
     Returns whether any island moved.
     """
-    n_dofs = constraint_state.search.shape[0]
     n_islands = constraint_state.island.n_islands[i_b]
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     ncone = nef
     if qd.static(rigid_config.enable_elliptic_friction):
         ncone = ncone + constraint_state.n_constraints_cone[i_b]
-    n_con = constraint_state.n_constraints[i_b]
 
-    # mv = M @ search and jv = J @ search over the islands still moving, through the island lists. An env holding one
-    # island reads every row densely, whose loads carry no dependent index.
+    is_moved = False
     if qd.static(rigid_config.is_single_island):
         func_mv_jv_dense(i_b, constraint_state, rigid_info)
+        is_moved = func_search_single_island(
+            i_b, 0, 1, dyn_state, constraint_state, dyn_info, rigid_info, rigid_config, is_coop=False
+        )
     else:
+        # mv = M @ search and jv = J @ search over the islands still moving, through the island lists. An env holding
+        # one island reads every row densely, whose loads carry no dependent index.
         if n_islands == 1:
             func_mv_jv_dense(i_b, constraint_state, rigid_info)
         else:
             func_mv_jv_islands(i_b, constraint_state, rigid_info)
-    is_moved = False
-    for i_island in range(n_islands):
-        if constraint_state.island.improved[i_island, i_b]:
-            dof_lo = constraint_state.island.dof_slices.start[i_island, i_b]
-            dof_hi = dof_lo + constraint_state.island.dof_slices.n[i_island, i_b]
-            if qd.static(rigid_config.is_single_island):
-                dof_lo = 0
-                dof_hi = constraint_state.search.shape[0]
-            row_lo = constraint_state.island.constraint_slices.start[i_island, i_b]
-            row_hi = row_lo + constraint_state.island.constraint_slices.n[i_island, i_b]
-            dof_base = constraint_state.island.dof_range_start[i_island, i_b]
-            row_base = func_list_range_start(constraint_state.island.constraint_id, row_lo, row_hi, i_b)
-            sums_dofs = qd.Vector.zero(gs.qd_float, 4)
-            for i_pos in range(dof_lo, dof_hi):
-                i_d = i_pos
-                if qd.static(not rigid_config.is_single_island or rigid_config.sparse_solve):
+        for i_island in range(n_islands):
+            if constraint_state.island.improved[i_island, i_b]:
+                dof_lo = constraint_state.island.dof_slices.start[i_island, i_b]
+                dof_hi = dof_lo + constraint_state.island.dof_slices.n[i_island, i_b]
+                row_lo = constraint_state.island.constraint_slices.start[i_island, i_b]
+                row_hi = row_lo + constraint_state.island.constraint_slices.n[i_island, i_b]
+                dof_base = constraint_state.island.dof_range_start[i_island, i_b]
+                row_base = func_list_range_start(constraint_state.island.constraint_id, row_lo, row_hi, i_b)
+                sums_dofs = qd.Vector.zero(gs.qd_float, 4)
+                for i_pos in range(dof_lo, dof_hi):
                     i_d = func_list_item(constraint_state.island.dof_id, i_pos, dof_lo, dof_base, i_b)
-                sums_dofs = sums_dofs + func_dof_p0_terms(i_d, i_b, dyn_state, constraint_state)
-            sums_rows = qd.Vector.zero(gs.qd_float, 4)
-            if qd.static(rigid_config.is_single_island):
-                # The island holds every row of the env: one sweep per class in constraint order knows the class of
-                # every row statically and reads the rows by index, sparing the class test and list lookup per row.
-                for i_c in range(ne):
-                    sums_rows = sums_rows + func_row_p0_terms(
-                        i_c, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=1
-                    )
-                for i_c in range(ne, nef):
-                    sums_rows = sums_rows + func_row_p0_terms(
-                        i_c, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=2
-                    )
-                if qd.static(rigid_config.enable_elliptic_friction):
-                    n_rows = qd.static(rigid_config.rows_per_contact)
-                    for i_cone in range((ncone - nef) // n_rows):
-                        sums_rows = sums_rows + func_row_p0_terms(
-                            nef + i_cone * n_rows, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=3
-                        )
-                for i_c in range(ncone, n_con):
-                    sums_rows = sums_rows + func_row_p0_terms(
-                        i_c, i_b, ne, nef, ncone, constraint_state, rigid_config, row_kind=4
-                    )
-            else:
+                    sums_dofs = sums_dofs + func_dof_p0_terms(i_d, i_b, dyn_state, constraint_state)
+                sums_rows = qd.Vector.zero(gs.qd_float, 4)
                 for i_pos in range(row_lo, row_hi):
                     sums_rows = sums_rows + func_row_p0_terms(
                         func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b),
@@ -690,46 +891,21 @@ def func_linesearch_islands_serial(
                         rigid_config,
                         row_kind=0,
                     )
-            phase, ls_result, gtol, base_1, base_2, p0_deriv_0, p0_deriv_1, alpha_0 = func_ls_state_init(
-                sums_dofs, sums_rows, constraint_state.island.inertia[i_island, i_b], rigid_info, rigid_config
-            )
-            n_alphas = 1
-            alphas = qd.Vector.zero(gs.qd_float, 3)
-            alphas[0] = alpha_0
-            p1 = qd.Vector.zero(gs.qd_float, 4)
-            p2 = qd.Vector.zero(gs.qd_float, 4)
-            p2update = 0
-            direction = 0
-            ls_it = 1
-            res_alpha = gs.qd_float(0.0)
-            improvement = gs.qd_float(0.0)
-            while phase < 3:
-                acc = qd.Vector.zero(gs.qd_float, 9)
-                if qd.static(rigid_config.is_single_island):
-                    for i_c in range(ne, nef):
-                        acc = acc + func_row_alpha_terms(
-                            i_c, i_b, n_alphas, alphas, ne, nef, ncone, constraint_state, rigid_config, row_kind=2
-                        )
-                    if qd.static(rigid_config.enable_elliptic_friction):
-                        n_rows = qd.static(rigid_config.rows_per_contact)
-                        for i_cone in range((ncone - nef) // n_rows):
-                            acc = acc + func_row_alpha_terms(
-                                nef + i_cone * n_rows,
-                                i_b,
-                                n_alphas,
-                                alphas,
-                                ne,
-                                nef,
-                                ncone,
-                                constraint_state,
-                                rigid_config,
-                                row_kind=3,
-                            )
-                    for i_c in range(ncone, n_con):
-                        acc = acc + func_row_alpha_terms(
-                            i_c, i_b, n_alphas, alphas, ne, nef, ncone, constraint_state, rigid_config, row_kind=4
-                        )
-                else:
+                phase, ls_result, gtol, base_1, base_2, p0_deriv_0, p0_deriv_1, alpha_0 = func_ls_state_init(
+                    sums_dofs, sums_rows, constraint_state.island.inertia[i_island, i_b], rigid_info, rigid_config
+                )
+                n_alphas = 1
+                alphas = qd.Vector.zero(gs.qd_float, 3)
+                alphas[0] = alpha_0
+                p1 = qd.Vector.zero(gs.qd_float, 4)
+                p2 = qd.Vector.zero(gs.qd_float, 4)
+                p2update = 0
+                direction = 0
+                ls_it = 1
+                res_alpha = gs.qd_float(0.0)
+                improvement = gs.qd_float(0.0)
+                while phase < 3:
+                    acc = qd.Vector.zero(gs.qd_float, 9)
                     for i_pos in range(row_lo, row_hi):
                         acc = acc + func_row_alpha_terms(
                             func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b),
@@ -743,62 +919,58 @@ def func_linesearch_islands_serial(
                             rigid_config,
                             row_kind=0,
                         )
-                (
-                    phase,
-                    n_alphas,
-                    alphas,
-                    p1,
-                    p2,
-                    p2update,
-                    direction,
-                    ls_it,
-                    res_alpha,
-                    improvement,
-                    ls_result,
-                ) = func_ls_state_advance(
-                    acc,
-                    n_alphas,
-                    alphas,
-                    phase,
-                    p1,
-                    p2,
-                    p2update,
-                    direction,
-                    ls_it,
-                    gtol,
-                    base_1,
-                    base_2,
-                    p0_deriv_0,
-                    p0_deriv_1,
-                    rigid_info,
-                )
-            # A null step converges the island; otherwise its dofs and rows take the step
-            if qd.abs(res_alpha) < rigid_info.EPS[None]:
-                res_alpha = 0.0
-                constraint_state.island.improved[i_island, i_b] = False
-            else:
-                is_moved = True
-                for i_pos in range(dof_lo, dof_hi):
-                    i_d = i_pos
-                    if qd.static(not rigid_config.is_single_island or rigid_config.sparse_solve):
+                    (
+                        phase,
+                        n_alphas,
+                        alphas,
+                        p1,
+                        p2,
+                        p2update,
+                        direction,
+                        ls_it,
+                        res_alpha,
+                        improvement,
+                        ls_result,
+                    ) = func_ls_state_advance(
+                        acc,
+                        n_alphas,
+                        alphas,
+                        phase,
+                        p1,
+                        p2,
+                        p2update,
+                        direction,
+                        ls_it,
+                        gtol,
+                        base_1,
+                        base_2,
+                        p0_deriv_0,
+                        p0_deriv_1,
+                        rigid_info,
+                    )
+                # A null step converges the island; otherwise its dofs and rows take the step
+                if qd.abs(res_alpha) < rigid_info.EPS[None]:
+                    res_alpha = 0.0
+                    constraint_state.island.improved[i_island, i_b] = False
+                else:
+                    is_moved = True
+                    for i_pos in range(dof_lo, dof_hi):
                         i_d = func_list_item(constraint_state.island.dof_id, i_pos, dof_lo, dof_base, i_b)
-                    constraint_state.qacc[i_d, i_b] = (
-                        constraint_state.qacc[i_d, i_b] + constraint_state.search[i_d, i_b] * res_alpha
-                    )
-                    constraint_state.Ma[i_d, i_b] = (
-                        constraint_state.Ma[i_d, i_b] + constraint_state.mv[i_d, i_b] * res_alpha
-                    )
-                    if qd.static(rigid_config.solver_type == gs.constraint_solver.CG):
-                        constraint_state.cg_prev_grad[i_d, i_b] = constraint_state.grad[i_d, i_b]
-                        constraint_state.cg_prev_Mgrad[i_d, i_b] = constraint_state.Mgrad[i_d, i_b]
-                for i_pos in range(row_lo, row_hi):
-                    i_c = i_pos
-                    if qd.static(not rigid_config.is_single_island):
+                        constraint_state.qacc[i_d, i_b] = (
+                            constraint_state.qacc[i_d, i_b] + constraint_state.search[i_d, i_b] * res_alpha
+                        )
+                        constraint_state.Ma[i_d, i_b] = (
+                            constraint_state.Ma[i_d, i_b] + constraint_state.mv[i_d, i_b] * res_alpha
+                        )
+                        if qd.static(rigid_config.solver_type == gs.constraint_solver.CG):
+                            constraint_state.cg_prev_grad[i_d, i_b] = constraint_state.grad[i_d, i_b]
+                            constraint_state.cg_prev_Mgrad[i_d, i_b] = constraint_state.Mgrad[i_d, i_b]
+                    for i_pos in range(row_lo, row_hi):
                         i_c = func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
-                    constraint_state.Jaref[i_c, i_b] = (
-                        constraint_state.Jaref[i_c, i_b] + constraint_state.jv[i_c, i_b] * res_alpha
-                    )
-            constraint_state.island.ls_improvement[i_island, i_b] = improvement
+                        constraint_state.Jaref[i_c, i_b] = (
+                            constraint_state.Jaref[i_c, i_b] + constraint_state.jv[i_c, i_b] * res_alpha
+                        )
+                constraint_state.island.ls_improvement[i_island, i_b] = improvement
     return is_moved
 
 
@@ -813,49 +985,47 @@ def func_exit_islands_serial(
     """Convergence test, or under certify the warm-start certificate, of every awake island of one env, serially.
 
     Each island's exit terms are summed over its own dofs, then the search direction of the dofs of every island that
-    iterates on is set.
+    iterates on is set. A single-island scene tests its one island by index (func_exit_single_island).
 
     Returns whether any island does.
     """
     n_islands = constraint_state.island.n_islands[i_b]
     improved_any = False
-    for i_island in range(n_islands):
-        if constraint_state.island.improved[i_island, i_b]:
-            dof_lo = constraint_state.island.dof_slices.start[i_island, i_b]
-            dof_hi = dof_lo + constraint_state.island.dof_slices.n[i_island, i_b]
-            if qd.static(rigid_config.is_single_island):
-                dof_lo = 0
-                dof_hi = constraint_state.search.shape[0]
-            dof_base = constraint_state.island.dof_range_start[i_island, i_b]
-            terms = qd.Vector.zero(gs.qd_float, 7)
-            for i_pos in range(dof_lo, dof_hi):
-                i_d = i_pos
-                if qd.static(not rigid_config.is_single_island or rigid_config.sparse_solve):
+    if qd.static(rigid_config.is_single_island):
+        improved_any = func_exit_single_island(
+            i_b, 0, 1, constraint_state, rigid_info, rigid_config, is_coop=False, certify=certify
+        )
+    else:
+        for i_island in range(n_islands):
+            if constraint_state.island.improved[i_island, i_b]:
+                dof_lo = constraint_state.island.dof_slices.start[i_island, i_b]
+                dof_hi = dof_lo + constraint_state.island.dof_slices.n[i_island, i_b]
+                dof_base = constraint_state.island.dof_range_start[i_island, i_b]
+                terms = qd.Vector.zero(gs.qd_float, 7)
+                for i_pos in range(dof_lo, dof_hi):
                     i_d = func_list_item(constraint_state.island.dof_id, i_pos, dof_lo, dof_base, i_b)
-                terms = terms + func_dof_exit_terms(i_d, i_b, constraint_state, rigid_config)
-            inertia = constraint_state.island.inertia[i_island, i_b]
-            improved = False
-            cg_beta = gs.qd_float(0.0)
-            if qd.static(certify):
-                improved = not func_certify_decision(terms, inertia, rigid_info, rigid_config)
-            else:
-                improved, cg_beta = func_exit_decision(
-                    terms, constraint_state.island.ls_improvement[i_island, i_b], inertia, rigid_info, rigid_config
-                )
-            constraint_state.island.improved[i_island, i_b] = improved
-            if improved:
-                improved_any = True
-                if qd.static(not certify):
-                    for i_pos in range(dof_lo, dof_hi):
-                        i_d = i_pos
-                        if qd.static(not rigid_config.is_single_island or rigid_config.sparse_solve):
+                    terms = terms + func_dof_exit_terms(i_d, i_b, constraint_state, rigid_config)
+                inertia = constraint_state.island.inertia[i_island, i_b]
+                improved = False
+                cg_beta = gs.qd_float(0.0)
+                if qd.static(certify):
+                    improved = not func_certify_decision(terms, inertia, rigid_info, rigid_config)
+                else:
+                    improved, cg_beta = func_exit_decision(
+                        terms, constraint_state.island.ls_improvement[i_island, i_b], inertia, rigid_info, rigid_config
+                    )
+                constraint_state.island.improved[i_island, i_b] = improved
+                if improved:
+                    improved_any = True
+                    if qd.static(not certify):
+                        for i_pos in range(dof_lo, dof_hi):
                             i_d = func_list_item(constraint_state.island.dof_id, i_pos, dof_lo, dof_base, i_b)
-                        if qd.static(rigid_config.solver_type == gs.constraint_solver.Newton):
-                            constraint_state.search[i_d, i_b] = -constraint_state.Mgrad[i_d, i_b]
-                        else:
-                            constraint_state.search[i_d, i_b] = (
-                                -constraint_state.Mgrad[i_d, i_b] + cg_beta * constraint_state.search[i_d, i_b]
-                            )
+                            if qd.static(rigid_config.solver_type == gs.constraint_solver.Newton):
+                                constraint_state.search[i_d, i_b] = -constraint_state.Mgrad[i_d, i_b]
+                            else:
+                                constraint_state.search[i_d, i_b] = (
+                                    -constraint_state.Mgrad[i_d, i_b] + cg_beta * constraint_state.search[i_d, i_b]
+                                )
     return improved_any
 
 
@@ -878,6 +1048,30 @@ def func_segment_add(tid, i_slot, n_valid, value, i_slot_prev, i_slot_next, sh_a
     total = qd.simt.subgroup.segmented_reduce_add_tiled(value, is_head, 5)
     if tid < n_valid and i_slot >= 0 and i_slot_next != i_slot:
         sh_acc[k * _K + i_slot] = sh_acc[k * _K + i_slot] + total
+
+
+@qd.func
+def func_mv_jv_coop(i_b, tid, constraint_state: array_class.ConstraintState, rigid_info: array_class.RigidInfo):
+    """Form mv = M @ search over the dofs and jv = J @ search over the rows of one env, by the _K lanes of its block."""
+    _K = qd.static(32)
+    n_dofs = constraint_state.search.shape[0]
+    n_con = constraint_state.n_constraints[i_b]
+    i_d1 = tid
+    while i_d1 < n_dofs:
+        mv = gs.qd_float(0.0)
+        for i_d2 in range(rigid_info.dofs_mass_block_start[i_d1], rigid_info.dofs_mass_block_end[i_d1]):
+            mv = mv + rigid_info.mass_mat[i_d1, i_d2, i_b] * constraint_state.search[i_d2, i_b]
+        constraint_state.mv[i_d1, i_b] = mv
+        i_d1 = i_d1 + _K
+    i_c = tid
+    while i_c < n_con:
+        jv = gs.qd_float(0.0)
+        for i_jd in range(constraint_state.jac_n_dofs[i_c, i_b]):
+            i_d = constraint_state.jac_dofs_idx[i_c, i_jd, i_b]
+            jv = jv + constraint_state.jac[i_c, i_d, i_b] * constraint_state.search[i_d, i_b]
+        constraint_state.jv[i_c, i_b] = jv
+        i_c = i_c + _K
+    qd.simt.block.sync()
 
 
 @qd.func
@@ -908,7 +1102,6 @@ def func_linesearch_islands_coop(
     Returns whether any island moved.
     """
     _K = qd.static(32)
-    n_dofs = constraint_state.search.shape[0]
     n_islands = constraint_state.island.n_islands[i_b]
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
@@ -916,23 +1109,7 @@ def func_linesearch_islands_coop(
     if qd.static(rigid_config.enable_elliptic_friction):
         ncone = ncone + constraint_state.n_constraints_cone[i_b]
     n_con = constraint_state.n_constraints[i_b]
-
-    i_d1 = tid
-    while i_d1 < n_dofs:
-        mv = gs.qd_float(0.0)
-        for i_d2 in range(rigid_info.dofs_mass_block_start[i_d1], rigid_info.dofs_mass_block_end[i_d1]):
-            mv = mv + rigid_info.mass_mat[i_d1, i_d2, i_b] * constraint_state.search[i_d2, i_b]
-        constraint_state.mv[i_d1, i_b] = mv
-        i_d1 = i_d1 + _K
-    i_c = tid
-    while i_c < n_con:
-        jv = gs.qd_float(0.0)
-        for i_jd in range(constraint_state.jac_n_dofs[i_c, i_b]):
-            i_d = constraint_state.jac_dofs_idx[i_c, i_jd, i_b]
-            jv = jv + constraint_state.jac[i_c, i_d, i_b] * constraint_state.search[i_d, i_b]
-        constraint_state.jv[i_c, i_b] = jv
-        i_c = i_c + _K
-    qd.simt.block.sync()
+    func_mv_jv_coop(i_b, tid, constraint_state, rigid_info)
 
     is_moved = False
     for i_group in range((n_islands + _K - 1) // _K):

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -5223,13 +5223,27 @@ def func_solve_init(
             for i_flat in range(_B * _K):
                 tid = i_flat % _K
                 i_b = i_flat // _K
-                sh_acc = qd.simt.block.SharedArray((7 * _K,), gs.qd_float)
-                sh_pending = qd.simt.block.SharedArray((_K,), gs.qd_int)
-                sh_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
                 if constraint_state.n_constraints[i_b] > 0:
-                    improved = linesearch.func_exit_islands_coop(
-                        i_b, tid, sh_acc, sh_pending, sh_alpha, constraint_state, rigid_info, rigid_config, certify=True
-                    )
+                    improved = False
+                    if qd.static(rigid_config.is_single_island):
+                        improved = linesearch.func_exit_single_island(
+                            i_b, tid, _K, constraint_state, rigid_info, rigid_config, is_coop=True, certify=True
+                        )
+                    else:
+                        sh_acc = qd.simt.block.SharedArray((7 * _K,), gs.qd_float)
+                        sh_pending = qd.simt.block.SharedArray((_K,), gs.qd_int)
+                        sh_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
+                        improved = linesearch.func_exit_islands_coop(
+                            i_b,
+                            tid,
+                            sh_acc,
+                            sh_pending,
+                            sh_alpha,
+                            constraint_state,
+                            rigid_info,
+                            rigid_config,
+                            certify=True,
+                        )
                     if tid == 0:
                         constraint_state.improved[i_b] = improved
         else:

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -117,14 +117,22 @@ def _func_update_qfrc_constraint_per_dof(constraint_state: array_class.Constrain
         n_dofs, _B, axes=qd.static((1, 0) if rigid_config.enable_cooperative_constraint_kernels else None)
     ):
         if constraint_state.n_constraints[i_b] > 0 and constraint_state.improved[i_b]:
-            # A dof of an island standing still keeps its value, see func_update_constraint_batch
-            i_island = constraint_state.island.dofs_island_idx[i_d, i_b]
-            if constraint_state.island.improved[i_island, i_b]:
-                qfrc = gs.qd_float(0.0)
+            # A dof of an island standing still keeps its value, see func_update_constraint_batch. A single-island
+            # scene sums the env's rows by index, its one island holding every row in order.
+            is_island_moving = True
+            con_base = 0
+            con_n = constraint_state.n_constraints[i_b]
+            if qd.static(not rigid_config.is_single_island):
+                i_island = constraint_state.island.dofs_island_idx[i_d, i_b]
+                is_island_moving = constraint_state.island.improved[i_island, i_b]
                 con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
                 con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+            if is_island_moving:
+                qfrc = gs.qd_float(0.0)
                 for i_lcon in range(con_n):
-                    i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+                    i_c = con_base + i_lcon
+                    if qd.static(not rigid_config.is_single_island):
+                        i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
                     qfrc += constraint_state.jac[i_c, i_d, i_b] * constraint_state.efc_force[i_c, i_b]
                 constraint_state.qfrc_constraint[i_d, i_b] = qfrc
 
@@ -156,8 +164,9 @@ def _func_islands_linesearch_and_apply(
     """Steps 1 to 4: the lockstep line search of every island of an env and the step applied, by the lanes of the env's
     block (see linesearch.py).
 
-    Without the cooperative kernels (a GPU where they are disabled, the arm pinned regardless) lane 0 runs the serial
-    sweeps.
+    A single-island scene runs the search of its one island by the lanes with the state in registers
+    (func_search_single_island). Without the cooperative kernels (a GPU where they are disabled, the arm pinned
+    regardless) lane 0 runs the serial sweeps.
     """
     _K = qd.static(32)
     _B = constraint_state.grad.shape[1]
@@ -165,13 +174,20 @@ def _func_islands_linesearch_and_apply(
     for i_flat in range(_B * _K):
         tid = i_flat % _K
         i_b = i_flat // _K
-        sh_acc = qd.simt.block.SharedArray((9 * _K,), gs.qd_float)
-        sh_alphas = qd.simt.block.SharedArray((3 * _K,), gs.qd_float)
-        sh_n_alphas = qd.simt.block.SharedArray((_K,), gs.qd_int)
-        sh_pending = qd.simt.block.SharedArray((_K,), gs.qd_int)
-        sh_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
         if constraint_state.n_constraints[i_b] > 0 and constraint_state.improved[i_b]:
-            if qd.static(rigid_config.enable_cooperative_constraint_kernels):
+            if qd.static(rigid_config.enable_cooperative_constraint_kernels and rigid_config.is_single_island):
+                linesearch.func_mv_jv_coop(i_b, tid, constraint_state, rigid_info)
+                is_moved = linesearch.func_search_single_island(
+                    i_b, tid, _K, dyn_state, constraint_state, dyn_info, rigid_info, rigid_config, is_coop=True
+                )
+                if tid == 0:
+                    constraint_state.improved[i_b] = is_moved
+            elif qd.static(rigid_config.enable_cooperative_constraint_kernels):
+                sh_acc = qd.simt.block.SharedArray((9 * _K,), gs.qd_float)
+                sh_alphas = qd.simt.block.SharedArray((3 * _K,), gs.qd_float)
+                sh_n_alphas = qd.simt.block.SharedArray((_K,), gs.qd_int)
+                sh_pending = qd.simt.block.SharedArray((_K,), gs.qd_int)
+                sh_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
                 is_moved = linesearch.func_linesearch_islands_coop(
                     i_b,
                     tid,
@@ -210,11 +226,17 @@ def _func_islands_update_search_direction(
     for i_flat in range(_B * _K):
         tid = i_flat % _K
         i_b = i_flat // _K
-        sh_acc = qd.simt.block.SharedArray((7 * _K,), gs.qd_float)
-        sh_pending = qd.simt.block.SharedArray((_K,), gs.qd_int)
-        sh_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
         if constraint_state.n_constraints[i_b] > 0 and constraint_state.improved[i_b]:
-            if qd.static(rigid_config.enable_cooperative_constraint_kernels):
+            if qd.static(rigid_config.enable_cooperative_constraint_kernels and rigid_config.is_single_island):
+                improved = linesearch.func_exit_single_island(
+                    i_b, tid, _K, constraint_state, rigid_info, rigid_config, is_coop=True, certify=False
+                )
+                if tid == 0:
+                    constraint_state.improved[i_b] = improved
+            elif qd.static(rigid_config.enable_cooperative_constraint_kernels):
+                sh_acc = qd.simt.block.SharedArray((7 * _K,), gs.qd_float)
+                sh_pending = qd.simt.block.SharedArray((_K,), gs.qd_int)
+                sh_alpha = qd.simt.block.SharedArray((_K,), gs.qd_float)
                 improved = linesearch.func_exit_islands_coop(
                     i_b, tid, sh_acc, sh_pending, sh_alpha, constraint_state, rigid_info, rigid_config, certify=False
                 )


### PR DESCRIPTION
## Description

- In a scene holding one dof-carrying kinematic tree (`is_single_island`), the decomposed arm searches and tests the env's one island with every lane of its block holding the search state in registers, advanced from subgroup-reduced sums, the dofs and rows read by index (`func_search_single_island`, `func_exit_single_island`). The lockstep machinery of the multi-island search (shared-memory accumulators, per-round block barriers, list lookups) is kept for every other scene.
- The serial and the cooperative arm share those two functions, which take the first lane and the stride (`0, 1` serially, `tid, _K` cooperatively) and reduce across the block under a static `is_coop`. The row sweeps by class are shared too (`func_row_p0_sums_by_class`, `func_row_alpha_sums_by_class`), and the alpha = 0 row terms are the candidate terms at alpha = 0, so every row formula is written once.
- The J^T f scatter of the decomposed arm sums the env's rows by index in a single-island scene.

## Motivation and Context

At 20000 envs the decomposed arm ran anymal 11% slower than the pre-islands base where at 4096 envs it matched it. With graph launches disabled, the kernel profiler put the gap in three sub-kernels of the Newton iteration (GPU ms per 300 steps, pre-islands vs `main`): line search 101 vs 138, J^T f scatter 25 vs 41, exit test and search direction 9 vs 23, the factor identical (108). In-kernel timers showed the line search's shared-memory traffic around the sweeps growing per env with the env count while the candidate rounds stayed flat.

RTX 5090, decomposed arm pinned, seed 7, two rounds, ms/step:

| | pre-islands | main | PR |
|---|---|---|---|
| anymal 20000 envs | 2.512 | 2.786 / 2.969 | 2.657 / 2.593 |
| g1_fall 4096 envs | | 1.805 | 1.763 |
| go2 4096 envs | 0.830 | 0.830 / 0.830 | 0.850 / 0.850 |

Showcase benchmark on one cluster node, defaults, against v1.4.0: anymal 0.977x in both passes (0.92x on `main`), go2 0.995x and 1.022x (0.95x on `main`).

The go2 4096 figure is 2.4% behind `main`; a per-sub-kernel profile at that env count is running to attribute it.

## How Has This Been / Can This Be Tested?

`tests/rigid/test_islands.py` and `test_friction.py` on CPU, `test_islands.py` on Metal. `tests/rigid/test_islands.py`, `test_dynamics.py`, `test_mujoco_parity.py` and `test_friction.py` on CUDA with `--dev` are running; the results follow in a comment.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [ ] All new and existing tests passed.
