### PR TITLE
[MISC] Skip the constraint grouping of single-robot scenes in the rigid solver.

### DIFF
--- a/genesis/engine/solvers/rigid/constraint/island.py
+++ b/genesis/engine/solvers/rigid/constraint/island.py
@@ -130,6 +130,29 @@ def func_constraint_island(i_c, i_b, constraint_state: array_class.ConstraintSta
 
 
 @qd.func
+def func_island_rows(i_b, i_island, constraint_state: array_class.ConstraintState, rigid_config: qd.template()):
+    """First list position and count of the rows of island i_island of env i_b: the env's whole row range in a
+    single-island scene, whose one island holds every row in constraint order, the island's slice of constraint_id
+    otherwise."""
+    row_lo = 0
+    row_n = constraint_state.n_constraints[i_b]
+    if qd.static(not rigid_config.is_single_island):
+        row_lo = constraint_state.island.constraint_slices.start[i_island, i_b]
+        row_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    return row_lo, row_n
+
+
+@qd.func
+def func_island_row(i_pos, i_b, constraint_state: array_class.ConstraintState, rigid_config: qd.template()):
+    """Row at position i_pos of the island lists of env i_b: the position itself in a single-island scene, the
+    constraint_id entry otherwise."""
+    i_c = i_pos
+    if qd.static(not rigid_config.is_single_island):
+        i_c = constraint_state.island.constraint_id[i_pos, i_b]
+    return i_c
+
+
+@qd.func
 def func_group_constraints_by_island(i_b, constraint_state: array_class.ConstraintState, rigid_config: qd.template()):
     """Group the constraints of one env by island and start every island iterating.
 
@@ -142,42 +165,45 @@ def func_group_constraints_by_island(i_b, constraint_state: array_class.Constrai
     """
     n_islands = constraint_state.island.n_islands[i_b]
     n_con = constraint_state.n_constraints[i_b]
-    if n_islands == 1:
-        # A single island spans the whole env, so every constraint belongs to island 0 in index order and the grouping
-        # is the identity. A constraint touching no dof carries jac == 0, so listing it in island 0 is harmless.
-        constraint_state.island.constraint_slices.start[0, i_b] = 0
-        constraint_state.island.constraint_slices.n[0, i_b] = n_con
-        constraint_state.island.constraint_slices.curr[0, i_b] = n_con
-        for i_c in range(n_con):
-            constraint_state.island.constraint_id[i_c, i_b] = i_c
-            constraint_state.island.constraint_island_idx[i_c, i_b] = 0
-    else:
-        for i_island in range(n_islands):
-            constraint_state.island.constraint_slices.n[i_island, i_b] = 0
+    # A single-island scene keeps no list, every reader indexing the rows directly (see func_island_rows)
+    if qd.static(not rigid_config.is_single_island):
+        if n_islands == 1:
+            # A single island spans the whole env, so every constraint belongs to island 0 in index order and the
+            # grouping is the identity. A constraint touching no dof carries jac == 0, so listing it in island 0 is
+            # harmless.
+            constraint_state.island.constraint_slices.start[0, i_b] = 0
+            constraint_state.island.constraint_slices.n[0, i_b] = n_con
+            constraint_state.island.constraint_slices.curr[0, i_b] = n_con
+            for i_c in range(n_con):
+                constraint_state.island.constraint_id[i_c, i_b] = i_c
+                constraint_state.island.constraint_island_idx[i_c, i_b] = 0
+        else:
+            for i_island in range(n_islands):
+                constraint_state.island.constraint_slices.n[i_island, i_b] = 0
 
-        for i_c in range(n_con):
-            i_island = func_constraint_island(i_c, i_b, constraint_state)
-            constraint_state.island.constraint_island_idx[i_c, i_b] = i_island
-            if i_island >= 0:
-                constraint_state.island.constraint_slices.n[i_island, i_b] = (
-                    constraint_state.island.constraint_slices.n[i_island, i_b] + 1
-                )
+            for i_c in range(n_con):
+                i_island = func_constraint_island(i_c, i_b, constraint_state)
+                constraint_state.island.constraint_island_idx[i_c, i_b] = i_island
+                if i_island >= 0:
+                    constraint_state.island.constraint_slices.n[i_island, i_b] = (
+                        constraint_state.island.constraint_slices.n[i_island, i_b] + 1
+                    )
 
-        con_list_start = 0
-        for i_island in range(n_islands):
-            constraint_state.island.constraint_slices.start[i_island, i_b] = con_list_start
-            constraint_state.island.constraint_slices.curr[i_island, i_b] = con_list_start
-            con_list_start = con_list_start + constraint_state.island.constraint_slices.n[i_island, i_b]
+            con_list_start = 0
+            for i_island in range(n_islands):
+                constraint_state.island.constraint_slices.start[i_island, i_b] = con_list_start
+                constraint_state.island.constraint_slices.curr[i_island, i_b] = con_list_start
+                con_list_start = con_list_start + constraint_state.island.constraint_slices.n[i_island, i_b]
 
-        for i_c in range(n_con):
-            i_island = constraint_state.island.constraint_island_idx[i_c, i_b]
-            if i_island >= 0:
-                constraint_state.island.constraint_id[
-                    constraint_state.island.constraint_slices.curr[i_island, i_b], i_b
-                ] = i_c
-                constraint_state.island.constraint_slices.curr[i_island, i_b] = (
-                    constraint_state.island.constraint_slices.curr[i_island, i_b] + 1
-                )
+            for i_c in range(n_con):
+                i_island = constraint_state.island.constraint_island_idx[i_c, i_b]
+                if i_island >= 0:
+                    constraint_state.island.constraint_id[
+                        constraint_state.island.constraint_slices.curr[i_island, i_b], i_b
+                    ] = i_c
+                    constraint_state.island.constraint_slices.curr[i_island, i_b] = (
+                        constraint_state.island.constraint_slices.curr[i_island, i_b] + 1
+                    )
 
     # Every awake island starts iterating, a constraint-free one included: a warm start leaves its acceleration at the
     # previous step's, which its own iteration brings back to the unconstrained one.
@@ -213,57 +239,59 @@ def func_group_constraints_by_island_coop(
     _K = qd.static(32)
     n_islands = constraint_state.island.n_islands[i_b]
     n_con = constraint_state.n_constraints[i_b]
-    if n_islands == 1:
-        if tid == 0:
-            constraint_state.island.constraint_slices.start[0, i_b] = 0
-            constraint_state.island.constraint_slices.n[0, i_b] = n_con
-            constraint_state.island.constraint_slices.curr[0, i_b] = n_con
-        i_c = tid
-        while i_c < n_con:
-            constraint_state.island.constraint_id[i_c, i_b] = i_c
-            constraint_state.island.constraint_island_idx[i_c, i_b] = 0
-            i_c = i_c + _K
-    else:
-        i_island = tid
-        while i_island < n_islands:
-            constraint_state.island.constraint_slices.n[i_island, i_b] = 0
-            i_island = i_island + _K
-        qd.simt.block.sync()
-        i_c = tid
-        while i_c < n_con:
-            i_island = func_constraint_island(i_c, i_b, constraint_state)
-            constraint_state.island.constraint_island_idx[i_c, i_b] = i_island
-            if i_island >= 0:
-                qd.atomic_add(constraint_state.island.constraint_slices.n[i_island, i_b], 1)
-            i_c = i_c + _K
-        qd.simt.block.sync()
-        carry = 0
-        for i_chunk in range((n_islands + _K - 1) // _K):
-            i_island = i_chunk * _K + tid
-            count = 0
-            if i_island < n_islands:
-                count = constraint_state.island.constraint_slices.n[i_island, i_b]
-            count_incl = qd.simt.subgroup.inclusive_add(count)
-            if i_island < n_islands:
-                constraint_state.island.constraint_slices.start[i_island, i_b] = carry + count_incl - count
-                constraint_state.island.constraint_slices.curr[i_island, i_b] = carry + count_incl - count
-            carry = carry + qd.simt.subgroup.broadcast(count_incl, qd.u32(_K - 1))
-        qd.simt.block.sync()
-        for i_chunk in range((n_con + _K - 1) // _K):
-            i_c = i_chunk * _K + tid
-            i_island = -1
-            if i_c < n_con:
-                i_island = constraint_state.island.constraint_island_idx[i_c, i_b]
-            sh_chunk[tid] = i_island
+    # A single-island scene keeps no list, every reader indexing the rows directly (see func_island_rows)
+    if qd.static(not rigid_config.is_single_island):
+        if n_islands == 1:
+            if tid == 0:
+                constraint_state.island.constraint_slices.start[0, i_b] = 0
+                constraint_state.island.constraint_slices.n[0, i_b] = n_con
+                constraint_state.island.constraint_slices.curr[0, i_b] = n_con
+            i_c = tid
+            while i_c < n_con:
+                constraint_state.island.constraint_id[i_c, i_b] = i_c
+                constraint_state.island.constraint_island_idx[i_c, i_b] = 0
+                i_c = i_c + _K
+        else:
+            i_island = tid
+            while i_island < n_islands:
+                constraint_state.island.constraint_slices.n[i_island, i_b] = 0
+                i_island = i_island + _K
             qd.simt.block.sync()
-            if i_island >= 0:
-                i_pos = constraint_state.island.constraint_slices.curr[i_island, i_b]
-                i_pos = i_pos + func_chunk_island_rank(tid, i_island, sh_chunk)
-                constraint_state.island.constraint_id[i_pos, i_b] = i_c
+            i_c = tid
+            while i_c < n_con:
+                i_island = func_constraint_island(i_c, i_b, constraint_state)
+                constraint_state.island.constraint_island_idx[i_c, i_b] = i_island
+                if i_island >= 0:
+                    qd.atomic_add(constraint_state.island.constraint_slices.n[i_island, i_b], 1)
+                i_c = i_c + _K
             qd.simt.block.sync()
-            if i_island >= 0:
-                qd.atomic_add(constraint_state.island.constraint_slices.curr[i_island, i_b], 1)
+            carry = 0
+            for i_chunk in range((n_islands + _K - 1) // _K):
+                i_island = i_chunk * _K + tid
+                count = 0
+                if i_island < n_islands:
+                    count = constraint_state.island.constraint_slices.n[i_island, i_b]
+                count_incl = qd.simt.subgroup.inclusive_add(count)
+                if i_island < n_islands:
+                    constraint_state.island.constraint_slices.start[i_island, i_b] = carry + count_incl - count
+                    constraint_state.island.constraint_slices.curr[i_island, i_b] = carry + count_incl - count
+                carry = carry + qd.simt.subgroup.broadcast(count_incl, qd.u32(_K - 1))
             qd.simt.block.sync()
+            for i_chunk in range((n_con + _K - 1) // _K):
+                i_c = i_chunk * _K + tid
+                i_island = -1
+                if i_c < n_con:
+                    i_island = constraint_state.island.constraint_island_idx[i_c, i_b]
+                sh_chunk[tid] = i_island
+                qd.simt.block.sync()
+                if i_island >= 0:
+                    i_pos = constraint_state.island.constraint_slices.curr[i_island, i_b]
+                    i_pos = i_pos + func_chunk_island_rank(tid, i_island, sh_chunk)
+                    constraint_state.island.constraint_id[i_pos, i_b] = i_c
+                qd.simt.block.sync()
+                if i_island >= 0:
+                    qd.atomic_add(constraint_state.island.constraint_slices.curr[i_island, i_b], 1)
+                qd.simt.block.sync()
 
     # Every awake island starts iterating, a constraint-free one included, see func_group_constraints_by_island
     i_island = tid

--- a/genesis/engine/solvers/rigid/constraint/noslip.py
+++ b/genesis/engine/solvers/rigid/constraint/noslip.py
@@ -3,6 +3,8 @@ import quadrants as qd
 import genesis as gs
 import genesis.utils.array_class as array_class
 
+from .island import func_island_row, func_island_rows
+
 
 @qd.func
 def func_solve_mass_block(i_d0, i_b, vec: qd.Tensor, rigid_info: array_class.RigidInfo):
@@ -122,9 +124,8 @@ def func_refresh_qacc_batch(
     list regardless of the skyline dof reorder).
     """
     n_dofs = constraint_state.island.dof_slices.n[i_island, i_b]
-    n_rows = constraint_state.island.constraint_slices.n[i_island, i_b]
     dof_start = constraint_state.island.dof_slices.start[i_island, i_b]
-    row_start = constraint_state.island.constraint_slices.start[i_island, i_b]
+    row_start, n_rows = func_island_rows(i_b, i_island, constraint_state, rigid_config)
 
     for i_d_ in range(n_dofs):
         i_d = constraint_state.island.dof_id[dof_start + i_d_, i_b]
@@ -132,7 +133,7 @@ def func_refresh_qacc_batch(
         constraint_state.qacc[i_d, i_b] = gs.qd_float(0.0)
 
     for i_c_ in range(n_rows):
-        i_c = constraint_state.island.constraint_id[row_start + i_c_, i_b]
+        i_c = func_island_row(row_start + i_c_, i_b, constraint_state, rigid_config)
         force = constraint_state.efc_force[i_c, i_b]
         for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
             i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
@@ -190,8 +191,7 @@ def func_noslip_batch(
     const_end = const_start + qd.static(rigid_config.rows_per_contact) * collider_state.n_contacts[i_b]
 
     n_dofs = constraint_state.island.dof_slices.n[i_island, i_b]
-    n_rows = constraint_state.island.constraint_slices.n[i_island, i_b]
-    row_start = constraint_state.island.constraint_slices.start[i_island, i_b]
+    row_start, n_rows = func_island_rows(i_b, i_island, constraint_state, rigid_config)
 
     scale = 1.0 / (rigid_info.meaninertia[i_b] * qd.max(1.0, n_dofs))
 
@@ -205,7 +205,7 @@ def func_noslip_batch(
         # opposing pyramid-edge pair (j_efc, j_efc + 1) projected with the normal force fixed. Equality and joint
         # limit rows only contribute to the iter-0 improvement correction.
         for i_c_ in range(n_rows):
-            i_c = constraint_state.island.constraint_id[row_start + i_c_, i_b]
+            i_c = func_island_row(row_start + i_c_, i_b, constraint_state, rigid_config)
 
             if i_iter == 0:
                 improvement += 0.5 * constraint_state.efc_force[i_c, i_b] ** 2 * constraint_state.diag[i_c, i_b]

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -4547,7 +4547,9 @@ def func_qfrc_scatter_sparse(i_b, constraint_state: array_class.ConstraintState,
                 i_d = linesearch.func_list_item(constraint_state.island.dof_id, i_pos, dof_lo, dof_base, i_b)
                 constraint_state.qfrc_constraint[i_d, i_b] = gs.qd_float(0.0)
             for i_pos in range(row_lo, row_hi):
-                i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
+                i_c = i_pos
+                if qd.static(walk_islands):
+                    i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
                 for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
                     i_d = constraint_state.jac_dofs_idx[i_c, i_d_, i_b]
                     constraint_state.qfrc_constraint[i_d, i_b] = (
@@ -4617,12 +4619,18 @@ def func_update_constraint_batch(
                 rigid_config.solver_type == gs.constraint_solver.Newton and rigid_config.enable_elliptic_friction
             ):
                 for i_pos in range(row_lo, row_hi):
-                    i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
+                    i_c = i_pos
+                    if qd.static(walk_islands):
+                        i_c = linesearch.func_list_item(
+                            constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b
+                        )
                     constraint_state.prev_active[i_c, i_b] = constraint_state.active[i_c, i_b]
             # Beware 'active' does not refer to whether a constraint is active, but rather whether its quadratic cost
             # is active
             for i_pos in range(row_lo, row_hi):
-                i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
+                i_c = i_pos
+                if qd.static(walk_islands):
+                    i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
                 cost_i = cost_i + _func_update_efc_force_body(i_c, i_b, constraint_state, rigid_config)
 
     # qfrc_constraint = J^T @ efc_force. The CPU skyline solve scatters each row over its sparse support, and so does an
@@ -4662,7 +4670,9 @@ def func_update_constraint_batch(
                     qacc[i_d, i_b] - dyn_state.dofs.acc_smooth[i_d, i_b]
                 )
             for i_pos in range(row_lo, row_hi):
-                i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
+                i_c = i_pos
+                if qd.static(walk_islands):
+                    i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, row_lo, row_base, i_b)
                 cost_i = cost_i + 0.5 * (
                     constraint_state.Jaref[i_c, i_b] ** 2
                     * constraint_state.efc_D[i_c, i_b]

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -21,6 +21,8 @@ from .island import (
     func_build_single_island_coop,
     func_group_constraints_by_island,
     func_group_constraints_by_island_coop,
+    func_island_row,
+    func_island_rows,
     func_sort_contacts,
     func_sort_contacts_coop,
 )
@@ -2001,8 +2003,7 @@ def func_compute_island_envelope(
         # The env's one island holds every dof, a count the compiler knows and fixes the trip counts below with.
         n = constraint_state.nt_H.shape[1]
     dof_base = constraint_state.island.dof_slices.start[i_island, i_b]
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
 
     for i_d_local in range(n):
         constraint_state.island.dof_env_start_local[dof_base + i_d_local, i_b] = i_d_local
@@ -2013,7 +2014,7 @@ def func_compute_island_envelope(
     # matches the whole-island scan it replaces and the assembly's outer guard, so DOFs that are structurally in the
     # support but currently have a zero Jacobian column are excluded identically, keeping the envelope deterministic.
     for i_lcon in range(con_n):
-        i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+        i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
         col_min = n
         for i_jd in range(constraint_state.jac_n_dofs[i_c, i_b]):
             i_d_local = constraint_state.island.dof_local_pos[constraint_state.jac_dofs_idx[i_c, i_jd, i_b], i_b]
@@ -2155,10 +2156,9 @@ def func_add_cone_hessian_block_island(
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_cone = constraint_state.n_constraints_cone[i_b]
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
     for i_lcon in range(con_n):
-        i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+        i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
         if i_c >= nef and i_c < nef + n_cone and (i_c - nef) % n_rows == 0:
             rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
                 i_c, i_b, constraint_state, rigid_config
@@ -2292,19 +2292,18 @@ def func_hessian_direct_batch(
         # The env's one island holds every dof, a count the compiler knows and fixes the trip counts below with.
         n = constraint_state.nt_H.shape[1]
     dof_base = constraint_state.island.dof_slices.start[i_island, i_b]
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
     # Self-contained scale refresh over the island's own DOFs and constraints: assembly consumes it below, and a
     # lone island's rebuild must not depend on any other island assembling (see nt_jacobi in array_class.py).
     if qd.static(rigid_config.enable_jacobi_equilibration):
-        con_n_scale = constraint_state.island.constraint_slices.n[i_island, i_b]
         for i_d in range(n):
             i_dg = constraint_state.island.dof_id[dof_base + i_d, i_b]
             constraint_state.nt_jacobi[i_dg, i_b] = rigid_info.mass_mat[i_dg, i_dg, i_b]
         # Each active row adds D * jac^2 to the diagonal of every dof of its support, the rows in list order so every
         # dof sums its rows in that order. Walking the rows' supports costs their total size, where a sweep of every dof
         # of the island over every row would read n_dofs * n_rows Jacobian entries, most of them structural zeros.
-        for i_lcon in range(con_n_scale):
-            i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+        for i_lcon in range(con_n):
+            i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
             if constraint_state.active[i_c, i_b]:
                 efc_D = constraint_state.efc_D[i_c, i_b]
                 for i_d_ in range(constraint_state.jac_n_dofs[i_c, i_b]):
@@ -2316,8 +2315,8 @@ def func_hessian_direct_batch(
             n_rows_scale = qd.static(rigid_config.rows_per_contact)
             nef_scale = constraint_state.n_constraints_equality[i_b] + constraint_state.n_constraints_frictionloss[i_b]
             n_cone_scale = constraint_state.n_constraints_cone[i_b]
-            for i_lcon in range(con_n_scale):
-                i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+            for i_lcon in range(con_n):
+                i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
                 if i_c >= nef_scale and i_c < nef_scale + n_cone_scale and (i_c - nef_scale) % n_rows_scale == 0:
                     rows_efc_D, rows_friction, con_mu, rows_jaref = _func_cone_head_load(
                         i_c, i_b, constraint_state, rigid_config
@@ -2343,7 +2342,6 @@ def func_hessian_direct_batch(
             if hess_diag > 0.0:
                 s = 1.0 / qd.sqrt(hess_diag)
             constraint_state.nt_jacobi[i_dg, i_b] = s
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
     # The assembly and the factor visit only the row's skyline envelope [env_start, i_d]: entries below env_start are
     # structurally zero (no constraint or mass coupling reaches them). The skyline solve reads within the same band; the
     # dense block solve (see func_cholesky_solve_batch) reads the whole lower triangle, so off the skyline path the
@@ -2362,13 +2360,13 @@ def func_hessian_direct_batch(
     n_rows = qd.static(rigid_config.rows_per_contact)
     i_lcon = 0
     while i_lcon < con_n:
-        i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+        i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
         jac_n = constraint_state.jac_n_dofs[i_c, i_b]
         n_block = 1
         if i_lcon + n_rows <= con_n:
             is_block = True
             for i_r in qd.static(range(1, n_rows)):
-                i_cr = constraint_state.island.constraint_id[con_base + i_lcon + i_r, i_b]
+                i_cr = func_island_row(con_base + i_lcon + i_r, i_b, constraint_state, rigid_config)
                 if i_cr != i_c + i_r or constraint_state.jac_n_dofs[i_cr, i_b] != jac_n:
                     is_block = False
                 else:
@@ -2491,8 +2489,7 @@ def func_island_assemble_factor_solve_tiled(
         # The env's one island holds every dof, a count the compiler knows and fixes the trip counts below with.
         n = constraint_state.nt_H.shape[1]
     dof_base = constraint_state.island.dof_slices.start[i_island, i_b]
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
     # The dof list of a single-island scene is the identity (its one island holds every dof in order), so its block
     # is the whole of nt_H and its dofs read by index; another scene reads them through the list.
     i_d_start = 0
@@ -2778,8 +2775,7 @@ def func_island_hessian_assemble_block(
         n = constraint_state.nt_H.shape[1]
     dof_lo = constraint_state.island.dof_slices.start[i_island, i_b]
     dof_base = constraint_state.island.dof_range_start[i_island, i_b]
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
     n_tri = n * (n + 1) // 2
     i_tri = tid
     while i_tri < n_tri:
@@ -2802,9 +2798,7 @@ def func_island_hessian_assemble_block(
             while i_flat < n_rows * n:
                 i_r = i_flat // n
                 i_d_local = i_flat % n
-                i_c = con_base + i_lcon_chunk + i_r
-                if qd.static(not rigid_config.is_single_island):
-                    i_c = constraint_state.island.constraint_id[con_base + i_lcon_chunk + i_r, i_b]
+                i_c = func_island_row(con_base + i_lcon_chunk + i_r, i_b, constraint_state, rigid_config)
                 i_d = i_d_local
                 if qd.static(not rigid_config.is_single_island):
                     i_d = linesearch.func_list_item(
@@ -2813,9 +2807,7 @@ def func_island_hessian_assemble_block(
                 sh_jac[i_r, i_d_local] = constraint_state.jac[i_c, i_d, i_b]
                 i_flat = i_flat + block_dim
             if tid < n_rows:
-                i_c = con_base + i_lcon_chunk + tid
-                if qd.static(not rigid_config.is_single_island):
-                    i_c = constraint_state.island.constraint_id[con_base + i_lcon_chunk + tid, i_b]
+                i_c = func_island_row(con_base + i_lcon_chunk + tid, i_b, constraint_state, rigid_config)
                 sh_D[tid] = constraint_state.efc_D[i_c, i_b] * constraint_state.active[i_c, i_b]
             qd.simt.block.sync()
             i_tri = tid
@@ -2848,9 +2840,7 @@ def func_island_hessian_assemble_block(
                 )
             h = constraint_state.nt_H[i_b, i_d, j_d]
             for i_lcon in range(con_n):
-                i_c = con_base + i_lcon
-                if qd.static(not rigid_config.is_single_island):
-                    i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+                i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
                 if constraint_state.active[i_c, i_b]:
                     h = (
                         h
@@ -2913,8 +2903,7 @@ def func_island_hessian_patch_block(
     """
     _K = qd.static(32)
     N_SUBGROUPS = qd.static(block_dim // _K)
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
     n_changed = 0
     i_chunk = 0
     while i_chunk < con_n:
@@ -2922,7 +2911,7 @@ def func_island_hessian_patch_block(
         i_c = -1
         is_flipped = 0
         if i_lcon < con_n:
-            i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+            i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
             if constraint_state.active[i_c, i_b] ^ constraint_state.prev_active[i_c, i_b]:
                 is_flipped = 1
         rank_incl = qd.simt.subgroup.inclusive_add(is_flipped)
@@ -3356,9 +3345,11 @@ def func_factor_island_incremental_dense(
 
     Returns True on a non-positive downdate pivot, the caller then refactoring the island directly.
     """
-    con_lo = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_hi = con_lo + constraint_state.island.constraint_slices.n[i_island, i_b]
-    con_base = linesearch.func_list_range_start(constraint_state.island.constraint_id, con_lo, con_hi, i_b)
+    con_lo, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
+    con_hi = con_lo + con_n
+    con_base = 0
+    if qd.static(not rigid_config.is_single_island):
+        con_base = linesearch.func_list_range_start(constraint_state.island.constraint_id, con_lo, con_hi, i_b)
     is_degenerated = False
     for i_pos in range(con_lo, con_hi):
         i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, con_lo, con_base, i_b)
@@ -3533,8 +3524,7 @@ def func_cone_rank_update_island(
     ne = constraint_state.n_constraints_equality[i_b]
     nef = ne + constraint_state.n_constraints_frictionloss[i_b]
     n_cone = constraint_state.n_constraints_cone[i_b]
-    con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-    con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
     n = constraint_state.island.dof_slices.n[i_island, i_b]
     if qd.static(rigid_config.is_single_island):
         # The env's one island holds every dof, a count the compiler knows and fixes the trip counts below with.
@@ -3547,7 +3537,7 @@ def func_cone_rank_update_island(
     is_degenerated = False
     for i_lcon in range(con_n):
         if not is_degenerated:
-            i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+            i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
             if i_c >= nef and i_c < nef + n_cone and (i_c - nef) % n_rows == 0:
                 i_cone_row = i_c - nef
                 rows_efc_D, rows_friction, con_mu, rows_jaref_cur = _func_cone_head_load(
@@ -3693,8 +3683,7 @@ def func_factor_island_incremental_or_direct(
     needlessly refactor quiescent islands whenever flips are spread thin across many of them (e.g. several separated
     piles each toggling a single contact).
     """
-    c_start = constraint_state.island.constraint_slices.start[i_island, i_b]
-    c_n = constraint_state.island.constraint_slices.n[i_island, i_b]
+    con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
 
     # Count active-set flips and, for the elliptic cone, the middle-zone cone contacts whose coupled block must be
     # refreshed this iteration (each fires one downdate + update below). A cone whose current AND previous
@@ -3706,8 +3695,8 @@ def func_factor_island_incremental_or_direct(
     if qd.static(rigid_config.enable_elliptic_friction):
         nef = constraint_state.n_constraints_equality[i_b] + constraint_state.n_constraints_frictionloss[i_b]
         ncone = nef + constraint_state.n_constraints_cone[i_b]
-        for i_lcon in range(c_n):
-            i_c = constraint_state.island.constraint_id[c_start + i_lcon, i_b]
+        for i_lcon in range(con_n):
+            i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
             if constraint_state.active[i_c, i_b] ^ constraint_state.prev_active[i_c, i_b]:
                 n_changed = n_changed + 1
                 # Keep the persisted cone-free Hessian synced with the current active set, whichever factor path
@@ -3719,8 +3708,8 @@ def func_factor_island_incremental_or_direct(
                 if _func_cone_head_is_middle(i_c, i_b, nef, constraint_state, rigid_config):
                     cone_passes = cone_passes + 1
     else:
-        for i_lcon in range(c_n):
-            i_c = constraint_state.island.constraint_id[c_start + i_lcon, i_b]
+        for i_lcon in range(con_n):
+            i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
             if constraint_state.active[i_c, i_b] ^ constraint_state.prev_active[i_c, i_b]:
                 n_changed = n_changed + 1
 
@@ -3756,8 +3745,8 @@ def func_factor_island_incremental_or_direct(
             # Gather the flipped constraints into fixed-size batches; apply each batch as one fused column sweep.
             batch_ic = qd.Vector.zero(gs.qd_int, rigid_config.hessian_rank_update_batch)
             n_u = 0
-            for i_lcon in range(c_n):
-                i_c = constraint_state.island.constraint_id[c_start + i_lcon, i_b]
+            for i_lcon in range(con_n):
+                i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
                 if constraint_state.active[i_c, i_b] ^ constraint_state.prev_active[i_c, i_b]:
                     batch_ic[n_u] = i_c
                     n_u = n_u + 1
@@ -4502,7 +4491,13 @@ def func_cone_update_rows(
 
 
 @qd.func
-def func_is_row_moving(i_c, i_b, constraint_state: array_class.ConstraintState, skip_settled_islands: qd.template()):
+def func_is_row_moving(
+    i_c,
+    i_b,
+    constraint_state: array_class.ConstraintState,
+    rigid_config: qd.template(),
+    skip_settled_islands: qd.template(),
+):
     """Whether constraint row i_c belongs to an island still iterating (see improved in IslandState).
 
     A row coupling no dof belongs to no island and is taken as moving, its update costing nothing. Always True unless
@@ -4510,7 +4505,7 @@ def func_is_row_moving(i_c, i_b, constraint_state: array_class.ConstraintState, 
     island then moves as a whole, and the island lookup is spared.
     """
     is_moving = True
-    if qd.static(skip_settled_islands):
+    if qd.static(skip_settled_islands and not rigid_config.is_single_island):
         if constraint_state.island.n_islands[i_b] > 1:
             i_island = constraint_state.island.constraint_island_idx[i_c, i_b]
             if i_island >= 0:

--- a/genesis/engine/solvers/rigid/constraint/solver.py
+++ b/genesis/engine/solvers/rigid/constraint/solver.py
@@ -3352,7 +3352,9 @@ def func_factor_island_incremental_dense(
         con_base = linesearch.func_list_range_start(constraint_state.island.constraint_id, con_lo, con_hi, i_b)
     is_degenerated = False
     for i_pos in range(con_lo, con_hi):
-        i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, con_lo, con_base, i_b)
+        i_c = i_pos
+        if qd.static(not rigid_config.is_single_island):
+            i_c = linesearch.func_list_item(constraint_state.island.constraint_id, i_pos, con_lo, con_base, i_b)
         if constraint_state.active[i_c, i_b] ^ constraint_state.prev_active[i_c, i_b]:
             if func_rank1_flip_dense_block(i_b, i_c, i_d_start, n, constraint_state, rigid_info, rigid_config):
                 is_degenerated = True

--- a/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
+++ b/genesis/engine/solvers/rigid/constraint/solver_breakdown.py
@@ -7,6 +7,7 @@ import genesis as gs
 import genesis.utils.array_class as array_class
 from . import linesearch
 from . import solver
+from .island import func_island_row, func_island_rows
 
 # Shared-memory reduction block size for the _jv path.
 _JV_BLOCK = 32
@@ -90,7 +91,7 @@ def _func_update_constraint_forces(constraint_state: array_class.ConstraintState
         len_constraints, _B, axes=qd.static((1, 0) if rigid_config.enable_cooperative_constraint_kernels else None)
     ):
         if i_c < constraint_state.n_constraints[i_b] and constraint_state.improved[i_b]:
-            if solver.func_is_row_moving(i_c, i_b, constraint_state, skip_settled_islands=True):
+            if solver.func_is_row_moving(i_c, i_b, constraint_state, rigid_config, skip_settled_islands=True):
                 _func_update_constraint_forces_body(i_c, i_b, constraint_state, rigid_config)
             elif qd.static(
                 rigid_config.solver_type == gs.constraint_solver.Newton and not rigid_config.enable_elliptic_friction
@@ -120,19 +121,15 @@ def _func_update_qfrc_constraint_per_dof(constraint_state: array_class.Constrain
             # A dof of an island standing still keeps its value, see func_update_constraint_batch. A single-island
             # scene sums the env's rows by index, its one island holding every row in order.
             is_island_moving = True
-            con_base = 0
-            con_n = constraint_state.n_constraints[i_b]
+            i_island = 0
             if qd.static(not rigid_config.is_single_island):
                 i_island = constraint_state.island.dofs_island_idx[i_d, i_b]
                 is_island_moving = constraint_state.island.improved[i_island, i_b]
-                con_base = constraint_state.island.constraint_slices.start[i_island, i_b]
-                con_n = constraint_state.island.constraint_slices.n[i_island, i_b]
             if is_island_moving:
+                con_base, con_n = func_island_rows(i_b, i_island, constraint_state, rigid_config)
                 qfrc = gs.qd_float(0.0)
                 for i_lcon in range(con_n):
-                    i_c = con_base + i_lcon
-                    if qd.static(not rigid_config.is_single_island):
-                        i_c = constraint_state.island.constraint_id[con_base + i_lcon, i_b]
+                    i_c = func_island_row(con_base + i_lcon, i_b, constraint_state, rigid_config)
                     qfrc += constraint_state.jac[i_c, i_d, i_b] * constraint_state.efc_force[i_c, i_b]
                 constraint_state.qfrc_constraint[i_d, i_b] = qfrc
 

--- a/genesis/utils/array_class.py
+++ b/genesis/utils/array_class.py
@@ -513,9 +513,12 @@ def get_island_state(solver, collider):
     # The (env, island) work-lists of the tiled seed are read where an env can hold several islands (see
     # func_island_tiled_factor_solve_all in solver.py)
     worklist_active = solver.rigid_config.enable_tiled_island_seed and not solver.rigid_config.is_single_island
+    # A single-island scene reads its rows by index, see func_island_rows in island.py
+    has_row_lists = not solver.rigid_config.is_single_island
     # Batch-first under the cooperative kernels, whose block serves one env: the lanes then read consecutive items of
     # their env from consecutive addresses (see the constraint-state layouts in get_constraint_state).
     island_layout = (1, 0) if solver.rigid_config.constraint_layout_batch_first else None
+    row_layout = island_layout if has_row_lists else None
     n_classes = len(
         island_tile_caps(solver.rigid_config.island_tile_cap_first, solver.rigid_config.island_tile_cap_last)
     )
@@ -554,9 +557,11 @@ def get_island_state(solver, collider):
             shape=maybe_shape((max_candidate_contacts, _B), rcm_active or coop_active),
             layout=island_layout if rcm_active or coop_active else None,
         ),
-        constraint_slices=get_slices(solver, island_layout),
-        constraint_id=V(dtype=gs.qd_int, shape=(n_constraints_max, _B), layout=island_layout),
-        constraint_island_idx=V(dtype=gs.qd_int, shape=(n_constraints_max, _B), layout=island_layout),
+        constraint_slices=get_slices(solver, island_layout, has_row_lists),
+        constraint_id=V(dtype=gs.qd_int, shape=maybe_shape((n_constraints_max, _B), has_row_lists), layout=row_layout),
+        constraint_island_idx=V(
+            dtype=gs.qd_int, shape=maybe_shape((n_constraints_max, _B), has_row_lists), layout=row_layout
+        ),
         is_hibernated=V(dtype=gs.qd_int, shape=maybe_shape((n_trees, _B), solver._use_hibernation)),
         hibernated_next_link=V(dtype=gs.qd_int, shape=maybe_shape((n_links, _B), solver._use_hibernation)),
         factor_worklist_i_b=V(dtype=gs.qd_int, shape=maybe_shape((n_classes * n_trees * _B,), worklist_active)),

--- a/tests/utils/mujoco_parity.py
+++ b/tests/utils/mujoco_parity.py
@@ -742,7 +742,12 @@ def check_mujoco_data_consistency(
         gs_islands_ls_improvement = qd_to_numpy(gs_island_state.ls_improvement, transpose=True)[0]
         gs_n_islands = qd_to_numpy(gs_island_state.n_islands)[0]
         gs_dofs_island = qd_to_numpy(gs_island_state.dofs_island_idx, transpose=True)[0]
-        gs_constraints_island = qd_to_numpy(gs_island_state.constraint_island_idx, transpose=True)[0, :gs_n_constraints]
+        # A single-island scene keeps no per-row island map, its one island holding every row (see func_island_rows)
+        gs_constraints_island = np.zeros(gs_n_constraints, dtype=gs.np_int)
+        if not gs_sim.rigid_solver.rigid_config.is_single_island:
+            gs_constraints_island = qd_to_numpy(gs_island_state.constraint_island_idx, transpose=True)[
+                0, :gs_n_constraints
+            ]
         gs_to_mj_dof = dict(zip(gs_dofs_idx, mj_dofs_idx))
         for gs_island in range(gs_n_islands):
             gs_island_dofs = np.flatnonzero(gs_dofs_island == gs_island)


### PR DESCRIPTION
## Description

- A single-island scene keeps no per-island row lists: the constraint grouping of `func_solve_init` skips its identity write, `constraint_slices`, `constraint_id` and `constraint_island_idx` are left unallocated, and every reader that walked them (envelope, direct and incremental Hessian assembly, cone rank updates, tiled seed, patch block, no-slip, force and qfrc updates, the moving-row test) reads the env's rows by index through two helpers, `func_island_rows` and `func_island_row`, whose static gate selects the list only where an env can hold several islands.

## Motivation and Context

Part of the residual cost a single-robot scene pays for the per-island machinery: the grouping wrote and the solve read back an identity permutation of the rows every step. RTX 5090, seed 7, two rounds interleaved with main, ms/step:

| | main | PR |
|---|---|---|
| go2 4096 envs, monolith arm | 0.968 / 0.967 | 0.966 / 0.967 |
| go2 4096 envs, decomposed arm | 0.814 / 0.814 | 0.810 / 0.809 |
| anymal 20000 envs, decomposed arm | 2.775 / 2.596 | 2.571 / 5.604 |

The second anymal run of the PR fell in the random slow regime that scene shows on main as well (4 to 6 ms per step in some processes).

## How Has This Been / Can This Be Tested?

`tests/rigid/test_islands.py`, `test_dynamics.py` and `test_friction.py` on CPU, `test_islands.py` on Metal. On CUDA with `--dev`, the four files plus `test_mujoco_parity.py`: running in both regimes (as they are, and with `get_gpu_core_count` patched to 0 for the scalar body regime), the results to be added here. go2 at 20000 envs on the decomposed arm runs 320 steps.

## Checklist:

- [x] I read the **CONTRIBUTING** document.
- [x] I followed the `Submitting Code Changes` section of **CONTRIBUTING** document.
- [x] I tagged the title correctly (including BUG FIX/FEATURE/MISC/BREAKING)
- [x] I updated the [documentation](https://github.com/Genesis-Embodied-AI/genesis-doc) accordingly or no change is needed.
- [x] I tested my changes and added instructions on how to test it for reviewers.
- [x] All new and existing tests passed.
