### PR TITLE
[MISC] Fix rigid solver perf regressions (cont'd).

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/linesearch.py
+++ b/genesis/engine/solvers/rigid/constraint/linesearch.py
@@ -563,6 +563,15 @@ def func_mv_jv_islands(i_b, constraint_state: array_class.ConstraintState, rigid
 
 
 @qd.func
+def func_block_sum(value):
+    """Sum value over the _K lanes of a block, every lane receiving the bits lane 0 holds."""
+    # The butterfly adds the same operands on the two lanes of every pair, but the compiler contracts the multiply that
+    # produced a lane's own operand into that add, so the two lanes round differently, and a decision every lane takes
+    # on the sum (the search rounds, the exit test) then diverges.
+    return qd.simt.subgroup.broadcast(qd.simt.subgroup.reduce_all_add_tiled(value, 5), qd.u32(0))
+
+
+@qd.func
 def func_row_p0_sums_by_class(
     i_b,
     i_first,
@@ -683,8 +692,8 @@ def func_search_single_island(
         sums_rows = func_row_p0_sums_by_class(i_b, tid, stride, ne, nef, ncone, n_con, constraint_state, rigid_config)
         if qd.static(is_coop):
             for k in qd.static(range(4)):
-                sums_dofs[k] = qd.simt.subgroup.reduce_all_add_tiled(sums_dofs[k], 5)
-                sums_rows[k] = qd.simt.subgroup.reduce_all_add_tiled(sums_rows[k], 5)
+                sums_dofs[k] = func_block_sum(sums_dofs[k])
+                sums_rows[k] = func_block_sum(sums_rows[k])
         phase, ls_result, gtol, base_1, base_2, p0_deriv_0, p0_deriv_1, alpha_0 = func_ls_state_init(
             sums_dofs, sums_rows, constraint_state.island.inertia[0, i_b], rigid_info, rigid_config
         )
@@ -698,7 +707,7 @@ def func_search_single_island(
         ls_it = 1
         res_alpha = gs.qd_float(0.0)
         improvement = gs.qd_float(0.0)
-        # Under is_coop the lanes hold identical state, the reductions handing every lane the same sums, so the
+        # Under is_coop the lanes hold identical state, the block sums handing every lane the same bits, so the
         # rounds are uniform across the block
         while phase < 3:
             acc = func_row_alpha_sums_by_class(
@@ -707,7 +716,7 @@ def func_search_single_island(
             if qd.static(is_coop):
                 for k in qd.static(range(9)):
                     if k < 3 * n_alphas:
-                        acc[k] = qd.simt.subgroup.reduce_all_add_tiled(acc[k], 5)
+                        acc[k] = func_block_sum(acc[k])
             (
                 phase,
                 n_alphas,
@@ -802,7 +811,7 @@ def func_exit_single_island(
         if qd.static(is_coop):
             # The Hager-Zhang terms stay zero under Newton, see func_dof_exit_terms
             for k in qd.static(range(7 if rigid_config.solver_type == gs.constraint_solver.CG else 2)):
-                terms[k] = qd.simt.subgroup.reduce_all_add_tiled(terms[k], 5)
+                terms[k] = func_block_sum(terms[k])
         inertia = constraint_state.island.inertia[0, i_b]
         cg_beta = gs.qd_float(0.0)
         if qd.static(certify):


### PR DESCRIPTION
## Description

- Every block sum that a lane-uniform decision reads in the single-island line search and exit test (the initialization sums, the candidate terms of each round, the exit terms) takes the bits of lane 0 (`func_block_sum`). The butterfly reduction adds the same operands on both lanes of a pair, but the compiler contracts the multiply that produced a lane's own operand into that add, so the lanes round differently, their search states drift apart, the `while` predicate of the rounds diverges and the next shuffle deadlocks.

## Motivation and Context

go2 at 20000 envs on the decomposed arm, pinned, stalls on `main` after 21 to 28 steps at full GPU load. A bisection over the three kernels of #3352 lands on the single-island line search, and the run completes once lane 0's phase is broadcast after each round. A micro-kernel shows the mechanism: the tiled reduction of a per-lane loaded value gives identical bits on every lane in 4096 of 4096 blocks, the reduction of a lane's own product gives lane-dependent bits in 1454 of them.

The divergent exit decisions also cost iterations. RTX 5090, decomposed arm pinned, seed 7, two rounds, ms/step:

| | main | PR |
|---|---|---|
| go2 4096 envs | 0.830 / 0.829 | 0.815 / 0.815 |
| anymal 20000 envs | 2.824 / 2.805 | 2.599 |
| Newton iterations per step, go2 4096 | 5.19 | 5.17 |
| go2 20000 envs, 320 steps | runs | runs (stalled before) |

## How Has This Been / Can This Be Tested?

The deadlock surfaces after tens of steps at 20000 envs, beyond the step budget of a unit test, so this PR carries no regression test. `tests/rigid/test_islands.py` on CPU and Metal. `tests/rigid/test_islands.py`, `test_dynamics.py`, `test_mujoco_parity.py` and `test_friction.py` on CUDA with `--dev`: 211 passed, 2 skipped as they are, 207 passed with the same 4 gate failures as on `main` with `get_gpu_core_count` patched to 0 (scalar body regime).

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
